### PR TITLE
fix(panel#1859): a promoted write blocked by a panel BUILD skew says so, and the version it names exists

### DIFF
--- a/scripts/codex-knowledge-parity-smoke.mjs
+++ b/scripts/codex-knowledge-parity-smoke.mjs
@@ -29,7 +29,7 @@ import { WebSocket } from "ws";
 /** Panel version the mock advertises (#1384). Kept in step with the product's own derived
  *  fence minimum by src/__tests__/scripts/knowledge-parity-mock-version.test.ts — a raised
  *  floor fails that test instead of silently refusing every graph write in the smoke. */
-const MOCK_PANEL_VERSION = "0.15.97";
+const MOCK_PANEL_VERSION = "0.15.101";
 /** A well-formed workflow uuid, so the per-command stamp fence has something to fence on. */
 // MOCK_WORKFLOW_UUID is imported above — it belongs with the executors that answer with it.
 

--- a/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
+++ b/src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts
@@ -155,7 +155,7 @@ const UNAVAILABLE_REFUSAL =
 
 describe("#2000 frontend-only type refused for an unavailable /object_info", () => {
   it("THE REPORTED CASE: names the fact that /object_info never lists this type, and says not to reinstall", async () => {
-    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, "0.15.97");
+    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, "0.15.96");
     expect(r.isError).toBe(true);
     // The panel's own refusal is KEPT — the note is appended, never a replacement.
     expect(r.text).toContain("object_info is unavailable");
@@ -186,19 +186,37 @@ describe("#2000 frontend-only type refused for an unavailable /object_info", () 
     expect(unknown.text).toMatch(/wait a moment and retry/i);
   });
 
-  it("THE REPORTER'S OWN VERSION is ABOVE the floor — so the note must not depend on skew", async () => {
-    // Measured, and it is the reason this note is not gated on the version floor at
-    // all: the reporter ran panel 0.15.98 while the floor is lower, because the floor
-    // tracks BRIDGE CAPABILITY requirements, not "the version with the latest fixes".
-    // Gating on it would have made this hint fire for almost nobody — and it is also
-    // why #1828's skew note could never have fired for this reporter.
-    const REPORTER_VERSION = "0.15.98";
-    expect(compareSemver(REPORTER_VERSION, requiredPanelVersion())).toBeGreaterThan(0);
-    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, REPORTER_VERSION);
+  it("a panel ABOVE the floor still gets the note — it must not depend on skew", async () => {
+    // The claim being pinned is that this hint is not gated on the version floor
+    // at all: the floor tracks BRIDGE CAPABILITY requirements, not "the version
+    // with the latest fixes", so gating on it would make the hint fire for
+    // almost nobody.
+    //
+    // This used to express that with the #2000 reporter's own 0.15.98, which was
+    // above the floor at the time. panel#1859 corrected the #2314 capability
+    // floor from a never-released 0.15.97 to the 0.15.101 that actually ships
+    // it, which moved 0.15.98 UNDER the line — so the input, not the claim, is
+    // what changed. Read the floor to pick an input that is above it today.
+    const ABOVE = "999.0.0";
+    expect(compareSemver(ABOVE, requiredPanelVersion())).toBeGreaterThan(0);
+    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, ABOVE);
     expect(r.text).toContain("FRONTEND-ONLY");
     expect(r.text).toMatch(/merely SLOW/i);
     // No skew evidence ⇒ no skew claim.
     expect(r.text).not.toMatch(/below this orchestrator's floor/i);
+  });
+
+  it("THE REPORTER'S OWN VERSION now sits below the floor, and still gets the note", async () => {
+    // 0.15.98 is a real published panel that cannot perform a promoted write, so
+    // the skew sentence firing for it is correct rather than noise. What must
+    // not change is the substance: the frontend-only explanation is still there,
+    // appended to the panel's own refusal.
+    const REPORTER_VERSION = "0.15.98";
+    expect(compareSemver(REPORTER_VERSION, requiredPanelVersion())).toBeLessThan(0);
+    const r = await addNode("MarkdownNote", UNAVAILABLE_REFUSAL, REPORTER_VERSION);
+    expect(r.text).toContain("object_info is unavailable");
+    expect(r.text).toContain("FRONTEND-ONLY");
+    expect(r.text).toMatch(/merely SLOW/i);
   });
 
   it("does NOT tell a REAL backend type that it is frontend-only", async () => {
@@ -207,7 +225,7 @@ describe("#2000 frontend-only type refused for an unavailable /object_info", () 
     const r = await addNode(
       "KSampler",
       UNAVAILABLE_REFUSAL.replace("MarkdownNote", "KSampler"),
-      "0.15.97",
+      "0.15.96",
     );
     expect(r.isError).toBe(true);
     expect(r.text).toContain("object_info is unavailable");

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -437,7 +437,7 @@ function bridge(opts: {
     // reaches the scope checks at all instead of stopping at the node-type fence.
     tabExpectedNodeTypeFenceCapability: () => true,
     tabExpectedScopeGraphIdentityFenceCapability: () =>
-      !legacyBuild && opts.scopeGraphIdentityFence !== false,
+      opts.scopeGraphIdentityFence === true || (!legacyBuild && opts.scopeGraphIdentityFence !== false),
     tabPromotedTerminalWitnessCapability: () =>
       !legacyBuild && opts.promotedTerminalWitnesses === true,
     tabPromotedParentRailFenceCapability: () =>
@@ -1510,51 +1510,25 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     // the refusal names the floor and the update rather than asking for a retry.
     expect(text).toContain("0.15.101");
     expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
-    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
-    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
-  });
-
-  it("checks the scope-identity fence capability EARLY and names the version requirement", async () => {
-    // #1859: When a panel is too old to support promoted widget writes (< 0.15.97),
-    // users get a clear error naming the version requirement instead of misleading
-    // "retry after binding stabilizes" advice that cannot work for a version shortfall.
-    // This test verifies (a) the early check catches it before scope extraction, and
-    // (b) the guidance names the version and tells users to update, not retry endlessly.
-    const { text, isError, calls } = await setWidget(
-      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
-      {
-        firstWrite: "ok",
-        subgraph: SAFE_ANIMA_SUBGRAPH,
-        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
-        scopeGraphIdentityFence: false,
-      },
-    );
-
-    expect(isError).toBe(true);
-    // The error should name the missing capability
-    expect(text).toMatch(/lacks the atomic promoted graph-identity write fence/);
-    // Guidance must name the version requirement, not suggest retrying for binding stability
-    expect(text).toMatch(/This session requires panel >= 0\.15\.97/);
-    expect(text).toMatch(/Update your panel/);
-    // The original misleading "retry after binding/mapping settle" guidance must NOT appear
-    expect(text).not.toMatch(/binding and subgraph mapping are stable/);
-    // CRITICAL: the safety guarantee "No graph_set_widget was dispatched" must be present
-    // so the caller knows nothing partial or wrong-target happened
+    // #2365 — the safety guarantee stays on every promoted refusal, so the caller
+    // knows nothing partial or wrong-target happened.
     expect(text).toMatch(/No graph_set_widget was dispatched/);
-    // No graph_set_widget should be sent because we reject early
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
-    // No subgraph enter/exit should happen
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
     expect(calls.map((c) => c.cmd)).not.toContain("graph_exit_subgraph");
   });
 
   it("always states no write was dispatched — property of every promoted-write refusal", async () => {
-    // SAFETY CRITICAL: every promoted-write refusal must guarantee that no graph_set_widget
-    // reached the graph, so the caller knows nothing partial or wrong-target happened.
-    // This property must hold for both capability-shortfall remedies AND non-capability
-    // reasons (like missing parent-rail witness). Test both remedy branches.
+    // #2365's SAFETY-CRITICAL property, kept: every promoted-write refusal must
+    // guarantee that no graph_set_widget reached the graph, whichever remedy the
+    // message carries. What changed is the second branch. #2365 labelled the
+    // parent-rail refusal "non-capability" and pinned it to the retry wording,
+    // but it is a capability shortfall in exactly the same sense as the first —
+    // a hello either advertises the fence or it does not — so pinning the retry
+    // advice there regression-locked the defect panel#1859 is about. The genuine
+    // transient is a third case, and it is covered below.
 
-    // Branch 1: capability shortfall (enforces_expected_scope_graph_identity_at_write missing)
+    // Branch 1: capability shortfall (enforces_expected_scope_graph_identity_at_write)
     const capabilityShortfall = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
@@ -1566,10 +1540,11 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
     expect(capabilityShortfall.isError).toBe(true);
     expect(capabilityShortfall.text).toMatch(/No graph_set_widget was dispatched/);
-    expect(capabilityShortfall.text).toMatch(/This session requires panel >= 0\.15\.97/);
+    expect(capabilityShortfall.text).toContain("0.15.101");
 
-    // Branch 2: non-capability reason (missing parent-rail witness, non-version remedy)
-    const nonCapabilityRefusal = await setWidget(
+    // Branch 2: a DIFFERENT capability shortfall (the final parent-rail fence).
+    // Same guarantee, and the same build-skew remedy rather than a retry.
+    const parentRailShortfall = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWrite: "ok",
@@ -1578,36 +1553,25 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         subgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
       },
     );
-    expect(nonCapabilityRefusal.isError).toBe(true);
-    expect(nonCapabilityRefusal.text).toMatch(/No graph_set_widget was dispatched/);
-    expect(nonCapabilityRefusal.text).toMatch(/binding and subgraph mapping are stable/);
-  });
+    expect(parentRailShortfall.isError).toBe(true);
+    expect(parentRailShortfall.text).toMatch(/No graph_set_widget was dispatched/);
+    expect(parentRailShortfall.text).toContain("0.15.101");
+    expect(parentRailShortfall.text).not.toMatch(/binding and subgraph mapping are stable/);
 
-  it("MUTATION: moving dispatch clause into capability remedy only breaks the transient path", async () => {
-    // This test proves that the dispatch guarantee is PROPERTY of promotedWriteRefusal,
-    // not a side effect of being in the capability branch. If the dispatch clause were
-    // moved into the capability remedy ternary:
-    //
-    //   const remedy = opts?.capabilityName === "enforces_expected_scope_graph_identity_at_write"
-    //     ? `No graph_set_widget was dispatched; This session requires panel >= ...`
-    //     : `No graph_set_widget was dispatched; Retry only after binding and subgraph mapping are stable.`
-    //
-    // Then the transient branch (non-capability refusals) would LOSE the dispatch guarantee,
-    // and this assertion would go RED, proving the test catches it. Currently the clause is
-    // outside the ternary, so BOTH branches get it, and the test is GREEN. A later refactor
-    // that naturally moves per-reason text into per-reason branches would break the guarantee
-    // unless this test is passing — which means the transient path really does have it.
-
-    const { text } = await setWidget(
+    // Branch 3: a genuinely TRANSIENT refusal — a malformed envelope from a
+    // current panel. Same guarantee, and this is the one a retry can clear.
+    const transient = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWrite: "ok",
-        promotedTerminalWitnesses: true,
-        promotedParentRailFence: false,
-        subgraph: CURRENT_SAFE_PROMOTED_SUBGRAPH,
+        subgraph: { ...SAFE_ANIMA_SUBGRAPH, node_count: 2 },
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
       },
     );
-    expect(text).toMatch(/No graph_set_widget was dispatched/);
+    expect(transient.isError).toBe(true);
+    expect(transient.text).toMatch(/No graph_set_widget was dispatched/);
+    expect(transient.text).toMatch(/binding and subgraph mapping are stable/);
+    expect(transient.text).not.toContain("0.15.101");
   });
 
   it("refuses a promoted mapping for a receiver without the final parent-rail fence", async () => {
@@ -2770,6 +2734,30 @@ describe("panel_set_widget promoted write against a pre-#2314 panel build (panel
     expect(isError).toBe(true);
     expect(text).toContain("0.15.101");
     expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
+  });
+
+  it("a receiver that DID advertise the fence but omits the identity keeps the retry advice", async () => {
+    // The narrow case the build-skew message must not swallow: the hello claims
+    // the fence, so an absent identity is an inconsistent reply rather than an
+    // old bundle, and retrying is a legitimate thing to ask for.
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        // Everything a legacy build implies EXCEPT the capability: the hello
+        // advertises the fence while the payload still omits graph_identity.
+        legacyPanelBuild: { version: "0.15.85" },
+        scopeGraphIdentityFence: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/did not publish a verifiable workflow and viewing-scope identity/);
+    expect(text).toMatch(/retry only after the panel binding and subgraph mapping are stable/);
+    expect(text).not.toContain("0.15.101");
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
   it("leaves the transient refusals on a CURRENT panel saying retry", async () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1147,7 +1147,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     // Unchanged from before panel#1869: a transport failure IS transient, so
     // "retry once stable" is honest advice there and must survive.
     expect(text).toContain("could not determine whether the addressed node is a promoted container");
-    expect(text).toContain("Retry only after the panel binding and subgraph mapping are stable");
+    expect(text).toContain("retry only after the panel binding and subgraph mapping are stable");
     expect(text).not.toContain("[canvas-root-divergence]");
   });
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -130,6 +130,12 @@ function bridge(opts: {
   };
   omitWorkflowUuid?: boolean;
   workflowUuid?: string;
+  /** panel#1859 — a real pre-0.15.101 panel build. It publishes no
+   * `graph_identity` anywhere (neither on `viewing` nor on `subgraph_of`) and
+   * its hello advertises `enforces_expected_node_type_at_write` but none of the
+   * #2314 scope capabilities. Verified against `v0.15.85:web/js/…`, where the
+   * reply is literally `subgraph_of: { node_id, title }`. */
+  legacyPanelBuild?: { version?: string };
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
@@ -154,10 +160,11 @@ function bridge(opts: {
     reason: "no current panel graph-scope witness has been observed",
   };
   const beforeWrite = { mutate: undefined as (() => void) | undefined };
+  const legacyBuild = opts.legacyPanelBuild !== undefined;
   const currentViewing = () => ({
     scope: inSubgraph ? "subgraph" : "root",
     ...(inSubgraph ? { owner_node_id: currentOwnerNodeId } : {}),
-    graph_identity: currentGraphIdentity,
+    ...(legacyBuild ? {} : { graph_identity: currentGraphIdentity }),
     ...(opts.omitWorkflowUuid ? {} : { workflow_uuid: workflowUuid }),
   });
   const withCurrentViewing = (value: Record<string, unknown>): Record<string, unknown> => {
@@ -167,14 +174,14 @@ function bridge(opts: {
     const rawOwnerEnvelope = result.subgraph_of;
     if (rawOwnerEnvelope && typeof rawOwnerEnvelope === "object" && !Array.isArray(rawOwnerEnvelope)) {
       const owner = rawOwnerEnvelope as Record<string, unknown>;
-      if (!Object.prototype.hasOwnProperty.call(owner, "graph_identity")) {
+      if (!legacyBuild && !Object.prototype.hasOwnProperty.call(owner, "graph_identity")) {
         result = { ...result, subgraph_of: { ...owner, graph_identity: targetGraphIdentity } };
       }
     }
     const rawViewing = result.viewing;
     if (rawViewing && typeof rawViewing === "object" && !Array.isArray(rawViewing)) {
       const viewingValue = rawViewing as Record<string, unknown>;
-      if (!Object.prototype.hasOwnProperty.call(viewingValue, "graph_identity")) {
+      if (!legacyBuild && !Object.prototype.hasOwnProperty.call(viewingValue, "graph_identity")) {
         result = { ...result, viewing: { ...viewingValue, graph_identity: currentGraphIdentity } };
       }
     }
@@ -426,11 +433,17 @@ function bridge(opts: {
           },
         }
       : {}),
+    // v0.15.85's hello DOES advertise this one, which is why a legacy build
+    // reaches the scope checks at all instead of stopping at the node-type fence.
     tabExpectedNodeTypeFenceCapability: () => true,
-    tabExpectedScopeGraphIdentityFenceCapability: () => opts.scopeGraphIdentityFence !== false,
-    tabPromotedTerminalWitnessCapability: () => opts.promotedTerminalWitnesses === true,
+    tabExpectedScopeGraphIdentityFenceCapability: () =>
+      !legacyBuild && opts.scopeGraphIdentityFence !== false,
+    tabPromotedTerminalWitnessCapability: () =>
+      !legacyBuild && opts.promotedTerminalWitnesses === true,
     tabPromotedParentRailFenceCapability: () =>
-      opts.promotedParentRailFence ?? opts.promotedTerminalWitnesses === true,
+      legacyBuild ? false : (opts.promotedParentRailFence ?? opts.promotedTerminalWitnesses === true),
+    advertisedPanelVersion: () =>
+      opts.legacyPanelBuild?.version !== undefined ? { version: opts.legacyPanelBuild.version } : {},
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     workflowUuidFor: () => ({ known: true, uuid: workflowUuid }),
   } as unknown as PanelToolCtx["bridge"];
@@ -1492,7 +1505,11 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/lacks the atomic promoted graph-identity write fence/);
+    expect(text).toMatch(/does not advertise the atomic promoted graph-identity write fence/);
+    // panel#1859 — a capability the hello did not advertise is a build fact, so
+    // the refusal names the floor and the update rather than asking for a retry.
+    expect(text).toContain("0.15.101");
+    expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
@@ -1605,7 +1622,9 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/lacks the atomic promoted parent-rail write fence/);
+    expect(text).toMatch(/does not advertise the atomic promoted parent-rail write fence/);
+    expect(text).toContain("0.15.101");
+    expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
@@ -2689,5 +2708,85 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(writes[0]).toMatchObject({ widget: "Width" });
     expect(writes[1]).toMatchObject({ node_id: 76, widget: "width", value: 1024 });
     expect(text).not.toMatch(/is not a promoted widget/);
+  });
+});
+
+/**
+ * panel#1859 — mcp 0.52.129 shipped the #2314 promoted-write fence twenty
+ * minutes BEFORE panel 0.15.101 shipped the `graph_identity` the fence reads.
+ * Anyone on an older panel therefore hit a permanent refusal whose own advice
+ * ("retry only after the panel binding and subgraph mapping are stable") can
+ * never reach the condition: the reporter retried five times, re-issued
+ * panel_set_workflow_target, and hard-refreshed the tab, and the bundle stayed
+ * at 0.15.85 through all of it.
+ *
+ * The refusal is CORRECT — a pre-0.15.101 panel cannot enforce the fence, so
+ * loosening it would reopen #2314. What these tests pin is that the message
+ * names the build skew, the version floor, and a remedy that exists.
+ */
+describe("panel_set_widget promoted write against a pre-#2314 panel build (panel#1859)", () => {
+  const LEGACY = { version: "0.15.85" } as const;
+
+  it("names the build skew, the floor, and the update instead of prescribing a retry", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        legacyPanelBuild: LEGACY,
+      },
+    );
+
+    expect(isError).toBe(true);
+    // Nothing was written, and the subgraph was never entered.
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
+
+    // The cause is the panel build, stated as such.
+    expect(text).toMatch(/panel build/i);
+    // The advertised version and the floor that fixes it are both named.
+    expect(text).toContain("0.15.85");
+    expect(text).toContain("0.15.101");
+    // The remedy that actually clears it.
+    expect(text).toMatch(/hard-refresh/i);
+    // …and the three things the reporter already tried are ruled OUT, rather
+    // than being what the message asks for.
+    expect(text).toMatch(/panel_enter_subgraph/);
+    expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
+  });
+
+  it("still names the floor when the panel never advertised its version", async () => {
+    const { text, isError } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        legacyPanelBuild: {},
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toContain("0.15.101");
+    expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
+  });
+
+  it("leaves the transient refusals on a CURRENT panel saying retry", async () => {
+    // Same handler, same fixture, current build: a malformed envelope is a
+    // genuine transient and must keep the retry advice it has always had.
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: { ...SAFE_ANIMA_SUBGRAPH, node_count: 2 },
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/retry only after the panel binding and subgraph mapping are stable/);
+    expect(text).not.toContain("0.15.101");
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
 });

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -136,6 +136,10 @@ function bridge(opts: {
    * #2314 scope capabilities. Verified against `v0.15.85:web/js/…`, where the
    * reply is literally `subgraph_of: { node_id, title }`. */
   legacyPanelBuild?: { version?: string };
+  /** panel#1859 — the tab drops (or becomes ambiguous) between the mapping read
+   * and the fence check, so `resolveTarget` throws and every capability reads
+   * `false` without that being a fact about the panel build. */
+  receiverUnresolvable?: boolean;
 }) {
   const calls: Array<Record<string, unknown>> = [];
   let writes = 0;
@@ -442,6 +446,10 @@ function bridge(opts: {
       !legacyBuild && opts.promotedTerminalWitnesses === true,
     tabPromotedParentRailFenceCapability: () =>
       legacyBuild ? false : (opts.promotedParentRailFence ?? opts.promotedTerminalWitnesses === true),
+    // panel#1859 / codex gate — a fence capability answers `false` both for "not
+    // advertised" and for "resolveTarget threw". Only a resolvable receiver lets
+    // a refusal blame the panel BUILD.
+    tabReceiverResolvable: () => opts.receiverUnresolvable !== true,
     advertisedPanelVersion: () =>
       opts.legacyPanelBuild?.version !== undefined ? { version: opts.legacyPanelBuild.version } : {},
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
@@ -2734,6 +2742,39 @@ describe("panel_set_widget promoted write against a pre-#2314 panel build (panel
     expect(isError).toBe(true);
     expect(text).toContain("0.15.101");
     expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
+  });
+
+  it("an UNRESOLVABLE receiver is not blamed on the panel build (codex gate)", async () => {
+    // The gate's P1 on the first round of this change. Every fence capability
+    // answers `false` when UiBridge's resolveTarget throws, so a tab that drops
+    // between the mapping read and the fence check looks identical to a
+    // pre-0.15.101 bundle. Calling that a BUILD skew — in a message that goes
+    // out of its way to say retrying cannot help — sends someone whose tab just
+    // needs to reconnect off to update their panel instead. Fail-closed on the
+    // WRITE, honest about which fact we actually have.
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: SAFE_ANIMA_SUBGRAPH,
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+        legacyPanelBuild: { version: "0.15.85" },
+        receiverUnresolvable: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/could not be resolved while its promoted-write fence capabilities were read/);
+    expect(text).toMatch(/not decidable from here/);
+    // No build claim, no version, no update instruction.
+    expect(text).not.toMatch(/BUILD skew/);
+    expect(text).not.toContain("0.15.101");
+    expect(text).not.toContain("0.15.85");
+    expect(text).not.toMatch(/HARD-REFRESH/i);
+    // The write is still refused — this only changes the wording.
+    expect(text).toMatch(/No graph_set_widget was dispatched/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
   it("a receiver that DID advertise the fence but omits the identity keeps the retry advice", async () => {

--- a/src/__tests__/services/panel-capability-floor.test.ts
+++ b/src/__tests__/services/panel-capability-floor.test.ts
@@ -1,0 +1,86 @@
+// panel#1859 — the #2314 promoted-write fence was gated on a panel version the
+// panel never released.
+//
+// `BRIDGE_CAPABILITY_MIN_PANEL_VERSION` said 0.15.97 for all three #2314
+// capabilities. The panel's tags go 0.15.96 → 0.15.98; there is no 0.15.97, and
+// the keys are absent from every published build up to and including 0.15.100.
+// They first appear in v0.15.101:web/js/lib/session-rebind.js — the same release
+// that added the `subgraph_of.graph_identity` the fence reads.
+//
+// The cost was not cosmetic. `requiredPanelVersion()` folds this table, so
+// install_comfyui(action:'panel', panel_action:'status') called 0.15.98,
+// 0.15.99 and 0.15.100 current while every promoted-container write on them was
+// refused — the user is told they are up to date by the same orchestrator that
+// is refusing them for being out of date.
+//
+// These numbers are therefore PINNED to a published tag, not to a merge commit:
+// a fix that lands after a release cut ships in the NEXT one, which is how the
+// off-by-one on `enforces_expected_node_type_at_write` (0.15.58 → 0.15.59)
+// happened too. To move one, check the tag, not the PR.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
+  panelVersionForCapability,
+  requiredPanelVersion,
+  SEMVER_RE,
+} from "../../services/ui-bridge.js";
+import { compareSemver } from "../../services/self-update.js";
+
+/** Capability → the first PUBLISHED panel tag whose bundle advertises it.
+ *  Verified with `git grep -c "<key>" v0.15.NNN -- web` in comfyui-mcp-panel. */
+const VERIFIED_AGAINST_A_PUBLISHED_TAG: Readonly<Record<string, string>> = {
+  // absent in v0.15.58, present in v0.15.59
+  enforces_expected_node_type_at_write: "0.15.59",
+  // absent in v0.15.96/98/99/100 (there is no v0.15.97), present in v0.15.101
+  enforces_expected_scope_at_write: "0.15.101",
+  enforces_expected_scope_graph_identity_at_write: "0.15.101",
+  enforces_promoted_parent_rail_at_write: "0.15.101",
+};
+
+describe("panel#1859 — the capability floor names a version the panel actually shipped", () => {
+  it.each(Object.entries(VERIFIED_AGAINST_A_PUBLISHED_TAG))(
+    "%s is pinned to %s",
+    (capability, tag) => {
+      expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION[capability]).toBe(tag);
+    },
+  );
+
+  it("does not reintroduce 0.15.97, which was never published", () => {
+    expect(Object.values(BRIDGE_CAPABILITY_MIN_PANEL_VERSION)).not.toContain("0.15.97");
+  });
+
+  it("the aggregate sync floor is at least the promoted-write floor", () => {
+    // The two answers are allowed to differ (the aggregate may be higher), but
+    // the aggregate must never sit BELOW a capability the orchestrator refuses
+    // on — that is the #708 shape this issue hit: "you are current" from the
+    // same build that is refusing you for being old.
+    const promoted = panelVersionForCapability("enforces_expected_scope_graph_identity_at_write");
+    expect(promoted).toBeTruthy();
+    expect(compareSemver(requiredPanelVersion(), String(promoted))).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("panel#1859 — panelVersionForCapability", () => {
+  it("returns the table entry for a known capability", () => {
+    expect(panelVersionForCapability("enforces_expected_scope_at_write")).toBe("0.15.101");
+  });
+
+  it("returns undefined for a capability the table does not know", () => {
+    // A message composed from this must degrade to naming the remedy without a
+    // number, never fall back to the aggregate floor (#352/#619) and never
+    // fabricate one.
+    expect(panelVersionForCapability("enforces_something_invented")).toBeUndefined();
+  });
+
+  it("returns undefined rather than a value SEMVER_RE would reject", () => {
+    // Guards the screen itself: every published entry must pass, so a future
+    // typo ("0.15.101.1", "v0.15.101-") surfaces here instead of reaching a
+    // user-facing sentence as an unverifiable number.
+    for (const [capability, value] of Object.entries(BRIDGE_CAPABILITY_MIN_PANEL_VERSION)) {
+      expect(SEMVER_RE.test(value.trim()), `${capability} = ${value}`).toBe(true);
+      expect(panelVersionForCapability(capability)).toBe(value.trim());
+    }
+  });
+});

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -19,6 +19,7 @@ import {
   isMutatingGraphCommand,
   requiresWorkflowStampEnforcement,
   BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
+  panelVersionForCapability,
   unclassifiedGraphCommandsSeen,
   __resetUnclassifiedGraphCommands,
 } from "../../services/ui-bridge.js";
@@ -69,6 +70,21 @@ afterEach(() => {
 });
 
 // #570 P0c — classifier that decides which commands must pass the enforcement+stamp gate.
+
+/** panel#1859 — a fence refusal must quote the floor from the capability table
+ * the gate itself reads, not a number someone typed beside it. Three of these
+ * messages had drifted onto a version the panel never released, so a user who
+ * followed them landed on a build that was still refused. Assert the LINK here;
+ * the numbers themselves are pinned in panel-capability-floor.test.ts. */
+function fenceFloorRe(fence: string, capability: string): RegExp {
+  const floor = panelVersionForCapability(capability);
+  expect(floor, `no parseable floor for ${capability}`).toBeTruthy();
+  // panelVersionForCapability only ever returns a SEMVER_RE-screened string, so
+  // the only regex metacharacter it can contain is the dot.
+  const escaped = String(floor).replace(/\./g, "\\.");
+  return new RegExp(`${fence} write fence.*to ${escaped}\\+`, "i");
+}
+
 describe("requiresWorkflowStampEnforcement (#570 P0c)", () => {
   it("gates every graph_* mutator, never a read", () => {
     expect(requiresWorkflowStampEnforcement({ cmd: "graph_add_node" })).toBe(true);
@@ -3160,7 +3176,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
         (err) => err,
       );
     expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toMatch(/atomic expected-node-type write fence.*0\.15\.58/i);
+    expect((caught as Error).message).toMatch(fenceFloorRe("atomic expected-node-type", "enforces_expected_node_type_at_write"));
     expect(isCapabilityRefusal(caught)).toBe(true);
     expect(dispatchOutcomeOf(caught)).toBe(false);
     old.close();
@@ -3269,7 +3285,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
         (err) => err,
       );
     expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toMatch(/atomic promoted-scope write fence.*0\.15\.97/i);
+    expect((caught as Error).message).toMatch(fenceFloorRe("atomic promoted-scope", "enforces_expected_scope_at_write"));
     expect(isCapabilityRefusal(caught)).toBe(true);
     expect(dispatchOutcomeOf(caught)).toBe(false);
     old.close();
@@ -3320,7 +3336,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
         (err) => err,
       );
     expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toMatch(/graph-identity write fence.*0\.15\.97/i);
+    expect((caught as Error).message).toMatch(fenceFloorRe("graph-identity", "enforces_expected_scope_graph_identity_at_write"));
     expect(isCapabilityRefusal(caught)).toBe(true);
     expect(dispatchOutcomeOf(caught)).toBe(false);
     old.close();
@@ -3374,7 +3390,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
         (err) => err,
       );
     expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toMatch(/atomic promoted parent-rail write fence.*0\.15\.97/i);
+    expect((caught as Error).message).toMatch(fenceFloorRe("atomic promoted parent-rail", "enforces_promoted_parent_rail_at_write"));
     expect(isCapabilityRefusal(caught)).toBe(true);
     expect(dispatchOutcomeOf(caught)).toBe(false);
     old.close();

--- a/src/__tests__/tools/panel-status-latest.test.ts
+++ b/src/__tests__/tools/panel-status-latest.test.ts
@@ -44,8 +44,11 @@ import { requiredPanelVersion } from "../../services/panel-sync.js";
 import { compareSemver } from "../../services/self-update.js";
 import { panelAction } from "../../tools/install-panel.js";
 
-/** A panel above the 0.15.97 capability floor, with a newer published release. */
-const INSTALLED = "0.15.97";
+/** A panel at the capability floor, with a newer published release.
+ *  Raised from 0.15.97 by panel#1859: the #2314 floor was corrected to the
+ *  0.15.101 that actually ships those capabilities, so 0.15.97 stopped being
+ *  above the line — and the canary below said so. */
+const INSTALLED = "0.15.101";
 const LATEST = "0.16.13";
 
 function status(over: Partial<PanelStatus> = {}): PanelStatus {
@@ -135,19 +138,19 @@ describe("#1983 — the status tool REACHES the latest-version probe", () => {
 
 describe("#1983 — floor and latest are two answers, never one", () => {
   it("the fixture is still above the floor (input precondition, not an expectation)", () => {
-    // If the derived floor ever rises past 0.15.97 these fixtures stop testing
+    // If the derived floor ever rises past INSTALLED these fixtures stop testing
     // the reported state. Fail here with a clear reason rather than three tests
-    // failing obscurely.
+    // failing obscurely. (It did rise, in panel#1859 — this canary is what said so.)
     expect(compareSemver(INSTALLED, requiredPanelVersion())).toBeGreaterThanOrEqual(0);
   });
 
-  it("16 versions behind latest, above the floor → behind:false AND behindLatest:true with the pair", async () => {
+  it("behind latest, above the floor → behind:false AND behindLatest:true with the pair", async () => {
     mocks.panelStatus.mockResolvedValue(status());
     stubFetch(() => new Response(pyproject(LATEST), { status: 200 }));
 
     const sync = await statusCall();
 
-    // The floor answer is UNCHANGED — 0.15.97 is not too old to work.
+    // The floor answer is UNCHANGED — the installed panel is not too old to work.
     expect(sync.behind).toBe(false);
     expect(sync.decision).toBe("meets-floor");
     // The latest answer is the one that was missing.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -89,7 +89,6 @@ import {
   tabIncarnationSlot,
   SHOW_MEDIA_KIND_MIN_PANEL_VERSION,
   showMediaItemsPanelCannotPaint,
-  BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
 } from "../services/ui-bridge.js";
 import { compareSemver } from "../services/self-update.js";
 import { describeInstallPanelAction } from "../services/panel-recovery.js";
@@ -6620,18 +6619,16 @@ async function authoritativePromotedScopeError(
   return { error, observed };
 }
 
-function promotedWriteRefusal(
-  widget: string,
-  reason: string,
-  options?: { capabilityName?: string },
-): ToolResult {
-  const remedy =
-    options?.capabilityName === "enforces_expected_scope_graph_identity_at_write"
-      ? `This session requires panel >= ${BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_expected_scope_graph_identity_at_write} for promoted widget writes. Update your panel, then retry.`
-      : `Retry only after the panel binding and subgraph mapping are stable.`;
+/** A refusal a retry can legitimately clear. Anything caused by the panel BUILD
+ * goes through {@link promotedPanelBuildRefusal} instead — #2365 carved the
+ * first of those out with a `capabilityName` option on this function, and that
+ * option is gone because every capability call site now uses the dedicated
+ * path, which also names the advertised version and a route that works. */
+function promotedWriteRefusal(widget: string, reason: string): ToolResult {
   return fail(
     `panel_set_widget refused the promoted "${widget}" write because ${reason}. ` +
-      `No graph_set_widget was dispatched; ${remedy}`,
+      `No graph_set_widget was dispatched; retry only after the panel binding and ` +
+      `subgraph mapping are stable.`,
   );
 }
 
@@ -6797,36 +6794,28 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph returned a malformed, stale, or incomplete ownership envelope",
     );
   }
-  // Check for required scope-identity fence capability early: if the panel doesn't
-  // support it, the scope witness cannot be extracted, and the real issue is the panel
-  // version, not a transient staleness. This guard comes before scope extraction so the
-  // error message correctly names the constraint (missing capability) rather than the
-  // symptom (missing viewing field).
+  // panel#1859 — ask the HELLO before reading the witness out of the envelope.
+  // A build that never advertised this fence also never writes
+  // `subgraph_of.graph_identity` (both landed in panel 0.15.101; v0.15.85
+  // replies with a bare `subgraph_of: { node_id, title }`), so diagnosing it as
+  // a missing field describes the symptom while the cause is the bundle on
+  // disk. This ordering is #2365's idea, kept.
+  //
+  // It also narrows the branch below to its true meaning: a receiver that DID
+  // advertise the fence and still failed to publish the identity is an
+  // inconsistent reply, which a retry can legitimately clear.
   if (ctx.tabExpectedScopeGraphIdentityFenceCapability?.() !== true) {
-    return promotedWriteRefusal(
+    return promotedPanelBuildRefusal(
+      ctx,
+      nodeId,
       widget,
-      "the receiving panel lacks the atomic promoted graph-identity write fence",
-      { capabilityName: "enforces_expected_scope_graph_identity_at_write" },
+      "does not advertise the atomic promoted graph-identity write fence, so it " +
+        "cannot publish the target graph identity a promoted write is fenced on",
+      "enforces_expected_scope_graph_identity_at_write",
     );
   }
   const scope = promotedScopeWitnessFromEnvelope(envelope);
   if (!scope) {
-    // panel#1859 — separate "the panel cannot say this" from "the panel said
-    // something wrong". A malformed `viewing` or `subgraph_of.graph_identity`
-    // is already rejected by validatePromotedSubgraphEnvelope above, so an
-    // ABSENT one here is a pre-0.15.101 bundle that never writes the field at
-    // all (v0.15.85 replies with a bare `subgraph_of: { node_id, title }`).
-    // No amount of retrying adds a key the JS on disk does not emit.
-    if (envelope.targetGraphIdentity === undefined || envelope.viewing === undefined) {
-      return promotedPanelBuildRefusal(
-        ctx,
-        nodeId,
-        widget,
-        "does not publish the target graph identity that graph_get_subgraph must " +
-          "carry before a promoted write can be fenced to the right graph",
-        "enforces_expected_scope_graph_identity_at_write",
-      );
-    }
     return promotedWriteRefusal(
       widget,
       "graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -82,6 +82,7 @@ import type {
   TabWorkflowUuidRead,
 } from "../services/ui-bridge.js";
 import {
+  panelVersionForCapability,
   requiredPanelVersion,
   SEMVER_RE,
   LATE_ASK_TTL_MS,
@@ -6635,6 +6636,59 @@ function promotedWriteRefusal(
 }
 
 /**
+ * panel#1859 — the same refusal, for the one cause a retry can never reach.
+ *
+ * MCP 0.52.129 shipped the #2314 promoted-write fence; the panel build that
+ * satisfies it shipped twenty minutes later in 0.15.101. Every user in between
+ * got {@link promotedWriteRefusal}'s "retry only after the panel binding and
+ * subgraph mapping are stable" for a condition that is a JS bundle on disk. The
+ * reporter retried five times, re-issued panel_set_workflow_target (which
+ * answered `already_current`), and hard-refreshed the tab; none of that
+ * replaces the bundle, so the loop had no exit.
+ *
+ * So this says what is actually wrong, rules out the three things a caller
+ * would otherwise try next, and names a route to the value that works today.
+ * The refusal itself is unchanged — a pre-0.15.101 panel genuinely cannot
+ * enforce the fence, and loosening it would reopen #2314.
+ */
+function promotedPanelBuildRefusal(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+  widget: string,
+  reason: string,
+  capability: string,
+): ToolResult {
+  const floor = panelVersionForCapability(capability);
+  const advertised = tabAdvertisedPanelVersion(ctx);
+  const update = describeInstallPanelAction(
+    "update",
+    "update the ComfyUI-MCP panel via ComfyUI Manager",
+  );
+  // Never interpolate the caller's raw node_id: it is untrusted argument shape.
+  // A container id that will not canonicalize is dropped from the sentence
+  // rather than echoed, which leaves the route stated but unparameterized.
+  const canonicalId = canonicalQueriedNodeId(nodeId);
+  const enterArg = canonicalId ? `node_id: ${canonicalId}` : "the container's node_id";
+  return fail(
+    `panel_set_widget refused the promoted "${widget}" write because the connected ` +
+      `panel build ${reason}. No graph_set_widget was dispatched.\n` +
+      `This is a panel BUILD skew, not a transient binding state. Retrying, ` +
+      `panel_set_workflow_target, and reloading the ComfyUI tab all leave the same ` +
+      `bundle running, so none of them can clear it.` +
+      (advertised ? ` This tab announced panel ${advertised}.` : "") +
+      ` A promoted-container write needs ${floor ? `panel ≥${floor}` : "a newer panel build"}. ` +
+      `${update}, then HARD-REFRESH the browser tab (Ctrl+Shift+R, or Cmd+Shift+R on ` +
+      `macOS); a restart alone leaves the tab running cached old JS.\n` +
+      `Until then the value is still reachable by hand: ` +
+      `panel_enter_subgraph(${enterArg}), then panel_set_widget on the ` +
+      `inner node that owns "${widget}". If the write does not stick because the ` +
+      `container's promoted rail holds the value, un-promote it first ` +
+      `(panel_promote_widget with demote:true), write the inner node, and re-promote — ` +
+      `that is the sequence panel#1859 reported as clearing it.`,
+  );
+}
+
+/**
  * #2314 — inspect a promoted target before the first write. A valid mapping is
  * not permission to write the wrapper: the plan carries the receiver identity,
  * inner node id, and inner type to an inner write whose final dispatch fence
@@ -6757,6 +6811,22 @@ async function preparePromotedWidgetWrite(
   }
   const scope = promotedScopeWitnessFromEnvelope(envelope);
   if (!scope) {
+    // panel#1859 — separate "the panel cannot say this" from "the panel said
+    // something wrong". A malformed `viewing` or `subgraph_of.graph_identity`
+    // is already rejected by validatePromotedSubgraphEnvelope above, so an
+    // ABSENT one here is a pre-0.15.101 bundle that never writes the field at
+    // all (v0.15.85 replies with a bare `subgraph_of: { node_id, title }`).
+    // No amount of retrying adds a key the JS on disk does not emit.
+    if (envelope.targetGraphIdentity === undefined || envelope.viewing === undefined) {
+      return promotedPanelBuildRefusal(
+        ctx,
+        nodeId,
+        widget,
+        "does not publish the target graph identity that graph_get_subgraph must " +
+          "carry before a promoted write can be fenced to the right graph",
+        "enforces_expected_scope_graph_identity_at_write",
+      );
+    }
     return promotedWriteRefusal(
       widget,
       "graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity",
@@ -6829,18 +6899,31 @@ async function preparePromotedWidgetWrite(
     const terminalBlocked = refuseKnownBadPromotedTerminal(inner.terminal);
     if (terminalBlocked) return terminalBlocked;
   }
+  // panel#1859 — these three are capability skew, exactly like the missing
+  // graph identity above: the hello either advertises the fence or it does not,
+  // and a caller cannot change that by trying again.
   if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
-    return promotedWriteRefusal(widget, "the receiving panel lacks the atomic inner-node write fence");
+    return promotedPanelBuildRefusal(
+      ctx,
+      nodeId,
+      widget,
+      "does not advertise the atomic inner-node write fence",
+      "enforces_expected_node_type_at_write",
+    );
   }
-  // Scope graph-identity fence capability was checked earlier (before scope extraction).
-  // If we reach this point, the capability was confirmed present. Legacy panels do not publish a parent-rail witness and retain the
+  // The graph-identity fence is checked before the scope witness above (#2365),
+  // so reaching here means the hello advertised it.
+  // Legacy panels do not publish a parent-rail witness and retain the
   // established same-name recovery contract. A current witness-capable panel
   // must advertise the synchronous final rail re-resolution before MCP sends
   // the inner/shared-subgraph write.
   if (publishesCompleteTerminalWitness && ctx.tabPromotedParentRailFenceCapability?.() !== true) {
-    return promotedWriteRefusal(
+    return promotedPanelBuildRefusal(
+      ctx,
+      nodeId,
       widget,
-      "the receiving panel lacks the atomic promoted parent-rail write fence",
+      "does not advertise the atomic promoted parent-rail write fence",
+      "enforces_promoted_parent_rail_at_write",
     );
   }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6655,6 +6655,24 @@ function promotedPanelBuildRefusal(
   reason: string,
   capability: string,
 ): ToolResult {
+  // A fence capability reads `false` for TWO different facts: this hello did
+  // not advertise it, or resolveTarget threw and there was no hello at all. Only
+  // the first is about the bundle on disk. If the receiver cannot be resolved,
+  // the honest answer is the transient one — telling someone whose tab just
+  // dropped to update and hard-refresh is the same unreachable advice this
+  // whole change exists to remove, and would be worse than what it replaced
+  // because the wording below is emphatic that retrying cannot help.
+  //
+  // Read in the SAME synchronous turn as the capability that sent us here, with
+  // no await between, so run-to-completion means both saw one connection.
+  if (ctx.tabReceiverResolvable?.() !== true) {
+    return promotedWriteRefusal(
+      widget,
+      "the receiving panel could not be resolved while its promoted-write fence " +
+        "capabilities were read, so whether this is a stale binding or an " +
+        "out-of-date panel build is not decidable from here",
+    );
+  }
   const floor = panelVersionForCapability(capability);
   const advertised = tabAdvertisedPanelVersion(ctx);
   const update = describeInstallPanelAction(
@@ -13000,6 +13018,11 @@ export interface PanelToolCtx {
   /** Whether the currently bound panel re-resolves the promoted parent rail
    * synchronously at the final graph_set_widget mutation boundary. */
   tabPromotedParentRailFenceCapability?: () => boolean;
+  /** panel#1859 — whether the receiver can be resolved at all, so a `false`
+   * from the three fence capabilities above can be read as "this build does not
+   * advertise it" rather than "there was no hello to read". Only used to pick
+   * the WORDING of a refusal; the refusals themselves stay fail-closed. */
+  tabReceiverResolvable?: () => boolean;
   /**
    * The same question TRI-STATE, for code that must REPORT the answer rather than
    * gate on it. `tabCanMutateGraph` fails closed (an unreadable probe becomes
@@ -14498,6 +14521,12 @@ export function makePanelToolCtx(
   ctx.tabPromotedParentRailFenceCapability = () =>
     typeof bridge.tabPromotedParentRailFenceCapability === "function" &&
     bridge.tabPromotedParentRailFenceCapability(ctx.tabId);
+  // Absent on a bridge that does not implement it, which reads as "cannot
+  // prove the receiver is there" — the conservative direction, since it only
+  // ever softens a refusal's wording away from blaming the panel build.
+  ctx.tabReceiverResolvable = () =>
+    typeof bridge.tabReceiverResolvable === "function" &&
+    bridge.tabReceiverResolvable(ctx.tabId);
   ctx.tabGraphMutationCapability = () => bridge.tabGraphMutationCapability(ctx.tabId);
   return ctx;
 }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -372,17 +372,50 @@ export const BRIDGE_CAPABILITY_MIN_PANEL_VERSION: Readonly<Record<string, string
   enforces_workflow_stamp_at_write: "0.11.35",
   // #2107 — graph_set_widget's optional expected_node_type fence shipped with
   // the panel-side write-boundary check.
-  enforces_expected_node_type_at_write: "0.15.58",
+  //
+  // panel#1859: read off the published tags rather than the merge commit. The
+  // key is absent from v0.15.58:web/js/lib/session-rebind.js and first present
+  // in v0.15.59 — the fix merged after the 0.15.58 release cut, so a 0.15.58
+  // floor authorized a published build that does not advertise it.
+  enforces_expected_node_type_at_write: "0.15.59",
   // #2314 — promoted inner writes carry an expected owner/workflow witness that
   // the panel validates immediately before mutating the current graph.
-  enforces_expected_scope_at_write: "0.15.97",
+  //
+  // panel#1859: these three said 0.15.97, which the panel NEVER RELEASED (its
+  // tags go 0.15.96 → 0.15.98). All three keys are absent from every tag up to
+  // and including v0.15.100 and first appear in v0.15.101 — the same release
+  // that added the `subgraph_of.graph_identity` the fence reads. The old number
+  // called 0.15.98/0.15.99/0.15.100 new enough for a promoted write when none
+  // of them can perform one, so `install_comfyui(action:'panel')` reported those
+  // installs current while every promoted write kept being refused — #708 in a
+  // second costume, and the reason panel#1859's remedy had no exit.
+  enforces_expected_scope_at_write: "0.15.101",
   // #2314 P1 — the promoted fence additionally validates the object-keyed live
   // graph identity, which is distinct from graph-local owner/node ids.
-  enforces_expected_scope_graph_identity_at_write: "0.15.97",
+  enforces_expected_scope_graph_identity_at_write: "0.15.101",
   // #2314 final-rail race — the promoted inner write re-resolves its live
   // authoritative parent rail at the synchronous mutation boundary.
-  enforces_promoted_parent_rail_at_write: "0.15.97",
+  enforces_promoted_parent_rail_at_write: "0.15.101",
 };
+
+/**
+ * The panel version ONE handshake capability first shipped in — the only number
+ * a refusal about THAT capability is entitled to quote.
+ *
+ * `undefined` when the table has no parseable entry, so a message degrades to
+ * naming the capability rather than fabricating a floor. Callers must not fall
+ * back to {@link requiredPanelVersion}: that is the aggregate sync answer and
+ * quoting it as one capability's requirement is the #352/#619 defect.
+ *
+ * panel#1859 added this because the four fence refusals below each hard-coded
+ * their number by hand, and three of them had copied a version that was never
+ * released. A hand-copied floor drifts silently from the table the gate
+ * actually reads; a derived one cannot.
+ */
+export function panelVersionForCapability(capability: string): string | undefined {
+  const min = BRIDGE_CAPABILITY_MIN_PANEL_VERSION[capability];
+  return typeof min === "string" && SEMVER_RE.test(min.trim()) ? min.trim() : undefined;
+}
 
 /**
  * The panel version each `show_media` *painter kind* was actually introduced in.
@@ -1565,36 +1598,37 @@ export interface BridgeCommand {
   [key: string]: unknown;
 }
 
-function expectedNodeTypeFenceRefusal(tabId: string): Error {
+/** panel#1859 — the floor comes from the table the gate itself reads, so the
+ * two can never disagree. With no parseable entry the sentence still names a
+ * remedy; it just cannot name a number, which beats naming a wrong one. */
+function fenceRefusal(tabId: string, fence: string, capability: string): Error {
+  const floor = panelVersionForCapability(capability);
   return new Error(
     `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
-      `does not advertise the atomic expected-node-type write fence. Update the ` +
-      `panel to 0.15.58+ and hard-refresh the browser tab.`,
+      `does not advertise the atomic ${fence} write fence. Update the ` +
+      `panel ${floor ? `to ${floor}+` : "to a build that advertises it"} and ` +
+      `hard-refresh the browser tab.`,
   );
+}
+
+function expectedNodeTypeFenceRefusal(tabId: string): Error {
+  return fenceRefusal(tabId, "expected-node-type", "enforces_expected_node_type_at_write");
 }
 
 function expectedScopeFenceRefusal(tabId: string): Error {
-  return new Error(
-    `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
-      `does not advertise the atomic promoted-scope write fence. Update the ` +
-      `panel to 0.15.97+ and hard-refresh the browser tab.`,
-  );
+  return fenceRefusal(tabId, "promoted-scope", "enforces_expected_scope_at_write");
 }
 
 function expectedScopeGraphIdentityFenceRefusal(tabId: string): Error {
-  return new Error(
-    `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
-      `does not advertise the atomic promoted graph-identity write fence. Update the ` +
-      `panel to 0.15.97+ and hard-refresh the browser tab.`,
+  return fenceRefusal(
+    tabId,
+    "promoted graph-identity",
+    "enforces_expected_scope_graph_identity_at_write",
   );
 }
 
 function promotedParentRailFenceRefusal(tabId: string): Error {
-  return new Error(
-    `graph_set_widget was refused before dispatch because panel tab ${tabId} ` +
-      `does not advertise the atomic promoted parent-rail write fence. Update the ` +
-      `panel to 0.15.97+ and hard-refresh the browser tab.`,
-  );
+  return fenceRefusal(tabId, "promoted parent-rail", "enforces_promoted_parent_rail_at_write");
 }
 
 function commandCarriesExpectedGraphIdentity(cmd: BridgeCommand): boolean {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -3681,6 +3681,32 @@ export class UiBridge {
     return r.known ? r.canMutate : false;
   }
 
+  /**
+   * panel#1859 — whether the receiver for `tabId` can be resolved AT ALL.
+   *
+   * Every capability accessor below answers `false` for two different facts:
+   * "this hello did not advertise it" and "resolveTarget threw, so there is no
+   * hello to read". Fail-closed is right for the GATE — an unreadable receiver
+   * must not be dispatched to. It is wrong for the MESSAGE: describing an
+   * unresolved tab as an out-of-date panel build tells a user to update and
+   * hard-refresh when what they need is to reconnect, which is the same class
+   * of unreachable advice panel#1859 is about.
+   *
+   * Same split the file already draws between `tabCanMutateGraph` (fail-closed
+   * boolean for readiness) and `tabGraphMutationCapability` (tri-state for
+   * callers that must DESCRIBE the state to a human). Read this in the same
+   * synchronous turn as the capability itself: with no await between them,
+   * run-to-completion guarantees both see the same connection.
+   */
+  tabReceiverResolvable(tabId: string): boolean {
+    try {
+      this.resolveTarget(tabId);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /** Whether THIS connected panel enforces graph_set_widget's optional
    * expected-node-type fence at the actual mutation boundary (#2107). */
   tabExpectedNodeTypeFenceCapability(tabId: string): boolean {


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#1859.

## What the reporter hit

```
panel_set_widget refused the promoted "prompt" write because graph_get_subgraph
did not publish a verifiable workflow and viewing-scope identity. No
graph_set_widget was dispatched; retry only after the panel binding and
subgraph mapping are stable.
```

They retried about five times, re-issued `panel_set_workflow_target(mode:"current")` (which answered `already_current`), and hard-refreshed the ComfyUI tab. Every one of those left the same JS bundle on disk, so the loop had no exit.

## Cause: a twenty-minute release gap between the two packages

- mcp `2349c20` ("fix(2314): guard promoted container widget writes (#2323)") first released in **0.52.129**, 2026-08-26 05:05Z.
- panel `ec0c288f` ("fix: atomically fence promoted widget receiver scope (#2314)") first released in **0.15.101**, 2026-08-26 05:25Z.

The orchestrator half reads `subgraph_of.graph_identity`; the panel half is what writes it. The reporter is on mcp 0.52.129 + panel 0.15.85, where the reply is literally `subgraph_of: { node_id, title }`. Every promoted-container write is refused before the widget name is even looked at — which is why `steps` (written from *inside* the subgraph, so the promoted preflight never runs) and `aspect_ratio` (not a container) both succeeded in the same session.

**The refusal is correct and is not loosened here.** A pre-0.15.101 panel cannot enforce the fence, and dispatching anyway is the #2314 wrong-node write. What changes is that it stops prescribing a remedy it knows cannot work.

## Three changes

**1. A capability shortfall says so.** The four promoted-write refusals caused by the panel build now name the build skew, the advertised version, the floor, the update action, and a route to the value that works today. The transient refusals are untouched and still say retry.

Before / after for the reporter's exact case:

> …did not publish a verifiable workflow and viewing-scope identity. No graph_set_widget was dispatched; **retry only after the panel binding and subgraph mapping are stable.**

> …the connected panel build **does not advertise the atomic promoted graph-identity write fence, so it cannot publish the target graph identity a promoted write is fenced on**. No graph_set_widget was dispatched.
>
> This is a panel **BUILD skew, not a transient binding state**. Retrying, panel_set_workflow_target, and reloading the ComfyUI tab all leave the same bundle running, so none of them can clear it. This tab announced panel **0.15.85**. A promoted-container write needs panel **≥0.15.101**. `install_comfyui(action:'panel', panel_action:'update')`, then HARD-REFRESH the browser tab (Ctrl+Shift+R…); a restart alone leaves the tab running cached old JS.
>
> Until then the value is still reachable by hand: `panel_enter_subgraph(node_id: 78)`, then panel_set_widget on the inner node that owns "prompt". If the write does not stick because the container's promoted rail holds the value, un-promote it first (`panel_promote_widget` with `demote:true`), write the inner node, and re-promote…

The last paragraph matters because "update the panel" is currently *unavailable* to this reporter — panel#1854 has the registry `latest_version` pinned at 0.15.85, which is why they are on 0.15.85. The demote → set → re-promote cycle is theirs, from the report.

**2. `BRIDGE_CAPABILITY_MIN_PANEL_VERSION` named a version the panel never released.** All three #2314 entries said `0.15.97`. The panel's tags go 0.15.96 → 0.15.98; there is no 0.15.97, and the keys are absent from every published build through 0.15.100, first appearing in `v0.15.101:web/js/lib/session-rebind.js`. `enforces_expected_node_type_at_write` was off by one the same way (absent in v0.15.58, present in v0.15.59). Both fixes merged after their release cut and shipped in the next tag.

This is not cosmetic. `requiredPanelVersion()` folds this table, so `install_comfyui(action:'panel', panel_action:'status')` called 0.15.98 / 0.15.99 / 0.15.100 **current** while every promoted write on them was refused — the same orchestrator telling a user they are up to date and refusing them for being out of date. That is #708 in a second costume, and it is why quoting the floor without fixing it would have reproduced this issue's own defect one layer down.

**3. Four fence refusals in `ui-bridge.ts` hard-coded their floor by hand**, and three carried the phantom version. They now derive it from the table the gate itself reads, so the two cannot disagree again.

## Relationship to #2365

A sibling autopilot agent opened #2365 on this issue 43 seconds before my claim landed. **Its ordering idea is right and is adopted here with credit** (second commit): ask the hello before reading the witness out of the envelope, because a build that never advertised the fence also never writes the field, so diagnosing a missing field describes the symptom.

I have left a full review on #2365. The blocking difference is that it quotes `>= 0.15.97` — derived faithfully from the wrong table entry — and pins that number in a test, so following its advice lands a user on a build that still refuses them. It also leaves the node-type and parent-rail paths on the retry wording, and regression-pins the retry wording onto the parent-rail refusal (a capability shortfall, labelled "non-capability" in its comment). Either PR can land as far as I am concerned, but `>= 0.15.97` should not reach a user.

## Where to look hardest

- **The ordering move changes which message some already-refused cases get.** The graph-identity capability check now runs before `promotedTerminalEvidenceError`, `resolvePromotedWriteTarget` and `refuseKnownBadPromotedTerminal`. A panel that lacks the capability *and* addresses a known-bad terminal now hears about the capability instead of the terminal. Both refuse and nothing is dispatched either way, but it is a behaviour change, not a pure message change.
- **Raising the floor to 0.15.101 makes `panel_sync` consider 0.15.98–0.15.100 below the line** and offer an update. I believe that is correct — those builds genuinely cannot perform a promoted write — but it is the change with the widest blast radius here.
- **`src/__tests__/orchestrator/add-node-frontend-only-skew.test.ts`** had a test whose premise was "the #2000 reporter's 0.15.98 is above the floor". The corrected floor moves 0.15.98 below it. I kept the claim (the FRONTEND-ONLY hint is not gated on the floor) and changed the input that expresses it, then added a second test covering the reporter's real version now that the skew sentence fires for it. If you think the original test was pinning something else, that is the place to say so.
- **The workaround paragraph is the reporter's observation, not my measurement.** I could not drive a live pre-0.15.101 panel, so the message is phrased as the sequence they reported clearing it, and the mechanism ("the container's promoted rail holds the value") is conditional. If that is too weak a claim for an error message, cut that sentence rather than firming it up.
- The two `enforces_workflow_stamp*` floors (0.11.30 / 0.11.35) are **not** verified: the panel repo has no v0.11.x tags to read them off. Left alone rather than guessed at.

## Verification

- `npx tsc --noEmit` clean. Full suite green: **678 files, 12,657 tests**, 6 skipped.
- **Reproduced by execution before the fix.** A harness option emulating a real v0.15.85 panel — no `graph_identity` on `viewing` or `subgraph_of`, hello advertising `enforces_expected_node_type_at_write` and none of the #2314 capabilities, exactly as `v0.15.85:web/js/lib/session-rebind.js` does — produced the reporter's string verbatim:

```
AssertionError: expected 'Error: panel_set_widget refused the p…' to match /panel build/i
+ Received: "Error: panel_set_widget refused the promoted \"quality_prompt\" write because
  graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity.
  No graph_set_widget was dispatched; retry only after the panel binding and subgraph
  mapping are stable."
```

- **Mutation-verified**, each part reverted independently with a named test going red:

| mutation | red |
|---|---|
| build-skew refusal reverted to `promotedWriteRefusal` | 3 tests, incl. `names the build skew, the floor, and the update` |
| table floor reverted to `0.15.97` | 5 tests across 2 files |
| `fenceRefusal` floor re-hardcoded to `0.15.97` | 4 tests in `ui-bridge.test.ts` |
| one capability call site reverted to the retry advice | `refuses a promoted mapping for an old receiver without the graph-identity fence` |

- **No browser gate.** This PR does not touch the panel bundle, and the panel's Playwright suite mocks the orchestrator bridge, so it cannot exercise an MCP-side message. Running it would have proved nothing about this change; I am not implying coverage I do not have. The user-visible string is verified by the tool-handler tests above, which drive the shipped `panel_set_widget` handler through `makePanelToolCtx`.
