### PR TITLE
fix: reject ambiguous localhost panel relay identity

### DIFF
--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -108,7 +108,7 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
     expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
 
-    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188", "http://localhost:8188"]) {
+    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188"]) {
       target = `${origin}/comfyapi`;
       observedOrigin = origin;
       expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(origin);
@@ -125,6 +125,41 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
+  });
+
+  it("refuses an exact localhost match before fetch can resolve another loopback listener", async () => {
+    let panelRequests = 0;
+    const panel = createServer((_req, res) => {
+      panelRequests += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ "unexpected-pack": [{ name: "wrong-listener" }] }));
+    });
+    const panelOrigin = await listen(panel);
+    servers.push({ close: () => closeServer(panel) });
+    const port = new URL(panelOrigin).port;
+    const target = `http://localhost:${port}/comfyapi`;
+    const observedOrigin = `http://localhost:${port}`;
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: () => "tab-1",
+      tabServerOrigin: () => observedOrigin,
+    };
+    const wiring = createPanelTemplateRelayWiring({
+      bridge,
+      currentTarget: () => target,
+      currentTargetGeneration: () => 0,
+      secrets: new Map([[SECRET, "orchestrator::codex"]]),
+    });
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+
+    const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
+    expect(panelRequests).toBe(0);
   });
 
   it("rejects a stale in-flight response after retargeting and still serves the current target", async () => {

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -220,7 +220,9 @@ describe("authenticated panel template relay (#2196)", () => {
     expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://127.0.0.1:8188");
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://[::1]:8188/comfyapi")).toBe("http://[::1]:8188");
-    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBe("http://localhost:8188");
+    // `localhost` is a name, not a listener identity. Accepting an exact
+    // localhost match would let the later fetch resolve a different family.
+    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://[::1]:8188/comfyapi")).toBeUndefined();

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -21,7 +21,10 @@ export const PANEL_TEMPLATE_RELAY_HTTP_PATH = "/__comfyui_mcp_panel_template_rel
 
 const ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const HEX_RE = /^[a-f0-9]{64}$/;
-const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+// A hostname does not identify which loopback listener a browser reached. Keep
+// relay destinations pinned to literal addresses so fetch cannot independently
+// resolve `localhost` to a different process or address family.
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1"]);
 
 export interface PanelTemplateRelayRequest {
   version: typeof PANEL_TEMPLATE_RELAY_VERSION;
@@ -408,10 +411,6 @@ function parsedHttpOrigin(raw: string | undefined): { origin: string; protocol: 
   }
 }
 
-function httpOrigin(raw: string | undefined): string | undefined {
-  return parsedHttpOrigin(raw)?.origin;
-}
-
 /**
  * A panel origin is usable only when it is a loopback listener and corroborates
  * the current target. The server-observed Origin is metadata, not authentication:
@@ -440,8 +439,9 @@ function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | u
   if (!raw) return undefined;
   try {
     const url = new URL(raw);
-    const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-    const normalizedAllowedOrigin = allowedOrigin === undefined ? undefined : httpOrigin(allowedOrigin);
+    const parsedUrlOrigin = parsedHttpOrigin(url.origin);
+    const parsedAllowedOrigin = parsedHttpOrigin(allowedOrigin);
+    const normalizedAllowedOrigin = parsedAllowedOrigin?.origin;
     if (
       (url.protocol !== "http:" && url.protocol !== "https:") ||
       url.username ||
@@ -450,6 +450,9 @@ function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | u
       url.hash ||
       !url.pathname.endsWith("/api/workflow_templates") ||
       !normalizedAllowedOrigin ||
+      !parsedUrlOrigin ||
+      !LOOPBACK_HOSTS.has(parsedUrlOrigin.host) ||
+      !LOOPBACK_HOSTS.has(parsedAllowedOrigin.host) ||
       url.origin !== normalizedAllowedOrigin
     ) return undefined;
     return url;


### PR DESCRIPTION
Fixes #2382. Exact canonical origin matching is preserved for literal 127.0.0.1 and ::1 identities; ambiguous localhost origins now fail closed so fetch cannot resolve a different loopback listener. Focused relay tests, build, lint, anti-slop, and git diff check pass.