### PR TITLE
chore(release): 0.52.131 — HOLD, re-cut after #2366

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.131] - 2026-08-26
+
+### MCP
+
+#### Fixed
+- guard promoted widget capability and name the version requirement (#2365)
+
+
 ## [0.52.130] - 2026-08-26
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.130",
+  "version": "0.52.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.130",
+      "version": "0.52.131",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.130",
+  "version": "0.52.131",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.52.131**, carrying the one merged fix sitting unreleased after v0.52.130.

### Contents

- **#2365** — fixes `artokun/comfyui-mcp-panel#1859` (and `#1860`, closed as a duplicate): a promoted-widget refusal now names the panel version requirement instead of advising a retry that cannot succeed.

`git log v0.52.130..origin/main` is exactly that one commit.

### Why it matters to ship promptly

Two independent users reported this today, on panel 0.15.58 and 0.15.85. Both were told to "retry only after the panel binding and subgraph mapping are stable" for a condition that is a static version shortfall, so retrying could never work — one of them burned about five attempts plus a hard browser refresh before finding a workaround. The refusal itself was correct; only the explanation was wrong, and the wrong explanation is what cost them the time.

After this, that refusal reads:

> panel_set_widget refused the promoted "prompt" write because the receiving panel lacks the atomic promoted graph-identity write fence. **No graph_set_widget was dispatched;** This session requires panel >= 0.15.97 for promoted widget writes. Update your panel, then retry.

The version is read from `BRIDGE_CAPABILITY_MIN_PANEL_VERSION`, so the message cannot drift from the constant.

### Verification carried over from #2365

Gate SHIP on `3fc6239` (the merged head), CI green on ubuntu/windows/macos plus the pack-and-install smoke. The "no graph_set_widget was dispatched" guarantee is pinned by a test exercising both remedy branches with genuinely different inputs — it briefly regressed during review and was caught before merge.

Bumped with `npm version patch --no-git-tag-version`; three files changed (`package.json`, `package-lock.json`, `CHANGELOG.md`), no strays.
