### PR TITLE
test(#2350): pin generation and witness.localPath clauses in localPathRecovered

### DIFF
--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -446,6 +446,79 @@ describe("#2319: list_local_models uses the target-aware listing service", () =>
     expect(coverage.usedFilesystem).toBe(false);
   });
 
+  it("#2350: generation round-trip with path recovery pins generation clause", async () => {
+    // A→B→A round trip changes generation even though final URL/remote match start.
+    // Even if comfyuiPath is recovered mid-listing, the generation change means
+    // the answer is stale. Without the generation clause, this would incorrectly
+    // be classified as localPathRecovered.
+    target.remote = false;
+    target.generation = 10;
+    target.baseUrl = "http://127.0.0.1:8188";
+    config.comfyuiPath = undefined;
+    const response = deferred<Response>();
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockReturnValue(response.promise);
+
+    const pending = listLocalModelsWithCoverage("checkpoints");
+    await Promise.resolve();
+
+    // A→B transition changes generation to 11
+    advanceTarget(true, "https://remote.example/comfy");
+    // B→A transition changes generation to 12, back to original URL/remote
+    advanceTarget(false, "http://127.0.0.1:8188");
+    // And path gets recovered mid-listing
+    config.comfyuiPath = "/recovered-comfy";
+    response.resolve(
+      new Response(JSON.stringify(["model-during-roundtrip.safetensors"]), { status: 200 }),
+    );
+
+    const { models, coverage } = await pending;
+
+    expect(models).toEqual([]);
+    // Generation clause is load-bearing: without it, this would be localPathRecovered
+    expect(coverage.targetChanged).toEqual({
+      startedBaseUrl: "http://127.0.0.1:8188",
+      currentBaseUrl: "http://127.0.0.1:8188",
+    });
+    expect(coverage.localPathRecovered).toBeUndefined();
+    expect(coverage.usedFilesystem).toBe(false);
+  });
+
+  it("#2350: witness.localPath clause pins that path was unknown at capture time", async () => {
+    // When witness.localPath is already set (path was known at capture), recovery
+    // in mid-listing is not the explanation. Without the witness.localPath===undefined
+    // clause, a path change could be misclassified as recovery. This existing case
+    // was already pinned; this test documents the invariant.
+    target.remote = false;
+    target.generation = 50;
+    target.baseUrl = "http://127.0.0.1:8188";
+    config.comfyuiPath = "/original-comfy";
+    const response = deferred<Response>();
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockReturnValue(response.promise);
+
+    const pending = listLocalModelsWithCoverage("checkpoints");
+    await Promise.resolve();
+
+    // Change the path mid-listing
+    config.comfyuiPath = "/new-comfy";
+    response.resolve(
+      new Response(JSON.stringify(["model-path-changed.safetensors"]), { status: 200 }),
+    );
+
+    const { models, coverage } = await pending;
+
+    expect(models).toEqual([]);
+    // witness.localPath=/original-comfy, so even though comfyuiPath changed,
+    // this is not "recovery" (it was known) — it's a target change
+    expect(coverage.targetChanged).toEqual({
+      startedBaseUrl: "http://127.0.0.1:8188",
+      currentBaseUrl: "http://127.0.0.1:8188",
+    });
+    expect(coverage.localPathRecovered).toBeUndefined();
+    expect(coverage.usedFilesystem).toBe(false);
+  });
+
   it("does not expose host files through the registered tool for a remote target", async () => {
     config.comfyuiPath = "/comfy";
     target.remote = true;


### PR DESCRIPTION
## Summary

Adds two tests that pin the load-bearing clauses in the `localPathRecovered` classifier:

1. **Generation round-trip with path recovery** — verifies that an A→B→A round trip that recovers `comfyuiPath` is still correctly classified as `targetChanged` (not `localPathRecovered`), because the generation changed even though URLs match.

2. **Witness.localPath clause** — documents that the existing test case (#2338) already pins this clause, where path recovery is only recognized when the path was unknown at capture time.

## Problem

Issue #2350 found that 4 of 5 clauses in `localPathRecovered` survived mutation testing against the baseline test suite. Only `witness.localPath === undefined` was pinned. This means a future refactor could silently invert which explanation (path recovery vs. target change) the user receives, even though the guard still refuses the stale listing correctly.

## Solution

Added tests that ensure the generation clause (the only truly independent one, per the issue analysis) cannot be removed without breaking the test. The generation clause is load-bearing because `setComfyuiTarget` bumps generation before recomputing the path, so an A→B→A round trip that recovers a path is still stale.

Note: baseUrl, remote, and config.comfyuiPath clauses cannot be tested in isolation because:
- baseUrl and remote always change together with generation (via `setComfyuiTarget`)
- config.comfyuiPath cannot be tested alone due to code structure where `targetMatchesWitness` short-circuits when it matches

Per the issue reporter's own analysis, the generation clause is the one that matters and is now pinned.

Fixes #2350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp