### PR TITLE
fix(panel#1869): a promoted write blocked by canvas/root divergence relays the panel's own diagnosis

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1047,6 +1047,89 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     ]);
   });
 
+  // panel#1869 — the panel's own `[canvas-root-divergence]` diagnosis, which the
+  // promoted-container wording used to swallow. These are the two remedy variants
+  // `getGraphCtx()` actually emits, copied from the panel's refuseDivergence().
+  const DIVERGENCE_ROOT_VARIANT =
+    "[canvas-root-divergence] The canvas you are looking at (31 node(s)) and the panel's bound " +
+    "root graph (0 node(s)) are two DIFFERENT graphs, so this command was NOT applied — the panel " +
+    "cannot tell which one it was meant for, and picking either could edit a graph you are not " +
+    "looking at. This usually follows a ComfyUI backend restart without a page reload. Save or " +
+    "export the canvas you want to keep, then reload the ComfyUI page (a panel-only reload does " +
+    "not rebuild this binding).";
+  const DIVERGENCE_SUBGRAPH_VARIANT =
+    "[canvas-root-divergence] The canvas you are looking at (4 node(s)) and the panel's bound " +
+    "root graph (12 node(s)) are two DIFFERENT graphs, so this command was NOT applied. Leave the " +
+    "open subgraph on the ComfyUI canvas (its breadcrumb, or double-click out) to get back to a " +
+    "graph the panel can identify; if that does not clear it, save or export anything you need " +
+    "from this view and reload the ComfyUI page.";
+
+  it("relays the panel's divergence diagnosis instead of the promoted-container wording", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: new Error(DIVERGENCE_ROOT_VARIANT),
+      },
+    );
+
+    // Still fail-closed: the guard is untouched and nothing was written.
+    expect(isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_get_subgraph"]);
+    expect(calls.map((c) => c.cmd)).not.toContain("graph_set_widget");
+    expect(mutations).toBe(0);
+
+    // The panel's cause AND its remedy survive to the caller.
+    expect(text).toContain("[canvas-root-divergence]");
+    expect(text).toContain("are two DIFFERENT graphs");
+    expect(text).toContain("reload the ComfyUI page (a panel-only reload does not rebuild this binding)");
+
+    // The two things panel#1869 was actually about: the wrong cause, and the
+    // remedy the reporter followed into a loop with no exit.
+    expect(text).not.toContain("could not determine whether the addressed node is a promoted container");
+    expect(text).not.toContain("retry only after the panel binding and subgraph mapping are stable");
+    expect(text).not.toMatch(/Retry only after the panel binding and subgraph mapping are stable/i);
+
+    // And it rules out what the reporter tried next.
+    expect(text).toContain("panel_open_workflow");
+  });
+
+  it("relays the SUBGRAPH-stranded remedy too, rather than a hardcoded one", async () => {
+    const { text, isError, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: new Error(DIVERGENCE_SUBGRAPH_VARIANT),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(mutations).toBe(0);
+    // The root-restart remedy must NOT appear for a subgraph-stranded canvas:
+    // that is the failure mode of naming a remedy here instead of relaying one.
+    expect(text).toContain("Leave the open subgraph on the ComfyUI canvas");
+    expect(text).not.toContain("This usually follows a ComfyUI backend restart");
+  });
+
+  it("leaves every NON-diagnosed indeterminate read on its original wording", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        subgraph: new Error("graph_get_subgraph unavailable"),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(mutations).toBe(0);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_get_subgraph"]);
+    // Unchanged from before panel#1869: a transport failure IS transient, so
+    // "retry once stable" is honest advice there and must survive.
+    expect(text).toContain("could not determine whether the addressed node is a promoted container");
+    expect(text).toContain("Retry only after the panel binding and subgraph mapping are stable");
+    expect(text).not.toContain("[canvas-root-divergence]");
+  });
+
   it("keeps a definitive non-promoted write valid", async () => {
     const { isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6357,6 +6357,58 @@ function isDefinitiveNonPromotedSubgraphRead(res: ToolResult): boolean {
   );
 }
 
+/**
+ * panel#1869 — the panel's `[canvas-root-divergence]` refusal is a DIAGNOSIS,
+ * and must not be replaced by the promoted-container wording.
+ *
+ * The panel's `graph_get_subgraph` opens with `getGraphCtx()`, so a diverged
+ * canvas throws there BEFORE the command can reach its own
+ * `Node <id> (<type>) is not a subgraph` line. That leaves the read genuinely
+ * indeterminate — {@link isDefinitiveNonPromotedSubgraphRead} is right to
+ * reject it, and is deliberately untouched — but indeterminate is not the same
+ * as unknown. The panel had already named the cause AND the only remedy that
+ * clears it, and we discarded both to say "retry only after the panel binding
+ * and subgraph mapping are stable". The reporter did exactly that: retried, and
+ * re-bound the tab with panel_open_workflow, and got the identical refusal every
+ * time, on three separate nodes. There was no exit from that loop.
+ */
+const CANVAS_ROOT_DIVERGENCE_MARKER = "[canvas-root-divergence]";
+
+/**
+ * The refusal for a failed `graph_get_subgraph` in the promoted-write path.
+ *
+ * Both branches are the same fail-closed refusal; the ONLY thing that varies is
+ * what the caller is told, so no reachable input to this function can authorize
+ * a write. `fallbackReason` is each call site's existing wording, kept verbatim
+ * for every error the panel did not diagnose.
+ *
+ * Keyed on the bracketed marker rather than the prose around it: the divergence
+ * message has two different remedy variants (a canvas stranded inside a subgraph
+ * the rebuilt root no longer owns, vs. two different root graphs) and is
+ * otherwise free to be reworded. Relaying the panel's text verbatim is what
+ * keeps BOTH variants correct here without this file knowing which is which.
+ */
+function promotedSubgraphReadRefusal(
+  widget: string,
+  res: ToolResult,
+  fallbackReason: string,
+): ToolResult {
+  const panelText = textOfToolResult(res);
+  if (!panelText.includes(CANVAS_ROOT_DIVERGENCE_MARKER)) {
+    return promotedWriteRefusal(widget, fallbackReason);
+  }
+  return fail(
+    `panel_set_widget refused the promoted "${widget}" write because the panel could not read ` +
+      `the addressed node at all: the canvas and the panel's bound root graph have DIVERGED. ` +
+      `No graph_set_widget was dispatched.\n` +
+      `This is not a transient binding state, and it is not about this node, this widget, or ` +
+      `promotion — every node in this tab reads the same way until the divergence is cleared. ` +
+      `Retrying, panel_open_workflow, and panel_set_workflow_target all re-bind the tab to the ` +
+      `same two diverged graphs, so on their own none of them clear it.\n` +
+      `The panel diagnosed it and named the remedy:\n${panelText}`,
+  );
+}
+
 function promotedMatchCount(payload: Record<string, unknown>, widget: string): number {
   const nodes = payload.nodes;
   if (!Array.isArray(nodes)) return 0;
@@ -6635,8 +6687,9 @@ async function preparePromotedWidgetWrite(
   const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
   if (sub.isError) {
     if (isDefinitiveNonPromotedSubgraphRead(sub)) return null;
-    return promotedWriteRefusal(
+    return promotedSubgraphReadRefusal(
       widget,
+      sub,
       "graph_get_subgraph could not determine whether the addressed node is a promoted container",
     );
   }
@@ -6833,8 +6886,9 @@ async function recheckPromotedOuterMapping(
     node_id: outerNodeId,
   });
   if (confirmation.isError) {
-    return promotedWriteRefusal(
+    return promotedSubgraphReadRefusal(
       widget,
+      confirmation,
       "the promoted mapping read was unavailable before the write",
     );
   }
@@ -6950,8 +7004,9 @@ async function recheckPromotedInnerTarget(
       node_id: expectedInner.innerNodeId,
     });
     if (nested.isError) {
-      return promotedWriteRefusal(
+      return promotedSubgraphReadRefusal(
         widget,
+        nested,
         "the nested promoted terminal could not be resolved in the entered graph",
       );
     }


### PR DESCRIPTION
## What the reporter saw

`panel_set_widget` refused promoted writes on **three separate nodes** in one workflow with:

> `panel_set_widget refused the promoted "text" write because graph_get_subgraph could not determine whether the addressed node is a promoted container. No graph_set_widget was dispatched; retry only after the panel binding and subgraph mapping are stable.`

They followed that advice — retried, and re-bound the tab with `panel_open_workflow` — and got the identical refusal every time. The loop had no exit, and the reporter ended up hand-configuring the nodes in the ComfyUI UI.

## Why

The panel's `graph_get_subgraph` (`web/js/comfyui-mcp-panel.js`) opens with `getGraphCtx()`. On a diverged canvas that throws `[canvas-root-divergence]` **before** the command can reach its own `Node <id> (<type>) is not a subgraph` line. `isDefinitiveNonPromotedSubgraphRead()` is anchored on that one sentence, so a divergence error is — correctly — not a definitive non-promoted read, and we fall through to the generic refusal.

The panel's error was never an unknown. It states the cause (the canvas and the bound root graph are two different graphs) and carries the **only** remedy that clears it:

> *"This usually follows a ComfyUI backend restart without a page reload. Save or export the canvas you want to keep, then reload the ComfyUI page (a panel-only reload does not rebuild this binding)."*

We discarded a diagnosis and substituted a guess. It also explains the reporter's differential exactly: `panel_new_workflow` + `panel_rename_workflow` (or a cross-workflow paste) can leave the canvas and the panel's bound root as two different graphs; a workflow opened normally from disk does not.

## The change

A `promotedSubgraphReadRefusal(widget, res, fallbackReason)` helper. **Both branches are the same fail-closed refusal** — the only thing that varies is what the caller is told, so no input to it can authorize a write. Applied at all three `graph_get_subgraph` reads in the promoted-write path (preflight, pre-write mapping confirmation, nested terminal); each keeps its existing wording as the fallback for errors the panel did not diagnose.

**`isDefinitiveNonPromotedSubgraphRead()` is not touched.** Widening what counts as "definitely not promoted" would let a genuine indeterminate read through and dispatch a write to a node whose promoted status was never established — strictly worse than this refusal.

## Where to look hardest

- **`promotedSubgraphReadRefusal` is a message-only fork.** The load-bearing claim is that it cannot change control flow. Both arms return a `ToolResult` with `isError`, neither returns `null`, and only `null` means "not promoted, proceed". Worth checking that reading holds.
- **Keyed on the `[canvas-root-divergence]` marker via `String.includes`, not on prose.** Deliberate: the divergence message has two remedy variants (canvas stranded inside a subgraph vs. two different roots), and relaying the panel's text verbatim is what keeps both correct without this file knowing which is which. The tradeoff is that `includes` is unanchored — a panel error that merely *quoted* the marker would route here. That only changes wording, never the refusal.
- **Relaying panel text verbatim** into an agent-facing message. This matches the existing convention at `panel-tools.ts:17905` (`graph_get_subgraph FAILED: ${textOfToolResult(sub)}`), and it is untruncated there too, but it is worth a second opinion.
- **Sites 2 and 3** (mapping confirmation, nested terminal) are covered by construction — same helper — but only site 1, the one the reporter hit, has a behavioural test. Stated rather than implied.

## Evidence

Three tests added to `promoted-widget.test.ts`, all driving the real `panel_set_widget` handler through `makePanelToolCtx` — not the helper in isolation.

**Verified by mutation, twice.** Not just "the suite is green":

1. Revert site 1 to `promotedWriteRefusal(widget, "...")` → **2 failed**, and the text the failure prints is verbatim the refusal from the issue report:
   `... could not determine whether the addressed node is a promoted container. No graph_set_widget was dispatched; Retry only after the panel binding and subgraph mapping are stable.`
   The control test (non-diagnosed error keeps its original wording) stays green.

2. Emulate the *near-miss* fix — pass the divergence text through as `promotedWriteRefusal`'s `reason` argument → **1 failed**, on `not.toMatch(/Retry only after the panel binding and subgraph mapping are stable/i)`. That surfaces the true cause but leaves the unactionable remedy as the **last** sentence, which is the position that shapes what the caller does next. This assertion is what pins the difference.

Full suite: **12660 passed, 1 unrelated failure** (`late-mutation-e2e.test.ts` "DID complete") which is a known wall-clock flake under full-suite load — **passes in isolation** (5/5) in this same worktree. `tsc --noEmit` clean.

**No browser gate.** This is orchestrator-only; the panel pack is untouched and the change alters a refusal string returned to the agent, nothing the sidebar renders. Playwright coverage would be theatre here, so I did not claim it.

## Note on a stale local branch

An earlier dispatch of this issue left `fix/1869-surface-divergence-cc` as two **unpushed** local commits with no PR. Its second commit replaced its own end-to-end tests with assertions like `expect("[canvas-root-divergence] ...".includes("[canvas-root-divergence]")).toBe(true)` — string literals compared against themselves, which pass with the fix reverted. This PR is authored fresh off `origin/main`; that branch should be deleted, not merged.

Fixes artokun/comfyui-mcp-panel#1869
