### PR TITLE
chore(release): 0.52.130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.130] - 2026-08-26
+
+### MCP
+
+#### Changed
+- fix-2356-reconcile-download-status-with-durable-partial (#2358)
+
+
 ## [0.52.129] - 2026-08-26
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.129",
+  "version": "0.52.130",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.129",
+      "version": "0.52.130",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.129",
+  "version": "0.52.130",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Summary

- Bump comfyui-mcp from 0.52.129 to 0.52.130.
- Generate the Keep a Changelog entry for merged #2358.
- No docs, vocabulary, asset-count, or pack-installer changes were required.

## Validation

- Version/changelog generation and idempotence: pass.
- Build/lint: pass.
- Vocabulary, exported vocabulary, asset counts, unknown-collapse, docs no-op, and pack-generator no-op: pass.
- Pack idempotence: pass with PYTHON=python; all installer second runs were no-ops and the LTX fix was idempotent.
- #2358 targeted tests: 10 files, 437 passed.
- Full serial Vitest: 677 files, 12,643 passed, 6 skipped.
- Remaining npm test checks: pass.
- Pack/install smoke: pass for comfyui-mcp@0.52.130; 38 core and 96 panel tools registered.
- The default Windows npm test runner was retried twice and hit the same unchanged-source timing failure in src/__tests__/orchestrator/late-mutation-e2e.test.ts (60 ms bridge reply timeout); the isolated test passed 5/5 and the serial full suite passed.

Release branch is based on origin/main at 15d24ccc14b7de1a79427a4487e6d8364af2c1d2.

No merge, tag, or publish was performed.