### PR TITLE
test(2341): pin the completion fence to its CALL SITE, not just the helper

### DIFF
--- a/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
+++ b/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
@@ -28,6 +28,26 @@ import { registerQueueManagementTools } from "../../tools/queue-management.js";
 const indexSrc = (): string =>
   readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
 
+/**
+ * The BODY of a function, brace-matched from its opening `{`.
+ *
+ * A fixed-size `slice(at, at + N)` window is not scope: it reads past the
+ * closing brace, so a guard that MOVED out of the function still satisfies a
+ * `toContain` against the window. Match the braces instead.
+ */
+const functionBody = (src: string, signature: string): string => {
+  const at = src.indexOf(signature);
+  if (at < 0) throw new Error(`orchestrator source no longer contains ${signature}`);
+  const open = src.indexOf("{", at);
+  if (open < 0) throw new Error(`no body found for ${signature}`);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}" && --depth === 0) return src.slice(open, i + 1);
+  }
+  throw new Error(`unbalanced body for ${signature}`);
+};
+
 describe("#1789 — the history fallback is WIRED into the orchestrator, not merely available", () => {
   it("SOURCE: completion fences remain reclaimable until the real turn ack", () => {
     const src = indexSrc();
@@ -39,6 +59,30 @@ describe("#1789 — the history fallback is WIRED into the orchestrator, not mer
     expect(ackBlock).toContain("completionFence.markDelivered(identity)");
     expect(ackBlock).toContain("RunCompletions.ack(token)");
     expect(ackBlock).toContain("completionFence.release(identity)");
+  });
+
+  // #2341 — THE CALL SITE, not the helper.
+  //
+  // scheduleRunCompletion() can be a perfect idempotency gate and never run.
+  // flushRunCompletions is the ONE place a journaled panel_run completion turns
+  // into an agent turn, so if its deliverPending callback stops routing through
+  // the gate, the recovered-completion replay storm comes straight back while
+  // every unit test of the gate stays green — the helper is still correct, just
+  // unreachable. Bypassing the gate here left 4257/4258 tests passing before
+  // this pin existed.
+  it("SOURCE: #2341 — flushRunCompletions schedules through the durable fence, never straight into injectEvent", () => {
+    const body = functionBody(indexSrc(), "function flushRunCompletions(");
+    // The journal's delivery callback hands every offer to the one gate…
+    expect(body).toContain("scheduleRunCompletion({");
+    // …against the DURABLE process-wide fence, not a fresh per-call one that
+    // would forget the completion across the reconnect it exists to survive.
+    expect(body).toContain("fence: completionFence,");
+    // …and the injection is reachable ONLY as that gate's `inject` option, so an
+    // edit cannot route around the fence while leaving the call in place.
+    const gateAt = body.indexOf("scheduleRunCompletion({");
+    const injectAt = body.indexOf("manager.injectEvent(");
+    expect(injectAt).toBeGreaterThan(gateAt);
+    expect(body.slice(gateAt, injectAt)).toContain("inject: () =>");
   });
 
   it("SOURCE: the orchestrator constructs the watchdog against the real journal", () => {


### PR DESCRIPTION
## What this is

A follow-up to #2343, which shipped the recovered-completion idempotency fence for #2341 (in `v0.52.127`).

**The fix on `main` is correct and it is wired.** `flushRunCompletions` — the one place a journaled `panel_run` completion becomes an agent turn — routes every offer through `scheduleRunCompletion`, which claims a durable `route + completion_key` fence before injecting.

**Nothing defended that wiring.** I bypassed the gate at the call site and re-ran the suite:

| | result |
|---|---|
| `scheduleRunCompletion({...})` replaced with a direct `inject()` | **4257 / 4258 tests still passed** |

The gate's own unit tests keep passing under that mutation because the helper is still perfect — it is simply unreachable. That is exactly the failure mode #2341 reported: the completion replays into a new turn on every reconnect.

## The load-bearing claim to review

`functionBody()` — the pin brace-matches the body of `flushRunCompletions` instead of slicing a fixed `(at, at + N)` window. **This is the part worth attacking.** The existing pins in this file use the fixed-window form, which reads *past* the closing brace and therefore cannot distinguish "the gate is in this function" from "the gate is somewhere after this function". Mutant C below is the test of that specific claim.

Second thing worth attacking: the pin asserts `injectAt > gateAt` and that `inject: () =>` sits between them, to force the injection to be reachable *only* as the gate's option. If you can construct an edit that routes around the fence and still satisfies that ordering, the pin is too weak.

## Mutation evidence

Each mutant kills **only** the new pin; the 11 sibling tests in the file survive all three, so they are valid controls rather than collateral.

| mutant | result |
|---|---|
| A — gate bypassed at the call site | FAIL |
| B — durable `completionFence` swapped for a per-call throwaway | FAIL |
| C — gate moved out of the function, decoy strings planted right after it | FAIL |
| clean `origin/main` | PASS |

Mutant C is the one a fixed-window pin would have survived.

## Verification

- `npx vitest run src/__tests__/orchestrator/` → **253 files / 4259 tests passed**
- `npx tsc --noEmit` → clean
- Note `tsc` excludes `src/__tests__`, so vitest is the only thing that validates this file; it was run directly.

## Scope

Test-only — one file. No production behaviour changes. Nothing panel-visible, so no Playwright run is claimed.

Relates to #2341 (already closed by #2343); this does not change its resolution.
