### PR TITLE
fix: decline an ambiguous localhost relay origin instead of failing the action (#2382 regression in 0.52.135)

### DIFF
--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -108,7 +108,7 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
     expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
 
-    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188"]) {
+    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188", "http://localhost:8188"]) {
       target = `${origin}/comfyapi`;
       observedOrigin = origin;
       expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(origin);
@@ -127,18 +127,22 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
   });
 
-  it("refuses an exact localhost match before fetch can resolve another loopback listener", async () => {
+  // #2382/#2385. Dropping "localhost" from LOOPBACK_HOSTS made this whole
+  // request fail NO_PANEL_ORIGIN, which shipped in 0.52.135. The mixed-name
+  // case below is the part that must stay refused: it is a genuine mismatch,
+  // not merely a name.
+  it("serves a localhost-served panel and still refuses a mixed localhost/127.0.0.1 pair", async () => {
     let panelRequests = 0;
     const panel = createServer((_req, res) => {
       panelRequests += 1;
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ "unexpected-pack": [{ name: "wrong-listener" }] }));
+      res.end(JSON.stringify({ "panel-pack": [{ name: "localhost-template" }] }));
     });
     const panelOrigin = await listen(panel);
     servers.push({ close: () => closeServer(panel) });
     const port = new URL(panelOrigin).port;
-    const target = `http://localhost:${port}/comfyapi`;
-    const observedOrigin = `http://localhost:${port}`;
+    let target = `http://localhost:${port}/comfyapi`;
+    let observedOrigin = `http://localhost:${port}`;
     const bridge = {
       canReach: () => true,
       resolveFailure: () => undefined,
@@ -151,15 +155,27 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
       currentTargetGeneration: () => 0,
       secrets: new Map([[SECRET, "orchestrator::codex"]]),
     });
-    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
-    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(observedOrigin);
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBe(`${observedOrigin}/comfyapi/api/workflow_templates`);
 
     const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
     servers.push(relay);
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+    await expect(requestPanelTemplateIndex()).resolves.toMatchObject({
+      "panel-pack": [{ name: "localhost-template" }],
+    });
+    expect(panelRequests).toBe(1);
+
+    // The observed Origin and the configured target must still be the SAME
+    // name. A browser on localhost with the target set to 127.0.0.1 is refused
+    // exactly as before, and never reaches the panel.
+    observedOrigin = `http://localhost:${port}`;
+    target = `http://127.0.0.1:${port}/comfyapi`;
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
-    expect(panelRequests).toBe(0);
+    expect(panelRequests).toBe(1);
   });
 
   it("rejects a stale in-flight response after retargeting and still serves the current target", async () => {

--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -108,7 +108,7 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
     expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
 
-    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188", "http://localhost:8188"]) {
+    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188"]) {
       target = `${origin}/comfyapi`;
       observedOrigin = origin;
       expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(origin);
@@ -127,16 +127,16 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
   });
 
-  // #2382/#2385. Dropping "localhost" from LOOPBACK_HOSTS made this whole
-  // request fail NO_PANEL_ORIGIN, which shipped in 0.52.135. The mixed-name
-  // case below is the part that must stay refused: it is a genuine mismatch,
-  // not merely a name.
-  it("serves a localhost-served panel and still refuses a mixed localhost/127.0.0.1 pair", async () => {
+  // #2382/#2385. 0.52.135 refused this pair with NO_PANEL_ORIGIN, which the
+  // child raises as an error and list_templates has no fallback for. It must
+  // DECLINE instead: undefined means "no panel route", which is exactly true of
+  // an origin that names a family rather than a listener.
+  it("declines an identical ambiguous localhost pair without fetching, and still fails a mixed pair", async () => {
     let panelRequests = 0;
     const panel = createServer((_req, res) => {
       panelRequests += 1;
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ "panel-pack": [{ name: "localhost-template" }] }));
+      res.end(JSON.stringify({ "unexpected-pack": [{ name: "wrong-listener" }] }));
     });
     const panelOrigin = await listen(panel);
     servers.push({ close: () => closeServer(panel) });
@@ -155,27 +155,28 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
       currentTargetGeneration: () => 0,
       secrets: new Map([[SECRET, "orchestrator::codex"]]),
     });
