### PR TITLE
fix(models): explain recovered listing path

### DIFF
--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -421,6 +421,31 @@ describe("#2319: list_local_models uses the target-aware listing service", () =>
     expect(coverage.usedFilesystem).toBe(false);
   });
 
+  it("#2338: records local path recovery without inventing a target change", async () => {
+    target.remote = false;
+    target.generation = 81;
+    target.baseUrl = "http://127.0.0.1:8188";
+    config.comfyuiPath = undefined;
+    const response = deferred<Response>();
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockReturnValue(response.promise);
+
+    const pending = listLocalModelsWithCoverage("checkpoints");
+    await Promise.resolve();
+
+    config.comfyuiPath = "/recovered-comfy";
+    response.resolve(
+      new Response(JSON.stringify(["stale-before-recovery.safetensors"]), { status: 200 }),
+    );
+
+    const { models, coverage } = await pending;
+
+    expect(models).toEqual([]);
+    expect(coverage.localPathRecovered).toBe(true);
+    expect(coverage.targetChanged).toBeUndefined();
+    expect(coverage.usedFilesystem).toBe(false);
+  });
+
   it("does not expose host files through the registered tool for a remote target", async () => {
     config.comfyuiPath = "/comfy";
     target.remote = true;
@@ -466,6 +491,31 @@ describe("#2319: list_local_models uses the target-aware listing service", () =>
     expect(text).toContain("No model names or paths from the stale target were returned");
     expect(text).not.toContain("stale-tool-model.safetensors");
     expect(text).not.toContain("/comfy/models/checkpoints/stale-tool-model.safetensors");
+    expect(text).not.toContain("install path was resolved");
+  });
+
+  it("#2338: explains path recovery through the registered tool without stale data", async () => {
+    config.comfyuiPath = undefined;
+    const response = deferred<Response>();
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockReturnValue(response.promise);
+
+    const pending = registeredListLocalModelsTool()({ action: "list", model_type: "checkpoints" });
+    await Promise.resolve();
+
+    config.comfyuiPath = "/recovered-comfy";
+    response.resolve(
+      new Response(JSON.stringify(["stale-recovery-model.safetensors"]), { status: 200 }),
+    );
+
+    const result = await pending;
+    const text = result.content[0].text;
+
+    expect(text).toContain("local ComfyUI install path was resolved while this listing was in progress");
+    expect(text).toContain("No model names or paths collected before the path was resolved were returned");
+    expect(text).not.toContain("target changed");
+    expect(text).not.toContain("stale-recovery-model.safetensors");
+    expect(text).not.toContain("/recovered-comfy/models/checkpoints/stale-recovery-model.safetensors");
   });
 });
 

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -463,6 +463,9 @@ export type ModelListingCoverage = {
   /** Set when neither path could run: no HTTP answer AND no local install path
    *  to scan, which is the exact shape that produced the false "no models". */
   noSourceAvailable?: boolean;
+  /** Set when the URL, mode, and generation stayed fixed while an initially
+   *  unknown local install path was filled in by orchestrator recovery (#2338). */
+  localPathRecovered?: true;
   /** Set when the ComfyUI target changed while this listing was in flight. Any
    *  names/paths collected before that change have been discarded. */
   targetChanged?: {
@@ -577,11 +580,22 @@ function refuseStaleModelListing(
 ): boolean {
   if (targetMatchesWitness(witness)) return false;
 
-  if (!coverage.targetChanged) {
-    coverage.targetChanged = {
-      startedBaseUrl: witness.baseUrl,
-      currentBaseUrl: getComfyUIBaseUrl(),
-    };
+  if (!coverage.localPathRecovered && !coverage.targetChanged) {
+    const currentBaseUrl = getComfyUIBaseUrl();
+    const localPathRecovered =
+      getComfyuiTargetGeneration() === witness.generation &&
+      currentBaseUrl === witness.baseUrl &&
+      isRemoteMode() === witness.remote &&
+      witness.localPath === undefined &&
+      config.comfyuiPath !== undefined;
+    if (localPathRecovered) {
+      coverage.localPathRecovered = true;
+    } else {
+      coverage.targetChanged = {
+        startedBaseUrl: witness.baseUrl,
+        currentBaseUrl,
+      };
+    }
   }
   coverage.answered.length = 0;
   coverage.unanswered.length = 0;

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -1386,6 +1386,14 @@ export function describeEmptyModelListing(
   coverage: ModelListingCoverage,
 ): string {
   const scope = modelType ? `${modelType} models` : "local models";
+  if (coverage.localPathRecovered) {
+    return (
+      `Could not determine which ${scope} are installed because the local ComfyUI install path ` +
+      `was resolved while this listing was in progress. No model names or paths collected before ` +
+      `the path was resolved were returned. Retry list_local_models now that the local install path ` +
+      `is available.`
+    );
+  }
   if (coverage.targetChanged) {
     return (
       `Could not determine which ${scope} are installed because the connected ComfyUI target ` +


### PR DESCRIPTION
## Summary
- classify only an unchanged generation, URL, and mode plus an undefined-to-value local path as orchestrator recovery
- preserve the fail-closed stale-listing refusal and existing retarget/path fencing
- render the observed path recovery through the registered list_local_models production message path

## Verification
- `npm.cmd exec vitest run src/__tests__/services/model-listing-coverage.test.ts` — 51 passed
- `npm.cmd exec vitest run src/__tests__/services/list-local-models.test.ts src/__tests__/tools/model-management.test.ts src/__tests__/tools/models-consolidated.test.ts` — 78 passed
- `npm.cmd run lint`
- `npm.cmd run build`
- `git diff --check`

Fixes #2338