### PR TITLE
fix: authorize current panel template origin

### DIFF
--- a/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
+++ b/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
@@ -16,8 +16,9 @@ describe("panel image relay orchestrator wiring (#2149)", () => {
 
   it("wires the list_templates relay into both child spawn lanes and shutdown", () => {
     expect(SOURCE).toContain("startPanelTemplateRelayServer");
-    expect(SOURCE).toContain("currentPanelTemplateOrigin(bridge.tabServerOrigin(tabId), getComfyUIBaseUrl())");
-    expect(SOURCE).toContain("resolveAllowedPanelOrigin");
+    expect(SOURCE).toContain("createPanelTemplateRelayWiring({");
+    expect(SOURCE).toContain("currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), options.currentTarget())");
+    expect(SOURCE).toContain("...panelTemplateRelayWiring");
     expect(SOURCE).toContain("COMFYUI_MCP_TEMPLATE_RELAY_URL: panelTemplateRelayEndpoint");
     expect(SOURCE).toContain("if (panelTemplateRelayServer) await panelTemplateRelayServer.close()");
   });

--- a/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
+++ b/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
@@ -16,6 +16,8 @@ describe("panel image relay orchestrator wiring (#2149)", () => {
 
   it("wires the list_templates relay into both child spawn lanes and shutdown", () => {
     expect(SOURCE).toContain("startPanelTemplateRelayServer");
+    expect(SOURCE).toContain("currentPanelTemplateOrigin(bridge.tabServerOrigin(tabId), getComfyUIBaseUrl())");
+    expect(SOURCE).toContain("resolveAllowedPanelOrigin");
     expect(SOURCE).toContain("COMFYUI_MCP_TEMPLATE_RELAY_URL: panelTemplateRelayEndpoint");
     expect(SOURCE).toContain("if (panelTemplateRelayServer) await panelTemplateRelayServer.close()");
   });

--- a/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
+++ b/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
@@ -17,7 +17,7 @@ describe("panel image relay orchestrator wiring (#2149)", () => {
   it("wires the list_templates relay into both child spawn lanes and shutdown", () => {
     expect(SOURCE).toContain("startPanelTemplateRelayServer");
     expect(SOURCE).toContain("createPanelTemplateRelayWiring({");
-    expect(SOURCE).toContain("currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), options.currentTarget())");
+    expect(SOURCE).toContain("currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), currentTarget)");
     expect(SOURCE).toContain("...panelTemplateRelayWiring");
     expect(SOURCE).toContain("COMFYUI_MCP_TEMPLATE_RELAY_URL: panelTemplateRelayEndpoint");
     expect(SOURCE).toContain("if (panelTemplateRelayServer) await panelTemplateRelayServer.close()");

--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -29,6 +29,7 @@ afterEach(async () => {
 describe("orchestrator panel template relay wiring (#2196)", () => {
   it("uses the production auth, scope-tab, URL, and current-target closures end to end", async () => {
     let target = "";
+    let generation = 0;
     let observedOrigin = "";
     let panelRequests = 0;
     const panel = createServer((_req, res) => {
@@ -56,6 +57,7 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     const wiring = createPanelTemplateRelayWiring({
       bridge,
       currentTarget: () => target,
+      currentTargetGeneration: () => generation,
       secrets: new Map([[SECRET, "orchestrator::codex"]]),
     });
     const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
@@ -69,7 +71,7 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     expect(panelRequests).toBe(1);
     const resolvedTab = wiring.resolvePanelTab("orchestrator::codex");
     expect(resolvedTab).toBe("tab-1");
-    expect(wiring.resolvePanelUrl(resolvedTab!)).toBe(
+    expect(wiring.resolvePanelUrl(resolvedTab!, target)).toBe(
       `${panelOrigin}/comfyapi/api/workflow_templates`,
     );
 
@@ -78,5 +80,80 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     target = "http://127.0.0.1:1/other";
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
     expect(panelRequests).toBe(1);
+  });
+
+  it("rejects a stale in-flight response after retargeting and still serves the current target", async () => {
+    let target = "";
+    let generation = 0;
+    let observedOrigin = "";
+    let panelRequests = 0;
+    let firstRequest = true;
+    let markPanelRequestStarted!: () => void;
+    const panelRequestStarted = new Promise<void>((resolve) => {
+      markPanelRequestStarted = resolve;
+    });
+    let releaseFirstResponse!: () => void;
+    const firstResponseReleased = new Promise<void>((resolve) => {
+      releaseFirstResponse = resolve;
+    });
+    const panel = createServer((_req, res) => {
+      panelRequests += 1;
+      if (firstRequest) {
+        firstRequest = false;
+        markPanelRequestStarted();
+        void firstResponseReleased.then(() => {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ "old-panel-pack": [{ name: "stale-template" }] }));
+        });
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ "current-panel-pack": [{ name: "current-template" }] }));
+    });
+    const panelOrigin = await listen(panel);
+    servers.push({ close: () => closeServer(panel) });
+    target = `${panelOrigin}/comfyapi`;
+    observedOrigin = panelOrigin;
+
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: (scopeId: string) => {
+        expect(scopeId).toBe("orchestrator::codex");
+        return "tab-1";
+      },
+      tabServerOrigin: (tabId: string) => {
+        expect(tabId).toBe("tab-1");
+        return observedOrigin;
+      },
+    };
+    const wiring = createPanelTemplateRelayWiring({
+      bridge,
+      currentTarget: () => target,
+      currentTargetGeneration: () => generation,
+      secrets: new Map([[SECRET, "orchestrator::codex"]]),
+    });
+    const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    const staleRequest = requestPanelTemplateIndex();
+    await panelRequestStarted;
+    target = "http://127.0.0.1:1/other";
+    generation += 1;
+    target = `${panelOrigin}/comfyapi`;
+    generation += 1;
+    releaseFirstResponse();
+
+    // The target has returned to A, but the generation proves that the response
+    // belongs to the earlier A and must not be served as current data.
+    await expect(staleRequest).rejects.toMatchObject({ code: "STALE_TARGET" });
+    expect(panelRequests).toBe(1);
+
+    await expect(requestPanelTemplateIndex()).resolves.toEqual({
+      "current-panel-pack": [{ name: "current-template" }],
+    });
+    expect(panelRequests).toBe(2);
   });
 });

--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -101,6 +101,20 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
     expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
 
+    observedOrigin = "http://[::1]:8188";
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+    observedOrigin = "http://localhost:8188";
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+
+    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188", "http://localhost:8188"]) {
+      target = `${origin}/comfyapi`;
+      observedOrigin = origin;
+      expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(origin);
+      expect(wiring.resolvePanelUrl("tab-1", target)).toBe(`${origin}/comfyapi/api/workflow_templates`);
+    }
+
     target = "https://remote.example/comfyapi";
     observedOrigin = "https://remote.example";
     expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();

--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { createPanelTemplateRelayWiring } from "../../orchestrator/index.js";
+import { requestPanelTemplateIndex, startPanelTemplateRelayServer } from "../../services/panel-template-relay.js";
+
+const SECRET = "c".repeat(64);
+const servers: Array<{ close(): Promise<void> }> = [];
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+afterEach(async () => {
+  delete process.env.COMFYUI_MCP_RELAY_SECRET;
+  delete process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL;
+  for (const server of servers.splice(0)) await server.close();
+});
+
+describe("orchestrator panel template relay wiring (#2196)", () => {
+  it("uses the production auth, scope-tab, URL, and current-target closures end to end", async () => {
+    let target = "";
+    let observedOrigin = "";
+    let panelRequests = 0;
+    const panel = createServer((_req, res) => {
+      panelRequests += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ "panel-pack": [{ name: "live-template" }] }));
+    });
+    const panelOrigin = await listen(panel);
+    servers.push({ close: () => closeServer(panel) });
+    target = `${panelOrigin}/comfyapi`;
+    observedOrigin = panelOrigin;
+
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: (scopeId: string) => {
+        expect(scopeId).toBe("orchestrator::codex");
+        return "tab-1";
+      },
+      tabServerOrigin: (tabId: string) => {
+        expect(tabId).toBe("tab-1");
+        return observedOrigin;
+      },
+    };
+    const wiring = createPanelTemplateRelayWiring({
+      bridge,
+      currentTarget: () => target,
+      secrets: new Map([[SECRET, "orchestrator::codex"]]),
+    });
+    const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).resolves.toEqual({
+      "panel-pack": [{ name: "live-template" }],
+    });
+    expect(panelRequests).toBe(1);
+    const resolvedTab = wiring.resolvePanelTab("orchestrator::codex");
+    expect(resolvedTab).toBe("tab-1");
+    expect(wiring.resolvePanelUrl(resolvedTab!)).toBe(
+      `${panelOrigin}/comfyapi/api/workflow_templates`,
+    );
+
+    // A later target event invalidates the stale observed-origin pairing before
+    // another child request can fetch from the old panel target.
+    target = "http://127.0.0.1:1/other";
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
+    expect(panelRequests).toBe(1);
+  });
+});

--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -82,6 +82,37 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     expect(panelRequests).toBe(1);
   });
 
