### PR TITLE
fix(2369): condition CONTINUE instruction for replayed completions

### DIFF
--- a/src/__tests__/orchestrator/inject-event-wiring.test.ts
+++ b/src/__tests__/orchestrator/inject-event-wiring.test.ts
@@ -69,6 +69,55 @@ describe("#977: the completion event carries the plan-aware directive", () => {
   });
 });
 
+// #2369 — replayed completions omit CONTINUE to break loops.
+// A re-delivered completion has no plan context to continue — it is journaled
+// after an MCP reconnect. Replayed completions that include "CONTINUE your plan"
+// turn a single late handoff into an unbounded loop: each replay becomes a new
+// user turn, the agent replies, and the next replay cycles it again. Replayed
+// completions always get acknowledge-and-stop, even if a plan remains in flight.
+describe("#2369: replayed completions omit the CONTINUE instruction", () => {
+  it("omits CONTINUE for replayed even when a plan is in flight", async () => {
+    recordTodo("tab-replay-plan", [
+      { text: "variant A", status: "completed" },
+      { text: "variant B", status: "pending" },
+    ]);
+    const { agent, backend } = startAgent("tab-replay-plan");
+    // A fresh completion gets CONTINUE when a plan is in flight.
+    await agent.injectEvent({ kind: "executed", images: [{ filename: "a.png" }] } as never);
+    const [freshTurn] = await backend.waitForTurns(1);
+    expect(freshTurn.text).toMatch(/CONTINUE your plan/);
+    await agent.stop?.();
+    // Now inject the same completion as replayed. It must NOT get CONTINUE.
+    recordTodo("tab-replay-plan", [
+      { text: "variant A", status: "completed" },
+      { text: "variant B", status: "pending" },
+    ]);
+    const { agent: agent2, backend: backend2 } = startAgent("tab-replay-plan");
+    await agent2.injectEvent(
+      { kind: "executed", images: [{ filename: "a.png" }], replayed: true } as never,
+    );
+
+    const [replayTurn] = await backend2.waitForTurns(1);
+    // Replayed must NOT get CONTINUE, even with the same plan.
+    expect(replayTurn.text).not.toMatch(/CONTINUE your plan/);
+    expect(replayTurn.text).toMatch(/you do NOT need to call any tools/);
+    await agent2.stop?.();
+  });
+
+  it("uses acknowledge-and-stop for replayed when plan is in flight", async () => {
+    recordTodo("tab-replay-ack", [{ text: "step 1", status: "pending" }]);
+    const { agent, backend } = startAgent("tab-replay-ack");
+    await agent.injectEvent(
+      { kind: "executed", images: [{ filename: "a.png" }], replayed: true } as never,
+    );
+
+    const [turn] = await backend.waitForTurns(1);
+    expect(turn.text).toMatch(/you do NOT need to call any tools/);
+    expect(turn.text).toMatch(/ONE short sentence/);
+    await agent.stop?.();
+  });
+});
+
 describe("#889: the run-error notice carries the real attribution", () => {
   const ERR = "Render status for prompt 9d70fd9d-1c2b-4e3f-8a01-7c6d5e4f3a2b could not be confirmed";
 

--- a/src/__tests__/orchestrator/todo-state.test.ts
+++ b/src/__tests__/orchestrator/todo-state.test.ts
@@ -179,3 +179,42 @@ describe("#977: the completion directive follows the plan", () => {
     expect(runCompletionDirective("t1")).toMatch(/ONE short sentence/);
   });
 });
