### PR TITLE
fix(codex): classify EventNotificationTransport panel failures

### DIFF
--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -48,6 +48,12 @@ const MCP_SERVERS = {
 const WORKER_TRANSPORT_FAILURE =
   "Transport send error: WorkerTransport<StreamableHttpClientWorker<...>> error: " +
   "HTTP request failed sending request to http://127.0.0.1:9198/orchestrator%3A%3Acodex";
+// The exact wrapper reported by panel_save_workflow -> immediate panel_run on
+// the affected EventNotificationTransport path. It is an outer HTTP-MCP client
+// failure, not a panel tool result; handling it must not retry panel_run.
+const EVENT_NOTIFICATION_TRANSPORT_FAILURE =
+  "Transport send error: EventNotificationTransport WorkerTransport StreamableHttpClientWorker error: " +
+  "Client error: HTTP request failed sending request to http://127.0.0.1:9198/orchestrator::codex";
 // Older Codex/MCP combinations scrubbed the WorkerTransport wrapper and used a
 // semicolon. This is an outer HTTP-MCP client error, not a UiBridge error from
 // inside the panel MCP handler.
@@ -86,7 +92,12 @@ interface Drive {
   pollParams: unknown[];
   turnStarts: number;
   endTurn(
-    kind?: "completed" | "worker-transport" | "worker-transport-retry" | "scrubbed-transport",
+    kind?:
+      | "completed"
+      | "worker-transport"
+      | "worker-transport-retry"
+      | "scrubbed-transport"
+      | "event-notification-transport",
   ): Promise<void>;
   releaseInterrupt(): void;
   waitForIdle(): Promise<void>;
@@ -204,7 +215,8 @@ function startDrive(opts: {
       if (
         kind === "worker-transport" ||
         kind === "worker-transport-retry" ||
-        kind === "scrubbed-transport"
+        kind === "scrubbed-transport" ||
+        kind === "event-notification-transport"
       ) {
         client.notificationHandler?.({
           method: "error",
@@ -212,7 +224,12 @@ function startDrive(opts: {
             threadId: "thread-1",
             turnId,
             error: {
-              message: kind === "scrubbed-transport" ? SCRUBBED_TRANSPORT_FAILURE : WORKER_TRANSPORT_FAILURE,
+              message:
+                kind === "scrubbed-transport"
+                  ? SCRUBBED_TRANSPORT_FAILURE
+                  : kind === "event-notification-transport"
+                    ? EVENT_NOTIFICATION_TRANSPORT_FAILURE
+                    : WORKER_TRANSPORT_FAILURE,
             },
             willRetry: kind === "worker-transport-retry",
           },
@@ -295,6 +312,27 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
     );
     expect(failure?.outcomeUnknown).toBe(true);
     expect(failure?.message).toMatch(/did not retry/i);
+
+    await drive.finish();
+  });
+
+  it("handles the EventNotificationTransport panel_run failure after a successful save (#2378)", async () => {
+    // The reported save -> immediate run sequence loses the outer MCP response
+    // before Codex can return a tool result. The wrapper must enter the same
+    // bounded reload path as the plain WorkerTransport form; it must not let
+    // Codex replay the mutation or claim that the render was not accepted.
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("event-notification-transport");
+
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.turnStarts).toBe(1);
+    const failure = drive.events.find(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failure?.outcomeUnknown).toBe(true);
+    expect(failure?.message).toMatch(/did not retry/i);
+    expect(failure?.message).toMatch(/outcome as UNKNOWN/i);
 
     await drive.finish();
   });

--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -41,10 +41,19 @@ const PANEL_GONE = [
   { name: "comfyui", runtimeStatus: "connected", tools: { list_tools: {}, call_tool: {} } },
   { name: "panel", runtimeStatus: "failed", tools: CACHED_PANEL_TOOLS },
 ];
+const PANEL_MCP_URL = "http://127.0.0.1:9198/orchestrator%3A%3Acodex";
 const MCP_SERVERS = {
   comfyui: { transport: "stdio" as const, command: "node", args: ["mcp.js"] },
-  panel: { transport: "http" as const, url: "http://127.0.0.1:9198/tab" },
+  panel: { transport: "http" as const, url: PANEL_MCP_URL },
 };
+const MCP_SERVERS_WITH_UNRELATED_HTTP = {
+  ...MCP_SERVERS,
+  unrelated: { transport: "http" as const, url: "http://127.0.0.1:9198/unrelated" },
+};
+const MCP_SERVERS_WITH_UNRELATED_HTTP_UP = [
+  ...PANEL_UP,
+  { name: "unrelated", runtimeStatus: "connected", tools: { unrelated_tool: {} } },
+];
 const WORKER_TRANSPORT_FAILURE =
   "Transport send error: WorkerTransport<StreamableHttpClientWorker<...>> error: " +
   "HTTP request failed sending request to http://127.0.0.1:9198/orchestrator%3A%3Acodex";
@@ -54,6 +63,10 @@ const WORKER_TRANSPORT_FAILURE =
 const EVENT_NOTIFICATION_TRANSPORT_FAILURE =
   "Transport send error: EventNotificationTransport WorkerTransport StreamableHttpClientWorker error: " +
   "Client error: HTTP request failed sending request to http://127.0.0.1:9198/orchestrator::codex";
+const UNRELATED_TRANSPORT_FAILURE = EVENT_NOTIFICATION_TRANSPORT_FAILURE.replace(
+  "http://127.0.0.1:9198/orchestrator::codex",
+  "http://127.0.0.1:9198/unrelated",
+);
 // Older Codex/MCP combinations scrubbed the WorkerTransport wrapper and used a
 // semicolon. This is an outer HTTP-MCP client error, not a UiBridge error from
 // inside the panel MCP handler.
@@ -97,7 +110,8 @@ interface Drive {
       | "worker-transport"
       | "worker-transport-retry"
       | "scrubbed-transport"
-      | "event-notification-transport",
+      | "event-notification-transport"
+      | "unrelated-transport",
   ): Promise<void>;
   releaseInterrupt(): void;
   waitForIdle(): Promise<void>;
@@ -109,6 +123,7 @@ function startDrive(opts: {
   reloadThrows?: boolean;
   holdInterrupt?: boolean;
   requiredMcpTools?: Readonly<Record<string, readonly string[]>>;
+  mcpServers?: typeof MCP_SERVERS | typeof MCP_SERVERS_WITH_UNRELATED_HTTP;
 }): Drive {
   const listings = [...opts.listings];
   const events: AgentEvent[] = [];
@@ -184,7 +199,7 @@ function startDrive(opts: {
 
   const backend: Backend = new CodexBackend({
     model: "gpt-5.6-sol",
-    mcpServers: MCP_SERVERS,
+    mcpServers: opts.mcpServers ?? MCP_SERVERS,
     requiredMcpTools: opts.requiredMcpTools,
   });
   Object.assign(backend, { client, liveCatalog: [{ id: "gpt-5.6-sol", supportsEffort: true }] });
@@ -216,7 +231,8 @@ function startDrive(opts: {
         kind === "worker-transport" ||
         kind === "worker-transport-retry" ||
         kind === "scrubbed-transport" ||
-        kind === "event-notification-transport"
+        kind === "event-notification-transport" ||
+        kind === "unrelated-transport"
       ) {
         client.notificationHandler?.({
           method: "error",
@@ -229,7 +245,9 @@ function startDrive(opts: {
                   ? SCRUBBED_TRANSPORT_FAILURE
                   : kind === "event-notification-transport"
                     ? EVENT_NOTIFICATION_TRANSPORT_FAILURE
-                    : WORKER_TRANSPORT_FAILURE,
+                    : kind === "unrelated-transport"
+                      ? UNRELATED_TRANSPORT_FAILURE
+                      : WORKER_TRANSPORT_FAILURE,
             },
             willRetry: kind === "worker-transport-retry",
           },
@@ -333,6 +351,25 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
     expect(failure?.outcomeUnknown).toBe(true);
     expect(failure?.message).toMatch(/did not retry/i);
     expect(failure?.message).toMatch(/outcome as UNKNOWN/i);
+
+    await drive.finish();
+  });
+
+  it("does not map an unrelated HTTP MCP transport failure to panel recovery", async () => {
+    const drive = startDrive({
+      listings: [MCP_SERVERS_WITH_UNRELATED_HTTP_UP],
+      mcpServers: MCP_SERVERS_WITH_UNRELATED_HTTP,
+    });
+    await drive.endTurn("unrelated-transport");
+
+    expect(drive.reloadCalls).toBe(0);
+    expect(drive.turnStarts).toBe(1);
+    const failure = drive.events.find(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failure?.outcomeUnknown).not.toBe(true);
+    expect(failure?.message).not.toMatch(/local panel MCP connection failed/i);
 
     await drive.finish();
   });

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -72,16 +72,42 @@ function msgOf(err: unknown): string {
   return errorText(err);
 }
 
+function normalizedHttpMcpEndpoint(value: string): { origin: string; pathname: string; search: string } | undefined {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+    return {
+      origin: url.origin,
+      pathname: decodeURIComponent(url.pathname),
+      search: url.search,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Codex wraps a failed request to the orchestrator-hosted HTTP MCP in its
- * WorkerTransport error. This is narrower than matching every HTTP/provider
- * error: the Codex lane has one HTTP MCP (`panel`) and the stdio `comfyui`
- * server cannot produce this transport shape.
+ * WorkerTransport error. The URL is part of the trusted panel registration;
+ * without this association, an unrelated configured HTTP MCP failure could be
+ * mistaken for the panel and cause a panel reload.
  */
-export function isCodexPanelMcpTransportFailure(message: string): boolean {
+export function isCodexPanelMcpTransportFailure(message: string, panelUrl: string): boolean {
+  if (
+    !/Transport send error\s*(?::\s*(?:EventNotificationTransport\s+)?WorkerTransport\b|;\s*)/i.test(message)
+  ) {
+    return false;
+  }
+  const failedUrl = message.match(/HTTP request failed sending request to\s+(https?:\/\/\S+)/i)?.[1];
+  if (!failedUrl) return false;
+  const observed = normalizedHttpMcpEndpoint(failedUrl);
+  const configured = normalizedHttpMcpEndpoint(panelUrl);
   return (
-    /Transport send error\s*(?::\s*(?:EventNotificationTransport\s+)?WorkerTransport\b|;\s*)/i.test(message) &&
-    /HTTP request failed sending request to\s+https?:\/\//i.test(message)
+    observed !== undefined &&
+    configured !== undefined &&
+    observed.origin === configured.origin &&
+    observed.pathname === configured.pathname &&
+    observed.search === configured.search
   );
 }
 
@@ -1501,7 +1527,7 @@ export class CodexBackend implements AgentBackend {
    * still unresolved; the next turn's status poll is its verdict. */
   private noteMcpTransportFailure(message: string): boolean {
     const panel = this.deps.mcpServers?.panel;
-    if (panel?.transport !== "http" || !isCodexPanelMcpTransportFailure(message)) return false;
+    if (panel?.transport !== "http" || !isCodexPanelMcpTransportFailure(message, panel.url)) return false;
     if (!this.mcpDown.has("panel") && !this.mcpReloadPending.has("panel")) {
       this.mcpTransportRecovery.add("panel");
     }

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -80,7 +80,7 @@ function msgOf(err: unknown): string {
  */
 export function isCodexPanelMcpTransportFailure(message: string): boolean {
   return (
-    /Transport send error\s*(?::\s*WorkerTransport\b|;\s*)/i.test(message) &&
+    /Transport send error\s*(?::\s*(?:EventNotificationTransport\s+)?WorkerTransport\b|;\s*)/i.test(message) &&
     /HTTP request failed sending request to\s+https?:\/\//i.test(message)
   );
 }


### PR DESCRIPTION
## Summary

- Recognize the EventNotificationTransport-wrapped HTTP MCP send error reported by #2378.
- Route it through the existing bounded panel MCP reload/recovery path.
- Preserve the existing UNKNOWN outcome and no-replay behavior for panel_run mutations.

## Validation

- Focused reconnect regression: 17 passed
- Related orchestrator suites: 430 passed
- lint: passed
- build: passed
- Full repository checks: all non-Vitest checks passed; one unrelated timing-sensitive late-mutation e2e failure passed when rerun in isolation (5 passed)

Fixes #2378