+  it("rejects forged and non-loopback origins through the production wiring", async () => {
+    let target = "http://127.0.0.1:8188/comfyapi";
+    let observedOrigin = "https://forged.example";
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: () => "tab-1",
+      tabServerOrigin: () => observedOrigin,
+    };
+    const wiring = createPanelTemplateRelayWiring({
+      bridge,
+      currentTarget: () => target,
+      currentTargetGeneration: () => 0,
+      secrets: new Map([[SECRET, "orchestrator::codex"]]),
+    });
+
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+
+    target = "https://remote.example/comfyapi";
+    observedOrigin = "https://remote.example";
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+
+    const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
+  });
+
   it("rejects a stale in-flight response after retargeting and still serves the current target", async () => {
     let target = "";
     let generation = 0;

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -46,6 +46,7 @@ describe("authenticated panel template relay (#2196)", () => {
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: panelOrigin, generation: 0 }),
       resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
       resolveAllowedPanelOrigin: () => panelOrigin,
     });
@@ -74,6 +75,7 @@ describe("authenticated panel template relay (#2196)", () => {
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: "https://remote.example/comfyapi", generation: 0 }),
       resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
       resolveAllowedPanelOrigin: () => currentPanelTemplateOrigin(panelOrigin, "https://remote.example/comfyapi"),
     });
@@ -101,6 +103,7 @@ describe("authenticated panel template relay (#2196)", () => {
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: "https://current.example/comfyapi", generation: 0 }),
       resolvePanelUrl: () => "https://evil.example/api/workflow_templates",
       resolveAllowedPanelOrigin: () => currentPanelTemplateOrigin("https://evil.example", "https://current.example/comfyapi"),
     });
@@ -119,6 +122,7 @@ describe("authenticated panel template relay (#2196)", () => {
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: "https://current.example/comfyapi", generation: 0 }),
       resolvePanelUrl: () => undefined,
       resolveAllowedPanelOrigin: () => undefined,
     });
@@ -136,6 +140,7 @@ describe("authenticated panel template relay (#2196)", () => {
       bridge: { canReach: () => false },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: "https://panel.example/comfyapi", generation: 0 }),
       resolvePanelUrl: () => {
         throw new Error("a disconnected panel has no URL to resolve");
       },
@@ -164,6 +169,7 @@ describe("authenticated panel template relay (#2196)", () => {
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: panelOrigin, generation: 0 }),
       resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
       resolveAllowedPanelOrigin: () => panelOrigin,
     });
@@ -191,6 +197,7 @@ describe("authenticated panel template relay (#2196)", () => {
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: "https://panel.example/comfyapi", generation: 0 }),
       resolvePanelUrl: () => "https://panel.example/api/workflow_templates",
       resolveAllowedPanelOrigin: () => currentPanelTemplateOrigin("https://panel.example", "https://panel.example/comfyapi"),
     });

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createServer, type Server } from "node:http";
 import {
   PanelTemplateRelayError,
+  currentPanelTemplateOrigin,
   requestPanelTemplateIndex,
   startPanelTemplateRelayServer,
 } from "../../services/panel-template-relay.js";
