### PR TITLE
chore(release): 0.52.129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.129] - 2026-08-26
+
+### MCP
+
+#### Fixed
+- separate wording for identified vs id-less POSSIBLE REPEAT cases (#2362)
+- guard promoted container widget writes (#2323)
+- name the exception when the traceback tail has no colon (rows D and E) (#2359)
+- handle ANSI escape sequences in log pattern matching (#2357)
+
+#### Changed
+- pin generation and witness.localPath clauses in localPathRecovered (#2354)
+
+
 ## [0.52.128] - 2026-08-26
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.128",
+  "version": "0.52.129",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.128",
+      "version": "0.52.129",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.128",
+  "version": "0.52.129",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Summary

- Bump package.json and package-lock.json from 0.52.128 to 0.52.129.
- Generate the 0.52.129 CHANGELOG.md section from the current v0.52.128..680768980babee6dd0c3bdea214d1eac1a03b34b range, including #2362 and the requested #2314 fix (PR #2323).
- Release metadata/artifacts only: CHANGELOG.md, package.json, package-lock.json.

Base: 680768980babee6dd0c3bdea214d1eac1a03b34b
Head: c98acce

## Validation

- npm.cmd run lint — pass
- npm.cmd run build — pass
- Targeted release/current-base tests — pass (19/19), plus boot-server-version and late-mutation-e2e reruns pass
- Final-base npm.cmd test — 676 files, 12,627 passed, 6 skipped; one timing-sensitive panel-image-relay.test.ts timeout, rerun passed (31/31)
- Version/changelog gates and changelog-section.mjs — pass
- Changelog generator idempotence — pass
- Generated docs substantive idempotence — pass
- Vocabulary, vocabulary export, asset-count, and pack/install smoke gates — pass

Do not merge, tag, or publish from this PR.