### PR TITLE
fix(2341): fence recovered completion turn replays

### DIFF
--- a/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
+++ b/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
@@ -29,6 +29,18 @@ const indexSrc = (): string =>
   readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
 
 describe("#1789 — the history fallback is WIRED into the orchestrator, not merely available", () => {
+  it("SOURCE: completion fences remain reclaimable until the real turn ack", () => {
+    const src = indexSrc();
+    expect(src).toContain("onAccepted: (identity) => completionFenceTokens.set(token, identity)");
+    expect(src).not.toContain("replay: payload.replayed === true");
+    const ackAt = src.indexOf("function ackEventToken(");
+    expect(ackAt).toBeGreaterThan(-1);
+    const ackBlock = src.slice(ackAt, ackAt + 1500);
+    expect(ackBlock).toContain("completionFence.markDelivered(identity)");
+    expect(ackBlock).toContain("RunCompletions.ack(token)");
+    expect(ackBlock).toContain("completionFence.release(identity)");
+  });
+
   it("SOURCE: the orchestrator constructs the watchdog against the real journal", () => {
     const src = indexSrc();
     expect(src).toContain("createRunCompletionWatchdog({");

--- a/src/__tests__/orchestrator/run-completion-idempotency.test.ts
+++ b/src/__tests__/orchestrator/run-completion-idempotency.test.ts
@@ -1,0 +1,222 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  completionFenceIdentity,
+  RunCompletionIdempotencyFence,
+  scheduleRunCompletion,
+} from "../../orchestrator/run-completion-idempotency.js";
+
+const tempDirs: string[] = [];
+
+function fencePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "cmcp-2341-"));
+  tempDirs.push(dir);
+  return join(dir, "run-completion-fence.json");
+}
+
+afterEach(() => {
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("run completion scheduling idempotency (#2341)", () => {
+  it("uses the stable completion key first and keeps the route/session in the identity", () => {
+    const identity = completionFenceIdentity("orchestrator::claude", {
+      prompt_id: "prompt-a",
+      completion_key: "route-session/prompt-a/generation-1",
+    });
+    expect(identity).toBe(
+      JSON.stringify(["panel_run", "orchestrator::claude", "completion_key", "route-session/prompt-a/generation-1"]),
+    );
+    expect(completionFenceIdentity("orchestrator::codex", { prompt_id: "prompt-a" })).not.toBe(
+      completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-a" }),
+    );
+  });
+
+  it("persists a seen/delivered fence across a new orchestrator instance", () => {
+    let now = 10_000;
+    const path = fencePath();
+    const first = new RunCompletionIdempotencyFence({ path, now: () => now });
+    const identity = completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-a" })!;
+
+    expect(first.claim(identity)).toBe(true);
+    expect(first.state(identity)).toBe("seen");
+    expect(first.markDelivered(identity)).toBe(true);
+    expect(first.state(identity)).toBe("delivered");
+    expect(JSON.parse(readFileSync(path, "utf8")).entries[identity].state).toBe("delivered");
+
+    const afterReconnect = new RunCompletionIdempotencyFence({ path, now: () => now });
+    expect(afterReconnect.claim(identity)).toBe(false);
+    expect(afterReconnect.state(identity)).toBe("delivered");
+
+    now += 6 * 60 * 60_000;
+    expect(afterReconnect.claim(identity)).toBe(true);
+    expect(afterReconnect.state(identity)).toBe("seen");
+  });
+
+  it("bounds retained identities and allows distinct routes and prompts", () => {
+    let now = 20_000;
+    const path = fencePath();
+    const fence = new RunCompletionIdempotencyFence({ path, now: () => now, maxEntries: 2 });
+    const a = completionFenceIdentity("route-a", { prompt_id: "a" })!;
+    const b = completionFenceIdentity("route-a", { prompt_id: "b" })!;
+    const c = completionFenceIdentity("route-b", { prompt_id: "a" })!;
+
+    expect(fence.claim(a)).toBe(true);
+    now += 1;
+    expect(fence.claim(b)).toBe(true);
+    now += 1;
+    expect(fence.claim(c)).toBe(true);
+    expect(fence.state(a)).toBeUndefined();
+    expect(fence.state(b)).toBe("seen");
+    expect(fence.state(c)).toBe("seen");
+  });
+
+  it("suppresses a repeat before injection, including a stale frontend on reconnect", () => {
+    const path = fencePath();
+    const fence = new RunCompletionIdempotencyFence({ path, now: () => 30_000 });
+    const payload = { kind: "executed", prompt_id: "prompt-replayed" };
+    let injections = 0;
+    const suppressed: string[] = [];
+    const schedule = (token: string, route = "orchestrator::claude", promptId = payload.prompt_id) =>
+      scheduleRunCompletion({
+        route,
+        payload: { ...payload, prompt_id: promptId },
+        token,
+        fence,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: (duplicateToken) => suppressed.push(duplicateToken),
+      });
+
+    expect(schedule("first")).toBe(true);
+    expect(schedule("stale-reconnect"), "same session + prompt must not create a second turn").toBe(true);
+    expect(injections).toBe(1);
+    expect(suppressed).toEqual(["stale-reconnect"]);
+
+    expect(schedule("different-session", "orchestrator::codex")).toBe(true);
+    expect(schedule("different-prompt", "orchestrator::claude", "prompt-distinct")).toBe(true);
+    expect(injections).toBe(3);
+  });
+
+  it("does not retain a refused hand-off as a false delivered fence", () => {
+    const path = fencePath();
+    const fence = new RunCompletionIdempotencyFence({ path, now: () => 40_000 });
+    const payload = { kind: "executed", prompt_id: "prompt-retry" };
+    let accept = false;
+    let injections = 0;
+    const schedule = (token: string) =>
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload,
+        token,
+        fence,
+        inject: () => {
+          injections += 1;
+          return accept;
+        },
+        suppress: () => undefined,
+      });
+
+    expect(schedule("refused")).toBe(false);
+    expect(fence.state(completionFenceIdentity("orchestrator::claude", payload)!)).toBeUndefined();
+    accept = true;
+    expect(schedule("retry")).toBe(true);
+    expect(injections).toBe(2);
+  });
+
+  it("allows the journal to replay the same hand-off after an agent teardown", () => {
+    const path = fencePath();
+    const fence = new RunCompletionIdempotencyFence({ path, now: () => 45_000 });
+    const identity = completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-replayed" })!;
+    let injections = 0;
+
+    expect(
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload: { kind: "executed", prompt_id: "prompt-replayed" },
+        token: "first",
+        fence,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => undefined,
+      }),
+    ).toBe(true);
+    expect(
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload: { kind: "executed", prompt_id: "prompt-replayed", replayed: true },
+        token: "journal-replay",
+        replay: true,
+        fence,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => undefined,
+      }),
+    ).toBe(true);
+
+    expect(injections).toBe(2);
+    expect(fence.state(identity)).toBe("delivered");
+  });
+
+  it("suppresses POSSIBLE_REPEAT even when an old panel has no stable id", () => {
+    const path = fencePath();
+    const fence = new RunCompletionIdempotencyFence({ path, now: () => 50_000 });
+    let injections = 0;
+    let suppressed = 0;
+    const handled = scheduleRunCompletion({
+      route: "orchestrator::claude",
+      payload: { kind: "executed", possible_repeat: true },
+      token: "unkeyed-repeat",
+      fence,
+      inject: () => {
+        injections += 1;
+        return true;
+      },
+      suppress: () => {
+        suppressed += 1;
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(injections).toBe(0);
+    expect(suppressed).toBe(1);
+  });
+
+  it("suppresses POSSIBLE_REPEAT even if the persisted fence was evicted", () => {
+    const path = fencePath();
+    const fence = new RunCompletionIdempotencyFence({ path, now: () => 60_000 });
+    let injections = 0;
+    let suppressed = 0;
+
+    expect(
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload: { kind: "executed", prompt_id: "prompt-repeat", possible_repeat: true },
+        token: "repeat-without-fence",
+        fence,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => {
+          suppressed += 1;
+        },
+      }),
+    ).toBe(true);
+
+    expect(injections).toBe(0);
+    expect(suppressed).toBe(1);
+    expect(fence.state(completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-repeat" })!)).toBe(
+      "delivered",
+    );
+  });
+});

--- a/src/__tests__/orchestrator/run-completion-idempotency.test.ts
+++ b/src/__tests__/orchestrator/run-completion-idempotency.test.ts
@@ -8,7 +8,10 @@ import {
   RunCompletionIdempotencyFence,
   scheduleRunCompletion,
 } from "../../orchestrator/run-completion-idempotency.js";
-import { RunCompletionJournalImpl } from "../../orchestrator/run-completion-journal.js";
+import {
+  RunCompletionJournalImpl,
+  type CompletionPayload,
+} from "../../orchestrator/run-completion-journal.js";
 
 const tempDirs: string[] = [];
 