-    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(observedOrigin);
-    expect(wiring.resolvePanelUrl("tab-1", target)).toBe(`${observedOrigin}/comfyapi/api/workflow_templates`);
+    // The relay still refuses to FETCH an ambiguous name...
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+    // ...but classifies it as a decline rather than a failure.
+    expect(wiring.resolveAmbiguousLoopbackOrigin("tab-1", target)).toBe(true);
 
     const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
     servers.push(relay);
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
-    await expect(requestPanelTemplateIndex()).resolves.toMatchObject({
-      "panel-pack": [{ name: "localhost-template" }],
-    });
-    expect(panelRequests).toBe(1);
+    // undefined, NOT a throw: the caller keeps its headless path.
+    await expect(requestPanelTemplateIndex()).resolves.toBeUndefined();
+    // And the ambiguous name was never fetched, so no wrong listener can answer.
+    expect(panelRequests).toBe(0);
 
-    // The observed Origin and the configured target must still be the SAME
-    // name. A browser on localhost with the target set to 127.0.0.1 is refused
-    // exactly as before, and never reaches the panel.
+    // A MIXED pair is a genuine mismatch, not a name ambiguity. It must still
+    // fail hard rather than quietly degrading to COMFYUI_URL.
     observedOrigin = `http://localhost:${port}`;
     target = `http://127.0.0.1:${port}/comfyapi`;
