### PR TITLE
fix(#2355): name the exception when the traceback tail has no colon (rows D and E)

### DIFF
--- a/src/__tests__/services/health-check.test.ts
+++ b/src/__tests__/services/health-check.test.ts
@@ -360,120 +360,174 @@ describe("recent_errors sees ComfyUI's own failures (#2347)", () => {
   });
 });
 
-// #2355 — ColoredFormatter wraps error/warning markers in ANSI escape sequences,
-// so patterns anchored to the start of the body (after stripping timestamp) need
-// to strip ANSI first. This catches a WARNING-level gap: a custom-node import
-// failure is logged at WARNING but covered only by the `^Traceback` pattern,
-// which was dead. ANSI escapes also reach the health report, confusing diagnostics.
-describe("handles ANSI escape sequences in log lines (#2355)", () => {
-  const TS = "2026-08-26T07:00:00.000Z";
-  const ansiRed = "\x1b[1m\x1b[31m";    // bold red
-  const ansiYellow = "\x1b[1m\x1b[33m"; // bold yellow
-  const ansiReset = "\x1b[0m";           // reset
+// #2355 — the two anchors #2347 added (`^!!! Exception during processing` and
+// `^Traceback\(`) could not fire on a real server, for one layer down from the
+// reason #2329's `^Traceback` could not: ColoredFormatter.format() prepends an
+// ANSI-wrapped `[LEVEL]` tag before delegating, so it sits between the timestamp
+// prefix and the anchor.
+//
+// The fixtures below are the SHAPE MEASURED from ComfyUI 0.34.0's own logger —
+// captured by importing app/logger.py, running its setup_logger(), emitting through
+// the exact production call sites, and serialising the deque the way
+// api_server/routes/internal/internal_routes.py:24 does. #2347's table was built by
+// reconstructing the format from its description instead, which is precisely why it
+// shipped two patterns that never matched. Only the file paths are shortened here;
+// the load-bearing bytes are verbatim.
+//
+// Three facts a reconstruction gets wrong, all of which these encode:
+//   * the tag is bold+colour for WARNING and above, colour-only below it, so INFO is
+//     `\x1b[32m[INFO]\x1b[0m ` with no bold;
+//   * a record's tag and timestamp appear on its FIRST physical line only — the
+//     continuation lines of a multi-line message (every traceback frame, and the
+//     exception tail) carry neither;
+//   * `logging.x(traceback.format_exc())` leaves a trailing BLANK line, because
+//     format_exc() already ends in a newline and the handler appends its terminator.
+describe("recent_errors survives ColoredFormatter's ANSI [LEVEL] tag (#2355)", () => {
+  const TS = "2026-08-26T07:00:00.000000";
+  // app/logger.py: f"{ANSI_BOLD}{colour}[{levelname}]{ANSI_RESET} ", bold only >= WARNING.
+  const ERR = "\x1b[1m\x1b[31m[ERROR]\x1b[0m ";
+  const WARN = "\x1b[1m\x1b[33m[WARNING]\x1b[0m ";
+  const INFO = "\x1b[32m[INFO]\x1b[0m ";
 
-  const logWithAnsi = (...messages: string[]): string =>
-    JSON.stringify(messages.map((m) => TS + " - " + m + "\n").join(""));
+  /**
+   * One /internal/logs body. Each argument is ONE logging call, so the timestamp
+   * goes on its first physical line only and the handler's terminator newline ends
+   * it — which is how the next record's timestamp comes to butt straight against it.
+   */
+  const payload = (...records: string[]): string =>
+    JSON.stringify(records.map((m) => `${TS} - ${m}\n`).join(""));
 
   const healthFor = async (body: string): Promise<string> => {
     fetchApi.mockImplementation(async (path: string) => {
       if (path === "/internal/logs") return new Response(body, { status: 200 });
       return new Response(JSON.stringify([]), { status: 200 });
     });
-    return runHealthCheck({ modelCategories: [], recentErrors: 10 });
+    return runHealthCheck({ modelCategories: [], recentErrors: 20 });
   };
 
-  it("strips ANSI escape sequences and matches anchored patterns", async () => {
-    // A real ERROR line from ColoredFormatter has ANSI codes prepended
+  // Row C of #2355, and the only row with no other cover: a custom-node import
+  // failure is logged at WARNING (nodes.py:2335-2336 — the traceback FIRST, then the
+  // "Cannot import" line), so the `[ERROR]`/`[EXCEPTION]` clause does not reach it.
+  // Before the fix the backward walk stopped dead: the `[WARNING] Traceback` line was
+  // not a header, not indented and not blank, so the user got the exception name with
+  // nothing that located it.
+  it("row C: a WARNING-level traceback keeps its header and its frames", async () => {
     const text = await healthFor(
-      logWithAnsi(
-        `${ansiRed}[ERROR]${ansiReset} !!! Exception during processing !!!`,
-        "Traceback (most recent call last):",
-        '  File "x.py", line 1, in run',
-        `${ansiRed}[ERROR]${ansiReset} RuntimeError: shape is invalid`,
+      payload(
+        `${WARN}Traceback (most recent call last):\n` +
+          '  File "C:\\ComfyUI\\nodes.py", line 2313, in load_custom_node\n' +
+          "    module_spec.loader.exec_module(module)\n" +
+          '  File "C:\\ComfyUI\\custom_nodes\\comfyui_controlnet_aux\\__init__.py", line 2, in <module>\n' +
+          "    import comfyui_controlnet_aux\n" +
+          "ModuleNotFoundError: No module named 'comfyui_controlnet_aux'\n",
+        `${WARN}Cannot import C:\\ComfyUI\\custom_nodes\\comfyui_controlnet_aux module for custom nodes: No module named 'comfyui_controlnet_aux'`,
       ),
     );
     expect(text).not.toMatch(/Recent errors\*\*: none/);
-    expect(text).toContain("RuntimeError: shape is invalid");
-    expect(text).toContain("Exception during processing");
+    // The exception name alone was what #2347 set out to stop being the whole report.
     expect(text).toContain("Traceback (most recent call last):");
-  });
-
-  it("WARNING-level traceback with ANSI is caught (row C from #2355)", async () => {
-    // Custom-node import failures are logged at WARNING level with ANSI escapes
-    const text = await healthFor(
-      logWithAnsi(
-        `${ansiYellow}[WARNING]${ansiReset} Cannot import cv2 module for custom nodes`,
-        `${ansiYellow}[WARNING]${ansiReset} Traceback (most recent call last):`,
-        '  File "nodes.py", line 2336',
-        "  File in import_module",
-        `${ansiYellow}[WARNING]${ansiReset} ModuleNotFoundError: No module named 'cv2'`,
-      ),
-    );
-    expect(text).not.toMatch(/Recent errors\*\*: none/);
-    // The issue says this should show the traceback header and frames
-    expect(text).toContain("Traceback");
-    expect(text).toContain("ModuleNotFoundError");
     expect(text).toContain("nodes.py");
+    expect(text).toContain("comfyui_controlnet_aux\\__init__.py");
+    expect(text).toContain("ModuleNotFoundError: No module named 'comfyui_controlnet_aux'");
   });
 
-  it("does not emit raw ANSI escape sequences in the health report", async () => {
-    // ANSI control characters should not appear in the emitted report
+  // Rows D and E: a second, independent gap. execution.py:637 formats the header as
+  // f"!!! Exception during processing !!! {ex}", which is EMPTY for a zero-arg
+  // exception, and the traceback's tail then renders with no colon — so #2347's
+  // `/^[A-Za-z0-9_.]*(Error|Exception)\s*:/` dropped it and the report named no
+  // exception at all.
+  it("row D: a zero-arg KeyboardInterrupt is still named", async () => {
     const text = await healthFor(
-      logWithAnsi(
-        `${ansiRed}[ERROR]${ansiReset} !!! Exception during processing !!!`,
-        "Traceback (most recent call last):",
-        '  File "x.py"',
-        `${ansiRed}[ERROR]${ansiReset} RuntimeError: boom`,
+      payload(
+        `${ERR}!!! Exception during processing !!! `,
+        `${ERR}Traceback (most recent call last):\n` +
+          '  File "C:\\ComfyUI\\execution.py", line 619, in execute\n' +
+          "    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all)\n" +
+          "KeyboardInterrupt\n",
       ),
     );
-    // Should not contain the ANSI escape sequences (x1b is the ESC character)
-    expect(text).not.toContain("\x1b[");
-    expect(text).not.toContain("[0m");
-    // But should contain the actual error message
+    expect(text).not.toMatch(/Recent errors\*\*: none/);
+    // The TAIL, as its own emitted line — `toContain` alone cannot tell it apart from
+    // a frame that happens to mention the same name, which is how row E first passed
+    // under the mutation that drops the tail entirely.
+    expect(text).toMatch(/^ {2}KeyboardInterrupt$/m);
+    expect(text).toContain("execution.py");
+  });
+
+  it("row E: a bare zero-arg RuntimeError is still named", async () => {
+    const text = await healthFor(
+      payload(
+        `${ERR}!!! Exception during processing !!! `,
+        `${ERR}Traceback (most recent call last):\n` +
+          '  File "C:\\ComfyUI\\custom_nodes\\pack\\node.py", line 41, in sample\n' +
+          "    raise RuntimeError\n" +
+          "RuntimeError\n",
+      ),
+    );
+    expect(text).not.toMatch(/Recent errors\*\*: none/);
+    // Not `toContain("RuntimeError")`: the frame above the tail is `raise RuntimeError`,
+    // so that assertion is satisfied by the frame whether or not the tail survives.
+    expect(text).toMatch(/^ {2}RuntimeError$/m);
+    expect(text).toContain("node.py");
+  });
+
+  // Rows A and B keep working. They are carried by the pre-existing `[ERROR]` clause
+  // rather than by the new anchors, so they are a REGRESSION guard, not proof the
+  // anchors fire — row C is what proves that.
+  it("row A: an ERROR-level render failure reports header, frames and tail", async () => {
+    const text = await healthFor(
+      payload(
+        `${ERR}!!! Exception during processing !!! mat1 and mat2 shapes cannot be multiplied (1x768 and 1024x1024)`,
+        `${ERR}Traceback (most recent call last):\n` +
+          '  File "C:\\ComfyUI\\execution.py", line 619, in execute\n' +
+          "    raise RuntimeError(...)\n" +
+          "RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x768 and 1024x1024)\n",
+      ),
+    );
+    expect(text).toContain("!!! Exception during processing !!!");
+    expect(text).toContain("RuntimeError: mat1 and mat2 shapes cannot be multiplied");
+  });
+
+  it("row B: the OOM notice is still reported", async () => {
+    const text = await healthFor(
+      payload(
+        `${ERR}!!! Exception during processing !!! Allocation on device`,
+        `${ERR}Got an OOM, unloading all loaded models.`,
+      ),
+    );
+    expect(text).toContain("Got an OOM, unloading all loaded models.");
+  });
+
+  // The report is a diagnostic users paste into bug reports. Raw escape bytes there
+  // are noise, and scrubLogLines never stripped them.
+  it("no raw ANSI escape reaches the health report", async () => {
+    const text = await healthFor(
+      payload(
+        `${ERR}!!! Exception during processing !!! boom`,
+        `${ERR}Traceback (most recent call last):\n` +
+          '  File "C:\\ComfyUI\\execution.py", line 619, in execute\n' +
+          "RuntimeError: boom\n",
+      ),
+    );
     expect(text).toContain("RuntimeError: boom");
-    expect(text).toContain("Exception during processing");
+    // eslint-disable-next-line no-control-regex
+    expect(text).not.toMatch(/\x1b/);
+    expect(text).not.toContain("[0m");
   });
 
-  it("handles OOM notice with ANSI codes", async () => {
+  // The control. A healthy log carries the SAME tags — INFO is colour-only, no bold —
+  // and "0 errors found" is the line #2329 was filed about. If this ever goes red the
+  // patterns have started matching prose, and the fix has become the bug.
+  it("control: a healthy log with the same ANSI tags still reports none", async () => {
     const text = await healthFor(
-      logWithAnsi(
-        `${ansiRed}[ERROR]${ansiReset} !!! Exception during processing !!!`,
-        `${ansiRed}[ERROR]${ansiReset} Got an OOM, unloading all loaded models.`,
-      ),
-    );
-    expect(text).not.toMatch(/Recent errors\*\*: none/);
-    expect(text).toContain("Got an OOM");
-    expect(text).not.toContain("\x1b[");
-  });
-
-  it("correctly strips ANSI while preserving indented frame lines", async () => {
-    // Frame lines are indented and should be preserved even when subsequent
-    // lines have ANSI codes
-    const text = await healthFor(
-      logWithAnsi(
-        `${ansiRed}[ERROR]${ansiReset} Traceback (most recent call last):`,
-        '  File "a.py", line 1, in <module>',
-        '  File "b.py", line 2, in func',
-        `${ansiRed}[ERROR]${ansiReset} ValueError: invalid value`,
-      ),
-    );
-    expect(text).not.toMatch(/Recent errors\*\*: none/);
-    expect(text).toContain("Traceback");
-    expect(text).toContain("a.py");
-    expect(text).toContain("b.py");
-    expect(text).toContain("ValueError");
-  });
-
-  it("control: genuinely healthy log with ANSI codes still reports none", async () => {
-    // A healthy log might have startup messages with ANSI formatting
-    const text = await healthFor(
-      logWithAnsi(
-        `${ansiYellow}[INFO]${ansiReset} ComfyUI startup`,
-        `${ansiYellow}[INFO]${ansiReset} Import successful: 0 errors`,
-        `${ansiYellow}[INFO]${ansiReset} Ready to process`,
+      payload(
+        `${INFO}Total VRAM 24564 MB, total RAM 65413 MB`,
+        `${INFO}Using pytorch attention`,
+        `${INFO}0 errors found in the model list`,
+        `${INFO}Exit code 0 from the last subprocess`,
+        `${INFO}Starting server`,
       ),
     );
     expect(text).toMatch(/Recent errors\*\*: none in \/internal\/logs/);
   });
 });
-

--- a/src/services/health-check.ts
+++ b/src/services/health-check.ts
@@ -197,23 +197,45 @@ export async function runHealthCheck(
         // could never fire: measured on a live 105-line log, 0 lines start with
         // "Traceback".
         //
-        // #2355 — ColoredFormatter prepends ANSI-wrapped `[LEVEL]` tags before the
-        // message, even when given ColoredFormatter("%(message)s"). After stripping
-        // the timestamp, the body still begins with `\x1b[1m\x1b[31m[ERROR]\x1b[0m `,
-        // so anchored patterns like `^!!!` or `^Traceback` need the ANSI escapes
-        // stripped first. The ColoredFormatter output has ANSI codes immediately after
-        // the timestamp prefix: `\x1b[...m[LEVEL]\x1b[0m message`.
+        // #2355 — and something STILL sits between the prefix and the anchor.
+        // ColoredFormatter (app/logger.py:35-45) prepends its own tag before it
+        // delegates, so ColoredFormatter("%(message)s") does NOT mean message-only:
         //
-        // Stripping ANSI leaves the [LEVEL] marker intact so existing patterns like
-        // `/[ERROR]/` continue to work. The anchored patterns need to account for
-        // the optional [LEVEL] tag that may precede them.
+        //     level_tag = f"{bold}{color}[{record.levelname}]{ANSI_RESET} "
+        //     return level_tag + super().format(record)
+        //
+        // and setup_logger swaps sys.stdout/sys.stderr for LogInterceptor BEFORE it
+        // builds the handlers (app/logger.py:107-108 vs :120), so what reaches the
+        // in-memory deque — and therefore /internal/logs — is
+        //
+        //     2026-... - ESC[1mESC[31m[ERROR]ESC[0m !!! Exception during processing !!! ...
+        //
+        // Measured on ComfyUI 0.34.0 by driving its own app/logger.py, NOT by
+        // reconstructing the format from its description — that reconstruction is
+        // exactly how #2347 shipped two anchors that could never fire.
+        //
+        // ANSI is stripped. The `[LEVEL]` tag deliberately is NOT: discarding it
+        // would disarm the `[ERROR]`/`[EXCEPTION]` clause below, which is the only
+        // cover for the Manager and file-handler shapes. The anchors tolerate the
+        // tag instead of the body losing it.
         const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
-        const bodyOf = (line: string): string => {
-          // Strip timestamp prefix and ANSI escape sequences
-          let body = line.replace(/^\S+ - /, "");
-          body = stripAnsi(body);
-          return body;
-        };
+        const bodyOf = (line: string): string => stripAnsi(line.replace(/^\S+ - /, ""));
+
+        // The tag is `[` + record.levelname + `]`, so it is one of Python's level
+        // names plus DETAIL, which ComfyUI adds (comfy/internal_logging.py). Spelled
+        // once: four copies of this alternation is four places for it to drift.
+        const LEVEL = String.raw`(?:\[(?:CRITICAL|ERROR|EXCEPTION|WARNING|INFO|DETAIL|DEBUG)\]\s*)?`;
+
+        // A traceback's last line is `Name: message` — or, when the exception was
+        // raised with no argument, just `Name`. #2347 required the colon, so a real
+        // KeyboardInterrupt and a bare `raise RuntimeError` (rows D and E of #2355,
+        // both measured against the live formatter) produced a group whose exception
+        // was never named. Accepting `:` OR end-of-line takes those without matching
+        // prose like "Exit code 0". Case-sensitive, as before, so that it cannot fire
+        // on "0 errors found".
+        const EXCEPTION_TAIL = new RegExp(
+          `^${LEVEL}[A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Exit)\\s*(?::|$)`,
+        );
 
         // What stock ComfyUI actually emits. #2329 keyed on `[ERROR]`/`[EXCEPTION]`,
         // which its in-memory handler never writes — app/logger.py formats the memory
@@ -227,17 +249,19 @@ export async function runHealthCheck(
         // render reported byte-identically to a healthy server in the diagnostic users
         // paste into bug reports.
         //
-        // #2355 — after stripping ANSI codes (which ColoredFormatter wraps around
-        // [LEVEL] tags), the body may be `[ERROR] !!! Exception...` instead of
-        // `!!! Exception...`. Patterns must account for this optional [LEVEL] prefix.
+        // #2355 — the body reaching these begins `[ERROR] !!! Exception...`, not
+        // `!!! Exception...`, so the two anchored patterns take the optional tag.
+        // WARNING is what makes this reachable rather than cosmetic: a custom-node
+        // import failure is logged at WARNING (nodes.py:2335-2336), and the
+        // `[ERROR]` clause below gives that no cover at all.
         const ERROR_HEADERS: readonly RegExp[] = [
-          /^(?:\[(?:ERROR|WARNING|INFO|DEBUG|CRITICAL|EXCEPTION)\]\s*)?!!!\s*Exception during processing/i,   // execution.py render failure, possibly with [LEVEL]
-          /^(?:\[(?:ERROR|WARNING|INFO|DEBUG|CRITICAL|EXCEPTION)\]\s*)?Traceback\s*\(/i,                       // traceback header, possibly with [LEVEL]
+          new RegExp(`^${LEVEL}!!!\\s*Exception during processing`, "i"), // execution.py:637
+          new RegExp(`^${LEVEL}Traceback\\s*\\(`, "i"),                     // a Python traceback header
           /\[ERROR\]|\[EXCEPTION\]/i,               // ComfyUI-Manager / file handler
         ];
         const ERROR_SIGNALS: readonly RegExp[] = [
           ...ERROR_HEADERS,
-          /^(?:\[(?:ERROR|WARNING|INFO|DEBUG|CRITICAL|EXCEPTION)\]\s*)?[A-Za-z0-9_.]*(Error|Exception)\s*:/,          // exception tail, possibly with [LEVEL]
+          EXCEPTION_TAIL,                           // a bare exception tail
           /\bGot an OOM\b/i,                        // model_management OOM notice
           /\bAllocation on device\b/i,              // torch allocator OOM
           /\bCUDA out of memory\b/i,
@@ -277,9 +301,10 @@ export async function runHealthCheck(
             const b = bodies[j];
             if (isHeader(b)) break;
             if (/^[ \t]/.test(b) || b.trim() === "") { group.push(allLines[j]); processed.add(j); continue; }
-            // A bare exception tail closes the traceback it belongs to; take it and stop.
-            // The tail may be prefixed with a [LEVEL] tag from ColoredFormatter.
-            if (/^(?:\[(?:ERROR|WARNING|INFO|DEBUG|CRITICAL|EXCEPTION)\]\s*)?[A-Za-z0-9_.]*(Error|Exception)\s*:/.test(b)) {
+            // A bare exception tail closes the traceback it belongs to; take it and
+            // stop. The SAME regex as the signal list — a second copy of it is how
+            // the two drift apart and the tail silently stops being taken.
+            if (EXCEPTION_TAIL.test(b)) {
               group.push(allLines[j]); processed.add(j);
             }
             break;
@@ -289,10 +314,10 @@ export async function runHealthCheck(
         // Take the last N error groups, then flatten them into lines for scrubbing
         const recentErrorGroups = errorGroups.slice(-recentErrors);
         const errorLines = recentErrorGroups.flat();
-        // Strip ANSI escape sequences before scrubbing secrets, so the patterns used
-        // by scrubSecretShapedText don't get confused by control bytes.
-        const ansiStripped = errorLines.map((line) => stripAnsi(line));
-        const errLines = scrubLogLines(ansiStripped);
+        // #2355 — strip ANSI on the way OUT too. These lines land in a diagnostic
+        // the user pastes into a bug report, where raw escape bytes are noise, and
+        // they would otherwise be what scrubSecretShapedText reasons about.
+        const errLines = scrubLogLines(errorLines.map(stripAnsi));
         if (errLines.length > 0) {
           lines.push(`\n**Recent errors** (last ${errLines.length}):`);
           for (const e of errLines) lines.push(`  ${e.trim()}`);


### PR DESCRIPTION
Follow-up to #2357, which landed the ANSI/`[LEVEL]` half of #2355 and auto-closed the
issue. Rows A, B, C and the healthy control are correct on `main` now. **Rows D and E
of #2355's own table are not** — they are a second, independent gap that #2357 did not
touch, and the merge closed the issue over them.

## What is still broken on `main`

`execution.py:637` formats its header as `f"!!! Exception during processing !!! {ex}"`,
which is **empty** when `str(ex)` is. A zero-arg exception's traceback tail then renders
with **no colon** — `KeyboardInterrupt`, or a bare `raise RuntimeError`. #2347's tail
pattern required the colon:

```
/^(?:\[LEVEL\]\s*)?[A-Za-z0-9_.]*(Error|Exception)\s*:/
```

so the forward walk hit that line, failed to match, and broke *without taking it*. The
report shows a traceback and names no exception at all — which is the same loss #2347
set out to fix for row A, one row over.

Measured on `main` (`d82550e`) against real bytes:

```
##### D_keyboard_interrupt #####          ##### E_bare_runtime_error #####
**Recent errors** (last 4):               **Recent errors** (last 4):
  ... [ERROR] !!! Exception during ...      ... [ERROR] !!! Exception during ...
  ... [ERROR] Traceback (most recent...     ... [ERROR] Traceback (most recent...
  File "...execution.py", line 64...        File "...node.py", line 73, in ...
  raise KeyboardInterrupt                   raise RuntimeError
                     ^ the exception is never named
```

With this change both rows name the exception, and all five rows of #2355's table are
correct.

## How this was verified — driving ComfyUI's own logger, not a reconstruction

#2347 shipped two anchors that could never fire because its fixtures were built from a
*description* of the log format. #2355 is that same failure one layer down, so I did not
reconstruct anything:

- imported ComfyUI 0.34.0's `app/logger.py` and ran **its** `setup_logger()`;
- emitted through the real production call sites — `execution.py:637-638` and
  `nodes.py:2335-2336` (which logs the traceback **first**, then the "Cannot import" line);
- serialised the deque exactly as `api_server/routes/internal/internal_routes.py:24` does
  (`"".join(l["t"] + " - " + l["m"])`);
- fed those bytes to `runHealthCheck`.

That capture also corrected three things the fixtures on `main` get wrong, all now encoded:

| | fixtures on `main` | what the formatter actually writes |
|---|---|---|
| tag placement | on every line | on a record's **first physical line only** — frames and the tail carry none |
| bold | on `[INFO]` too | bold only at `WARNING` and above (`ANSI_BOLD if record.levelno >= logging.WARNING`) |
| `format_exc()` | no trailing blank | leaves a **trailing blank line** (it ends in `\n`, the handler appends its terminator) |

## Also in this diff

- **The `[LEVEL]` alternation is spelled once.** `main` has four copies of
  `(?:\[(?:ERROR|WARNING|INFO|DEBUG|CRITICAL|EXCEPTION)\]\s*)?`, and the tail acceptor
  inside the forward walk is a *fifth, separate literal* — the exact shape that lets a
  signal and its acceptor drift apart with nothing failing. `DETAIL`, which is ComfyUI's
  own custom level (`comfy/internal_logging.py`), was missing from all of them.
- Rows D and E had **no test coverage at all** (#2355 noted #2352's row-D test was
  actually a row-B variant).

## Where to look hardest

1. **The widened tail — `(?:Error|Exception|Interrupt|Exit)\s*(?::|$)`.** Broadening a
   pattern that *starts* an error group is the risk here. The `(?::|$)` terminator is
   what keeps it off prose: the healthy control feeds it `Exit code 0 from the last
   subprocess` and asserts `none`. Mutation **M5** below loosens exactly that terminator
   and the control goes red, so the control is load-bearing rather than vacuously green.
   It stays case-sensitive, as before, so `0 errors found` cannot match.
2. **`LEVEL` is now interpolated into `new RegExp`,** so the escaping level changed
   (`\\s` in a template literal). Nothing but the tests proves I got that right.
3. **A behaviour change worth calling out:** `[WARNING] Traceback` is now a *header*, so
   a custom-node import failure at startup appears in `recent_errors`. That is what row C
   asks for, but on a server with several failing packs it does mean more groups than
   before. `recentErrors` defaults to 20 groups, so it truncates rather than floods.
4. **Deliberate non-goal:** the `Cannot import <pack> module for custom nodes` line is
   still not a signal, so row C's group names the `ModuleNotFoundError` and its frames
   but not which pack failed. Adding it is a judgement call beyond this issue and I left
   it alone rather than widening the predicate further.

## Mutation matrix — every part of the fix, deleted, one at a time

Run against `src/__tests__/services/health-check.test.ts` on the SHA in this PR:

| mutation | tests that go red |
|---|---|
| M1 — `bodyOf` stops stripping ANSI | row C |
| M2 — tail requires a colon again (#2347's pattern) | rows D **and** E |
| M3 — headers stop tolerating `[LEVEL]` | row C |
| M4 — no ANSI strip on the emitted lines | "no raw ANSI escape reaches the health report" |
| M5 — tail terminator made optional (*loosening*, not a removal) | the healthy control |

One weak pin was found and fixed this way: row E first asserted
`toContain("RuntimeError")` and stayed **green** under M2, because the frame directly
above the tail is `raise RuntimeError` and satisfied it whether or not the tail survived.
Both rows now anchor to the tail's own emitted line (`/^ {2}RuntimeError$/m`).

## Checks

- `npx vitest run` — 676 files, 12544 passed / 6 skipped, 0 failed.
- `npx tsc --noEmit` and `npm run build` clean.
- No Playwright run: this is orchestrator-side text in a tool result, nothing the panel
  renders.
