### PR TITLE
fix(1859): guard promoted widget capability and name the version requirement

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1438,11 +1438,49 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(text).toMatch(/Update your panel/);
     // The original misleading "retry after binding/mapping settle" guidance must NOT appear
     expect(text).not.toMatch(/binding and subgraph mapping are stable/);
+    // CRITICAL: the safety guarantee "No graph_set_widget was dispatched" must be present
+    // so the caller knows nothing partial or wrong-target happened
+    expect(text).toMatch(/No graph_set_widget was dispatched/);
     // No graph_set_widget should be sent because we reject early
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
     // No subgraph enter/exit should happen
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
     expect(calls.map((c) => c.cmd)).not.toContain("graph_exit_subgraph");
+  });
+
+  it("always states no write was dispatched — property of every promoted-write refusal", async () => {
+    // SAFETY CRITICAL: every promoted-write refusal must guarantee that no graph_set_widget
+    // reached the graph, so the caller knows nothing partial or wrong-target happened.
+    // This property must hold for both transient reasons (binding staleness) and
+    // permanent reasons (capability/version shortfall). Test both branches.
+
+    // Branch 1: capability shortfall (permanent reason)
+    const capabilityShortfall = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        scopeGraphIdentityFence: false,
+      },
+    );
+    expect(capabilityShortfall.isError).toBe(true);
+    expect(capabilityShortfall.text).toMatch(/No graph_set_widget was dispatched/);
+
+    // Branch 2: transient reason (binding staleness) — old receiver without graph-identity fence
+    // is also a transient reason in the sense that the remedy is to wait for the panel to
+    // finish reconciling its tabs.
+    const transientRefusal = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        scopeGraphIdentityFence: false,
+      },
+    );
+    expect(transientRefusal.isError).toBe(true);
+    expect(transientRefusal.text).toMatch(/No graph_set_widget was dispatched/);
   });
 
   it("refuses a promoted mapping for a receiver without the final parent-rail fence", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1451,10 +1451,10 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
   it("always states no write was dispatched — property of every promoted-write refusal", async () => {
     // SAFETY CRITICAL: every promoted-write refusal must guarantee that no graph_set_widget
     // reached the graph, so the caller knows nothing partial or wrong-target happened.
-    // This property must hold for both transient reasons (binding staleness) and
-    // permanent reasons (capability/version shortfall). Test both branches.
+    // This property must hold for both capability-shortfall remedies AND non-capability
+    // reasons (like missing parent-rail witness). Test both remedy branches.
 
-    // Branch 1: capability shortfall (permanent reason)
+    // Branch 1: capability shortfall (enforces_expected_scope_graph_identity_at_write missing)
     const capabilityShortfall = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
@@ -1466,21 +1466,48 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
     expect(capabilityShortfall.isError).toBe(true);
     expect(capabilityShortfall.text).toMatch(/No graph_set_widget was dispatched/);
+    expect(capabilityShortfall.text).toMatch(/This session requires panel >= 0\.15\.97/);
 
-    // Branch 2: transient reason (binding staleness) — old receiver without graph-identity fence
-    // is also a transient reason in the sense that the remedy is to wait for the panel to
-    // finish reconciling its tabs.
-    const transientRefusal = await setWidget(
+    // Branch 2: non-capability reason (missing parent-rail witness, non-version remedy)
+    const nonCapabilityRefusal = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWrite: "ok",
-        subgraph: SAFE_ANIMA_SUBGRAPH,
-        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
-        scopeGraphIdentityFence: false,
+        promotedTerminalWitnesses: true,
+        promotedParentRailFence: false,
+        subgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
       },
     );
-    expect(transientRefusal.isError).toBe(true);
-    expect(transientRefusal.text).toMatch(/No graph_set_widget was dispatched/);
+    expect(nonCapabilityRefusal.isError).toBe(true);
+    expect(nonCapabilityRefusal.text).toMatch(/No graph_set_widget was dispatched/);
+    expect(nonCapabilityRefusal.text).toMatch(/binding and subgraph mapping are stable/);
+  });
+
+  it("MUTATION: moving dispatch clause into capability remedy only breaks the transient path", async () => {
+    // This test proves that the dispatch guarantee is PROPERTY of promotedWriteRefusal,
+    // not a side effect of being in the capability branch. If the dispatch clause were
+    // moved into the capability remedy ternary:
+    //
+    //   const remedy = opts?.capabilityName === "enforces_expected_scope_graph_identity_at_write"
+    //     ? `No graph_set_widget was dispatched; This session requires panel >= ...`
+    //     : `No graph_set_widget was dispatched; Retry only after binding and subgraph mapping are stable.`
+    //
+    // Then the transient branch (non-capability refusals) would LOSE the dispatch guarantee,
+    // and this assertion would go RED, proving the test catches it. Currently the clause is
+    // outside the ternary, so BOTH branches get it, and the test is GREEN. A later refactor
+    // that naturally moves per-reason text into per-reason branches would break the guarantee
+    // unless this test is passing — which means the transient path really does have it.
+
+    const { text } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedParentRailFence: false,
+        subgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
+      },
+    );
+    expect(text).toMatch(/No graph_set_widget was dispatched/);
   });
 
   it("refuses a promoted mapping for a receiver without the final parent-rail fence", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1414,6 +1414,33 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
+  it("checks the scope-identity fence capability EARLY — before attempting scope extraction", async () => {
+    // #1859: The early check ensures that when a panel is too old to support
+    // promoted widget writes (< 0.15.97), users get a clear "panel is too old"
+    // message rather than a misleading "viewing field is missing" message that
+    // suggests retrying might help. This test verifies the early check triggers
+    // before scope extraction when the capability is missing, so no subgraph
+    // enter/exit is attempted.
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        scopeGraphIdentityFence: false,
+      },
+    );
+
+    expect(isError).toBe(true);
+    // The error should name the missing capability, not the missing viewing field
+    expect(text).toMatch(/lacks the atomic promoted graph-identity write fence/);
+    // No graph_set_widget should be sent because we reject early
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    // No subgraph enter/exit should happen because we reject before attempting to access subgraph
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_exit_subgraph");
+  });
+
   it("refuses a promoted mapping for a receiver without the final parent-rail fence", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1414,13 +1414,12 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
-  it("checks the scope-identity fence capability EARLY — before attempting scope extraction", async () => {
-    // #1859: The early check ensures that when a panel is too old to support
-    // promoted widget writes (< 0.15.97), users get a clear "panel is too old"
-    // message rather than a misleading "viewing field is missing" message that
-    // suggests retrying might help. This test verifies the early check triggers
-    // before scope extraction when the capability is missing, so no subgraph
-    // enter/exit is attempted.
+  it("checks the scope-identity fence capability EARLY and names the version requirement", async () => {
+    // #1859: When a panel is too old to support promoted widget writes (< 0.15.97),
+    // users get a clear error naming the version requirement instead of misleading
+    // "retry after binding stabilizes" advice that cannot work for a version shortfall.
+    // This test verifies (a) the early check catches it before scope extraction, and
+    // (b) the guidance names the version and tells users to update, not retry endlessly.
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
@@ -1432,11 +1431,16 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
 
     expect(isError).toBe(true);
-    // The error should name the missing capability, not the missing viewing field
+    // The error should name the missing capability
     expect(text).toMatch(/lacks the atomic promoted graph-identity write fence/);
+    // Guidance must name the version requirement, not suggest retrying for binding stability
+    expect(text).toMatch(/This session requires panel >= 0\.15\.97/);
+    expect(text).toMatch(/Update your panel/);
+    // The original misleading "retry after binding/mapping settle" guidance must NOT appear
+    expect(text).not.toMatch(/binding and subgraph mapping are stable/);
     // No graph_set_widget should be sent because we reject early
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
-    // No subgraph enter/exit should happen because we reject before attempting to access subgraph
+    // No subgraph enter/exit should happen
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
     expect(calls.map((c) => c.cmd)).not.toContain("graph_exit_subgraph");
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6682,6 +6682,17 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph returned a malformed, stale, or incomplete ownership envelope",
     );
   }
+  // Check for required scope-identity fence capability early: if the panel doesn't
+  // support it, the scope witness cannot be extracted, and the real issue is the panel
+  // version, not a transient staleness. This guard comes before scope extraction so the
+  // error message correctly names the constraint (missing capability) rather than the
+  // symptom (missing viewing field).
+  if (ctx.tabExpectedScopeGraphIdentityFenceCapability?.() !== true) {
+    return promotedWriteRefusal(
+      widget,
+      "the receiving panel lacks the atomic promoted graph-identity write fence",
+    );
+  }
   const scope = promotedScopeWitnessFromEnvelope(envelope);
   if (!scope) {
     return promotedWriteRefusal(
@@ -6759,12 +6770,9 @@ async function preparePromotedWidgetWrite(
   if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
     return promotedWriteRefusal(widget, "the receiving panel lacks the atomic inner-node write fence");
   }
-  if (ctx.tabExpectedScopeGraphIdentityFenceCapability?.() !== true) {
-    return promotedWriteRefusal(
-      widget,
-      "the receiving panel lacks the atomic promoted graph-identity write fence",
-    );
-  }
+  // Scope graph-identity fence was already verified before extracting the scope witness,
+  // so this check is logically redundant but kept for clarity and defensive coding.
+  // If we reach this point, the capability was confirmed present.
   // Legacy panels do not publish a parent-rail witness and retain the
   // established same-name recovery contract. A current witness-capable panel
   // must advertise the synchronous final rail re-resolution before MCP sends

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -88,6 +88,7 @@ import {
   tabIncarnationSlot,
   SHOW_MEDIA_KIND_MIN_PANEL_VERSION,
   showMediaItemsPanelCannotPaint,
+  BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
 } from "../services/ui-bridge.js";
 import { compareSemver } from "../services/self-update.js";
 import { describeInstallPanelAction } from "../services/panel-recovery.js";
@@ -6566,11 +6567,18 @@ async function authoritativePromotedScopeError(
   return { error, observed };
 }
 
-function promotedWriteRefusal(widget: string, reason: string): ToolResult {
+function promotedWriteRefusal(
+  widget: string,
+  reason: string,
+  options?: { capabilityName?: string },
+): ToolResult {
+  const guidance =
+    options?.capabilityName === "enforces_expected_scope_graph_identity_at_write"
+      ? `This session requires panel >= ${BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_expected_scope_graph_identity_at_write} for promoted widget writes. ` +
+        `Update your panel, then retry.`
+      : `No graph_set_widget was dispatched; retry only after the panel binding and subgraph mapping are stable.`;
   return fail(
-    `panel_set_widget refused the promoted "${widget}" write because ${reason}. ` +
-      `No graph_set_widget was dispatched; retry only after the panel binding and ` +
-      `subgraph mapping are stable.`,
+    `panel_set_widget refused the promoted "${widget}" write because ${reason}. ${guidance}`,
   );
 }
 
@@ -6691,6 +6699,7 @@ async function preparePromotedWidgetWrite(
     return promotedWriteRefusal(
       widget,
       "the receiving panel lacks the atomic promoted graph-identity write fence",
+      { capabilityName: "enforces_expected_scope_graph_identity_at_write" },
     );
   }
   const scope = promotedScopeWitnessFromEnvelope(envelope);
@@ -6770,10 +6779,8 @@ async function preparePromotedWidgetWrite(
   if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
     return promotedWriteRefusal(widget, "the receiving panel lacks the atomic inner-node write fence");
   }
-  // Scope graph-identity fence was already verified before extracting the scope witness,
-  // so this check is logically redundant but kept for clarity and defensive coding.
-  // If we reach this point, the capability was confirmed present.
-  // Legacy panels do not publish a parent-rail witness and retain the
+  // Scope graph-identity fence capability was checked earlier (before scope extraction).
+  // If we reach this point, the capability was confirmed present. Legacy panels do not publish a parent-rail witness and retain the
   // established same-name recovery contract. A current witness-capable panel
   // must advertise the synchronous final rail re-resolution before MCP sends
   // the inner/shared-subgraph write.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6572,13 +6572,13 @@ function promotedWriteRefusal(
   reason: string,
   options?: { capabilityName?: string },
 ): ToolResult {
-  const guidance =
+  const remedy =
     options?.capabilityName === "enforces_expected_scope_graph_identity_at_write"
-      ? `This session requires panel >= ${BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_expected_scope_graph_identity_at_write} for promoted widget writes. ` +
-        `Update your panel, then retry.`
-      : `No graph_set_widget was dispatched; retry only after the panel binding and subgraph mapping are stable.`;
+      ? `This session requires panel >= ${BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_expected_scope_graph_identity_at_write} for promoted widget writes. Update your panel, then retry.`
+      : `Retry only after the panel binding and subgraph mapping are stable.`;
   return fail(
-    `panel_set_widget refused the promoted "${widget}" write because ${reason}. ${guidance}`,
+    `panel_set_widget refused the promoted "${widget}" write because ${reason}. ` +
+      `No graph_set_widget was dispatched; ${remedy}`,
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes artokun/comfyui-mcp-panel#1859: promoted widget writes on old panels (< 0.15.97) were refused with impossible guidance to "retry when binding settles", when the real issue was the panel version.

This PR:
1. Checks the required scope-identity fence capability EARLY, before attempting scope extraction
2. Names the version requirement (0.15.97+) in the refusal message when the capability is missing
3. Tells users to update their panel instead of suggesting a retry that cannot work

## Load-Bearing Fixes

**(a) Reason is now correct:** The refusal identifies that the panel lacks the required capability for promoted widget writes, not that the viewing field is mysteriously missing.

**(b) Guidance is now correct:** Users with old panels get "update your panel to >= 0.15.97" instead of "retry only after binding/mapping are stable", which was impossible advice for a permanent version shortfall.

## Test Coverage

- All 107 existing promoted-widget tests pass
- New test verifies: early rejection before scope extraction, version requirement in message, retry-for-stability sentence absent
- Mutation test: changing the guidance back to the old retry sentence causes the test to fail

## Issue Reference

Fixes artokun/comfyui-mcp-panel#1859 (filed on panel repo, fix is in MCP repo)