-    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
-    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+    expect(wiring.resolveAmbiguousLoopbackOrigin("tab-1", target)).toBe(false);
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
-    expect(panelRequests).toBe(1);
+    expect(panelRequests).toBe(0);
   });
 
   it("rejects a stale in-flight response after retargeting and still serves the current target", async () => {

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createServer, type Server } from "node:http";
 import {
   PanelTemplateRelayError,
+  ambiguousLoopbackNameOrigin,
   currentPanelTemplateOrigin,
   requestPanelTemplateIndex,
   startPanelTemplateRelayServer,
@@ -216,14 +217,34 @@ describe("authenticated panel template relay (#2196)", () => {
     await expect(requestPanelTemplateIndex()).resolves.toBeUndefined();
   });
 
+  it("separates an identical ambiguous loopback name from a genuine origin mismatch (#2382)", () => {
+    // Identical on both sides -> decline, so the caller may continue headless
+    // against what is provably the same origin string.
+    expect(ambiguousLoopbackNameOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBe(true);
+    expect(ambiguousLoopbackNameOrigin("http://localhost:8188", "http://localhost:8188")).toBe(true);
+    // A MIXED pair is a real mismatch and must stay a hard refusal, never a
+    // decline: the two operands do not name the same thing.
+    expect(ambiguousLoopbackNameOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBe(false);
+    expect(ambiguousLoopbackNameOrigin("http://127.0.0.1:8188", "http://localhost:8188/comfyapi")).toBe(false);
+    expect(ambiguousLoopbackNameOrigin("http://localhost:8189", "http://localhost:8188/comfyapi")).toBe(false);
+    // Literal loopback addresses are authorized outright, never declined.
+    expect(ambiguousLoopbackNameOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi")).toBe(false);
+    expect(ambiguousLoopbackNameOrigin("http://[::1]:8188", "http://[::1]:8188/comfyapi")).toBe(false);
+    // Nothing off-loopback may ever be treated as a benign decline.
+    expect(ambiguousLoopbackNameOrigin("https://remote.example", "https://remote.example/comfyapi")).toBe(false);
+    expect(ambiguousLoopbackNameOrigin("https://localhost.evil.example", "https://localhost.evil.example/x")).toBe(false);
+    expect(ambiguousLoopbackNameOrigin(undefined, "http://localhost:8188")).toBe(false);
+    expect(ambiguousLoopbackNameOrigin("http://localhost:8188", undefined)).toBe(false);
+  });
+
   it("only authorizes a loopback origin corroborated by the current target", () => {
     expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://127.0.0.1:8188");
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://[::1]:8188/comfyapi")).toBe("http://[::1]:8188");
-    // An exact `localhost` pair stays authorized (#2382). Refusing it removed
-    // the relay for localhost-served users without closing a reachable hazard —
-    // see the LOOPBACK_HOSTS comment for the Happy-Eyeballs measurement.
-    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBe("http://localhost:8188");
+    // `localhost` never authorizes a relay fetch: it names a family, not a
+    // listener (#2382). It is DECLINED rather than failed — see
+    // ambiguousLoopbackNameOrigin below.
+    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://[::1]:8188/comfyapi")).toBeUndefined();

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -227,6 +227,11 @@ describe("authenticated panel template relay (#2196)", () => {
     expect(ambiguousLoopbackNameOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBe(false);
     expect(ambiguousLoopbackNameOrigin("http://127.0.0.1:8188", "http://localhost:8188/comfyapi")).toBe(false);
     expect(ambiguousLoopbackNameOrigin("http://localhost:8189", "http://localhost:8188/comfyapi")).toBe(false);
+    // Same name and port, different scheme, is still a mismatch: degrading would
+    // send the caller to a COMFYUI_URL that is not the origin the panel is on.
+    expect(ambiguousLoopbackNameOrigin("https://localhost:8188", "http://localhost:8188/comfyapi")).toBe(false);
+    expect(ambiguousLoopbackNameOrigin("http://localhost:8188", "https://localhost:8188/comfyapi")).toBe(false);
+    expect(ambiguousLoopbackNameOrigin("https://localhost:8188", "https://localhost:8188/comfyapi")).toBe(true);
     // Literal loopback addresses are authorized outright, never declined.
     expect(ambiguousLoopbackNameOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi")).toBe(false);
     expect(ambiguousLoopbackNameOrigin("http://[::1]:8188", "http://[::1]:8188/comfyapi")).toBe(false);

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -220,9 +220,10 @@ describe("authenticated panel template relay (#2196)", () => {
     expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://127.0.0.1:8188");
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://[::1]:8188/comfyapi")).toBe("http://[::1]:8188");
-    // `localhost` is a name, not a listener identity. Accepting an exact
-    // localhost match would let the later fetch resolve a different family.
-    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBeUndefined();
+    // An exact `localhost` pair stays authorized (#2382). Refusing it removed
+    // the relay for localhost-served users without closing a reachable hazard —
+    // see the LOOPBACK_HOSTS comment for the Happy-Eyeballs measurement.
+    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBe("http://localhost:8188");
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://[::1]:8188/comfyapi")).toBeUndefined();

--- a/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
+++ b/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
@@ -4,6 +4,9 @@ import { createServer, type Server } from "node:http";
 const state = vi.hoisted(() => ({
   baseUrl: "http://127.0.0.1:8188",
   headlessCalls: 0,
+  headlessUrls: [] as string[],
+  /** When set, the headless COMFYUI_URL path answers with this index instead of throwing. */
+  headlessIndex: undefined as Record<string, unknown> | undefined,
 }));
 
 vi.mock("../../config.js", () => ({
@@ -12,9 +15,16 @@ vi.mock("../../config.js", () => ({
 }));
 
 vi.mock("../../comfyui/fetch.js", () => ({
-  comfyuiFetch: async () => {
+  comfyuiFetch: async (url: string) => {
     state.headlessCalls += 1;
-    throw new Error("the panel-backed path must not use COMFYUI_URL");
+    state.headlessUrls.push(url);
+    // Default: assert the panel-backed path never reaches COMFYUI_URL. Tests
+    // that EXPECT the headless path set state.headlessIndex first.
+    if (state.headlessIndex === undefined) throw new Error("the panel-backed path must not use COMFYUI_URL");
+    return new Response(JSON.stringify(state.headlessIndex), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
   },
 }));
 
@@ -73,6 +83,8 @@ afterEach(async () => {
   delete process.env.COMFYUI_MCP_RELAY_SECRET;
   delete process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL;
   state.headlessCalls = 0;
+  state.headlessUrls = [];
+  state.headlessIndex = undefined;
   for (const server of servers.splice(0)) await server.close();
   vi.restoreAllMocks();
 });
@@ -108,23 +120,30 @@ describe("list_packs -> panel template relay production boundary (#2196)", () =>
     });
     expect(state.headlessCalls).toBe(0);
   });
-  // #2382/#2385 REGRESSION PIN. 0.52.135 dropped "localhost" from the relay's
-  // loopback set, so this exact call returned "The connected panel template
-  // relay failed (NO_PANEL_ORIGIN)." instead of the index for every user whose
-  // ComfyUI is served at http://localhost:<port>. The headless COMFYUI_URL path
-  // is fail-closed once a panel route exists, so there was nothing to fall back
-  // to. This drives the REAL orchestrator wiring, not a hand-written origin
-  // resolver, because the defect lived in what that wiring authorizes.
-  it("serves list_templates through the relay when the panel is served at localhost", async () => {
+  // #2382/#2385 REGRESSION PIN — the user-visible surface.
+  //
+  // 0.52.135 dropped "localhost" from the relay's loopback set, so this exact
+  // call returned "The connected panel template relay failed (NO_PANEL_ORIGIN)."
+  // instead of the index for every user whose ComfyUI is served at
+  // http://localhost:<port>, with no headless fallback to catch it.
+  //
+  // The relay still refuses to FETCH the ambiguous name — that part of the
+  // refusal is correct — but it now declines, so list_templates completes on
+  // the established headless path. Drives the REAL orchestrator wiring, because
+  // the defect lived in what that wiring authorizes.
+  it("completes list_templates headlessly when the panel is served at localhost", async () => {
+    let panelRequests = 0;
     const panel = createServer((_req, res) => {
+      panelRequests += 1;
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ "panel-pack": [{ name: "localhost-template" }] }));
+      res.end(JSON.stringify({ "wrong-listener": [{ name: "must-not-be-fetched" }] }));
     });
     const boundOrigin = await listen(panel);
     servers.push({ close: () => closeServer(panel) });
     const port = new URL(boundOrigin).port;
     const localhostOrigin = `http://localhost:${port}`;
-    state.baseUrl = `${localhostOrigin}/comfyapi`;
+    state.baseUrl = localhostOrigin;
+    state.headlessIndex = { "headless-pack": [{ name: "localhost-template" }] };
 
     const bridge = {
       canReach: () => true,
@@ -147,12 +166,15 @@ describe("list_packs -> panel template relay production boundary (#2196)", () =>
 
     const result = await listPacksHandler()({ action: "list_templates" });
     const text = result.content.map((block) => block.text).join(" ");
+    // The 0.52.135 symptom, verbatim, must not be what the user sees.
     expect(text).not.toContain("NO_PANEL_ORIGIN");
     expect(JSON.parse(text)).toMatchObject({
-      source_count: 1,
-      template_count: 1,
-      templates: { "panel-pack": [{ name: "localhost-template" }] },
+      templates: { "headless-pack": [{ name: "localhost-template" }] },
     });
-    expect(state.headlessCalls).toBe(0);
+    // It completed BECAUSE it degraded, against the same origin the panel is on.
+    expect(state.headlessCalls).toBe(1);
+    expect(state.headlessUrls).toEqual([`${localhostOrigin}/api/workflow_templates`]);
+    // And the ambiguous name was never relayed, so no other listener could answer.
+    expect(panelRequests).toBe(0);
   });
 });

--- a/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
+++ b/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../services/manifest.js", () => ({
 
 import { registerSkillsAccessTools } from "../../tools/skills-access.js";
 import { startPanelTemplateRelayServer } from "../../services/panel-template-relay.js";
+import { createPanelTemplateRelayWiring } from "../../orchestrator/index.js";
 
 const SECRET = "b".repeat(64);
 const servers: Array<{ close(): Promise<void> }> = [];
@@ -104,6 +105,53 @@ describe("list_packs -> panel template relay production boundary (#2196)", () =>
       source_count: 1,
       template_count: 1,
       templates: { "panel-pack": [{ name: "live-template" }] },
+    });
+    expect(state.headlessCalls).toBe(0);
+  });
+  // #2382/#2385 REGRESSION PIN. 0.52.135 dropped "localhost" from the relay's
+  // loopback set, so this exact call returned "The connected panel template
+  // relay failed (NO_PANEL_ORIGIN)." instead of the index for every user whose
+  // ComfyUI is served at http://localhost:<port>. The headless COMFYUI_URL path
+  // is fail-closed once a panel route exists, so there was nothing to fall back
+  // to. This drives the REAL orchestrator wiring, not a hand-written origin
+  // resolver, because the defect lived in what that wiring authorizes.
+  it("serves list_templates through the relay when the panel is served at localhost", async () => {
+    const panel = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ "panel-pack": [{ name: "localhost-template" }] }));
+    });
+    const boundOrigin = await listen(panel);
+    servers.push({ close: () => closeServer(panel) });
+    const port = new URL(boundOrigin).port;
+    const localhostOrigin = `http://localhost:${port}`;
+    state.baseUrl = `${localhostOrigin}/comfyapi`;
+
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: () => "tab-1",
+      tabServerOrigin: () => localhostOrigin,
+    };
+    const relay = await startPanelTemplateRelayServer({
+      bridge,
+      ...createPanelTemplateRelayWiring({
+        bridge,
+        currentTarget: () => state.baseUrl,
+        currentTargetGeneration: () => 0,
+        secrets: new Map([[SECRET, "orchestrator::codex"]]),
+      }),
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    const result = await listPacksHandler()({ action: "list_templates" });
+    const text = result.content.map((block) => block.text).join(" ");
+    expect(text).not.toContain("NO_PANEL_ORIGIN");
+    expect(JSON.parse(text)).toMatchObject({
+      source_count: 1,
+      template_count: 1,
+      templates: { "panel-pack": [{ name: "localhost-template" }] },
     });
     expect(state.headlessCalls).toBe(0);
   });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -115,6 +115,7 @@ import {
 } from "../services/panel-image-relay.js";
 import {
   startPanelTemplateRelayServer,
+  ambiguousLoopbackNameOrigin,
   currentPanelTemplateOrigin,
   verifyPanelTemplateRelayCapability,
   type PanelTemplateRelayResolvedAgent,
@@ -954,6 +955,7 @@ export interface PanelTemplateRelayWiring {
   resolveCurrentTarget: () => PanelTemplateRelayTarget;
   resolvePanelUrl: (tabId: string, currentTarget: string) => string | undefined;
   resolveAllowedPanelOrigin: (tabId: string, currentTarget: string) => string | undefined;
+  resolveAmbiguousLoopbackOrigin: (tabId: string, currentTarget: string) => boolean;
 }
 
 /**
@@ -987,6 +989,11 @@ export function createPanelTemplateRelayWiring(options: {
   });
   const resolveAllowedPanelOrigin = (tabId: string, currentTarget: string): string | undefined =>
     currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), currentTarget);
+  // #2382 — separates "cannot authorize this origin" from "this origin is an
+  // ambiguous loopback NAME identical on both sides". Only the latter degrades
+  // to the headless path; everything else stays a hard relay failure.
+  const resolveAmbiguousLoopbackOrigin = (tabId: string, currentTarget: string): boolean =>
+    ambiguousLoopbackNameOrigin(options.bridge.tabServerOrigin(tabId), currentTarget);
   const resolvePanelUrl = (tabId: string, currentTarget: string): string | undefined => {
     const origin = currentPanelTemplateOrigin(options.bridge.tabServerOrigin(tabId), currentTarget);
     if (!origin) return undefined;
@@ -1003,6 +1010,7 @@ export function createPanelTemplateRelayWiring(options: {
     resolveCurrentTarget,
     resolvePanelUrl,
     resolveAllowedPanelOrigin,
+    resolveAmbiguousLoopbackOrigin,
   };
 }
 

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -21,10 +21,29 @@ export const PANEL_TEMPLATE_RELAY_HTTP_PATH = "/__comfyui_mcp_panel_template_rel
 
 const ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const HEX_RE = /^[a-f0-9]{64}$/;
-// A hostname does not identify which loopback listener a browser reached. Keep
-// relay destinations pinned to literal addresses so fetch cannot independently
-// resolve `localhost` to a different process or address family.
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1"]);
+// `localhost` is a NAME, not a listener identity, so an exact origin match does
+// not prove the later fetch reaches the socket the browser is on (#2382). It is
+// still accepted here, because refusing it costs more than it buys:
+//
+//   - Refusing it (#2385, shipped in 0.52.135) took `list_packs
+//     action:"list_templates"` from working to erroring for every user whose
+//     ComfyUI is served at `http://localhost:<port>` — an ordinary setup, and
+//     the panel Origin is the browser's. The relay declines, and
+//     `listWorkflowTemplatesAction` deliberately does not fall back to
+//     COMFYUI_URL once a panel route exists, so the action has no path left.
+//   - The non-adversarial hazard it was meant to prevent does not occur on a
+//     supported runtime. Node >=20 connects with Happy Eyeballs
+//     (`autoSelectFamily`), so `fetch("http://localhost:<port>")` reaches a
+//     127.0.0.1-only OR a ::1-only listener; measured on Node 24.16.0 against
+//     both single-family binds. There is no "resolved the wrong family and the
+//     fetch failed" case to fix.
+//   - What remains is a second local process squatting the other loopback
+//     family, which one-machine/one-trust-domain puts out of scope.
+//
+// So the destination stays loopback-only, and `localhost` stays usable. A
+// mixed pair (`localhost` observed vs `127.0.0.1` configured, or vice versa)
+// is still refused below by the exact-origin equality.
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
 export interface PanelTemplateRelayRequest {
   version: typeof PANEL_TEMPLATE_RELAY_VERSION;

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -21,29 +21,23 @@ export const PANEL_TEMPLATE_RELAY_HTTP_PATH = "/__comfyui_mcp_panel_template_rel
 
 const ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const HEX_RE = /^[a-f0-9]{64}$/;
-// `localhost` is a NAME, not a listener identity, so an exact origin match does
-// not prove the later fetch reaches the socket the browser is on (#2382). It is
-// still accepted here, because refusing it costs more than it buys:
+// Relay destinations are LITERAL loopback addresses only. A hostname does not
+// identify which listener a browser reached, so `localhost` must never become a
+// relay fetch target: Node >=20 connects with Happy Eyeballs, and with a second
+// process on the other loopback family that fetch can reach the wrong one
+// (#2382).
 //
-//   - Refusing it (#2385, shipped in 0.52.135) took `list_packs
-//     action:"list_templates"` from working to erroring for every user whose
-//     ComfyUI is served at `http://localhost:<port>` — an ordinary setup, and
-//     the panel Origin is the browser's. The relay declines, and
-//     `listWorkflowTemplatesAction` deliberately does not fall back to
-//     COMFYUI_URL once a panel route exists, so the action has no path left.
-//   - The non-adversarial hazard it was meant to prevent does not occur on a
-//     supported runtime. Node >=20 connects with Happy Eyeballs
-//     (`autoSelectFamily`), so `fetch("http://localhost:<port>")` reaches a
-//     127.0.0.1-only OR a ::1-only listener; measured on Node 24.16.0 against
-//     both single-family binds. There is no "resolved the wrong family and the
-//     fetch failed" case to fix.
-//   - What remains is a second local process squatting the other loopback
-//     family, which one-machine/one-trust-domain puts out of scope.
-//
-// So the destination stays loopback-only, and `localhost` stays usable. A
-// mixed pair (`localhost` observed vs `127.0.0.1` configured, or vice versa)
-// is still refused below by the exact-origin equality.
-const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+// `localhost` is NOT simply refused, though — refusing it outright (#2385,
+// shipped in 0.52.135) took `list_packs action:"list_templates"` from working to
+// erroring for every user whose ComfyUI is served at `http://localhost:<port>`.
+// See AMBIGUOUS_LOOPBACK_NAMES: that case declines the RELAY and lets the caller
+// continue on its established headless path instead.
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1"]);
+
+// Loopback names that resolve to an address family rather than naming one. An
+// origin built from these cannot authorize a relay fetch, but it is also not an
+// error: see ambiguousLoopbackNameOrigin.
+const AMBIGUOUS_LOOPBACK_NAMES = new Set(["localhost"]);
 
 export interface PanelTemplateRelayRequest {
   version: typeof PANEL_TEMPLATE_RELAY_VERSION;
@@ -100,6 +94,11 @@ export interface PanelTemplateRelayServerOptions {
   resolvePanelUrl: (tabId: string, currentTarget: string) => string | undefined;
   /** Must return undefined unless the tab's origin is authorized for currentTarget. */
   resolveAllowedPanelOrigin: (tabId: string, currentTarget: string) => string | undefined;
+  /**
+   * True when the refusal is only an ambiguous loopback NAME identical on both
+   * sides, which the child reports as "no panel route" rather than a failure.
+   */
+  resolveAmbiguousLoopbackOrigin?: (tabId: string, currentTarget: string) => boolean;
 }
 
 export interface PanelTemplateRelayServer {
@@ -240,6 +239,7 @@ function validateResponse(value: unknown, requestId: string, secret: string): Re
 
 function errorMessage(error: string): string {
   const known = new Set([
+    "AMBIGUOUS_PANEL_ORIGIN",
     "AMBIGUOUS_REQUESTER",
     "BACKLOG_FULL",
     "HTTP_ERROR",
@@ -454,6 +454,37 @@ export function currentPanelTemplateOrigin(
   return exactLoopbackOrigin ? observed.origin : undefined;
 }
 
+/**
+ * True when the panel Origin and the configured target are the SAME ambiguous
+ * loopback name (`http://localhost:8188` on both sides).
+ *
+ * This is the one refusal that must not surface as an error. The relay cannot
+ * use the origin — `localhost` does not name a listener, so fetching it could
+ * reach a different process on the other loopback family (#2382). But because
+ * the two operands are byte-identical, the caller's headless COMFYUI_URL path
+ * points at *the same origin string the panel is on*, so degrading to it cannot
+ * "silently list a different server's templates" — the concern that makes the
+ * relay fail-closed everywhere else. By construction there is no other server.
+ *
+ * A MIXED pair (`localhost` observed vs `127.0.0.1` configured, or the reverse)
+ * is a genuine mismatch and stays a hard refusal.
+ */
+export function ambiguousLoopbackNameOrigin(
+  panelOrigin: string | undefined,
+  currentTarget: string | undefined,
+): boolean {
+  const observed = parsedHttpOrigin(panelOrigin);
+  const target = parsedHttpOrigin(currentTarget);
+  if (!observed || !target) return false;
+  return (
+    AMBIGUOUS_LOOPBACK_NAMES.has(observed.host) &&
+    AMBIGUOUS_LOOPBACK_NAMES.has(target.host) &&
+    observed.protocol === target.protocol &&
+    observed.port === target.port &&
+    observed.origin === target.origin
+  );
+}
+
 function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | undefined): URL | undefined {
   if (!raw) return undefined;
   try {
@@ -580,7 +611,15 @@ export async function startPanelTemplateRelayServer(
               options.bridge.resolveFailure?.(auth.agentKey) === "ambiguous" ? "AMBIGUOUS_REQUESTER" : "NO_LIVE_PANEL",
             );
           } else if (!panelUrl) {
-            response = failureResponse(request.requestId, "NO_PANEL_ORIGIN");
+            // An identical ambiguous loopback name is a DECLINE, not a failure:
+            // the child turns AMBIGUOUS_PANEL_ORIGIN back into "no panel route"
+            // so list_templates continues headless instead of erroring (#2382).
+            response = failureResponse(
+              request.requestId,
+              options.resolveAmbiguousLoopbackOrigin?.(panelTab, targetAtStart.url)
+                ? "AMBIGUOUS_PANEL_ORIGIN"
+                : "NO_PANEL_ORIGIN",
+            );
           } else {
             try {
               const body = await withinDeadline(fetchPanelIndex(panelUrl, requestDeadline(request)), requestDeadline(request));
@@ -684,6 +723,10 @@ export async function requestPanelTemplateIndex(): Promise<Record<string, unknow
     throw new PanelTemplateRelayError("The connected panel template relay is unavailable.", code, httpResponse.status >= 500);
   }
   const response = validateResponse(decoded, request.requestId, secret);
+  // The relay declined an ambiguous loopback name rather than failing. That is
+  // "this child has no usable panel route" — the documented meaning of
+  // undefined — so the caller keeps its established headless path (#2382).
+  if (response.ok === false && response.error === "AMBIGUOUS_PANEL_ORIGIN") return undefined;
   if (response.ok === false) responseFailureMessage(response);
   const age = Date.now() - response.updated;
   if (

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -468,6 +468,14 @@ export function currentPanelTemplateOrigin(
  *
  * A MIXED pair (`localhost` observed vs `127.0.0.1` configured, or the reverse)
  * is a genuine mismatch and stays a hard refusal.
+ *
+ * Unlike currentPanelTemplateOrigin, this does NOT compare `.origin`. There the
+ * comparison is load-bearing, because LOOPBACK_HOSTS holds two members and
+ * `127.0.0.1` vs `::1` would otherwise pass. Here the clauses below already
+ * force both origins to be equal — same single-name host, same protocol, same
+ * port — so an origin comparison could not fail, and a clause that cannot fail
+ * reads as a guard while guarding nothing. If AMBIGUOUS_LOOPBACK_NAMES ever
+ * gains a second name, add `observed.host === target.host` here.
  */
 export function ambiguousLoopbackNameOrigin(
   panelOrigin: string | undefined,
@@ -480,8 +488,7 @@ export function ambiguousLoopbackNameOrigin(
     AMBIGUOUS_LOOPBACK_NAMES.has(observed.host) &&
     AMBIGUOUS_LOOPBACK_NAMES.has(target.host) &&
     observed.protocol === target.protocol &&
-    observed.port === target.port &&
-    observed.origin === target.origin
+    observed.port === target.port
   );
 }
 


### PR DESCRIPTION
## What this is

**A regression fix for something live on npm `latest`.** #2385 merged at 22:52:40Z and shipped as **0.52.135**, the current published `latest`. It took `list_packs action:"list_templates"` from working to erroring for every user whose ComfyUI is served at `http://localhost:<port>`.

**#2385's refusal was right; its *shape* was wrong.** This keeps the refusal and changes it from a failure into a decline.

## Reproduced by execution

Driving the real orchestrator wiring (`createPanelTemplateRelayWiring`) through the real `list_packs` handler, one variable changed — the panel host:

| | panel at `127.0.0.1:<p>` | panel at `localhost:<p>` |
|---|---|---|
| **0.52.135 (shipped)** | `RELAYED-OK` | `The connected panel template relay failed (NO_PANEL_ORIGIN).` |
| **this PR** | `RELAYED-OK` | completes on the headless path |

`127.0.0.1` is the control and survives both arms. In the broken arm the headless-fallback counter stays at **0**: `listWorkflowTemplatesAction` is fail-closed once a panel route exists, so there was no path left for the user.

## The design

`localhost` still **never becomes a relay fetch target** — it names an address family, not a listener, so with a second process on the other loopback family the fetch could reach the wrong one. `LOOPBACK_HOSTS` stays literal-addresses-only, exactly as #2385 left it.

What changes is what happens next. An **identical** ambiguous pair (`http://localhost:8188` on both sides) now returns `AMBIGUOUS_PANEL_ORIGIN`, which the child converts back to `undefined` — the already-documented *"this MCP child has no panel relay route"* — so the caller continues on its established headless path instead of raising.

**Why degrading is safe here and nowhere else:** the two operands are byte-identical, so `COMFYUI_URL` is provably the same origin string the panel is on. The rule this seems to bend — *"falling back to COMFYUI_URL could silently list a different server's templates"* — cannot apply, because by construction there is no different server. A **mixed** pair (`localhost` vs `127.0.0.1`) is a genuine mismatch and stays a hard `NO_PANEL_ORIGIN` failure.

## Gate round 1

The first revision simply re-admitted `localhost`, and the gate returned NO-SHIP on it, naming the wrong-listener fetch. That finding was correct about the mechanism, so I did not argue it — I removed the fetch instead. The relay no longer resolves an ambiguous name at all; only the *reporting* of that refusal changed.

## Where the load-bearing claims are — please attack these

1. **The "provably the same server" argument** is what licenses the fallback. It rests on `ambiguousLoopbackNameOrigin` requiring equal host, scheme and port. If that predicate can return true for two origins that are not the same server, the fail-closed rule is broken and this PR is wrong.
2. **Returning `undefined` for `AMBIGUOUS_PANEL_ORIGIN`** widens the meaning of a documented sentinel. I claim it is exactly the documented meaning; worth checking against every other caller of `requestPanelTemplateIndex()`.
3. **The headless path inherits the ambiguity** — `comfyuiFetch` to `http://localhost:8188` re-resolves the same name. This PR does not close that, and does not claim to: it is the pre-existing behaviour of every non-panel user and is out of scope here.

## Verification — mutation, clause by clause

Every clause was reverted **independently** against committed code, and each kills at least one test (16 tests across 3 files; the rest survive as controls):

| mutation | result |
|---|---|
| child no longer converts the decline to `undefined` | **2 failed** |
| server never emits `AMBIGUOUS_PANEL_ORIGIN` | **2 failed** |
| `resolveAmbiguousLoopbackOrigin` dropped from the orchestrator wiring | **2 failed** |
| name-set membership check removed | **3 failed** |
| scheme clause removed | **1 failed** |
| port clause removed | **1 failed** |
| `localhost` re-added to `LOOPBACK_HOSTS` | **3 failed** |

Two of these were found *because* a mutation survived, and both were fixed rather than explained away:

- **`observed.origin === target.origin` survived removal** — with a single-name `AMBIGUOUS_LOOPBACK_NAMES`, equal host + scheme + port already forces equal origins, so the clause could not fail. Removed, with the sufficiency argument written down and a note to restore a host comparison if the set ever grows. (`currentPanelTemplateOrigin` keeps its origin comparison — there it *is* load-bearing, because `LOOPBACK_HOSTS` has two members.)
- **The scheme clause survived** because no test varied it. Added https/http `localhost` pairs, which kill it.

Also: two earlier mutation attempts **never applied** (CRLF anchors, then an anchor that matched both functions) and would have read as "survived". Re-run with unique CRLF-aware anchors; the numbers above are from applied mutations only.

Other gates: full suite **680 files, 12688 passed, 6 skipped, 0 failed** (collection confirmed non-zero inside the worktree); `npm run build` clean; `npm run lint` clean (anti-slop "none added").

**No browser gate was run and none is claimed** — this is entirely orchestrator/service-side and renders nothing in the panel.

## On the issue

The underlying mechanism recorded in #2382 — that a browser Origin naming `localhost` cannot identify a listener — is unchanged by this PR; it is avoided rather than solved. I am reopening #2382 and marking it `autopilot:parked`, matching its reporter's own sizing: P3, no report of the failure occurring, and both "make localhost unambiguous" designs need a resolution the Origin header cannot supply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
