### PR TITLE
chore(release): 0.52.131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.131] - 2026-08-26
+
+### MCP
+
+#### Fixed
+- a promoted write blocked by canvas/root divergence relays the panel's own diagnosis (#2374)
+- an empty local output listing states the temp/ blind spot it has (#2372)
+- condition CONTINUE instruction for replayed completions (#2371)
+- guard promoted widget capability and name the version requirement (#2365)
+
+
 ## [0.52.130] - 2026-08-26
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.130",
+  "version": "0.52.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.130",
+      "version": "0.52.131",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.130",
+  "version": "0.52.131",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Re-cut of **0.52.131** from current `main`. Supersedes #2367, which was cut before three of these fixes existed and is now closed.

### Contents — four merged fixes, all user-facing

| PR | what it fixes |
|---|---|
| **#2374** (panel#1869) | a promoted write blocked by canvas/root divergence relays the panel's own diagnosis instead of replacing it with the promoted-container wording |
| **#2372** (#2370) | an empty local output listing states the `temp/` blind spot it has, instead of reporting nothing for a video that exists |
| **#2371** (#2369) | a replayed completion no longer carries "CONTINUE your plan", so a late handoff cannot cascade into an unbounded reply loop |
| **#2365** (panel#1859) | a promoted-write refusal names the panel version requirement instead of advising a retry that cannot succeed |

`git log v0.52.130..origin/main` is exactly those four.

### A known-wrong value, shipping deliberately — and why

The floor #2365 quotes reads **0.15.97**, and **the panel never released that version.** Its tags go 0.15.96 → 0.15.98, and the capability first appears in **0.15.101**. That is my defect: #2365 promoted an already-wrong internal constant into a user-facing string.

**#2366** corrects the floors. It is open, gated SHIP, and stalled — its CI never scheduled during the GitHub Actions outage, and its only green run belongs to an earlier commit (`3d2b1c5`, not the head `51769b7`). It has not moved in about four and a half hours.

I held this release behind it earlier today. I now think that was wrong, for one reason I under-weighted: **the action the message prescribes is correct even though the number is not.** It says *"update your panel, then retry"*, and a user who updates to current (0.15.103) lands above the real floor and succeeds. Compare what 0.52.130 tells them today — *"retry only after the panel binding and subgraph mapping are stable"* — which can never work for a version shortfall.

So the residual defect is a wrong number in a message whose remedy works. Holding four fixes behind that — including one for chat flooding a user called "nauseating", and one that stops a video's completion being reported as absent — is the worse trade. #2366 ships the corrected floors in the next cut.

### Verification

Every commit here was gated and CI-green before merge. Two were reworked after a gate refusal rather than merged over it:

- **#2371** — I verified after merge that its call site is the final operand of a multi-line concatenation, not a discarded statement; a NO-SHIP claiming otherwise was a false positive, confirmed by reading `panel-agent.ts` around the `text =` assignment.
- **#2365** — took two gate rounds; the first correctly caught that the dispatch guarantee had gone missing from one branch.

Bumped with `npm version patch --no-git-tag-version`. Three files, no strays.