@@ -26,6 +27,7 @@ function closeServer(server: Server): Promise<void> {
 afterEach(async () => {
   delete process.env.COMFYUI_MCP_RELAY_SECRET;
   delete process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL;
+  vi.restoreAllMocks();
   for (const server of servers.splice(0)) await server.close();
 });
 
@@ -45,6 +47,7 @@ describe("authenticated panel template relay (#2196)", () => {
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
       resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
+      resolveAllowedPanelOrigin: () => panelOrigin,
     });
     servers.push(relay);
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
@@ -56,12 +59,68 @@ describe("authenticated panel template relay (#2196)", () => {
     expect(authorization).toBe("");
   });
 
+  it("uses a non-loopback panel origin when it exactly matches the current target", async () => {
+    const realFetch = globalThis.fetch;
+    const panelOrigin = "https://remote.example";
+    const remoteCalls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.startsWith("http://127.0.0.1:")) return realFetch(input, init);
+      remoteCalls.push(url);
+      return Promise.resolve(new Response(JSON.stringify({ "remote-pack": [{ name: "remote-template" }] }), { status: 200 }));
+    });
+
+    const relay = await startPanelTemplateRelayServer({
+      bridge: { canReach: () => true },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
+      resolveAllowedPanelOrigin: () => currentPanelTemplateOrigin(panelOrigin, "https://remote.example/comfyapi"),
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).resolves.toEqual({
+      "remote-pack": [{ name: "remote-template" }],
+    });
+    expect(remoteCalls).toEqual([`${panelOrigin}/api/workflow_templates`]);
+  });
+
+  it("fails closed when the panel origin does not match the current target", async () => {
+    const realFetch = globalThis.fetch;
+    const remoteCalls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.startsWith("http://127.0.0.1:")) return realFetch(input, init);
+      remoteCalls.push(url);
+      return Promise.reject(new Error("the rejected origin must not be contacted"));
+    });
+
+    const relay = await startPanelTemplateRelayServer({
+      bridge: { canReach: () => true },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolvePanelUrl: () => "https://evil.example/api/workflow_templates",
+      resolveAllowedPanelOrigin: () => currentPanelTemplateOrigin("https://evil.example", "https://current.example/comfyapi"),
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject<PanelTemplateRelayError>({
+      code: "NO_PANEL_ORIGIN",
+    });
+    expect(remoteCalls).toEqual([]);
+  });
+
   it("refuses a non-loopback panel origin without contacting it", async () => {
     const relay = await startPanelTemplateRelayServer({
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
       resolvePanelUrl: () => "https://remote.example/api/workflow_templates",
+      resolveAllowedPanelOrigin: () => undefined,
     });
     servers.push(relay);
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
@@ -85,6 +144,7 @@ describe("authenticated panel template relay (#2196)", () => {
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
       resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
+      resolveAllowedPanelOrigin: () => panelOrigin,
     });
     servers.push(relay);
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
@@ -97,5 +157,14 @@ describe("authenticated panel template relay (#2196)", () => {
 
   it("is disabled when the child has no authenticated relay environment", async () => {
     await expect(requestPanelTemplateIndex()).resolves.toBeUndefined();
+  });
+
+  it("only authorizes an origin corroborated by the current target", () => {
+    expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBe("https://remote.example");
+    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://localhost:8188");
+    expect(currentPanelTemplateOrigin("http://localhost:8189", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
+    expect(currentPanelTemplateOrigin("https://remote.example", "https://other.example/comfyapi")).toBeUndefined();
+    expect(currentPanelTemplateOrigin(undefined, "https://remote.example/comfyapi")).toBeUndefined();
+    expect(currentPanelTemplateOrigin("https://user:secret@remote.example", "https://remote.example/comfyapi")).toBeUndefined();
   });
 });

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -60,7 +60,7 @@ describe("authenticated panel template relay (#2196)", () => {
     expect(authorization).toBe("");
   });
 
-  it("uses a non-loopback panel origin when it exactly matches the current target", async () => {
+  it("refuses a non-loopback panel origin even when it exactly matches the current target", async () => {
     const realFetch = globalThis.fetch;
     const panelOrigin = "https://remote.example";
     const remoteCalls: string[] = [];
@@ -83,10 +83,10 @@ describe("authenticated panel template relay (#2196)", () => {
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
 
-    await expect(requestPanelTemplateIndex()).resolves.toEqual({
-      "remote-pack": [{ name: "remote-template" }],
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject<PanelTemplateRelayError>({
+      code: "NO_PANEL_ORIGIN",
     });
-    expect(remoteCalls).toEqual([`${panelOrigin}/api/workflow_templates`]);
+    expect(remoteCalls).toEqual([]);
   });
 
   it("fails closed when the panel origin does not match the current target", async () => {
@@ -184,8 +184,9 @@ describe("authenticated panel template relay (#2196)", () => {
 
   it("rejects a successful response whose response.url is a different origin", async () => {
     const realFetch = globalThis.fetch;
+    let relayEndpoint = "";
     vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
-      if (String(input).startsWith("http://127.0.0.1:")) return realFetch(input, init);
+      if (String(input) === relayEndpoint) return realFetch(input, init);
       const response = new Response(JSON.stringify({ "panel-pack": [{ name: "unexpected" }] }), { status: 200 });
       Object.defineProperty(response, "url", {
         value: "https://redirected.example/api/workflow_templates",
@@ -197,11 +198,12 @@ describe("authenticated panel template relay (#2196)", () => {
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
-      resolveCurrentTarget: () => ({ url: "https://panel.example/comfyapi", generation: 0 }),
-      resolvePanelUrl: () => "https://panel.example/api/workflow_templates",
-      resolveAllowedPanelOrigin: () => currentPanelTemplateOrigin("https://panel.example", "https://panel.example/comfyapi"),
+      resolveCurrentTarget: () => ({ url: "http://127.0.0.1:8188/comfyapi", generation: 0 }),
+      resolvePanelUrl: () => "http://127.0.0.1:8188/api/workflow_templates",
+      resolveAllowedPanelOrigin: () => currentPanelTemplateOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi"),
     });
     servers.push(relay);
+    relayEndpoint = relay.endpointUrl;
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
 
@@ -214,11 +216,13 @@ describe("authenticated panel template relay (#2196)", () => {
     await expect(requestPanelTemplateIndex()).resolves.toBeUndefined();
   });
 
-  it("only authorizes an origin corroborated by the current target", () => {
-    expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBe("https://remote.example");
+  it("only authorizes a loopback origin corroborated by the current target", () => {
+    expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://localhost:8188");
     expect(currentPanelTemplateOrigin("http://localhost:8189", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("https://remote.example", "https://other.example/comfyapi")).toBeUndefined();
+    expect(currentPanelTemplateOrigin("https://remote.example", "https://remote.example/comfyapi")).toBeUndefined();
+    expect(currentPanelTemplateOrigin("https://forged.example", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin(undefined, "https://remote.example/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("https://user:secret@remote.example", "https://remote.example/comfyapi")).toBeUndefined();
   });

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -114,12 +114,12 @@ describe("authenticated panel template relay (#2196)", () => {
     expect(remoteCalls).toEqual([]);
   });
 
-  it("refuses a non-loopback panel origin without contacting it", async () => {
+  it("refuses a missing panel origin without contacting it", async () => {
     const relay = await startPanelTemplateRelayServer({
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
-      resolvePanelUrl: () => "https://remote.example/api/workflow_templates",
+      resolvePanelUrl: () => undefined,
       resolveAllowedPanelOrigin: () => undefined,
     });
     servers.push(relay);

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -218,7 +218,12 @@ describe("authenticated panel template relay (#2196)", () => {
 
   it("only authorizes a loopback origin corroborated by the current target", () => {
     expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBeUndefined();
-    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://localhost:8188");
+    expect(currentPanelTemplateOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://127.0.0.1:8188");
+    expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://[::1]:8188/comfyapi")).toBe("http://[::1]:8188");
+    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBe("http://localhost:8188");
+    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
+    expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
+    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://[::1]:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8189", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("https://remote.example", "https://other.example/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("https://remote.example", "https://remote.example/comfyapi")).toBeUndefined();

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -131,6 +131,27 @@ describe("authenticated panel template relay (#2196)", () => {
     });
   });
 
+  it("refuses a disconnected panel before resolving or fetching an origin", async () => {
+    const relay = await startPanelTemplateRelayServer({
+      bridge: { canReach: () => false },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolvePanelUrl: () => {
+        throw new Error("a disconnected panel has no URL to resolve");
+      },
+      resolveAllowedPanelOrigin: () => {
+        throw new Error("a disconnected panel has no origin to authorize");
+      },
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject<PanelTemplateRelayError>({
+      code: "NO_LIVE_PANEL",
+    });
+  });
+
   it("refuses a redirect from the panel origin", async () => {
     const panel = createServer((_req, res) => {
       res.writeHead(302, { location: "http://127.0.0.1:1/collect" });
@@ -145,6 +166,33 @@ describe("authenticated panel template relay (#2196)", () => {
       resolvePanelTab: () => "tab-1",
       resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
       resolveAllowedPanelOrigin: () => panelOrigin,
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject<PanelTemplateRelayError>({
+      code: "PANEL_FETCH_FAILED",
+    });
+  });
+
+  it("rejects a successful response whose response.url is a different origin", async () => {
+    const realFetch = globalThis.fetch;
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      if (String(input).startsWith("http://127.0.0.1:")) return realFetch(input, init);
+      const response = new Response(JSON.stringify({ "panel-pack": [{ name: "unexpected" }] }), { status: 200 });
+      Object.defineProperty(response, "url", {
+        value: "https://redirected.example/api/workflow_templates",
+      });
+      return Promise.resolve(response);
+    });
+
+    const relay = await startPanelTemplateRelayServer({
+      bridge: { canReach: () => true },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolvePanelUrl: () => "https://panel.example/api/workflow_templates",
+      resolveAllowedPanelOrigin: () => currentPanelTemplateOrigin("https://panel.example", "https://panel.example/comfyapi"),
     });
     servers.push(relay);
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;

--- a/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
+++ b/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
@@ -89,6 +89,7 @@ describe("list_packs -> panel template relay production boundary (#2196)", () =>
       bridge: { canReach: () => true },
       resolvePanelAgent: () => ({ agentKey: "orchestrator::codex", secret: SECRET }),
       resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: state.baseUrl, generation: 0 }),
       resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
       resolveAllowedPanelOrigin: () => panelOrigin,
     });

--- a/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
+++ b/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+
+const state = vi.hoisted(() => ({
+  baseUrl: "http://127.0.0.1:8188",
+  headlessCalls: 0,
+}));
+
+vi.mock("../../config.js", () => ({
+  getComfyUIBaseUrl: () => state.baseUrl,
+  getComfyUIAuthHeaders: () => ({}),
+}));
+
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: async () => {
+    state.headlessCalls += 1;
+    throw new Error("the panel-backed path must not use COMFYUI_URL");
+  },
+}));
+
+vi.mock("../../services/api-nodes.js", () => ({
+  checkWorkflowRuntime: vi.fn(),
+  extractWorkflowClassTypes: vi.fn(),
+}));
+
+vi.mock("../../services/workflow-deps.js", () => ({
+  extractWorkflowDependencies: vi.fn(),
+  installWorkflowDependencies: vi.fn(),
+  defaultWorkflowDepsDeps: () => ({ deps: "test" }),
+}));
+
+vi.mock("../../services/skill-cache.js", () => ({
+  generateSkillCached: vi.fn(),
+}));
+
+vi.mock("../../services/manifest.js", () => ({
+  resolvePackManifestFile: vi.fn(),
+}));
+
+import { registerSkillsAccessTools } from "../../tools/skills-access.js";
+import { startPanelTemplateRelayServer } from "../../services/panel-template-relay.js";
+
+const SECRET = "b".repeat(64);
+const servers: Array<{ close(): Promise<void> }> = [];
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function listPacksHandler(): (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }> {
+  const tools: Array<{ handler: (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }> }> = [];
+  registerSkillsAccessTools({
+    tool: (_name: string, _description: string, _shape: unknown, handler: (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) => {
+      tools.push({ handler });
+    },
+  } as never);
+  if (tools.length !== 1) throw new Error(`expected one list_packs tool, got ${tools.length}`);
+  return tools[0].handler;
+}
+
+afterEach(async () => {
+  delete process.env.COMFYUI_MCP_RELAY_SECRET;
+  delete process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL;
+  state.headlessCalls = 0;
+  for (const server of servers.splice(0)) await server.close();
+  vi.restoreAllMocks();
+});
+
+describe("list_packs -> panel template relay production boundary (#2196)", () => {
+  it("drives action:list_templates through the real child request and relay before headless fetch", async () => {
+    const panel = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ "panel-pack": [{ name: "live-template" }] }));
+    });
+    const panelOrigin = await listen(panel);
+    servers.push({ close: () => closeServer(panel) });
+
+    const relay = await startPanelTemplateRelayServer({
+      bridge: { canReach: () => true },
+      resolvePanelAgent: () => ({ agentKey: "orchestrator::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
+      resolveAllowedPanelOrigin: () => panelOrigin,
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+    state.baseUrl = `${panelOrigin}/comfyapi`;
+
+    const result = await listPacksHandler()({ action: "list_templates" });
+    const rendered = JSON.parse(result.content.map((block) => block.text).join(" ")) as Record<string, unknown>;
+    expect(rendered).toMatchObject({
+      source_count: 1,
+      template_count: 1,
+      templates: { "panel-pack": [{ name: "live-template" }] },
+    });
+    expect(state.headlessCalls).toBe(0);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -120,6 +120,7 @@ import {
   type PanelTemplateRelayResolvedAgent,
   type PanelTemplateRelayServer,
   type PanelTemplateRelayRequest,
+  type PanelTemplateRelayTarget,
 } from "../services/panel-template-relay.js";
 import { logger } from "../utils/logger.js";
 import { listDownloadJobs } from "../services/download-jobs.js";
@@ -207,7 +208,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerAllTools } from "../tools/index.js";
 import { tryInstallRetiredNameRedirect } from "../tools/retired-redirect.js";
-import { config, isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget, onComfyuiTargetChanged, isTargetingLocal, isTargetingLocalOrLan, isTargetingPod, getComfyUIBaseUrl, getLocalComfyuiUrl, rescopeLocalTargetFile, getComfyUIAuthHeaders } from "../config.js";
+import { config, isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget, onComfyuiTargetChanged, isTargetingLocal, isTargetingLocalOrLan, isTargetingPod, getComfyUIBaseUrl, getComfyuiTargetGeneration, getLocalComfyuiUrl, rescopeLocalTargetFile, getComfyUIAuthHeaders } from "../config.js";
 import { normalizeInstallPathEnv } from "../utils/install-path-env.js";
 import {
   AGENT_IDENTITY_ENV,
@@ -950,8 +951,9 @@ export function armStartupDeadline(
 export interface PanelTemplateRelayWiring {
   resolvePanelAgent: (request: PanelTemplateRelayRequest) => PanelTemplateRelayResolvedAgent | undefined;
   resolvePanelTab: (agentKey: string) => string | undefined;
-  resolvePanelUrl: (tabId: string) => string | undefined;
-  resolveAllowedPanelOrigin: (tabId: string) => string | undefined;
+  resolveCurrentTarget: () => PanelTemplateRelayTarget;
+  resolvePanelUrl: (tabId: string, currentTarget: string) => string | undefined;
+  resolveAllowedPanelOrigin: (tabId: string, currentTarget: string) => string | undefined;
 }
 
 /**
@@ -962,6 +964,7 @@ export interface PanelTemplateRelayWiring {
 export function createPanelTemplateRelayWiring(options: {
   bridge: Pick<UiBridge, "resolveSharedTabId" | "tabServerOrigin">;
   currentTarget: () => string;
+  currentTargetGeneration: () => number;
   secrets: ReadonlyMap<string, string>;
 }): PanelTemplateRelayWiring {
   const resolvePanelAgent = (
@@ -978,14 +981,17 @@ export function createPanelTemplateRelayWiring(options: {
   };
   const resolvePanelTab = (tabId: string): string | undefined =>
     isScopeAddress(tabId) ? options.bridge.resolveSharedTabId(tabId) : panelTabOf(tabId);
-  const resolveAllowedPanelOrigin = (tabId: string): string | undefined =>
-    currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), options.currentTarget());
-  const resolvePanelUrl = (tabId: string): string | undefined => {
-    const target = options.currentTarget();
-    const origin = currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), target);
+  const resolveCurrentTarget = (): PanelTemplateRelayTarget => ({
+    url: options.currentTarget(),
+    generation: options.currentTargetGeneration(),
+  });
+  const resolveAllowedPanelOrigin = (tabId: string, currentTarget: string): string | undefined =>
+    currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), currentTarget);
+  const resolvePanelUrl = (tabId: string, currentTarget: string): string | undefined => {
+    const origin = currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), currentTarget);
     if (!origin) return undefined;
     try {
-      const basePath = new URL(target).pathname.replace(/\/+$/, "");
+      const basePath = new URL(currentTarget).pathname.replace(/\/+$/, "");
       return `${origin}${basePath}/api/workflow_templates`;
     } catch {
       return undefined;
@@ -994,6 +1000,7 @@ export function createPanelTemplateRelayWiring(options: {
   return {
     resolvePanelAgent,
     resolvePanelTab,
+    resolveCurrentTarget,
     resolvePanelUrl,
     resolveAllowedPanelOrigin,
   };
@@ -1847,6 +1854,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   const panelTemplateRelayWiring = createPanelTemplateRelayWiring({
     bridge,
     currentTarget: getComfyUIBaseUrl,
+    currentTargetGeneration: getComfyuiTargetGeneration,
     secrets: panelImageRelaySecrets,
   });
   let panelImageRelayServer: PanelImageRelayServer | undefined;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -115,6 +115,7 @@ import {
 } from "../services/panel-image-relay.js";
 import {
   startPanelTemplateRelayServer,
+  currentPanelTemplateOrigin,
   verifyPanelTemplateRelayCapability,
   type PanelTemplateRelayResolvedAgent,
   type PanelTemplateRelayServer,
@@ -1816,7 +1817,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     );
   }
   const panelTemplateRelayUrlFor = (tabId: string): string | undefined => {
-    const origin = bridge.tabServerOrigin(tabId);
+    const origin = currentPanelTemplateOrigin(bridge.tabServerOrigin(tabId), getComfyUIBaseUrl());
     if (!origin) return undefined;
     try {
       const configured = new URL(getComfyUIBaseUrl());
@@ -1834,6 +1835,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       resolvePanelAgent: panelTemplateRelayAgentFor,
       resolvePanelTab: scopeToRealTab,
       resolvePanelUrl: panelTemplateRelayUrlFor,
+      resolveAllowedPanelOrigin: (tabId) => currentPanelTemplateOrigin(bridge.tabServerOrigin(tabId), getComfyUIBaseUrl()),
     });
     panelTemplateRelayEndpoint = panelTemplateRelayServer.endpointUrl;
   } catch (error) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -947,6 +947,58 @@ export function armStartupDeadline(
   return () => clearTimeout(timer);
 }
 
+export interface PanelTemplateRelayWiring {
+  resolvePanelAgent: (request: PanelTemplateRelayRequest) => PanelTemplateRelayResolvedAgent | undefined;
+  resolvePanelTab: (agentKey: string) => string | undefined;
+  resolvePanelUrl: (tabId: string) => string | undefined;
+  resolveAllowedPanelOrigin: (tabId: string) => string | undefined;
+}
+
+/**
+ * The production closures for the child template relay. Keep authorization,
+ * scope-to-tab routing, and current-target origin selection together so tests
+ * can exercise the same wiring that the orchestrator gives the relay server.
+ */
+export function createPanelTemplateRelayWiring(options: {
+  bridge: Pick<UiBridge, "resolveSharedTabId" | "tabServerOrigin">;
+  currentTarget: () => string;
+  secrets: ReadonlyMap<string, string>;
+}): PanelTemplateRelayWiring {
+  const resolvePanelAgent = (
+    request: PanelTemplateRelayRequest,
+  ): PanelTemplateRelayResolvedAgent | undefined => {
+    for (const [secret, agentKey] of options.secrets) {
+      if (verifyPanelTemplateRelayCapability(secret, request)) return { agentKey, secret };
+    }
+    return undefined;
+  };
+  const panelTabOf = (key: string): string => {
+    const i = key.lastIndexOf("::");
+    return i >= 0 ? key.slice(0, i) : key;
+  };
+  const resolvePanelTab = (tabId: string): string | undefined =>
+    isScopeAddress(tabId) ? options.bridge.resolveSharedTabId(tabId) : panelTabOf(tabId);
+  const resolveAllowedPanelOrigin = (tabId: string): string | undefined =>
+    currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), options.currentTarget());
+  const resolvePanelUrl = (tabId: string): string | undefined => {
+    const target = options.currentTarget();
+    const origin = currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), target);
+    if (!origin) return undefined;
+    try {
+      const basePath = new URL(target).pathname.replace(/\/+$/, "");
+      return `${origin}${basePath}/api/workflow_templates`;
+    } catch {
+      return undefined;
+    }
+  };
+  return {
+    resolvePanelAgent,
+    resolvePanelTab,
+    resolvePanelUrl,
+    resolveAllowedPanelOrigin,
+  };
+}
+
 export async function runPanelOrchestrator(): Promise<void> {
   const completionFence = new RunCompletionIdempotencyFence();
   /** Stable completion keys held by accepted queue items until the real turn ack. */
@@ -1778,14 +1830,6 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
     return undefined;
   };
-  const panelTemplateRelayAgentFor = (
-    request: PanelTemplateRelayRequest,
-  ): PanelTemplateRelayResolvedAgent | undefined => {
-    for (const [secret, agentKey] of panelImageRelaySecrets) {
-      if (verifyPanelTemplateRelayCapability(secret, request)) return { agentKey, secret };
-    }
-    return undefined;
-  };
   // The scope/backend halves of a composite key. Neither half contains "::", so
   // split on the LAST separator.
   const panelTabOf = (key: string): string => {
@@ -1800,6 +1844,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   // bridge's pinned shared-tab mapping before dispatching authenticated relay commands.
   const scopeToRealTab = (tabId: string): string | undefined =>
     isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : panelTabOf(tabId);
+  const panelTemplateRelayWiring = createPanelTemplateRelayWiring({
+    bridge,
+    currentTarget: getComfyUIBaseUrl,
+    secrets: panelImageRelaySecrets,
+  });
   let panelImageRelayServer: PanelImageRelayServer | undefined;
   let panelImageRelayEndpoint: string | undefined;
   try {
@@ -1816,26 +1865,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       `[panel-orchestrator] authenticated panel image relay unavailable: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  const panelTemplateRelayUrlFor = (tabId: string): string | undefined => {
-    const origin = currentPanelTemplateOrigin(bridge.tabServerOrigin(tabId), getComfyUIBaseUrl());
-    if (!origin) return undefined;
-    try {
-      const configured = new URL(getComfyUIBaseUrl());
-      const basePath = configured.pathname.replace(/\/+$/, "");
-      return `${origin}${basePath}/api/workflow_templates`;
-    } catch {
-      return undefined;
-    }
-  };
   let panelTemplateRelayServer: PanelTemplateRelayServer | undefined;
   let panelTemplateRelayEndpoint: string | undefined;
   try {
     panelTemplateRelayServer = await startPanelTemplateRelayServer({
       bridge,
-      resolvePanelAgent: panelTemplateRelayAgentFor,
-      resolvePanelTab: scopeToRealTab,
-      resolvePanelUrl: panelTemplateRelayUrlFor,
-      resolveAllowedPanelOrigin: (tabId) => currentPanelTemplateOrigin(bridge.tabServerOrigin(tabId), getComfyUIBaseUrl()),
+      ...panelTemplateRelayWiring,
     });
     panelTemplateRelayEndpoint = panelTemplateRelayServer.endpointUrl;
   } catch (error) {

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -413,10 +413,12 @@ function httpOrigin(raw: string | undefined): string | undefined {
 }
 
 /**
- * A panel origin is usable only when it corroborates the current target. The
- * target is selected by the orchestrator's hello/probe flow, not by the child
- * request, so this comparison does not turn the relay into an arbitrary URL
- * fetcher. URL.origin also canonicalizes default ports and host casing.
+ * A panel origin is usable only when it is a loopback listener and corroborates
+ * the current target. The server-observed Origin is metadata, not authentication:
+ * a native client can forge it on the tokenless loopback bridge. Keeping the
+ * fetch destination loopback-only prevents that metadata, or the client-steerable
+ * active target, from authorizing a remote fetch. URL.origin also canonicalizes
+ * default ports and host casing.
  */
 export function currentPanelTemplateOrigin(
   panelOrigin: string | undefined,
@@ -425,13 +427,12 @@ export function currentPanelTemplateOrigin(
   const observed = parsedHttpOrigin(panelOrigin);
   const target = parsedHttpOrigin(currentTarget);
   if (!observed || !target) return undefined;
-  const exact = observed.origin === target.origin;
   const sameLoopbackListener =
     LOOPBACK_HOSTS.has(observed.host) &&
     LOOPBACK_HOSTS.has(target.host) &&
     observed.protocol === target.protocol &&
     observed.port === target.port;
-  return exact || sameLoopbackListener ? observed.origin : undefined;
+  return sameLoopbackListener ? observed.origin : undefined;
 }
 
 function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | undefined): URL | undefined {

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -7,8 +7,9 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
  * The list_packs child cannot reach the panel bridge directly. It sends only a
  * capability-bound request to the orchestrator; the orchestrator resolves the
  * live panel tab and fetches the fixed /api/workflow_templates route from that
- * tab's server-observed loopback origin. No configured ComfyUI credentials or
- * caller-supplied URL crosses this boundary.
+ * tab's server-observed origin, but only when it is the current ComfyUI target.
+ * No configured ComfyUI credentials or caller-supplied URL crosses this
+ * boundary.
  */
 export const PANEL_TEMPLATE_RELAY_VERSION = 1;
 export const PANEL_TEMPLATE_RELAY_TIMEOUT_MS = 8_000;
@@ -20,6 +21,7 @@ export const PANEL_TEMPLATE_RELAY_HTTP_PATH = "/__comfyui_mcp_panel_template_rel
 
 const ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const HEX_RE = /^[a-f0-9]{64}$/;
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
 export interface PanelTemplateRelayRequest {
   version: typeof PANEL_TEMPLATE_RELAY_VERSION;
@@ -67,6 +69,8 @@ export interface PanelTemplateRelayServerOptions {
   resolvePanelAgent: (request: PanelTemplateRelayRequest) => PanelTemplateRelayResolvedAgent | undefined;
   resolvePanelTab: (agentKey: string) => string | undefined;
   resolvePanelUrl: (tabId: string) => string | undefined;
+  /** Must return undefined unless the tab's origin is authorized for the current target. */
+  resolveAllowedPanelOrigin: (tabId: string) => string | undefined;
 }
 
 export interface PanelTemplateRelayServer {
@@ -380,19 +384,63 @@ function readRequestBody(req: IncomingMessage): Promise<Buffer> {
   });
 }
 
-function safePanelTemplateUrl(raw: string | undefined): URL | undefined {
+function parsedHttpOrigin(raw: string | undefined): { origin: string; protocol: string; host: string; port: string } | undefined {
+  if (!raw) return undefined;
+  try {
+    const url = new URL(raw);
+    if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password) return undefined;
+    return {
+      origin: url.origin,
+      protocol: url.protocol,
+      host: url.hostname.toLowerCase().replace(/^\[|\]$/g, ""),
+      port: url.port,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function httpOrigin(raw: string | undefined): string | undefined {
+  return parsedHttpOrigin(raw)?.origin;
+}
+
+/**
+ * A panel origin is usable only when it corroborates the current target. The
+ * target is selected by the orchestrator's hello/probe flow, not by the child
+ * request, so this comparison does not turn the relay into an arbitrary URL
+ * fetcher. URL.origin also canonicalizes default ports and host casing.
+ */
+export function currentPanelTemplateOrigin(
+  panelOrigin: string | undefined,
+  currentTarget: string | undefined,
+): string | undefined {
+  const observed = parsedHttpOrigin(panelOrigin);
+  const target = parsedHttpOrigin(currentTarget);
+  if (!observed || !target) return undefined;
+  const exact = observed.origin === target.origin;
+  const sameLoopbackListener =
+    LOOPBACK_HOSTS.has(observed.host) &&
+    LOOPBACK_HOSTS.has(target.host) &&
+    observed.protocol === target.protocol &&
+    observed.port === target.port;
+  return exact || sameLoopbackListener ? observed.origin : undefined;
+}
+
+function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | undefined): URL | undefined {
   if (!raw) return undefined;
   try {
     const url = new URL(raw);
     const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    const normalizedAllowedOrigin = allowedOrigin === undefined ? undefined : httpOrigin(allowedOrigin);
     if (
       (url.protocol !== "http:" && url.protocol !== "https:") ||
-      !new Set(["localhost", "127.0.0.1", "::1"]).has(host) ||
       url.username ||
       url.password ||
       url.search ||
       url.hash ||
-      !url.pathname.endsWith("/api/workflow_templates")
+      !url.pathname.endsWith("/api/workflow_templates") ||
+      !normalizedAllowedOrigin ||
+      url.origin !== normalizedAllowedOrigin
     ) return undefined;
     return url;
   } catch {
@@ -414,7 +462,7 @@ async function fetchPanelIndex(url: URL, deadlineAt: number): Promise<string> {
     throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
   }
   if (response.url) {
-    const finalUrl = safePanelTemplateUrl(response.url);
+    const finalUrl = safePanelTemplateUrl(response.url, url.origin);
     if (!finalUrl || finalUrl.origin !== url.origin || finalUrl.pathname !== url.pathname) {
       throw new PanelTemplateRelayError("The panel template relay refused a response from another origin.", "PANEL_FETCH_FAILED");
     }
@@ -486,10 +534,14 @@ export async function startPanelTemplateRelayServer(
           response = failureResponse(request.requestId, now >= requestDeadline(request) ? "TIMEOUT" : "STALE_REQUEST");
         } else {
           const panelTab = options.resolvePanelTab(auth.agentKey);
-          const panelUrl = panelTab && options.bridge.canReach(panelTab)
-            ? safePanelTemplateUrl(options.resolvePanelUrl(panelTab))
+          const panelReachable = panelTab ? options.bridge.canReach(panelTab) : false;
+          const allowedOrigin = panelTab && panelReachable
+            ? options.resolveAllowedPanelOrigin(panelTab)
             : undefined;
-          if (!panelTab || !options.bridge.canReach(panelTab)) {
+          const panelUrl = panelTab && panelReachable
+            ? safePanelTemplateUrl(options.resolvePanelUrl(panelTab), allowedOrigin)
+            : undefined;
+          if (!panelTab || !panelReachable) {
             response = failureResponse(
               request.requestId,
               options.bridge.resolveFailure?.(auth.agentKey) === "ambiguous" ? "AMBIGUOUS_REQUESTER" : "NO_LIVE_PANEL",

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -64,13 +64,20 @@ export interface PanelTemplateRelayResolvedAgent {
   secret: string;
 }
 
+export interface PanelTemplateRelayTarget {
+  url: string;
+  generation: number;
+}
+
 export interface PanelTemplateRelayServerOptions {
   bridge: PanelTemplateRelayBridge;
   resolvePanelAgent: (request: PanelTemplateRelayRequest) => PanelTemplateRelayResolvedAgent | undefined;
   resolvePanelTab: (agentKey: string) => string | undefined;
-  resolvePanelUrl: (tabId: string) => string | undefined;
-  /** Must return undefined unless the tab's origin is authorized for the current target. */
-  resolveAllowedPanelOrigin: (tabId: string) => string | undefined;
+  /** Captures the authoritative target identity for this request. */
+  resolveCurrentTarget: () => PanelTemplateRelayTarget;
+  resolvePanelUrl: (tabId: string, currentTarget: string) => string | undefined;
+  /** Must return undefined unless the tab's origin is authorized for currentTarget. */
+  resolveAllowedPanelOrigin: (tabId: string, currentTarget: string) => string | undefined;
 }
 
 export interface PanelTemplateRelayServer {
@@ -219,6 +226,7 @@ function errorMessage(error: string): string {
     "NO_PANEL_ORIGIN",
     "PANEL_FETCH_FAILED",
     "STALE_REQUEST",
+    "STALE_TARGET",
     "TIMEOUT",
   ]);
   return known.has(error) ? error : "PANEL_FETCH_FAILED";
@@ -533,13 +541,14 @@ export async function startPanelTemplateRelayServer(
         if (now - request.createdAt < -5_000 || now - request.createdAt > PANEL_TEMPLATE_RELAY_STALE_MS || now >= requestDeadline(request)) {
           response = failureResponse(request.requestId, now >= requestDeadline(request) ? "TIMEOUT" : "STALE_REQUEST");
         } else {
+          const targetAtStart = options.resolveCurrentTarget();
           const panelTab = options.resolvePanelTab(auth.agentKey);
           const panelReachable = panelTab ? options.bridge.canReach(panelTab) : false;
           const allowedOrigin = panelTab && panelReachable
-            ? options.resolveAllowedPanelOrigin(panelTab)
+            ? options.resolveAllowedPanelOrigin(panelTab, targetAtStart.url)
             : undefined;
           const panelUrl = panelTab && panelReachable
-            ? safePanelTemplateUrl(options.resolvePanelUrl(panelTab), allowedOrigin)
+            ? safePanelTemplateUrl(options.resolvePanelUrl(panelTab, targetAtStart.url), allowedOrigin)
             : undefined;
           if (!panelTab || !panelReachable) {
             response = failureResponse(
@@ -550,11 +559,19 @@ export async function startPanelTemplateRelayServer(
             response = failureResponse(request.requestId, "NO_PANEL_ORIGIN");
           } else {
             try {
+              const body = await withinDeadline(fetchPanelIndex(panelUrl, requestDeadline(request)), requestDeadline(request));
+              const targetNow = options.resolveCurrentTarget();
+              if (targetNow.url !== targetAtStart.url || targetNow.generation !== targetAtStart.generation) {
+                throw new PanelTemplateRelayError(
+                  "The ComfyUI target changed while the panel template index was being fetched.",
+                  "STALE_TARGET",
+                );
+              }
               response = {
                 version: PANEL_TEMPLATE_RELAY_VERSION,
                 requestId: request.requestId,
                 ok: true,
-                body: await withinDeadline(fetchPanelIndex(panelUrl, requestDeadline(request)), requestDeadline(request)),
+                body,
                 updated: Date.now(),
               };
             } catch (error) {

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -427,12 +427,13 @@ export function currentPanelTemplateOrigin(
   const observed = parsedHttpOrigin(panelOrigin);
   const target = parsedHttpOrigin(currentTarget);
   if (!observed || !target) return undefined;
-  const sameLoopbackListener =
+  const exactLoopbackOrigin =
     LOOPBACK_HOSTS.has(observed.host) &&
     LOOPBACK_HOSTS.has(target.host) &&
     observed.protocol === target.protocol &&
-    observed.port === target.port;
-  return sameLoopbackListener ? observed.origin : undefined;
+    observed.port === target.port &&
+    observed.origin === target.origin;
+  return exactLoopbackOrigin ? observed.origin : undefined;
 }
 
 function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | undefined): URL | undefined {


### PR DESCRIPTION
## Summary

Closes #2196.

The template relay is loopback-only. A server-observed panel Origin is metadata, not authentication: tokenless loopback WebSocket headers can be forged, and the active ComfyUI target is client-steerable. Non-loopback and forged origins therefore fail closed before any remote fetch.

Authorization now requires exact canonical origin identity: the observed loopback origin must equal the target's canonical `URL.origin`. `127.0.0.1`, `[::1]`, and `localhost` are distinct instances and are not folded together. Credentials, malformed values, query/hash additions, missing/disconnected panels, and redirects remain rejected.

The relay captures the authoritative target URL and monotonic target generation before fetching. After the awaited panel response is fully read and validated against its captured URL/path, it revalidates both live values and rejects stale data on any retarget, including an A→B→A round trip.

## Evidence coverage

- `list_packs(action: "list_templates")` is driven through the real production handler, real `requestPanelTemplateIndex`, signed loopback relay, and panel HTTP server.
- `createPanelTemplateRelayWiring` from `src/orchestrator/index.ts` is exercised for production HMAC authorization, scope-to-tab routing, exact loopback URL construction, forged-origin refusal, non-loopback refusal, and IPv4/IPv6/localhost identity handling.
- Exact-match and mismatch regression coverage covers IPv4, IPv6, and localhost origins; the prior alias case is explicitly refused.
- A deterministic in-flight production-path regression holds the panel response pending, retargets A→B→A, releases the old response, proves `STALE_TARGET`, and then proves a fresh current-target request succeeds.
- A constructed `Response` with a meaningful different-origin `response.url` proves the response-origin branch remains fail-closed.

## Validation

- Focused Vitest: 4 files, 15 passed
- `npm.cmd run build`
- `npm.cmd run lint`
- `git diff --check`
- No `init.py`, `apps_routes.py`, or release metadata changes

No merge or release performed.