@@ -22,12 +25,69 @@ function stablePayload(promptId = "prompt-a", completionKey = `completion/${prom
   return { kind: "executed", prompt_id: promptId, completion_key: completionKey };
 }
 
+/** The real production ordering: deliverPending → scheduler → queue acceptance,
+ * then a later onEventDelivered/onEventUndelivered callback settles the fence. */
+function productionHarness(path = fencePath()) {
+  const journal = new RunCompletionJournalImpl();
+  const fence = new RunCompletionIdempotencyFence({ path, now: () => 100_000 });
+  const accepted = new Map<string, string>();
+  const injected: CompletionPayload[] = [];
+  const suppressed: string[] = [];
+  let accepts = true;
+
+  const deliver = () =>
+    journal.deliverPending("route/session", (payload, token) =>
+      scheduleRunCompletion({
+        route: "route/session",
+        payload,
+        token,
+        fence,
+        inject: () => {
+          injected.push(payload);
+          return accepts;
+        },
+        onAccepted: (identity) => accepted.set(token, identity),
+        suppress: (duplicateToken) => {
+          suppressed.push(duplicateToken);
+          journal.suppress(duplicateToken);
+        },
+      }),
+    );
+
+  const ack = (token: string) => {
+    const identity = accepted.get(token);
+    if (identity) fence.markDelivered(identity);
+    accepted.delete(token);
+    journal.ack(token);
+  };
+
+  const release = (token: string) => {
+    const identity = accepted.get(token);
+    if (identity) fence.release(identity);
+    accepted.delete(token);
+    journal.release(token);
+  };
+
+  return {
+    journal,
+    fence,
+    injected,
+    suppressed,
+    deliver,
+    ack,
+    release,
+    setAccepts: (value: boolean) => {
+      accepts = value;
+    },
+  };
+}
+
 afterEach(() => {
   while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
 });
 
 describe("run completion scheduling idempotency (#2341)", () => {
-  it("uses a stable completion key first and requires journal proof for prompt ids", () => {
+  it("uses only a stable completion key as a durable identity", () => {
     const keyed = completionFenceIdentity("orchestrator::claude", {
       prompt_id: "prompt-a",
       completion_key: "route-session/prompt-a/generation-1",
@@ -35,54 +95,54 @@ describe("run completion scheduling idempotency (#2341)", () => {
     expect(keyed).toBe(
       JSON.stringify(["panel_run", "orchestrator::claude", "completion_key", "route-session/prompt-a/generation-1"]),
     );
-
     expect(completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-a" })).toBeNull();
-    const proven = completionFenceIdentity(
-      "orchestrator::claude",
-      { prompt_id: "prompt-a" },
-      { journalProven: true },
-    );
-    expect(proven).toBe(JSON.stringify(["panel_run", "orchestrator::claude", "prompt_id", "prompt-a"]));
+  });
+
+  it("does not suppress a prompt id after restart because journal proof is process-local", () => {
+    const path = fencePath();
+    const payload = { kind: "executed", prompt_id: "reused-after-restart", possible_repeat: true };
+    let injections = 0;
+
+    const first = new RunCompletionIdempotencyFence({ path, now: () => 10_000 });
     expect(
-      completionFenceIdentity("orchestrator::codex", { prompt_id: "prompt-a" }, { journalProven: true }),
-    ).not.toBe(proven);
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload,
+        token: "before-restart",
+        fence: first,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => undefined,
+      }),
+    ).toBe(true);
+
+    const afterRestart = new RunCompletionIdempotencyFence({ path, now: () => 10_000 });
+    expect(
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload,
+        token: "after-restart",
+        fence: afterRestart,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => undefined,
+      }),
+    ).toBe(true);
+    expect(injections).toBe(2);
   });
 
-  it("exposes journal proof only for an exact non-reused ticket generation", () => {
-    const journal = new RunCompletionJournalImpl();
-    journal.openRun("prompt-proven", { tabId: "tab-a", conversation: "orchestrator::claude" });
-    const matched = journal.record(
-      "orchestrator::claude",
-      { kind: "executed", prompt_id: "prompt-proven" },
-      { conversation: "orchestrator::claude" },
-    );
-    expect(journal.isJournalProvenForScheduling(matched.token)).toBe(true);
-
-    const foreign = journal.record(
-      "orchestrator::codex",
-      { kind: "executed", prompt_id: "prompt-proven" },
-      { conversation: "orchestrator::codex" },
-    );
-    expect(journal.isJournalProvenForScheduling(foreign.token)).toBe(false);
-
-    journal.openRun("prompt-reused", { tabId: "tab-a", conversation: "orchestrator::claude" });
-    journal.openRun("prompt-reused", { tabId: "tab-a", conversation: "orchestrator::claude" });
-    const reused = journal.record(
-      "orchestrator::claude",
-      { kind: "executed", prompt_id: "prompt-reused" },
-      { conversation: "orchestrator::claude" },
-    );
-    expect(journal.isJournalProvenForScheduling(reused.token)).toBe(false);
-  });
-
-  it("persists a delivered fence across a new orchestrator instance", () => {
-    let now = 10_000;
+  it("persists a delivered stable-key fence across a new orchestrator instance", () => {
+    let now = 20_000;
     const path = fencePath();
     const first = new RunCompletionIdempotencyFence({ path, now: () => now });
     const identity = completionFenceIdentity("orchestrator::claude", stablePayload())!;
 
     expect(first.claim(identity)).toBe(true);
-    expect(first.state(identity)).toBe("seen");
+    expect(first.markAccepted(identity)).toBe(true);
     expect(first.markDelivered(identity)).toBe(true);
     expect(first.state(identity)).toBe("delivered");
     expect(JSON.parse(readFileSync(path, "utf8")).entries[identity].state).toBe("delivered");
@@ -96,8 +156,98 @@ describe("run completion scheduling idempotency (#2341)", () => {
     expect(afterReconnect.state(identity)).toBe("seen");
   });
 
-  it("bounds retained identities and allows distinct routes and completions", () => {
-    let now = 20_000;
+  it("keeps accepted-but-unacked work reclaimable after a crash/restart", () => {
+    const path = fencePath();
+    const first = productionHarness(path);
+    const entry = first.journal.record(
+      "route/session",
+      { ...stablePayload("crash-before-ack", "completion/crash-before-ack"), possible_repeat: true },
+    );
+
+    expect(first.deliver().delivered).toBe(1);
+    const identity = completionFenceIdentity("route/session", entry.payload)!;
+    expect(first.fence.state(identity)).toBe("accepted");
+    expect(first.injected).toHaveLength(1);
+
+    // The accepted queue item was never read/acked before the orchestrator died.
+    const afterRestart = new RunCompletionIdempotencyFence({ path, now: () => 100_000 });
+    let reinjected = 0;
+    let suppressed = 0;
+    expect(
+      scheduleRunCompletion({
+        route: "route/session",
+        payload: entry.payload,
+        token: "recovered-after-crash",
+        fence: afterRestart,
+        inject: () => {
+          reinjected += 1;
+          return true;
+        },
+        suppress: () => {
+          suppressed += 1;
+        },
+      }),
+    ).toBe(true);
+    expect(reinjected).toBe(1);
+    expect(suppressed).toBe(0);
+  });
+
+  it("keeps the fence through refusal, replayed retry, stale frame, and actual ack", () => {
+    const harness = productionHarness();
+    const payload = { ...stablePayload("refusal-retry", "completion/refusal-retry"), possible_repeat: true };
+    const entry = harness.journal.record("route/session", payload);
+
+    harness.setAccepts(false);
+    expect(harness.deliver().blockedOn?.token).toBe(entry.token);
+    expect(harness.fence.state(completionFenceIdentity("route/session", payload)!)).toBeUndefined();
+
+    harness.setAccepts(true);
+    harness.release(entry.token);
+    expect(harness.deliver().delivered).toBe(1);
+    expect(harness.injected).toHaveLength(2);
+    expect(harness.injected[1].replayed).toBe(true);
+    const identity = completionFenceIdentity("route/session", payload)!;
+    expect(harness.fence.state(identity)).toBe("accepted");
+
+    // A stale panel frame must not mint a second turn while the retried item is
+    // accepted but not yet read/acked.
+    expect(
+      scheduleRunCompletion({
+        route: "route/session",
+        payload,
+        token: "stale-before-ack",
+        fence: harness.fence,
+        inject: () => {
+          harness.injected.push(payload);
+          return true;
+        },
+        suppress: (token) => harness.suppressed.push(token),
+      }),
+    ).toBe(true);
+    expect(harness.injected).toHaveLength(2);
+    expect(harness.suppressed).toEqual(["stale-before-ack"]);
+
+    harness.ack(entry.token);
+    expect(harness.fence.state(identity)).toBe("delivered");
+    expect(
+      scheduleRunCompletion({
+        route: "route/session",
+        payload,
+        token: "stale-after-ack",
+        fence: harness.fence,
+        inject: () => {
+          harness.injected.push(payload);
+          return true;
+        },
+        suppress: (token) => harness.suppressed.push(token),
+      }),
+    ).toBe(true);
+    expect(harness.injected).toHaveLength(2);
+    expect(harness.suppressed).toEqual(["stale-before-ack", "stale-after-ack"]);
+  });
+
+  it("bounds retained identities and keeps distinct stable completions separate", () => {
+    let now = 30_000;
     const path = fencePath();
     const fence = new RunCompletionIdempotencyFence({ path, now: () => now, maxEntries: 2 });
     const a = completionFenceIdentity("route-a", stablePayload("a", "a"))!;
@@ -114,163 +264,15 @@ describe("run completion scheduling idempotency (#2341)", () => {
     expect(fence.state(c)).toBe("seen");
   });
 
-  it("suppresses a duplicate after a durable hand-off, including a stale frontend", () => {
-    const path = fencePath();
-    const fence = new RunCompletionIdempotencyFence({ path, now: () => 30_000 });
-    const payload = { kind: "executed", prompt_id: "prompt-replayed" };
-    let injections = 0;
-    const suppressed: string[] = [];
-    const schedule = (token: string, route = "orchestrator::claude", promptId = payload.prompt_id) =>
-      scheduleRunCompletion({
-        route,
-        payload: { ...payload, prompt_id: promptId },
-        token,
-        journalProven: true,
-        fence,
-        inject: () => {
-          injections += 1;
-          return true;
-        },
-        suppress: (duplicateToken) => suppressed.push(duplicateToken),
-      });
-
-    expect(schedule("first")).toBe(true);
-    expect(schedule("stale-reconnect"), "same session + prompt must not create a second turn").toBe(true);
-    expect(injections).toBe(1);
-    expect(suppressed).toEqual(["stale-reconnect"]);
-
-    expect(schedule("different-session", "orchestrator::codex")).toBe(true);
-    expect(schedule("different-prompt", "orchestrator::claude", "prompt-distinct")).toBe(true);
-    expect(injections).toBe(3);
-  });
-
-  it("does not retain a refused hand-off as a false delivered fence", () => {
-    const path = fencePath();
-    const fence = new RunCompletionIdempotencyFence({ path, now: () => 40_000 });
-    const payload = stablePayload("prompt-retry", "completion/retry");
-    let accept = false;
-    let injections = 0;
-
-    const schedule = (token: string) =>
-      scheduleRunCompletion({
-        route: "orchestrator::claude",
-        payload,
-        token,
-        fence,
-        inject: () => {
-          injections += 1;
-          return accept;
-        },
-        suppress: () => undefined,
-      });
-
-    expect(schedule("refused")).toBe(false);
-    expect(fence.state(completionFenceIdentity("orchestrator::claude", payload)!)).toBeUndefined();
-    accept = true;
-    expect(schedule("retry")).toBe(true);
-    expect(injections).toBe(2);
-  });
-
-  it("allows the journal to replay the same hand-off after an agent teardown", () => {
-    const path = fencePath();
-    const fence = new RunCompletionIdempotencyFence({ path, now: () => 45_000 });
-    const identity = completionFenceIdentity("orchestrator::claude", stablePayload("prompt-replayed"))!;
-    let injections = 0;
-
-    expect(
-      scheduleRunCompletion({
-        route: "orchestrator::claude",
-        payload: stablePayload("prompt-replayed"),
-        token: "first",
-        fence,
-        inject: () => {
-          injections += 1;
-          return true;
-        },
-        suppress: () => undefined,
-      }),
-    ).toBe(true);
-    expect(
-      scheduleRunCompletion({
-        route: "orchestrator::claude",
-        payload: { ...stablePayload("prompt-replayed"), replayed: true },
-        token: "journal-replay",
-        replay: true,
-        fence,
-        inject: () => {
-          injections += 1;
-          return true;
-        },
-        suppress: () => undefined,
-      }),
-    ).toBe(true);
-
-    expect(injections).toBe(2);
-    expect(fence.state(identity)).toBe("delivered");
-  });
-
   it("injects POSSIBLE_REPEAT when there is no stable identity", () => {
-    const fence = new RunCompletionIdempotencyFence({ path: fencePath(), now: () => 50_000 });
+    const fence = new RunCompletionIdempotencyFence({ path: fencePath(), now: () => 40_000 });
     let injections = 0;
     let suppressed = 0;
-    const handled = scheduleRunCompletion({
-      route: "orchestrator::claude",
-      payload: { kind: "executed", possible_repeat: true },
-      token: "unkeyed-repeat",
-      fence,
-      inject: () => {
-        injections += 1;
-        return true;
-      },
-      suppress: () => {
-        suppressed += 1;
-      },
-    });
-
-    expect(handled).toBe(true);
-    expect(injections).toBe(1);
-    expect(suppressed).toBe(0);
-  });
-
-  it("does not use an ambiguous or unprovable prompt id as a repeat fallback", () => {
-    const fence = new RunCompletionIdempotencyFence({ path: fencePath(), now: () => 55_000 });
-    const payload = { kind: "executed", prompt_id: "reused-id", possible_repeat: true };
-    let injections = 0;
-    let suppressed = 0;
-
-    expect(completionFenceIdentity("orchestrator::claude", payload)).toBeNull();
     expect(
       scheduleRunCompletion({
         route: "orchestrator::claude",
-        payload,
-        token: "unprovable-repeat",
-        fence,
-        inject: () => {
-          injections += 1;
-          return true;
-        },
-        suppress: () => {
-          suppressed += 1;
-        },
-      }),
-    ).toBe(true);
-
-    expect(injections).toBe(1);
-    expect(suppressed).toBe(0);
-  });
-
-  it("suppresses POSSIBLE_REPEAT only after a stable completion was durably handed off", () => {
-    const path = fencePath();
-    const fence = new RunCompletionIdempotencyFence({ path, now: () => 60_000 });
-    const payload = { ...stablePayload("prompt-repeat", "completion/repeat"), possible_repeat: true };
-    let injections = 0;
-    let suppressed = 0;
-
-    expect(
-      scheduleRunCompletion({
-        route: "orchestrator::claude",
-        payload,
-        token: "first-repeat",
+        payload: { kind: "executed", possible_repeat: true },
+        token: "unkeyed-repeat",
         fence,
         inject: () => {
           injections += 1;
@@ -283,75 +285,19 @@ describe("run completion scheduling idempotency (#2341)", () => {
     ).toBe(true);
     expect(injections).toBe(1);
     expect(suppressed).toBe(0);
-
-    expect(
-      scheduleRunCompletion({
-        route: "orchestrator::claude",
-        payload,
-        token: "durable-repeat",
-        fence,
-        inject: () => {
-          injections += 1;
-          return true;
-        },
-        suppress: () => {
-          suppressed += 1;
-        },
-      }),
-    ).toBe(true);
-    expect(injections).toBe(1);
-    expect(suppressed).toBe(1);
-  });
-
-  it("reclaims a persisted seen reservation after a crash before injection", () => {
-    const now = 70_000;
-    const path = fencePath();
-    const first = new RunCompletionIdempotencyFence({ path, now: () => now });
-    const payload = { ...stablePayload("prompt-crash", "completion/crash"), possible_repeat: true };
-    const identity = completionFenceIdentity("orchestrator::claude", payload)!;
-
-    // Simulate the crash window after the durable reservation and before manager.injectEvent.
-    expect(first.claim(identity)).toBe(true);
-    expect(first.state(identity)).toBe("seen");
-    const afterRestart = new RunCompletionIdempotencyFence({ path, now: () => now });
-    expect(afterRestart.state(identity)).toBe("seen");
-
-    let injections = 0;
-    let suppressed = 0;
-    expect(
-      scheduleRunCompletion({
-        route: "orchestrator::claude",
-        payload,
-        token: "after-crash",
-        fence: afterRestart,
-        inject: () => {
-          injections += 1;
-          return true;
-        },
-        suppress: () => {
-          suppressed += 1;
-        },
-      }),
-    ).toBe(true);
-    expect(injections).toBe(1);
-    expect(suppressed).toBe(0);
-    expect(afterRestart.state(identity)).toBe("delivered");
   });
 
   it("keeps a possible repeat pending when the fence cannot become durable", () => {
     const fenceFileDirectory = mkdtempSync(join(tmpdir(), "cmcp-2341-unwritable-"));
     tempDirs.push(fenceFileDirectory);
-    const fence = new RunCompletionIdempotencyFence({
-      path: fenceFileDirectory,
-      now: () => 80_000,
-    });
+    const fence = new RunCompletionIdempotencyFence({ path: fenceFileDirectory, now: () => 50_000 });
     let injections = 0;
     let suppressed = 0;
 
     expect(
       scheduleRunCompletion({
         route: "orchestrator::claude",
-        payload: { ...stablePayload("prompt-no-durable-handoff", "completion/no-durable"), possible_repeat: true },
+        payload: { ...stablePayload("no-durable", "completion/no-durable"), possible_repeat: true },
         token: "no-durable-fence",
         fence,
         inject: () => {
@@ -365,5 +311,46 @@ describe("run completion scheduling idempotency (#2341)", () => {
     ).toBe(false);
     expect(injections).toBe(0);
     expect(suppressed).toBe(0);
+  });
+
+  it("retains dropped-completion disclosure when its carrier is fence-suppressed", () => {
+    const journal = new RunCompletionJournalImpl();
+    const fence = new RunCompletionIdempotencyFence({ path: fencePath(), now: () => 60_000 });
+    for (let i = 0; i < 40; i += 1) {
+      journal.record("route/session", stablePayload(`overflow-${i}`, `completion/overflow-${i}`));
+    }
+    const lost = journal.droppedFor("route/session");
+    expect(lost).toBeGreaterThan(0);
+    const carrier = journal.outstanding("route/session").find((entry) => (entry.disclose ?? 0) > 0);
+    expect(carrier).toBeDefined();
+    const carrierIdentity = completionFenceIdentity("route/session", carrier!.payload)!;
+    expect(fence.claim(carrierIdentity)).toBe(true);
+    expect(fence.markAccepted(carrierIdentity)).toBe(true);
+    expect(fence.markDelivered(carrierIdentity)).toBe(true);
+
+    const seen: Array<{ payload: CompletionPayload; token: string }> = [];
+    const suppressed = new Set<string>();
+    journal.deliverPending("route/session", (payload, token) => {
+      seen.push({ payload, token });
+      return scheduleRunCompletion({
+        route: "route/session",
+        payload,
+        token,
+        fence,
+        inject: () => true,
+        suppress: (duplicateToken) => {
+          suppressed.add(duplicateToken);
+          journal.suppress(duplicateToken);
+        },
+      });
+    });
+
+    const disclosed = seen.find(
+      ({ payload, token }) => payload.dropped_completions === lost && !suppressed.has(token),
+    );
+    expect(disclosed).toBeDefined();
+    expect(journal.droppedFor("route/session")).toBe(lost);
+    journal.ack(disclosed!.token);
+    expect(journal.droppedFor("route/session")).toBe(0);
   });
 });

--- a/src/__tests__/orchestrator/run-completion-idempotency.test.ts
+++ b/src/__tests__/orchestrator/run-completion-idempotency.test.ts
@@ -8,6 +8,7 @@ import {
   RunCompletionIdempotencyFence,
   scheduleRunCompletion,
 } from "../../orchestrator/run-completion-idempotency.js";
+import { RunCompletionJournalImpl } from "../../orchestrator/run-completion-journal.js";
 
 const tempDirs: string[] = [];
 
@@ -17,29 +18,68 @@ function fencePath(): string {
   return join(dir, "run-completion-fence.json");
 }
 
+function stablePayload(promptId = "prompt-a", completionKey = `completion/${promptId}`) {
+  return { kind: "executed", prompt_id: promptId, completion_key: completionKey };
+}
+
 afterEach(() => {
   while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
 });
 
 describe("run completion scheduling idempotency (#2341)", () => {
-  it("uses the stable completion key first and keeps the route/session in the identity", () => {
-    const identity = completionFenceIdentity("orchestrator::claude", {
+  it("uses a stable completion key first and requires journal proof for prompt ids", () => {
+    const keyed = completionFenceIdentity("orchestrator::claude", {
       prompt_id: "prompt-a",
       completion_key: "route-session/prompt-a/generation-1",
     });
-    expect(identity).toBe(
+    expect(keyed).toBe(
       JSON.stringify(["panel_run", "orchestrator::claude", "completion_key", "route-session/prompt-a/generation-1"]),
     );
-    expect(completionFenceIdentity("orchestrator::codex", { prompt_id: "prompt-a" })).not.toBe(
-      completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-a" }),
+
+    expect(completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-a" })).toBeNull();
+    const proven = completionFenceIdentity(
+      "orchestrator::claude",
+      { prompt_id: "prompt-a" },
+      { journalProven: true },
     );
+    expect(proven).toBe(JSON.stringify(["panel_run", "orchestrator::claude", "prompt_id", "prompt-a"]));
+    expect(
+      completionFenceIdentity("orchestrator::codex", { prompt_id: "prompt-a" }, { journalProven: true }),
+    ).not.toBe(proven);
   });
 
-  it("persists a seen/delivered fence across a new orchestrator instance", () => {
+  it("exposes journal proof only for an exact non-reused ticket generation", () => {
+    const journal = new RunCompletionJournalImpl();
+    journal.openRun("prompt-proven", { tabId: "tab-a", conversation: "orchestrator::claude" });
+    const matched = journal.record(
+      "orchestrator::claude",
+      { kind: "executed", prompt_id: "prompt-proven" },
+      { conversation: "orchestrator::claude" },
+    );
+    expect(journal.isJournalProvenForScheduling(matched.token)).toBe(true);
+
+    const foreign = journal.record(
+      "orchestrator::codex",
+      { kind: "executed", prompt_id: "prompt-proven" },
+      { conversation: "orchestrator::codex" },
+    );
+    expect(journal.isJournalProvenForScheduling(foreign.token)).toBe(false);
+
+    journal.openRun("prompt-reused", { tabId: "tab-a", conversation: "orchestrator::claude" });
+    journal.openRun("prompt-reused", { tabId: "tab-a", conversation: "orchestrator::claude" });
+    const reused = journal.record(
+      "orchestrator::claude",
+      { kind: "executed", prompt_id: "prompt-reused" },
+      { conversation: "orchestrator::claude" },
+    );
+    expect(journal.isJournalProvenForScheduling(reused.token)).toBe(false);
+  });
+
+  it("persists a delivered fence across a new orchestrator instance", () => {
     let now = 10_000;
     const path = fencePath();
     const first = new RunCompletionIdempotencyFence({ path, now: () => now });
-    const identity = completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-a" })!;
+    const identity = completionFenceIdentity("orchestrator::claude", stablePayload())!;
 
     expect(first.claim(identity)).toBe(true);
     expect(first.state(identity)).toBe("seen");
@@ -56,13 +96,13 @@ describe("run completion scheduling idempotency (#2341)", () => {
     expect(afterReconnect.state(identity)).toBe("seen");
   });
 
-  it("bounds retained identities and allows distinct routes and prompts", () => {
+  it("bounds retained identities and allows distinct routes and completions", () => {
     let now = 20_000;
     const path = fencePath();
     const fence = new RunCompletionIdempotencyFence({ path, now: () => now, maxEntries: 2 });
-    const a = completionFenceIdentity("route-a", { prompt_id: "a" })!;
-    const b = completionFenceIdentity("route-a", { prompt_id: "b" })!;
-    const c = completionFenceIdentity("route-b", { prompt_id: "a" })!;
+    const a = completionFenceIdentity("route-a", stablePayload("a", "a"))!;
+    const b = completionFenceIdentity("route-a", stablePayload("b", "b"))!;
+    const c = completionFenceIdentity("route-b", stablePayload("a", "a"))!;
 
     expect(fence.claim(a)).toBe(true);
     now += 1;
@@ -74,7 +114,7 @@ describe("run completion scheduling idempotency (#2341)", () => {
     expect(fence.state(c)).toBe("seen");
   });
 
-  it("suppresses a repeat before injection, including a stale frontend on reconnect", () => {
+  it("suppresses a duplicate after a durable hand-off, including a stale frontend", () => {
     const path = fencePath();
     const fence = new RunCompletionIdempotencyFence({ path, now: () => 30_000 });
     const payload = { kind: "executed", prompt_id: "prompt-replayed" };
@@ -85,6 +125,7 @@ describe("run completion scheduling idempotency (#2341)", () => {
         route,
         payload: { ...payload, prompt_id: promptId },
         token,
+        journalProven: true,
         fence,
         inject: () => {
           injections += 1;
@@ -106,9 +147,10 @@ describe("run completion scheduling idempotency (#2341)", () => {
   it("does not retain a refused hand-off as a false delivered fence", () => {
     const path = fencePath();
     const fence = new RunCompletionIdempotencyFence({ path, now: () => 40_000 });
-    const payload = { kind: "executed", prompt_id: "prompt-retry" };
+    const payload = stablePayload("prompt-retry", "completion/retry");
     let accept = false;
     let injections = 0;
+
     const schedule = (token: string) =>
       scheduleRunCompletion({
         route: "orchestrator::claude",
@@ -132,13 +174,13 @@ describe("run completion scheduling idempotency (#2341)", () => {
   it("allows the journal to replay the same hand-off after an agent teardown", () => {
     const path = fencePath();
     const fence = new RunCompletionIdempotencyFence({ path, now: () => 45_000 });
-    const identity = completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-replayed" })!;
+    const identity = completionFenceIdentity("orchestrator::claude", stablePayload("prompt-replayed"))!;
     let injections = 0;
 
     expect(
       scheduleRunCompletion({
         route: "orchestrator::claude",
-        payload: { kind: "executed", prompt_id: "prompt-replayed" },
+        payload: stablePayload("prompt-replayed"),
         token: "first",
         fence,
         inject: () => {
@@ -151,7 +193,7 @@ describe("run completion scheduling idempotency (#2341)", () => {
     expect(
       scheduleRunCompletion({
         route: "orchestrator::claude",
-        payload: { kind: "executed", prompt_id: "prompt-replayed", replayed: true },
+        payload: { ...stablePayload("prompt-replayed"), replayed: true },
         token: "journal-replay",
         replay: true,
         fence,
@@ -167,9 +209,8 @@ describe("run completion scheduling idempotency (#2341)", () => {
     expect(fence.state(identity)).toBe("delivered");
   });
 
-  it("suppresses POSSIBLE_REPEAT even when an old panel has no stable id", () => {
-    const path = fencePath();
-    const fence = new RunCompletionIdempotencyFence({ path, now: () => 50_000 });
+  it("injects POSSIBLE_REPEAT when there is no stable identity", () => {
+    const fence = new RunCompletionIdempotencyFence({ path: fencePath(), now: () => 50_000 });
     let injections = 0;
     let suppressed = 0;
     const handled = scheduleRunCompletion({
@@ -187,21 +228,22 @@ describe("run completion scheduling idempotency (#2341)", () => {
     });
 
     expect(handled).toBe(true);
-    expect(injections).toBe(0);
-    expect(suppressed).toBe(1);
+    expect(injections).toBe(1);
+    expect(suppressed).toBe(0);
   });
 
-  it("suppresses POSSIBLE_REPEAT even if the persisted fence was evicted", () => {
-    const path = fencePath();
-    const fence = new RunCompletionIdempotencyFence({ path, now: () => 60_000 });
+  it("does not use an ambiguous or unprovable prompt id as a repeat fallback", () => {
+    const fence = new RunCompletionIdempotencyFence({ path: fencePath(), now: () => 55_000 });
+    const payload = { kind: "executed", prompt_id: "reused-id", possible_repeat: true };
     let injections = 0;
     let suppressed = 0;
 
+    expect(completionFenceIdentity("orchestrator::claude", payload)).toBeNull();
     expect(
       scheduleRunCompletion({
         route: "orchestrator::claude",
-        payload: { kind: "executed", prompt_id: "prompt-repeat", possible_repeat: true },
-        token: "repeat-without-fence",
+        payload,
+        token: "unprovable-repeat",
         fence,
         inject: () => {
           injections += 1;
@@ -213,10 +255,115 @@ describe("run completion scheduling idempotency (#2341)", () => {
       }),
     ).toBe(true);
 
-    expect(injections).toBe(0);
+    expect(injections).toBe(1);
+    expect(suppressed).toBe(0);
+  });
+
+  it("suppresses POSSIBLE_REPEAT only after a stable completion was durably handed off", () => {
+    const path = fencePath();
+    const fence = new RunCompletionIdempotencyFence({ path, now: () => 60_000 });
+    const payload = { ...stablePayload("prompt-repeat", "completion/repeat"), possible_repeat: true };
+    let injections = 0;
+    let suppressed = 0;
+
+    expect(
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload,
+        token: "first-repeat",
+        fence,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => {
+          suppressed += 1;
+        },
+      }),
+    ).toBe(true);
+    expect(injections).toBe(1);
+    expect(suppressed).toBe(0);
+
+    expect(
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload,
+        token: "durable-repeat",
+        fence,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => {
+          suppressed += 1;
+        },
+      }),
+    ).toBe(true);
+    expect(injections).toBe(1);
     expect(suppressed).toBe(1);
-    expect(fence.state(completionFenceIdentity("orchestrator::claude", { prompt_id: "prompt-repeat" })!)).toBe(
-      "delivered",
-    );
+  });
+
+  it("reclaims a persisted seen reservation after a crash before injection", () => {
+    const now = 70_000;
+    const path = fencePath();
+    const first = new RunCompletionIdempotencyFence({ path, now: () => now });
+    const payload = { ...stablePayload("prompt-crash", "completion/crash"), possible_repeat: true };
+    const identity = completionFenceIdentity("orchestrator::claude", payload)!;
+
+    // Simulate the crash window after the durable reservation and before manager.injectEvent.
+    expect(first.claim(identity)).toBe(true);
+    expect(first.state(identity)).toBe("seen");
+    const afterRestart = new RunCompletionIdempotencyFence({ path, now: () => now });
+    expect(afterRestart.state(identity)).toBe("seen");
+
+    let injections = 0;
+    let suppressed = 0;
+    expect(
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload,
+        token: "after-crash",
+        fence: afterRestart,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => {
+          suppressed += 1;
+        },
+      }),
+    ).toBe(true);
+    expect(injections).toBe(1);
+    expect(suppressed).toBe(0);
+    expect(afterRestart.state(identity)).toBe("delivered");
+  });
+
+  it("keeps a possible repeat pending when the fence cannot become durable", () => {
+    const fenceFileDirectory = mkdtempSync(join(tmpdir(), "cmcp-2341-unwritable-"));
+    tempDirs.push(fenceFileDirectory);
+    const fence = new RunCompletionIdempotencyFence({
+      path: fenceFileDirectory,
+      now: () => 80_000,
+    });
+    let injections = 0;
+    let suppressed = 0;
+
+    expect(
+      scheduleRunCompletion({
+        route: "orchestrator::claude",
+        payload: { ...stablePayload("prompt-no-durable-handoff", "completion/no-durable"), possible_repeat: true },
+        token: "no-durable-fence",
+        fence,
+        inject: () => {
+          injections += 1;
+          return true;
+        },
+        suppress: () => {
+          suppressed += 1;
+        },
+      }),
+    ).toBe(false);
+    expect(injections).toBe(0);
+    expect(suppressed).toBe(0);
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -948,6 +948,8 @@ export function armStartupDeadline(
 
 export async function runPanelOrchestrator(): Promise<void> {
   const completionFence = new RunCompletionIdempotencyFence();
+  /** Stable completion keys held by accepted queue items until the real turn ack. */
+  const completionFenceTokens = new Map<string, string>();
   // Crash guard: the orchestrator is a long-lived background process the user
   // can't see. A stray rejection (e.g. a fire-and-forget push to a tab that
   // vanished mid-flight, or an SDK hiccup) must never silently kill it —
@@ -3119,8 +3121,6 @@ export async function runPanelOrchestrator(): Promise<void> {
         route: key,
         payload,
         token,
-        replay: payload.replayed === true,
-        journalProven: RunCompletions.isJournalProvenForScheduling(token),
         fence: completionFence,
         // #884 P0 — the injected turn carries the completion's ORIGIN tab, so it
         // pins/stamps there (show the render on the tab that ran it), never on
@@ -3130,6 +3130,7 @@ export async function runPanelOrchestrator(): Promise<void> {
             eventToken: token,
             mid: turnOrigins.mintInjectionOrigin(panelTabId),
           }),
+        onAccepted: (identity) => completionFenceTokens.set(token, identity),
         suppress: (duplicateToken) => RunCompletions.suppress(duplicateToken),
         log: (message) =>
           logger.info(
@@ -3206,12 +3207,35 @@ export async function runPanelOrchestrator(): Promise<void> {
     // #486 — the ask journal verifies WHICH agent instance is acking, so a
     // provider switch cannot let the new conversation certify the old one's
     // answer. Run completions have their own turn-marker gate and need none.
-    if (token.startsWith("aa")) AskAnswers.ack(token, from);
-    else RunCompletions.ack(token);
+    if (token.startsWith("aa")) {
+      AskAnswers.ack(token, from);
+      return;
+    }
+    const identity = completionFenceTokens.get(token);
+    if (identity && !completionFence.markDelivered(identity)) {
+      logger.warn(
+        `[panel-orchestrator] could not persist the delivered completion fence for ${token}; a restart may replay it (#2341)`,
+      );
+    }
+    if (identity) completionFenceTokens.delete(token);
+    RunCompletions.ack(token);
   }
   function releaseEventToken(token: string, carried: boolean): void {
-    if (token.startsWith("aa")) AskAnswers.release(token, { carried });
-    else RunCompletions.release(token, { carried });
+    if (token.startsWith("aa")) {
+      AskAnswers.release(token, { carried });
+      return;
+    }
+    // Release the scheduling reservation BEFORE re-arming the journal. The
+    // journal's release hook immediately flushes a replacement agent, so the
+    // replay must be able to reclaim the identity in the same call stack.
+    const identity = completionFenceTokens.get(token);
+    if (identity && !completionFence.release(identity)) {
+      logger.warn(
+        `[panel-orchestrator] could not release the completion fence for ${token}; replay remains durability-blocked (#2341)`,
+      );
+    }
+    if (identity) completionFenceTokens.delete(token);
+    RunCompletions.release(token, { carried });
   }
 
   // Flag the mobile mirror picker's "session attached" (green) dot from live agents.

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -274,6 +274,10 @@ import {
   type CompletionPayload,
 } from "./run-completion-journal.js";
 import {
+  RunCompletionIdempotencyFence,
+  scheduleRunCompletion,
+} from "./run-completion-idempotency.js";
+import {
   createRunCompletionWatchdog,
   resolveHistoryCompletionImages,
   resolveHistoryCompletionStatus,
@@ -943,6 +947,7 @@ export function armStartupDeadline(
 }
 
 export async function runPanelOrchestrator(): Promise<void> {
+  const completionFence = new RunCompletionIdempotencyFence();
   // Crash guard: the orchestrator is a long-lived background process the user
   // can't see. A stray rejection (e.g. a fire-and-forget push to a tab that
   // vanished mid-flight, or an SDK hiccup) must never silently kill it —
@@ -3110,10 +3115,26 @@ export async function runPanelOrchestrator(): Promise<void> {
   function flushRunCompletions(panelTabId: string): void {
     const key = agentKeyFor(panelTabId);
     const { blockedOn } = RunCompletions.deliverPending(panelTabId, (payload, token) =>
-      // #884 P0 — the injected turn carries the completion's ORIGIN tab, so it
-      // pins/stamps there (show the render on the tab that ran it), never on
-      // whatever tab is active (confirming-gate 2).
-      manager.injectEvent(key, payload, { eventToken: token, mid: turnOrigins.mintInjectionOrigin(panelTabId) }),
+      scheduleRunCompletion({
+        route: key,
+        payload,
+        token,
+        replay: payload.replayed === true,
+        fence: completionFence,
+        // #884 P0 — the injected turn carries the completion's ORIGIN tab, so it
+        // pins/stamps there (show the render on the tab that ran it), never on
+        // whatever tab is active (confirming-gate 2).
+        inject: () =>
+          manager.injectEvent(key, payload, {
+            eventToken: token,
+            mid: turnOrigins.mintInjectionOrigin(panelTabId),
+          }),
+        suppress: (duplicateToken) => RunCompletions.suppress(duplicateToken),
+        log: (message) =>
+          logger.info(
+            `[panel-orchestrator] tab ${panelTabId.slice(0, 8)} ${message} before creating another agent turn (#2341)`,
+          ),
+      }),
     );
     if (blockedOn) {
       logger.warn(

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3120,6 +3120,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         payload,
         token,
         replay: payload.replayed === true,
+        journalProven: RunCompletions.isJournalProvenForScheduling(token),
         fence: completionFence,
         // #884 P0 — the injected turn carries the completion's ORIGIN tab, so it
         // pins/stamps there (show the render on the tab that ran it), never on

--- a/src/orchestrator/run-completion-idempotency.ts
+++ b/src/orchestrator/run-completion-idempotency.ts
@@ -1,0 +1,249 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { logger } from "../utils/logger.js";
+import { writeFileDurable } from "../utils/durable-write.js";
+import type { CompletionPayload } from "./run-completion-journal.js";
+
+/** A prompt id is already bounded by the panel protocol; keep the disk key bounded too. */
+const MAX_ID_LENGTH = 512;
+
+/** A restarted orchestrator must remember a completion long enough to outlive reconnect churn. */
+export const DEFAULT_COMPLETION_FENCE_TTL_MS = 6 * 60 * 60_000;
+
+/** Bound the persisted map even if a panel manufactures many distinct prompt ids. */
+export const DEFAULT_COMPLETION_FENCE_MAX_ENTRIES = 2048;
+
+type FenceState = "seen" | "delivered";
+
+export type CompletionFenceClaim = "claimed" | "duplicate" | "unavailable";
+
+type FenceEntry = {
+  state: FenceState;
+  at: number;
+};
+
+type FenceFile = {
+  version: 1;
+  entries: Record<string, FenceEntry>;
+};
+
+export type CompletionFenceOptions = {
+  path?: string;
+  now?: () => number;
+  ttlMs?: number;
+  maxEntries?: number;
+};
+
+function usable(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0 && value.length <= MAX_ID_LENGTH;
+}
+
+/**
+ * Stable scheduling identity for a panel completion.
+ *
+ * The route/session is deliberately outside the panel tab id: a stale frontend
+ * reconnect gets a new tab address, but it is still the same agent conversation.
+ * A panel completion key is preferred because it survives prompt-id reuse; older
+ * panels fall back to ComfyUI's prompt id.
+ */
+export function completionFenceIdentity(
+  route: string,
+  payload: Pick<CompletionPayload, "prompt_id" | "completion_key">,
+): string | null {
+  const routeId = typeof route === "string" ? route.trim() : "";
+  if (!routeId || routeId.length > MAX_ID_LENGTH) return null;
+  if (usable(payload.completion_key)) {
+    return JSON.stringify(["panel_run", routeId, "completion_key", payload.completion_key]);
+  }
+  if (usable(payload.prompt_id)) {
+    return JSON.stringify(["panel_run", routeId, "prompt_id", payload.prompt_id]);
+  }
+  return null;
+}
+
+function defaultFencePath(): string {
+  return join(homedir(), ".comfyui-mcp", "run-completion-fence.json");
+}
+
+function validEntry(value: unknown): value is FenceEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<FenceEntry>;
+  return (
+    (entry.state === "seen" || entry.state === "delivered") &&
+    typeof entry.at === "number" &&
+    Number.isFinite(entry.at) &&
+    entry.at >= 0
+  );
+}
+
+/**
+ * Small, synchronous, atomic fence used immediately around agent scheduling.
+ *
+ * `seen` is written before the queue hand-off; `delivered` is written after the
+ * manager accepts the event. Both states suppress a later replay. The journal
+ * remains responsible for replaying a hand-off that the agent never consumed;
+ * this fence is specifically responsible for preventing a stale frontend from
+ * minting a second turn for the same completion.
+ */
+export class RunCompletionIdempotencyFence {
+  private readonly filePath: string;
+  private readonly now: () => number;
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private entries = new Map<string, FenceEntry>();
+
+  constructor(options: CompletionFenceOptions = {}) {
+    this.filePath = options.path ?? defaultFencePath();
+    this.now = options.now ?? Date.now;
+    this.ttlMs = Math.max(1, options.ttlMs ?? DEFAULT_COMPLETION_FENCE_TTL_MS);
+    this.maxEntries = Math.max(1, Math.floor(options.maxEntries ?? DEFAULT_COMPLETION_FENCE_MAX_ENTRIES));
+    this.load();
+  }
+
+  /** Claim an identity before creating a new agent turn. */
+  claim(identity: string): boolean {
+    return this.claimResult(identity) === "claimed";
+  }
+
+  /** Distinguish a duplicate from a failed durability write. */
+  claimResult(identity: string): CompletionFenceClaim {
+    if (!identity) return "unavailable";
+    const now = this.now();
+    const previous = new Map(this.entries);
+    this.prune(now);
+    const existing = this.entries.get(identity);
+    if (existing && now - existing.at < this.ttlMs) {
+      return "duplicate";
+    }
+    this.entries.set(identity, { state: "seen", at: now });
+    this.trim();
+    if (this.persist()) return "claimed";
+    this.entries = previous;
+    return "unavailable";
+  }
+
+  /** Mark a successfully accepted queue hand-off as delivered to the agent. */
+  markDelivered(identity: string): boolean {
+    const entry = this.entries.get(identity);
+    if (!entry) return false;
+    const previous = entry.state;
+    entry.state = "delivered";
+    if (this.persist()) return true;
+    // Keep the already-written `seen` fence if the second write fails. It is
+    // still safer than allowing an un-fenced replay after a transient disk error.
+    entry.state = previous;
+    return false;
+  }
+
+  /** Remove a reservation when the manager refused the hand-off. */
+  release(identity: string): boolean {
+    if (!this.entries.has(identity)) return true;
+    const previous = this.entries;
+    this.entries = new Map(previous);
+    this.entries.delete(identity);
+    if (this.persist()) return true;
+    this.entries = previous;
+    return false;
+  }
+
+  /** Test/diagnostic seam. */
+  state(identity: string): FenceState | undefined {
+    return this.entries.get(identity)?.state;
+  }
+
+  private load(): void {
+    if (!existsSync(this.filePath)) return;
+    try {
+      const parsed = JSON.parse(readFileSync(this.filePath, "utf8")) as Partial<FenceFile>;
+      if (parsed.version !== 1 || !parsed.entries || typeof parsed.entries !== "object") return;
+      const loaded = Object.entries(parsed.entries)
+        .filter(([, value]) => validEntry(value))
+        .sort(([, a], [, b]) => a.at - b.at);
+      for (const [identity, entry] of loaded) this.entries.set(identity, entry);
+      const before = this.entries.size;
+      this.prune(this.now());
+      if (this.entries.size !== before) this.persist();
+    } catch (error) {
+      logger.warn(`[run-completion-fence] ignoring unreadable fence ${this.filePath}: ${String(error)}`);
+      this.entries.clear();
+    }
+  }
+
+  private prune(now: number): void {
+    for (const [identity, entry] of this.entries) {
+      if (now - entry.at >= this.ttlMs || now < entry.at) this.entries.delete(identity);
+    }
+    this.trim();
+  }
+
+  private trim(): void {
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+
+  private persist(): boolean {
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true });
+      const file: FenceFile = { version: 1, entries: Object.fromEntries(this.entries) };
+      writeFileDurable(this.filePath, JSON.stringify(file) + "\n");
+      return true;
+    } catch (error) {
+      logger.warn(`[run-completion-fence] could not persist ${this.filePath}: ${String(error)}`);
+      return false;
+    }
+  }
+}
+
+export type ScheduleCompletionOptions = {
+  route: string;
+  payload: CompletionPayload;
+  token: string;
+  /** True when the journal is replaying the same entry after a hand-off failed. */
+  replay?: boolean;
+  fence: RunCompletionIdempotencyFence;
+  inject: () => boolean;
+  suppress: (token: string) => void;
+  log?: (message: string) => void;
+};
+
+/**
+ * The one scheduling gate for recovered and live `panel_run` completions.
+ * Returning true for a suppressed entry tells the journal that the queue offer
+ * was handled; `suppress` removes the duplicate, so it cannot be retried into a
+ * new turn on every reconnect.
+ */
+export function scheduleRunCompletion(options: ScheduleCompletionOptions): boolean {
+  const identity = completionFenceIdentity(options.route, options.payload);
+  // POSSIBLE_REPEAT is already a journal-level verdict. Persist a fence when
+  // possible, then remove the entry without ever asking the manager to create a
+  // turn. This remains fail-closed if an old panel supplied no stable identity.
+  if (options.payload.possible_repeat === true) {
+    if (identity && options.fence.claimResult(identity) === "claimed") options.fence.markDelivered(identity);
+    options.suppress(options.token);
+    options.log?.("suppressed a POSSIBLE_REPEAT before creating an agent turn");
+    return true;
+  }
+  // A journal replay is the SAME completion whose queue hand-off was lost or
+  // whose carrying turn ended before ack. It must be allowed through; the
+  // durable fence only rejects a NEW entry for an identity already scheduled.
+  if (options.replay === true) return options.inject();
+  if (!identity) {
+    return options.inject();
+  }
+  const claim = options.fence.claimResult(identity);
+  if (claim === "unavailable") return false;
+  if (claim === "duplicate") {
+    options.suppress(options.token);
+    options.log?.(`suppressed a replay for ${identity}`);
+    return true;
+  }
+  const handedOff = options.inject();
+  if (handedOff) options.fence.markDelivered(identity);
+  else options.fence.release(identity);
+  return handedOff;
+}

--- a/src/orchestrator/run-completion-idempotency.ts
+++ b/src/orchestrator/run-completion-idempotency.ts
@@ -36,6 +36,11 @@ export type CompletionFenceOptions = {
   maxEntries?: number;
 };
 
+export type CompletionFenceIdentityOptions = {
+  /** True only when the journal matched this prompt id to one exact run generation. */
+  journalProven?: boolean;
+};
+
 function usable(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0 && value.length <= MAX_ID_LENGTH;
 }
@@ -45,19 +50,21 @@ function usable(value: unknown): value is string {
  *
  * The route/session is deliberately outside the panel tab id: a stale frontend
  * reconnect gets a new tab address, but it is still the same agent conversation.
- * A panel completion key is preferred because it survives prompt-id reuse; older
- * panels fall back to ComfyUI's prompt id.
+ * A panel completion key is preferred because it survives prompt-id reuse. A
+ * prompt id is usable only when the journal proved the exact run generation;
+ * an unproven or reused prompt id is a bucket, not a stable identity.
  */
 export function completionFenceIdentity(
   route: string,
   payload: Pick<CompletionPayload, "prompt_id" | "completion_key">,
+  options: CompletionFenceIdentityOptions = {},
 ): string | null {
   const routeId = typeof route === "string" ? route.trim() : "";
   if (!routeId || routeId.length > MAX_ID_LENGTH) return null;
   if (usable(payload.completion_key)) {
     return JSON.stringify(["panel_run", routeId, "completion_key", payload.completion_key]);
   }
-  if (usable(payload.prompt_id)) {
+  if (options.journalProven === true && usable(payload.prompt_id)) {
     return JSON.stringify(["panel_run", routeId, "prompt_id", payload.prompt_id]);
   }
   return null;
@@ -82,10 +89,11 @@ function validEntry(value: unknown): value is FenceEntry {
  * Small, synchronous, atomic fence used immediately around agent scheduling.
  *
  * `seen` is written before the queue hand-off; `delivered` is written after the
- * manager accepts the event. Both states suppress a later replay. The journal
- * remains responsible for replaying a hand-off that the agent never consumed;
- * this fence is specifically responsible for preventing a stale frontend from
- * minting a second turn for the same completion.
+ * manager accepts the event. Only `delivered` suppresses a later replay. A
+ * persisted `seen` reservation is deliberately reclaimable: if the process
+ * crashes after the reservation but before injection, a restarted orchestrator
+ * must be able to retry the journal entry instead of treating an incomplete
+ * hand-off as proof that an agent received it.
  */
 export class RunCompletionIdempotencyFence {
   private readonly filePath: string;
@@ -114,7 +122,7 @@ export class RunCompletionIdempotencyFence {
     const previous = new Map(this.entries);
     this.prune(now);
     const existing = this.entries.get(identity);
-    if (existing && now - existing.at < this.ttlMs) {
+    if (existing?.state === "delivered" && now - existing.at < this.ttlMs) {
       return "duplicate";
     }
     this.entries.set(identity, { state: "seen", at: now });
@@ -205,6 +213,8 @@ export type ScheduleCompletionOptions = {
   token: string;
   /** True when the journal is replaying the same entry after a hand-off failed. */
   replay?: boolean;
+  /** True only for a prompt id matched to an exact, non-reused journal ticket. */
+  journalProven?: boolean;
   fence: RunCompletionIdempotencyFence;
   inject: () => boolean;
   suppress: (token: string) => void;
@@ -218,16 +228,9 @@ export type ScheduleCompletionOptions = {
  * new turn on every reconnect.
  */
 export function scheduleRunCompletion(options: ScheduleCompletionOptions): boolean {
-  const identity = completionFenceIdentity(options.route, options.payload);
-  // POSSIBLE_REPEAT is already a journal-level verdict. Persist a fence when
-  // possible, then remove the entry without ever asking the manager to create a
-  // turn. This remains fail-closed if an old panel supplied no stable identity.
-  if (options.payload.possible_repeat === true) {
-    if (identity && options.fence.claimResult(identity) === "claimed") options.fence.markDelivered(identity);
-    options.suppress(options.token);
-    options.log?.("suppressed a POSSIBLE_REPEAT before creating an agent turn");
-    return true;
-  }
+  const identity = completionFenceIdentity(options.route, options.payload, {
+    journalProven: options.journalProven,
+  });
   // A journal replay is the SAME completion whose queue hand-off was lost or
   // whose carrying turn ended before ack. It must be allowed through; the
   // durable fence only rejects a NEW entry for an identity already scheduled.
@@ -239,7 +242,11 @@ export function scheduleRunCompletion(options: ScheduleCompletionOptions): boole
   if (claim === "unavailable") return false;
   if (claim === "duplicate") {
     options.suppress(options.token);
-    options.log?.(`suppressed a replay for ${identity}`);
+    options.log?.(
+      options.payload.possible_repeat === true
+        ? `suppressed a POSSIBLE_REPEAT with a durable delivered fence for ${identity}`
+        : `suppressed a replay for ${identity}`,
+    );
     return true;
   }
   const handedOff = options.inject();

--- a/src/orchestrator/run-completion-idempotency.ts
+++ b/src/orchestrator/run-completion-idempotency.ts
@@ -15,7 +15,7 @@ export const DEFAULT_COMPLETION_FENCE_TTL_MS = 6 * 60 * 60_000;
 /** Bound the persisted map even if a panel manufactures many distinct prompt ids. */
 export const DEFAULT_COMPLETION_FENCE_MAX_ENTRIES = 2048;
 
-type FenceState = "seen" | "delivered";
+type FenceState = "seen" | "accepted" | "delivered";
 
 export type CompletionFenceClaim = "claimed" | "duplicate" | "unavailable";
 
@@ -36,11 +36,6 @@ export type CompletionFenceOptions = {
   maxEntries?: number;
 };
 
-export type CompletionFenceIdentityOptions = {
-  /** True only when the journal matched this prompt id to one exact run generation. */
-  journalProven?: boolean;
-};
-
 function usable(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0 && value.length <= MAX_ID_LENGTH;
 }
@@ -50,22 +45,18 @@ function usable(value: unknown): value is string {
  *
  * The route/session is deliberately outside the panel tab id: a stale frontend
  * reconnect gets a new tab address, but it is still the same agent conversation.
- * A panel completion key is preferred because it survives prompt-id reuse. A
- * prompt id is usable only when the journal proved the exact run generation;
- * an unproven or reused prompt id is a bucket, not a stable identity.
+ * A panel completion key is the only identity durable across orchestrator
+ * restarts. Journal ticket generations are process-local, so prompt_id alone is
+ * never a fence key here.
  */
 export function completionFenceIdentity(
   route: string,
   payload: Pick<CompletionPayload, "prompt_id" | "completion_key">,
-  options: CompletionFenceIdentityOptions = {},
 ): string | null {
   const routeId = typeof route === "string" ? route.trim() : "";
   if (!routeId || routeId.length > MAX_ID_LENGTH) return null;
   if (usable(payload.completion_key)) {
     return JSON.stringify(["panel_run", routeId, "completion_key", payload.completion_key]);
-  }
-  if (options.journalProven === true && usable(payload.prompt_id)) {
-    return JSON.stringify(["panel_run", routeId, "prompt_id", payload.prompt_id]);
   }
   return null;
 }
@@ -78,7 +69,7 @@ function validEntry(value: unknown): value is FenceEntry {
   if (!value || typeof value !== "object") return false;
   const entry = value as Partial<FenceEntry>;
   return (
-    (entry.state === "seen" || entry.state === "delivered") &&
+    (entry.state === "seen" || entry.state === "accepted" || entry.state === "delivered") &&
     typeof entry.at === "number" &&
     Number.isFinite(entry.at) &&
     entry.at >= 0
@@ -88,12 +79,11 @@ function validEntry(value: unknown): value is FenceEntry {
 /**
  * Small, synchronous, atomic fence used immediately around agent scheduling.
  *
- * `seen` is written before the queue hand-off; `delivered` is written after the
- * manager accepts the event. Only `delivered` suppresses a later replay. A
- * persisted `seen` reservation is deliberately reclaimable: if the process
- * crashes after the reservation but before injection, a restarted orchestrator
- * must be able to retry the journal entry instead of treating an incomplete
- * hand-off as proof that an agent received it.
+ * `seen` is written before the queue hand-off; `accepted` is written after the
+ * manager accepts the event; `delivered` is written only from the journal's
+ * actual turn-ack hook. `accepted` is process-local suppression only: a fresh
+ * fence instance treats a persisted `accepted` or `seen` entry as reclaimable,
+ * so a restart cannot lose a completion that was queued but never read.
  */
 export class RunCompletionIdempotencyFence {
   private readonly filePath: string;
@@ -101,6 +91,8 @@ export class RunCompletionIdempotencyFence {
   private readonly ttlMs: number;
   private readonly maxEntries: number;
   private entries = new Map<string, FenceEntry>();
+  /** Reservations accepted by THIS orchestrator, but not yet turn-acked. */
+  private readonly active = new Set<string>();
 
   constructor(options: CompletionFenceOptions = {}) {
     this.filePath = options.path ?? defaultFencePath();
@@ -125,34 +117,65 @@ export class RunCompletionIdempotencyFence {
     if (existing?.state === "delivered" && now - existing.at < this.ttlMs) {
       return "duplicate";
     }
+    if (this.active.has(identity)) return "duplicate";
     this.entries.set(identity, { state: "seen", at: now });
     this.trim();
-    if (this.persist()) return "claimed";
+    if (this.persist()) {
+      this.active.add(identity);
+      return "claimed";
+    }
     this.entries = previous;
     return "unavailable";
   }
 
-  /** Mark a successfully accepted queue hand-off as delivered to the agent. */
+  /** Mark a successfully accepted queue hand-off, without claiming it was read. */
+  markAccepted(identity: string): boolean {
+    const entry = this.entries.get(identity);
+    if (!entry) return false;
+    const previous = entry.state;
+    entry.state = "accepted";
+    if (this.persist()) return true;
+    // The pre-injection `seen` write is still durable. Keep the local active
+    // reservation so a same-process stale frame cannot mint another turn; a
+    // restart will reclaim the persisted seen entry.
+    entry.state = previous;
+    return false;
+  }
+
+  /** Mark a queue hand-off delivered only after the agent turn actually acks it. */
   markDelivered(identity: string): boolean {
     const entry = this.entries.get(identity);
     if (!entry) return false;
     const previous = entry.state;
     entry.state = "delivered";
-    if (this.persist()) return true;
-    // Keep the already-written `seen` fence if the second write fails. It is
-    // still safer than allowing an un-fenced replay after a transient disk error.
+    if (this.persist()) {
+      this.active.delete(identity);
+      return true;
+    }
+    // Keep the already-written accepted/seen fence if the second write fails.
+    // It remains process-local suppression, while a restart can reclaim it.
     entry.state = previous;
     return false;
   }
 
   /** Remove a reservation when the manager refused the hand-off. */
   release(identity: string): boolean {
-    if (!this.entries.has(identity)) return true;
+    if (!this.entries.has(identity)) {
+      this.active.delete(identity);
+      return true;
+    }
     const previous = this.entries;
     this.entries = new Map(previous);
     this.entries.delete(identity);
-    if (this.persist()) return true;
+    if (this.persist()) {
+      this.active.delete(identity);
+      return true;
+    }
     this.entries = previous;
+    // Let a later retry re-attempt the durable release/claim. Keeping the
+    // in-memory reservation here would turn a persistence failure into a
+    // permanent same-process refusal.
+    this.active.delete(identity);
     return false;
   }
 
@@ -181,7 +204,10 @@ export class RunCompletionIdempotencyFence {
 
   private prune(now: number): void {
     for (const [identity, entry] of this.entries) {
-      if (now - entry.at >= this.ttlMs || now < entry.at) this.entries.delete(identity);
+      if (now - entry.at >= this.ttlMs || now < entry.at) {
+        this.entries.delete(identity);
+        this.active.delete(identity);
+      }
     }
     this.trim();
   }
@@ -191,6 +217,7 @@ export class RunCompletionIdempotencyFence {
       const oldest = this.entries.keys().next().value;
       if (oldest === undefined) break;
       this.entries.delete(oldest);
+      this.active.delete(oldest);
     }
   }
 
@@ -211,12 +238,10 @@ export type ScheduleCompletionOptions = {
   route: string;
   payload: CompletionPayload;
   token: string;
-  /** True when the journal is replaying the same entry after a hand-off failed. */
-  replay?: boolean;
-  /** True only for a prompt id matched to an exact, non-reused journal ticket. */
-  journalProven?: boolean;
   fence: RunCompletionIdempotencyFence;
   inject: () => boolean;
+  /** Bind the fence identity to the journal token until the real turn ack. */
+  onAccepted?: (identity: string) => void;
   suppress: (token: string) => void;
   log?: (message: string) => void;
 };
@@ -228,13 +253,7 @@ export type ScheduleCompletionOptions = {
  * new turn on every reconnect.
  */
 export function scheduleRunCompletion(options: ScheduleCompletionOptions): boolean {
-  const identity = completionFenceIdentity(options.route, options.payload, {
-    journalProven: options.journalProven,
-  });
-  // A journal replay is the SAME completion whose queue hand-off was lost or
-  // whose carrying turn ended before ack. It must be allowed through; the
-  // durable fence only rejects a NEW entry for an identity already scheduled.
-  if (options.replay === true) return options.inject();
+  const identity = completionFenceIdentity(options.route, options.payload);
   if (!identity) {
     return options.inject();
   }
@@ -250,7 +269,11 @@ export function scheduleRunCompletion(options: ScheduleCompletionOptions): boole
     return true;
   }
   const handedOff = options.inject();
-  if (handedOff) options.fence.markDelivered(identity);
-  else options.fence.release(identity);
+  if (handedOff) {
+    options.fence.markAccepted(identity);
+    options.onAccepted?.(identity);
+  } else {
+    options.fence.release(identity);
+  }
   return handedOff;
 }

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -1434,6 +1434,23 @@ export class RunCompletionJournalImpl {
     this.entries.delete(token);
   }
 
+  /**
+   * Whether this entry has a journal proof strong enough to use prompt_id as a
+   * scheduling identity. Generation zero, reused ids, foreign correlations,
+   * and superseded entries are intentionally not proof: those completions may
+   * be distinct renders and must remain deliverable.
+   */
+  isJournalProvenForScheduling(token: string): boolean {
+    const entry = this.entries.get(token);
+    return Boolean(
+      entry &&
+        entry.correlation.status === "matched" &&
+        (entry.ticketSeq ?? 0) > 0 &&
+        entry.ambiguousId !== true &&
+        entry.superseded !== true,
+    );
+  }
+
   /** Move every entry AND every open run ticket from `from` onto `to` — a panel
    *  tab-id migration re-keys the agent, and both must move WITH it or a later
    *  completion for a run queued under the old id reads as foreign. This

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -231,9 +231,9 @@ export interface JournalEntry {
   /** How many turns carried this completion and then ended without a provable
    *  ack. Bounds the replay loop — see release(). */
   carriedReleases?: number;
-  /** ID-LESS only: an identical completion was delivered recently, so this may be
-   *  the same frame re-sent. Delivered anyway (never swallowed) but FLAGGED, so
-   *  the agent doesn't double-count it. */
+  /** An identical completion was delivered recently, so this may be the same
+   *  frame re-sent. The scheduling fence consumes this marker before a second
+   *  agent turn; it is retained here so the journal's verdict cannot be lost. */
   possibleRepeat?: boolean;
   /** This entry's prompt id was queued AGAIN while it was still undelivered, so
    *  it belongs to the older run. Still delivered, but it can no longer be merged
@@ -865,11 +865,11 @@ export class RunCompletionJournalImpl {
    *    re-sent frame producing two turns (the agent double-reporting, or acting
    *    twice on one output), while a later genuinely different render — or the
    *    same content long afterwards — is still delivered.
-   * NEVER returns null: a completion is always journaled and always delivered.
-   * The most this does is COLLAPSE onto a twin that nobody has seen yet, or FLAG
-   * one as a possible repeat. Suppression was the source of every loss this file
-   * kept re-growing, because each proof it rested on is bounded and any expiry at
-   * the wrong moment turned a new run's result into a discarded "duplicate".
+   * NEVER returns null: a completion is always journaled. The most this does is
+   * COLLAPSE onto a twin that nobody has seen yet, or FLAG one as a possible
+   * repeat. The final scheduling boundary consumes that flag before creating a
+   * second agent turn; the journal itself never drops the event before that
+   * boundary, so a normal replay remains recoverable.
    */
   record(
     key: string,
@@ -979,7 +979,7 @@ export class RunCompletionJournalImpl {
       // Both cases fall back to the standing rule: duplicate over loss, each
       // delivered on its own and labelled UNDETERMINED.
       idUnprovable = idReused || gen === 0;
-      // ALREADY-DELIVERED IS A LABEL, NEVER A VETO.
+      // ALREADY-DELIVERED IS A JOURNAL VERDICT, NOT THE SCHEDULING VETO.
       //
       // This used to `return null` — suppressing the completion outright — and
       // that single decision produced defect after defect, because every proof it
@@ -989,18 +989,16 @@ export class RunCompletionJournalImpl {
       // swallowed: exactly the failure this whole file exists to prevent, and the
       // one the project's rules call worse than a duplicate.
       //
-      // So the journal now NEVER suppresses an identified completion. It delivers
-      // it FLAGGED as a possible repeat and lets the agent — which can read the
-      // prompt id, see the outputs, and call get_history — decide. No expiry can
-      // turn that into a loss, and the honest failure mode is a second turn
-      // saying "this may be the same render", not silence.
+      // The journal records it FLAGGED as a possible repeat. The orchestrator's
+      // scheduling boundary consumes that flag before creating another turn;
+      // this journal still retains the entry until that boundary handles it.
       if (
         !idUnprovable &&
         (this.delivered.has(deliveredKey(ownerOf(key, conversation), correlation.promptId, gen)) ||
           (settledTicket?.settled === true && ownsRun(settledTicket, key, conversation)))
       ) {
         logger.info(
-          `[run-completions] a completion for ${describe(correlation)} was already delivered to tab ${key.slice(0, 8)} — forwarding this one FLAGGED as a possible repeat (never suppressed)`,
+          `[run-completions] a completion for ${describe(correlation)} was already delivered to tab ${key.slice(0, 8)} — forwarding this one FLAGGED for the scheduling fence`,
         );
         alreadyDelivered = true;
       }
@@ -1073,7 +1071,7 @@ export class RunCompletionJournalImpl {
       idlessRepeat = repeatHint || twinJournaled;
       if (idlessRepeat) {
         logger.info(
-          `[run-completions] tab ${key.slice(0, 8)}: an id-less completion with identical content is already known — forwarding this one FLAGGED as a possible repeat (never merged, never suppressed: content is not identity)`,
+          `[run-completions] tab ${key.slice(0, 8)}: an id-less completion with identical content is already known — forwarding this one FLAGGED for the scheduling fence`,
         );
       }
     }
@@ -1425,6 +1423,15 @@ export class RunCompletionJournalImpl {
       }
     }
     entry.state = "pending";
+  }
+
+  /**
+   * Remove a duplicate at the scheduling boundary without settling a ticket.
+   * The durable completion fence has already proven that another entry for the
+   * same route/run was accepted, so this duplicate must not become another turn.
+   */
+  suppress(token: string): void {
+    this.entries.delete(token);
   }
 
   /** Move every entry AND every open run ticket from `from` onto `to` — a panel

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -371,6 +371,8 @@ export class RunCompletionJournalImpl {
   private forgottenOwnRuns = new Set<string>();
   /** token → entry (insertion-ordered, which is also delivery order). */
   private entries = new Map<string, JournalEntry>();
+  /** Entries suppressed by the scheduling callback during the current flush. */
+  private suppressedDuringDelivery = new Set<string>();
   /** (tab, run) pairs whose completion was ACKED — a bounded FIFO memo so a
    *  panel that re-sends the frame after the entry was removed can't produce a
    *  second delivery. */
@@ -1201,9 +1203,10 @@ export class RunCompletionJournalImpl {
         ...(entry.possibleRepeat ? { possible_repeat: true } : {}),
       };
       const handedOff = inject(payload, entry.token);
+      const suppressed = this.suppressedDuringDelivery.delete(entry.token);
       this.noteAttempt(entry.token, handedOff);
       if (!handedOff) return { delivered, blockedOn: entry };
-      if (lost > 0) {
+      if (lost > 0 && !suppressed) {
         // CONSOLIDATE onto the entry; do NOT consider the disclosure spent yet.
         // A hand-off is not consumption: if this agent is stopped before its turn
         // runs, the entry is released and replayed, and the warning must go with
@@ -1429,26 +1432,18 @@ export class RunCompletionJournalImpl {
    * Remove a duplicate at the scheduling boundary without settling a ticket.
    * The durable completion fence has already proven that another entry for the
    * same route/run was accepted, so this duplicate must not become another turn.
+   * A suppressed carrier is NOT a successful disclosure delivery: move any
+   * eviction count it carried back to the side map so a later non-suppressed
+   * entry resurfaces it.
    */
   suppress(token: string): void {
-    this.entries.delete(token);
-  }
-
-  /**
-   * Whether this entry has a journal proof strong enough to use prompt_id as a
-   * scheduling identity. Generation zero, reused ids, foreign correlations,
-   * and superseded entries are intentionally not proof: those completions may
-   * be distinct renders and must remain deliverable.
-   */
-  isJournalProvenForScheduling(token: string): boolean {
     const entry = this.entries.get(token);
-    return Boolean(
-      entry &&
-        entry.correlation.status === "matched" &&
-        (entry.ticketSeq ?? 0) > 0 &&
-        entry.ambiguousId !== true &&
-        entry.superseded !== true,
-    );
+    if (!entry) return;
+    this.suppressedDuringDelivery.add(token);
+    if ((entry.disclose ?? 0) > 0) {
+      this.dropped.set(entry.key, (this.dropped.get(entry.key) ?? 0) + entry.disclose!);
+    }
+    this.entries.delete(token);
   }
 
   /** Move every entry AND every open run ticket from `from` onto `to` — a panel
@@ -1701,6 +1696,7 @@ export class RunCompletionJournalImpl {
   reset(): void {
     this.tickets.clear();
     this.entries.clear();
+    this.suppressedDuringDelivery.clear();
     this.dropped.clear();
     this.delivered.clear();
     this.completionReceipts.clear();


### PR DESCRIPTION
Closes #2341. Correction cycle 3 at 4ab79428da49ab0db852616734a3d4f69e9b1e2e: durable fence identity now uses only stable completion_key; prompt_id and process-local journal generations never suppress. Queue acceptance records reclaimable accepted/seen state; only the real onEventDelivered journal ack writes delivered. replayed metadata no longer bypasses the fence, and refusal releases before replay. Suppressed disclosure carriers return dropped-completion counts to the ledger until a non-suppressed carrier succeeds. Validation: focused production-path and wiring tests 20/20; related completion/reconnect/watchdog suite 219/219; npm.cmd run lint; npm.cmd run build; git diff --check. Do not merge; wait for fresh independent review and hosted CI.