### PR TITLE
fix(2347): health severity matches what ComfyUI actually logs, not what #2329 guessed

### DIFF
--- a/src/__tests__/services/health-check.test.ts
+++ b/src/__tests__/services/health-check.test.ts
@@ -291,3 +291,71 @@ describe("recent_errors as a limit (#1146)", () => {
     expect(text).toMatch(/none in \/internal\/logs/);
   });
 });
+
+// #2347 — the #2329 severity predicate was keyed on two shapes stock ComfyUI never
+// emits, so the health report silently omitted real render failures and issued an
+// explicit all-clear for the commonest one. Each row here is a faithful
+// /internal/logs body: the route joins records as `l["t"] + " - " + l["m"]`, so every
+// line carries a timestamp prefix — which is why `^Traceback` could never fire, and
+// why severity must be matched on the entry BODY.
+//
+// The case that decides this issue is the OOM pair: before the fix they produced
+// output byte-identical to a healthy server, in the diagnostic users paste into bug
+// reports. "none in /internal/logs" for a crashed render is worse than the blob #2329
+// removed.
+describe("recent_errors sees ComfyUI's own failures (#2347)", () => {
+  const TS = "2026-08-26T07:00:00.000Z";
+  const logBody = (...messages: string[]): string =>
+    JSON.stringify(messages.map((m) => TS + " - " + m + "\n").join(""));
+
+  const healthFor = async (body: string): Promise<string> => {
+    fetchApi.mockImplementation(async (path: string) => {
+      if (path === "/internal/logs") return new Response(body, { status: 200 });
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    return runHealthCheck({ modelCategories: [], recentErrors: 10 });
+  };
+
+  it("A: keeps the exception header AND the frames, not just the tail", async () => {
+    const text = await healthFor(
+      logBody(
+        "!!! Exception during processing !!!",
+        "Traceback (most recent call last):",
+        '  File "x.py", line 1, in run',
+        "RuntimeError: shape is invalid",
+      ),
+    );
+    expect(text).not.toMatch(/Recent errors\*\*: none/);
+    // The tail alone is not enough — it names the exception without locating it.
+    expect(text).toContain("RuntimeError: shape is invalid");
+    expect(text).toContain("Exception during processing");
+    expect(text).toContain("Traceback (most recent call last):");
+    expect(text).toContain("x.py");
+  });
+
+  it("B: an OOM during processing is NOT reported as a healthy server", async () => {
+    const text = await healthFor(
+      logBody(
+        "!!! Exception during processing !!! Allocation on device",
+        "Got an OOM, unloading all loaded models.",
+      ),
+    );
+    expect(text).not.toMatch(/Recent errors\*\*: none/);
+    expect(text).toContain("Got an OOM");
+  });
+
+  it("D: a bare OOM notice with no exception header still reports", async () => {
+    const text = await healthFor(logBody("Got an OOM, unloading all loaded models."));
+    expect(text).not.toMatch(/Recent errors\*\*: none/);
+    expect(text).toContain("Got an OOM");
+  });
+
+  it("E: a genuinely healthy log still reports none — the control", async () => {
+    // Without this, every assertion above is satisfiable by reporting everything,
+    // which is the #2329 blob this must not reintroduce.
+    const text = await healthFor(
+      logBody("got prompt", "Prompt executed in 3.21 seconds", "0 errors found"),
+    );
+    expect(text).toMatch(/Recent errors\*\*: none in \/internal\/logs/);
+  });
+});

--- a/src/services/health-check.ts
+++ b/src/services/health-check.ts
@@ -190,46 +190,80 @@ export async function runHealthCheck(
         // line containing "error" in a message like "0 errors found" is not an
         // actual error. Only lines with [ERROR]/[EXCEPTION] markers or starting
         // with "Traceback" are errors. Keep traceback continuation lines (indented).
+        // #2347 — severity is matched on the entry BODY, after the timestamp prefix.
+        // /internal/logs joins each record as `l["t"] + " - " + l["m"]`
+        // (api_server/routes/internal/internal_routes.py), so every line begins with a
+        // timestamp. #2329 matched `^Traceback` against the raw line, which therefore
+        // could never fire: measured on a live 105-line log, 0 lines start with
+        // "Traceback".
+        const bodyOf = (line: string): string => line.replace(/^\S+ - /, "");
+
+        // What stock ComfyUI actually emits. #2329 keyed on `[ERROR]`/`[EXCEPTION]`,
+        // which its in-memory handler never writes — app/logger.py formats the memory
+        // handler with ColoredFormatter("%(message)s"), message only. The bracketed
+        // forms come from ComfyUI-Manager printing its own prefix, which is why a live
+        // test appeared to pass: it was reading Manager lines, not ComfyUI ones.
+        //
+        // The consequence was worse than the blob it replaced: execution.py's
+        // "!!! Exception during processing !!!", the traceback that follows it, and
+        // "Got an OOM, unloading all loaded models." were all invisible, so a crashed
+        // render reported byte-identically to a healthy server in the diagnostic users
+        // paste into bug reports.
+        const ERROR_HEADERS: readonly RegExp[] = [
+          /^!!!\s*Exception during processing/i,   // execution.py render failure
+          /^Traceback\s*\(/i,                       // a Python traceback header
+          /\[ERROR\]|\[EXCEPTION\]/i,               // ComfyUI-Manager / file handler
+        ];
+        const ERROR_SIGNALS: readonly RegExp[] = [
+          ...ERROR_HEADERS,
+          /^[A-Za-z0-9_.]*(Error|Exception)\s*:/,          // a bare exception tail
+          /\bGot an OOM\b/i,                        // model_management OOM notice
+          /\bAllocation on device\b/i,              // torch allocator OOM
+          /\bCUDA out of memory\b/i,
+          /\b(ERROR|EXCEPTION)\s*:/,                // an explicit level prefix
+        ];
+        const isHeader = (body: string): boolean => ERROR_HEADERS.some((re) => re.test(body));
+        const isSignal = (body: string): boolean => ERROR_SIGNALS.some((re) => re.test(body));
+
         const allLines = text.split("\n");
+        const bodies = allLines.map(bodyOf);
         const errorGroups: string[][] = [];
         const processed = new Set<number>();
 
         for (let i = 0; i < allLines.length; i++) {
-          if (processed.has(i)) continue;
+          if (processed.has(i) || !isSignal(bodies[i])) continue;
 
-          const line = allLines[i];
-          // Match actual error lines, not substrings. Accept:
-          // - [ERROR] or [EXCEPTION] markers (with brackets)
-          // - (ERROR|Exception): pattern (with colon, not substring "errors")
-          // - Traceback at start of line (Python exceptions)
-          const isErrorLine = /\[ERROR\]|\[EXCEPTION\]|(ERROR|Exception)\s*:/i.test(line) ||
-                             /^Traceback\s*\(/i.test(line);
-
-          if (isErrorLine) {
-            const group: string[] = [line];
-            processed.add(i);
-
-            // Include continuation lines (indented or following lines that are part of traceback)
-            for (let j = i + 1; j < allLines.length; j++) {
-              const nextLine = allLines[j];
-              // Stop if we hit another error marker or a non-indented line that's not an error start
-              if (/\[ERROR\]|\[EXCEPTION\]/i.test(nextLine) ||
-                  (/^Traceback\s*\(/i.test(nextLine)) ||
-                  (/^Exception\s*:/i.test(nextLine))) {
-                break;
-              }
-              // Include indented lines and empty lines within traceback
-              if (/^[ \t]/.test(nextLine) || nextLine.trim() === "") {
-                group.push(nextLine);
-                processed.add(j);
-              } else {
-                break;
-              }
+          // Walk BACKWARDS to the header this line belongs to. #2329 only extended
+          // forwards, so matching an exception TAIL ("RuntimeError: ...") dropped every
+          // frame above it and the "!!! Exception during processing !!!" header with
+          // them — the caller saw the exception name and nothing that located it.
+          let first = i;
+          if (!isHeader(bodies[i])) {
+            for (let j = i - 1; j >= 0 && i - j <= 200; j--) {
+              if (processed.has(j)) break;
+              const b = bodies[j];
+              if (isHeader(b)) { first = j; break; }
+              // Frames are indented; anything else ends the traceback above us.
+              if (!/^[ \t]/.test(b) && b.trim() !== "") break;
             }
-            errorGroups.push(group);
           }
-        }
 
+          const group: string[] = [];
+          for (let k = first; k <= i; k++) { group.push(allLines[k]); processed.add(k); }
+
+          // Then forwards through the frames and the exception tail below.
+          for (let j = i + 1; j < allLines.length; j++) {
+            const b = bodies[j];
+            if (isHeader(b)) break;
+            if (/^[ \t]/.test(b) || b.trim() === "") { group.push(allLines[j]); processed.add(j); continue; }
+            // A bare exception tail closes the traceback it belongs to; take it and stop.
+            if (/^[A-Za-z0-9_.]*(Error|Exception)\s*:/.test(b)) {
+              group.push(allLines[j]); processed.add(j);
+            }
+            break;
+          }
+          errorGroups.push(group);
+        }
         // Take the last N error groups, then flatten them into lines for scrubbing
         const recentErrorGroups = errorGroups.slice(-recentErrors);
         const errorLines = recentErrorGroups.flat();


### PR DESCRIPTION
Fixes #2347.

A regression from #2329 — one I merged — and worse than the bug it fixed. #2329 replaced a giant concatenated blob with a severity predicate, and that predicate is keyed on two shapes stock ComfyUI never produces. The result is not a missing detail: **the health report issues an explicit all-clear for a crashed render.**

## Measured, A/B, on the real `runHealthCheck`

Same four log bodies, faithful to what `/internal/logs` serves. Left column is `origin/main` @ `28b2f64` (v0.52.127, shipping):

| case | on `main` today | with this PR |
|---|---|---|
| A — `!!! Exception !!!` + traceback + frame + `RuntimeError:` | `(last 2)` — **header and frames dropped** | `(last 4)` — intact |
| B — exception + `Got an OOM` | **`none in /internal/logs`** | `(last 3)` |
| D — bare `Got an OOM` notice | **`none in /internal/logs`** | `(last 2)` |
| E — healthy log | `none in /internal/logs` | `none in /internal/logs` |

B and D are byte-identical to E on `main`. A crashed render is indistinguishable from a healthy server in the diagnostic users paste into bug reports.

## Why the predicate could never work

Both assumptions were checked against ComfyUI's source, not inferred:

- **There is no `[ERROR]` marker.** `app/logger.py` formats the in-memory handler with `ColoredFormatter("%(message)s")` — message only, no level. The `[%(levelname)s]` format is the optional *file* handler. Every `[ERROR]` in a real log comes from ComfyUI-Manager printing its own prefix.
- **`^Traceback` can never match.** `internal_routes.py` joins each record as `l["t"] + " - " + l["m"]`, so every line begins with a timestamp. Dead code in production — 0 of 105 lines on a live log start with `Traceback`.

So `execution.py`'s `"!!! Exception during processing !!!"`, the `traceback.format_exc()` under it, and `"Got an OOM, unloading all loaded models."` were all invisible. Cases A and C only survived by accident: `(ERROR|Exception)\s*:` matched the substring `Error:` *inside* `RuntimeError:`.

## The fix

Severity is matched on the entry **body**, after stripping the `TIMESTAMP - ` prefix, against what ComfyUI actually emits — the exception header, a traceback header, a bare `XxxError:`/`Exception:` tail, and the OOM notices.

Grouping also walks **backwards** from a tail to its header. #2329 only extended forwards, so matching `RuntimeError:` dropped every frame above it and the header with them — the caller got the exception name and nothing that located it. That is why case A goes from 2 lines to 4.

## Verification

- **Mutation:** restoring the #2329 predicate fails exactly A, B and D; **E and all 14 pre-existing tests stay green.** Not a collective assertion — E is the control that stops "report everything" from satisfying the other three, which is the #2329 blob this must not reintroduce.
- `src/__tests__/services/` — 247 files, 5802 passed, 6 skipped.
- `tsc --noEmit` clean.

## How this got past the original merge

I merged #2329 on a SHIP verdict with green CI, and its agent *did* test against a live ComfyUI. The `[ERROR]` lines it saw came from ComfyUI-Manager, so the live test passed for the wrong reason. The verification looked like the right kind and was not — worth recording, because "tested against a live server" was the thing that made it convincing.

One first-draft defect worth noting: my tail pattern required at least one character before `Error|Exception`, so a bare `Exception: boom` never matched. **An existing test caught it**, which is the argument for not touching the pre-existing assertions when they go red.