+
+// #2369 — replayed completions break loops by conditioning the instruction.
+// A re-delivered completion has no plan context to continue — it is an ancient
+// message journaled after an MCP reconnect. Replayed completions that include
+// "CONTINUE your plan" turn a single late handoff into an unbounded loop:
+// each replay becomes a new user turn, the agent replies, and the next replay
+// cycles it again. Replayed completions always get acknowledge-and-stop, even
+// if a plan remains in flight.
+describe("#2369: replayed completions omit the CONTINUE instruction", () => {
+  it("omits CONTINUE for replayed even when a plan is in flight", () => {
+    recordTodo("t1", [item("A", "pending"), item("B", "pending")]);
+    const nreplayed = runCompletionDirective("t1");
+    const replayed = runCompletionDirective("t1", { replayed: true });
+    // Normal completion tells the agent to CONTINUE when a plan remains.
+    expect(nreplayed).toMatch(/CONTINUE your plan/);
+    // Replayed completion NEVER gets CONTINUE, even with the same plan.
+    expect(replayed).not.toMatch(/CONTINUE your plan/);
+  });
+
+  it("uses acknowledge-and-stop for replayed when plan is in flight", () => {
+    recordTodo("t1", [item("A", "pending")]);
+    const replayed = runCompletionDirective("t1", { replayed: true });
+    expect(replayed).toMatch(/you do NOT need to call any tools/);
+  });
+
+  it("still asks for the one-sentence acknowledgement when replayed", () => {
+    recordTodo("t1", [item("A", "pending")]);
+    const replayed = runCompletionDirective("t1", { replayed: true });
+    expect(replayed).toMatch(/ONE short sentence/);
+  });
+
+  it("uses the same wording for replayed as for no plan at all", () => {
+    recordTodo("t1", [item("A", "pending")]);
+    const replayed = runCompletionDirective("t1", { replayed: true });
+    __resetTodoState();
+    const noPlan = runCompletionDirective("t1");
+    expect(replayed).toBe(noPlan);
+  });
+});

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1094,7 +1094,9 @@ export class PanelAgent {
         // entries remain, this render is a STEP, not an ending. Positive
         // evidence only — no checklist, or one that is finished, keeps the
         // acknowledge-and-stop wording, so nothing changes for a single render.
-        runCompletionDirective(this.tabId);
+        // #2369 — replayed completions carry no plan context, so they always get
+        // the acknowledge-and-stop wording to avoid an unbounded reply loop.
+        runCompletionDirective(this.tabId, { replayed: ev.replayed });
       // Attach the outputs inline so the agent SEES the render without a fetch —
       // up to the bound above. Past it (or for an UNDETERMINED origin) the text
       // says so and points at get_image, so a fetch is needed but never a guess.

--- a/src/orchestrator/todo-state.ts
+++ b/src/orchestrator/todo-state.ts
@@ -97,8 +97,21 @@ export function __resetTodoState(): void {
  * reads as "stop now", and an agent three renders into a sweep it announced will
  * obey the most recent, most specific instruction over the system prompt telling
  * it to keep going.
+ *
+ * #2369 — a replayed (re-delivered after journal replay) completion has no plan
+ * context to continue. A completion-only replay that includes "CONTINUE your plan"
+ * turns a single late handoff into an unbounded loop: each replay becomes a new
+ * user turn, the agent replies, and the next replay cycles it again. Replayed
+ * completions always get the acknowledge-and-stop wording, even if a plan remains
+ * in flight.
  */
-export function runCompletionDirective(tabId: string | undefined): string {
+export function runCompletionDirective(tabId: string | undefined, opts?: { replayed?: boolean }): string {
+  // Replayed completions carry no plan context — they are ancient messages
+  // re-delivered from the journal after an MCP reconnect. Instruct the agent to
+  // acknowledge and stop, not continue, even if a plan remains.
+  if (opts?.replayed) {
+    return `Reply with ONE short sentence acknowledging the result and suggesting a sensible next step — you do NOT need to call any tools. Don't repeat an earlier comment.`;
+  }
   return planInFlight(tabId)
     ? `Acknowledge the result in ONE short sentence, then CONTINUE your plan — you have unfinished items on your todo list, so do NOT stop here or wait for the user. Carry straight on with the next step (queue it now if that is what the plan says). Don't repeat an earlier comment.`
     : `Reply with ONE short sentence acknowledging the result and suggesting a sensible next step — you do NOT need to call any tools. Don't repeat an earlier comment.`;


### PR DESCRIPTION
## Summary

Fixes the unbounded reply loop when a panel_run completion is re-delivered from the journal after an MCP reconnect.

A replayed (re-delivered) completion has no plan context to continue — it is an ancient message journaled after the orchestrator restarts its MCP connection. When such a completion included "CONTINUE your plan", it turned a single late handoff into a loop: each replay became a new user turn, the agent replied, and the next replay cycled it again.

The fix: replayed completions always get the acknowledge-and-stop wording, even if a plan remains in flight for the tab. This breaks the loop without requiring new dedup machinery.

## Changes

- `src/orchestrator/todo-state.ts`: Updated `runCompletionDirective()` to accept an optional `{ replayed?: boolean }` parameter. When replayed=true, returns acknowledge-and-stop wording regardless of plan state.
- `src/orchestrator/panel-agent.ts`: Updated the call to `runCompletionDirective()` to pass `{ replayed: ev.replayed }` (line 1097).
- Tests added to verify:
  - Unit tests in `todo-state.test.ts`: 4 new tests covering replayed behavior
  - Production wiring tests in `inject-event-wiring.test.ts`: 2 new tests using live PanelAgent to verify the exact text delivered

## Testing

All 26 tests pass (20 existing + 6 new in modified test files).

Production caller verified: `run-completion-journal.ts` line 1201 sets `replayed: true` when `entry.attempts > 0`, exactly what the tests drive.

Gate verdict: **SHIP** ✓

## Related issues
- Closes #2369
- Related to comfyui-mcp-panel#1851 (same symptom, durable solution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp