### PR TITLE
fix(2382): pin the relay fetch to literal loopback addresses so localhost works again

### DIFF
--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -108,7 +108,7 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
     expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
 
-    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188"]) {
+    for (const origin of ["http://127.0.0.1:8188", "http://[::1]:8188", "http://localhost:8188"]) {
       target = `${origin}/comfyapi`;
       observedOrigin = origin;
       expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(origin);
@@ -127,17 +127,23 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
   });
 
-  it("refuses an exact localhost match before fetch can resolve another loopback listener", async () => {
+  // #2382/#2385. Dropping "localhost" from LOOPBACK_HOSTS made this request
+  // fail NO_PANEL_ORIGIN, which shipped in 0.52.135 and is still live: #2387
+  // documented the fail-closed rule but changed no behaviour here. Authorizing
+  // the origin — rather than declining it — is also what keeps the fetch under
+  // the relay's own generation fence, instead of handing it to a child that may
+  // still hold the pre-retarget target (#1429).
+  it("serves a localhost-served panel and still refuses a mixed localhost/127.0.0.1 pair", async () => {
     let panelRequests = 0;
     const panel = createServer((_req, res) => {
       panelRequests += 1;
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ "unexpected-pack": [{ name: "wrong-listener" }] }));
+      res.end(JSON.stringify({ "panel-pack": [{ name: "localhost-template" }] }));
     });
     const panelOrigin = await listen(panel);
     servers.push({ close: () => closeServer(panel) });
     const port = new URL(panelOrigin).port;
-    const target = `http://localhost:${port}/comfyapi`;
+    let target = `http://localhost:${port}/comfyapi`;
     const observedOrigin = `http://localhost:${port}`;
     const bridge = {
       canReach: () => true,
@@ -151,14 +157,25 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
       currentTargetGeneration: () => 0,
       secrets: new Map([[SECRET, "orchestrator::codex"]]),
     });
-    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
-    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(observedOrigin);
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBe(`${observedOrigin}/comfyapi/api/workflow_templates`);
+
     const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
     servers.push(relay);
     process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
     process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+    await expect(requestPanelTemplateIndex()).resolves.toMatchObject({
+      "panel-pack": [{ name: "localhost-template" }],
+    });
+    expect(panelRequests).toBe(1);
+
+    // A MIXED pair is a genuine mismatch, not a name ambiguity, and must stay a
+    // hard refusal that never reaches the panel.
+    target = `http://127.0.0.1:${port}/comfyapi`;
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
-    expect(panelRequests).toBe(0);
+    expect(panelRequests).toBe(1);
   });
 
   it("rejects a stale in-flight response after retargeting and still serves the current target", async () => {

--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -316,4 +316,58 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     expect(hits.length).toBeGreaterThan(0);
     for (const host of hits) expect(host).not.toContain("localhost");
   });
+  // #2382 — a listener that answers BADLY is still a listener. The pinned fetch
+  // must not quietly prefer whichever address happened to return valid JSON:
+  // the erroring one could be the real panel, and then we would be serving the
+  // other process's index — the exact bug pinning exists to prevent.
+  it("refuses when one loopback listener 503s and another returns a valid index", async () => {
+    const v4 = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ "v4-pack": [{ name: "from-127" }] }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      v4.once("error", reject);
+      v4.listen({ host: "127.0.0.1", port: 0 }, () => resolve());
+    });
+    const addr = v4.address();
+    if (!addr || typeof addr === "string") throw new Error("no bind");
+    const port = addr.port;
+    servers.push({ close: () => closeServer(v4) });
+
+    const v6 = createServer((_req, res) => {
+      res.writeHead(503);
+      res.end("unavailable");
+    });
+    let v6Bound = true;
+    await new Promise<void>((resolve) => {
+      v6.once("error", () => { v6Bound = false; resolve(); });
+      v6.listen({ host: "::1", port, ipv6Only: true }, () => resolve());
+    });
+    if (!v6Bound) return; // No IPv6 loopback here; nothing to disagree with.
+    servers.push({ close: () => closeServer(v6) });
+
+    const target = `http://localhost:${port}/comfyapi`;
+    const observedOrigin = `http://localhost:${port}`;
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: () => "tab-1",
+      tabServerOrigin: () => observedOrigin,
+    };
+    const relay = await startPanelTemplateRelayServer({
+      bridge,
+      ...createPanelTemplateRelayWiring({
+        bridge,
+        currentTarget: () => target,
+        currentTargetGeneration: () => 0,
+        secrets: new Map([[SECRET, "orchestrator::codex"]]),
+      }),
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    // NOT the v4 index, even though v4 answered perfectly well.
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "AMBIGUOUS_PANEL_LISTENER" });
+  });
 });

--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -252,4 +252,68 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     });
     expect(panelRequests).toBe(2);
   });
+  // #2382 — the ambiguity is REMOVED, not refused. `localhost` authorizes the
+  // origin, but the fetch is pinned to literal addresses, and when more than one
+  // loopback address answers they must agree.
+  it("pins a localhost fetch to a literal address and refuses two disagreeing listeners", async () => {
+    const hits: string[] = [];
+    const makeServer = (payload: string) =>
+      createServer((req, res) => {
+        hits.push(`${req.headers.host ?? "?"}`);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(payload);
+      });
+    // Bind the SAME port on both loopback families. Two distinct processes on a
+    // dual-stack machine look exactly like this.
+    const v4 = makeServer(JSON.stringify({ "v4-pack": [{ name: "from-127" }] }));
+    await new Promise<void>((resolve, reject) => {
+      v4.once("error", reject);
+      v4.listen({ host: "127.0.0.1", port: 0 }, () => resolve());
+    });
+    const addr = v4.address();
+    if (!addr || typeof addr === "string") throw new Error("no bind");
+    const port = addr.port;
+    servers.push({ close: () => closeServer(v4) });
+
+    const v6 = makeServer(JSON.stringify({ "v6-pack": [{ name: "from-::1" }] }));
+    let v6Bound = true;
+    await new Promise<void>((resolve) => {
+      v6.once("error", () => { v6Bound = false; resolve(); });
+      v6.listen({ host: "::1", port, ipv6Only: true }, () => resolve());
+    });
+    if (v6Bound) servers.push({ close: () => closeServer(v6) });
+
+    const target = `http://localhost:${port}/comfyapi`;
+    const observedOrigin = `http://localhost:${port}`;
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: () => "tab-1",
+      tabServerOrigin: () => observedOrigin,
+    };
+    const wiring = createPanelTemplateRelayWiring({
+      bridge,
+      currentTarget: () => target,
+      currentTargetGeneration: () => 0,
+      secrets: new Map([[SECRET, "orchestrator::codex"]]),
+    });
+    // The origin is authorized — that is the half #2385 removed.
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(observedOrigin);
+
+    const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    if (v6Bound) {
+      // Two listeners, two different indexes: refuse rather than guess.
+      await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "AMBIGUOUS_PANEL_LISTENER" });
+    } else {
+      await expect(requestPanelTemplateIndex()).resolves.toMatchObject({ "v4-pack": [{ name: "from-127" }] });
+    }
+    // Whatever happened, the NAME was never the destination: every request
+    // arrived with a literal-address Host header.
+    expect(hits.length).toBeGreaterThan(0);
+    for (const host of hits) expect(host).not.toContain("localhost");
+  });
 });

--- a/src/__tests__/services/panel-template-relay-dns-pin.test.ts
+++ b/src/__tests__/services/panel-template-relay-dns-pin.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+
+// #2382. The relay resolves an ambiguous loopback NAME itself, so this file
+// controls what that name resolves to. Before the fetch was pinned, only the
+// ORIGIN STRING was checked against the loopback set — a hosts-file entry
+// pointing `localhost` off-box would have been fetched with no check at all.
+// A dedicated file because every other relay test needs real resolution.
+const dnsState = vi.hoisted(() => ({ addresses: [] as Array<{ address: string; family: number }> }));
+
+vi.mock("node:dns", () => ({
+  lookup: (
+    _hostname: string,
+    _options: unknown,
+    cb: (err: NodeJS.ErrnoException | null, addresses: Array<{ address: string; family: number }>) => void,
+  ) => {
+    cb(null, dnsState.addresses);
+  },
+}));
+
+const { startPanelTemplateRelayServer, requestPanelTemplateIndex } = await import("../../services/panel-template-relay.js");
+
+const SECRET = "c".repeat(64);
+const servers: Array<{ close(): Promise<void> }> = [];
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  return address.port;
+}
+
+afterEach(async () => {
+  delete process.env.COMFYUI_MCP_RELAY_SECRET;
+  delete process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL;
+  for (const server of servers.splice(0)) await server.close();
+});
+
+async function driveLocalhostRelay(): Promise<{ readonly panelRequests: number }> {
+  let panelRequests = 0;
+  const panel = createServer((_req, res) => {
+    panelRequests += 1;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ "panel-pack": [{ name: "served" }] }));
+  });
+  const port = await listen(panel);
+  servers.push({ close: () => new Promise<void>((resolve) => { panel.close(() => resolve()); }) });
+  const origin = `http://localhost:${port}`;
+  const target = `${origin}/comfyapi`;
+  const relay = await startPanelTemplateRelayServer({
+    bridge: { canReach: () => true },
+    resolvePanelAgent: () => ({ agentKey: "orchestrator::codex", secret: SECRET }),
+    resolvePanelTab: () => "tab-1",
+    resolveCurrentTarget: () => ({ url: target, generation: 0 }),
+    resolvePanelUrl: () => `${origin}/comfyapi/api/workflow_templates`,
+    resolveAllowedPanelOrigin: () => origin,
+  } as never);
+  servers.push(relay);
+  process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+  process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+  // A getter, not a snapshot: the count must be read AFTER the request.
+  return { get panelRequests() { return panelRequests; } };
+}
+
+describe("panel template relay pins an ambiguous name to loopback literals (#2382)", () => {
+  it("refuses a localhost that resolves off-loopback, without issuing the fetch", async () => {
+    dnsState.addresses = [{ address: "203.0.113.7", family: 4 }];
+    const state = await driveLocalhostRelay();
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
+    expect(state.panelRequests).toBe(0);
+  });
+
+  it("refuses when only ONE of the resolved addresses is off-loopback", async () => {
+    // Partial trust is not trust: a name that points anywhere off-box is
+    // refused whole, never honoured for its loopback half.
+    dnsState.addresses = [
+      { address: "127.0.0.1", family: 4 },
+      { address: "203.0.113.7", family: 4 },
+    ];
+    const state = await driveLocalhostRelay();
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
+    expect(state.panelRequests).toBe(0);
+  });
+
+  it("serves the index when the name resolves to a single loopback literal", async () => {
+    dnsState.addresses = [{ address: "127.0.0.1", family: 4 }];
+    const state = await driveLocalhostRelay();
+    await expect(requestPanelTemplateIndex()).resolves.toMatchObject({ "panel-pack": [{ name: "served" }] });
+    expect(state.panelRequests).toBe(1);
+  });
+});

--- a/src/__tests__/services/panel-template-relay-dns-pin.test.ts
+++ b/src/__tests__/services/panel-template-relay-dns-pin.test.ts
@@ -72,16 +72,16 @@ async function driveLocalhostRelay(
 }
 
 describe("panel template relay pins an ambiguous name to loopback literals (#2382)", () => {
-  it("does NOT pin an https origin, so a cert issued to the name still verifies", async () => {
-    // Rewriting https://localhost to https://127.0.0.1 would fail certificate
-    // verification for an ordinary localhost cert. HTTPS therefore keeps the
-    // name — TLS is already the listener check. Proven by the ERROR CODE: an
-    // off-loopback resolution refuses an http origin outright (NO_PANEL_ORIGIN,
-    // below), but an https origin never reaches that guard and instead fails at
-    // the transport, because nothing is speaking TLS on the test server.
+  it("refuses an off-loopback https localhost too, not just http", async () => {
+    // HTTPS keeps the NAME so a cert issued to `localhost` still verifies, but
+    // it must NOT skip the address check on the way: a trusted cert for a
+    // `localhost` pointed off-box by a hosts entry would otherwise be fetched
+    // and relayed. Keeping the name and validating where it points are separate
+    // decisions, and only the first is scheme-dependent.
     dnsState.addresses = [{ address: "203.0.113.7", family: 4 }];
-    await driveLocalhostRelay({ scheme: "https" });
-    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "PANEL_FETCH_FAILED" });
+    const state = await driveLocalhostRelay({ scheme: "https" });
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
+    expect(state.panelRequests).toBe(0);
   });
 
 

--- a/src/__tests__/services/panel-template-relay-dns-pin.test.ts
+++ b/src/__tests__/services/panel-template-relay-dns-pin.test.ts
@@ -72,13 +72,14 @@ async function driveLocalhostRelay(
 }
 
 describe("panel template relay pins an ambiguous name to loopback literals (#2382)", () => {
-  it("refuses an off-loopback https localhost too, not just http", async () => {
-    // HTTPS keeps the NAME so a cert issued to `localhost` still verifies, but
-    // it must NOT skip the address check on the way: a trusted cert for a
-    // `localhost` pointed off-box by a hosts entry would otherwise be fetched
-    // and relayed. Keeping the name and validating where it points are separate
-    // decisions, and only the first is scheme-dependent.
-    dnsState.addresses = [{ address: "203.0.113.7", family: 4 }];
+  it("refuses an https localhost outright, so nothing is fetched by name over TLS", async () => {
+    // Over TLS the address cannot be pinned without breaking verification of a
+    // certificate issued to the name, which would leave the fetch re-resolving
+    // it. So https://localhost is not authorized at all -- which is exactly what
+    // main does today, so declining to restore it regresses nobody. Resolution
+    // is set to a LOOPBACK address here to prove the refusal is about the
+    // scheme, not about where the name points.
+    dnsState.addresses = [{ address: "127.0.0.1", family: 4 }];
     const state = await driveLocalhostRelay({ scheme: "https" });
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "NO_PANEL_ORIGIN" });
     expect(state.panelRequests).toBe(0);

--- a/src/__tests__/services/panel-template-relay-dns-pin.test.ts
+++ b/src/__tests__/services/panel-template-relay-dns-pin.test.ts
@@ -39,16 +39,22 @@ afterEach(async () => {
   for (const server of servers.splice(0)) await server.close();
 });
 
-async function driveLocalhostRelay(): Promise<{ readonly panelRequests: number }> {
+async function driveLocalhostRelay(
+  options: { scheme?: string; handler?: (res: import("node:http").ServerResponse) => void } = {},
+): Promise<{ readonly panelRequests: number }> {
   let panelRequests = 0;
   const panel = createServer((_req, res) => {
     panelRequests += 1;
+    if (options.handler) {
+      options.handler(res);
+      return;
+    }
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ "panel-pack": [{ name: "served" }] }));
   });
   const port = await listen(panel);
   servers.push({ close: () => new Promise<void>((resolve) => { panel.close(() => resolve()); }) });
-  const origin = `http://localhost:${port}`;
+  const origin = `${options.scheme ?? "http"}://localhost:${port}`;
   const target = `${origin}/comfyapi`;
   const relay = await startPanelTemplateRelayServer({
     bridge: { canReach: () => true },
@@ -66,6 +72,19 @@ async function driveLocalhostRelay(): Promise<{ readonly panelRequests: number }
 }
 
 describe("panel template relay pins an ambiguous name to loopback literals (#2382)", () => {
+  it("does NOT pin an https origin, so a cert issued to the name still verifies", async () => {
+    // Rewriting https://localhost to https://127.0.0.1 would fail certificate
+    // verification for an ordinary localhost cert. HTTPS therefore keeps the
+    // name — TLS is already the listener check. Proven by the ERROR CODE: an
+    // off-loopback resolution refuses an http origin outright (NO_PANEL_ORIGIN,
+    // below), but an https origin never reaches that guard and instead fails at
+    // the transport, because nothing is speaking TLS on the test server.
+    dnsState.addresses = [{ address: "203.0.113.7", family: 4 }];
+    await driveLocalhostRelay({ scheme: "https" });
+    await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "PANEL_FETCH_FAILED" });
+  });
+
+
   it("refuses a localhost that resolves off-loopback, without issuing the fetch", async () => {
     dnsState.addresses = [{ address: "203.0.113.7", family: 4 }];
     const state = await driveLocalhostRelay();

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -225,6 +225,10 @@ describe("authenticated panel template relay (#2196)", () => {
     // the LOOPBACK_HOSTS comment for the Happy-Eyeballs measurement and for why
     // neither pinning the fetch nor declining to the headless path works here.
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBe("http://localhost:8188");
+    // Over TLS the name is refused: the address cannot be pinned without
+    // breaking verification of a cert issued to it. Literal hosts are fine.
+    expect(currentPanelTemplateOrigin("https://localhost:8188", "https://localhost:8188/comfyapi")).toBeUndefined();
+    expect(currentPanelTemplateOrigin("https://127.0.0.1:8188", "https://127.0.0.1:8188/comfyapi")).toBe("https://127.0.0.1:8188");
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://[::1]:8188/comfyapi")).toBeUndefined();

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -220,9 +220,11 @@ describe("authenticated panel template relay (#2196)", () => {
     expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://127.0.0.1:8188");
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://[::1]:8188/comfyapi")).toBe("http://[::1]:8188");
-    // `localhost` is a name, not a listener identity. Accepting an exact
-    // localhost match would let the later fetch resolve a different family.
-    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBeUndefined();
+    // An exact `localhost` pair is authorized (#2382). Refusing it removed the
+    // relay for localhost-served users without closing a reachable hazard — see
+    // the LOOPBACK_HOSTS comment for the Happy-Eyeballs measurement and for why
+    // neither pinning the fetch nor declining to the headless path works here.
+    expect(currentPanelTemplateOrigin("http://localhost:8188", "http://localhost:8188/comfyapi")).toBe("http://localhost:8188");
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://[::1]:8188", "http://127.0.0.1:8188/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://localhost:8188", "http://[::1]:8188/comfyapi")).toBeUndefined();

--- a/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
+++ b/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
@@ -155,4 +155,58 @@ describe("list_packs -> panel template relay production boundary (#2196)", () =>
     expect(panelRequests).toBe(0);
     expect(state.headlessCalls).toBe(0);
   });
+  // #2382/#2385 REGRESSION PIN — the user-visible surface, still red on main.
+  //
+  // 0.52.135 dropped "localhost" from the relay's loopback set, so this exact
+  // call returns isError with "NO_PANEL_ORIGIN" instead of the index for every
+  // user whose ComfyUI is served at http://localhost:<port>. #2387 documented
+  // the fail-closed rule but changed no behaviour, so the regression survived it.
+  //
+  // The sibling test above pins the OTHER direction — a genuine post-retarget
+  // mismatch must still refuse. Both must hold at once: this one would pass if
+  // someone made the refusal fall through, and that one would then fail.
+  it("serves list_templates through the relay when the panel is served at localhost", async () => {
+    const panel = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ "panel-pack": [{ name: "localhost-template" }] }));
+    });
+    const boundOrigin = await listen(panel);
+    servers.push({ close: () => closeServer(panel) });
+    const port = new URL(boundOrigin).port;
+    const localhostOrigin = `http://localhost:${port}`;
+    state.baseUrl = `${localhostOrigin}/comfyapi`;
+
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: () => "tab-1",
+      tabServerOrigin: () => localhostOrigin,
+    };
+    const relay = await startPanelTemplateRelayServer({
+      bridge,
+      ...createPanelTemplateRelayWiring({
+        bridge,
+        currentTarget: () => state.baseUrl,
+        currentTargetGeneration: () => 0,
+        secrets: new Map([[SECRET, "orchestrator::codex"]]),
+      }),
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    const result = await listPacksHandler()({ action: "list_templates" });
+    const text = result.content.map((block) => block.text).join(" ");
+    // The 0.52.135 symptom, verbatim, must not be what the user gets.
+    expect(result.isError ?? false).toBe(false);
+    expect(text).not.toContain("NO_PANEL_ORIGIN");
+    expect(JSON.parse(text)).toMatchObject({
+      source_count: 1,
+      template_count: 1,
+      templates: { "panel-pack": [{ name: "localhost-template" }] },
+    });
+    // Served BY THE RELAY, under its generation fence — not by a child-side
+    // COMFYUI_URL fetch that a retarget could leave stale.
+    expect(state.headlessCalls).toBe(0);
+  });
 });

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -1,4 +1,6 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { lookup as dnsLookupCb } from "node:dns";
+import { promisify } from "node:util";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 
 /**
@@ -21,43 +23,47 @@ export const PANEL_TEMPLATE_RELAY_HTTP_PATH = "/__comfyui_mcp_panel_template_rel
 
 const ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const HEX_RE = /^[a-f0-9]{64}$/;
-// `localhost` is a NAME, not a listener identity, so an exact origin match does
-// not prove the later fetch reaches the socket the browser is on (#2382). It is
-// accepted anyway, because every alternative costs more than it buys.
+// Hosts that may AUTHORIZE a relay origin. `localhost` is included, but it is
+// never fetched as a name — see LOOPBACK_LITERALS and pinnedLoopbackUrls.
 //
-// WHAT REFUSING IT COST. Dropping it (#2385, shipped in 0.52.135) took
-// `list_packs action:"list_templates"` from working to erroring for every user
-// whose ComfyUI is served at `http://localhost:<port>` — an ordinary setup, and
-// the panel Origin is the browser's. The relay declines, and the caller is
-// fail-closed once a panel route exists, so the action has no path left.
+// #2382 is the reason this needs saying. `localhost` names an address family,
+// not a listener, so an exact origin match does not prove that a later
+// `fetch(url)` reaches the socket the browser is on: Node >=20 connects with
+// Happy Eyeballs, so the name can land on either loopback family. #2385
+// answered that by dropping `localhost` from this set, which took `list_packs
+// action:"list_templates"` from working to erroring for every user whose
+// ComfyUI is served at `http://localhost:<port>` — an ordinary setup, since the
+// panel Origin is the browser's — and the caller is fail-closed once a panel
+// route exists, so nothing caught it.
 //
-// WHY THE HAZARD IS NARROWER THAN IT LOOKS. The non-adversarial case does not
-// occur on a supported runtime: Node >=20 connects with Happy Eyeballs
-// (`autoSelectFamily`), so `fetch("http://localhost:<port>")` reaches a
-// 127.0.0.1-only OR a ::1-only listener — measured on Node 24.16.0 against both
-// single-family binds. What remains is a second local process squatting the
-// other loopback family, which one-machine/one-trust-domain puts out of scope.
+// The refusal was not the only option, and it was not the right one. The
+// ambiguity lives in the SECOND name resolution, not in the origin check, so it
+// is removed rather than refused: the destination is resolved once, here, and
+// every request goes to a literal address. Where a name resolves to more than
+// one loopback address the candidates must AGREE, which is the property that
+// actually matters and is checkable, unlike listener identity, which is not.
 //
-// WHY NEITHER HARDENING WORKS HERE — recorded so they are not re-attempted:
-//
-//   - Pinning the fetch to a literal address needs the family the browser
-//     reached, and the Origin header does not carry it. Probing cannot recover
-//     it either: a dual-stack ComfyUI bound to `::` answers on BOTH 127.0.0.1
-//     and ::1 and is byte-indistinguishable from two separate processes, so
-//     "both families answer" cannot be read as ambiguity without refusing an
-//     ordinary working setup. The only place the question is answerable is the
-//     browser, which knows its own origin — a panel-side fetch, i.e. a
-//     cross-repo change, not a bug fix.
-//   - Letting the refusal fall through to the headless COMFYUI_URL path is
-//     unsafe for the reason #2387 documents below: a mid-turn child keeps the
-//     PREVIOUS target across a retarget (#1429, retargetAllForMcpEnv), so it
-//     can list a stale server's index. The relay fetching the current target
-//     under its own generation fence is what prevents that — and is why
-//     authorizing the origin here, rather than declining it, is the safe half.
+// Not falling through to the headless COMFYUI_URL path on a refusal is
+// deliberate and stays that way (#2387): a mid-turn child keeps the PREVIOUS
+// target across a retarget (#1429, retargetAllForMcpEnv), so it can list a
+// stale server's index. Fetching here, under the relay's own generation fence,
+// is what prevents that.
 //
 // A mixed pair (`localhost` observed vs `127.0.0.1` configured, or the reverse)
 // is still refused by the exact-origin equality below.
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+// Relay fetches only ever go to a LITERAL loopback address. `localhost` may
+// authorize an origin (above), but it is never a fetch destination: see
+// pinnedLoopbackUrls, which resolves it to these before any request is made.
+const LOOPBACK_LITERALS = new Set(["127.0.0.1", "::1"]);
+
+// Promisified so the single resolution happens in ONE place we control.
+const dnsLookup = promisify(dnsLookupCb) as (
+  hostname: string,
+  options: { all: true; verbatim: boolean },
+) => Promise<Array<{ address: string; family: number }>>;
+const AMBIGUOUS_LOOPBACK_NAMES = new Set(["localhost"]);
 
 export interface PanelTemplateRelayRequest {
   version: typeof PANEL_TEMPLATE_RELAY_VERSION;
@@ -254,6 +260,7 @@ function validateResponse(value: unknown, requestId: string, secret: string): Re
 
 function errorMessage(error: string): string {
   const known = new Set([
+    "AMBIGUOUS_PANEL_LISTENER",
     "AMBIGUOUS_REQUESTER",
     "BACKLOG_FULL",
     "HTTP_ERROR",
@@ -494,6 +501,92 @@ function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | u
   }
 }
 
+/**
+ * Expands a relay URL into the literal-address URLs that will actually be
+ * fetched, so `fetch` never performs a second, independent name resolution
+ * (#2382).
+ *
+ * A literal host is returned unchanged. An ambiguous NAME is resolved once,
+ * here, and every resolved address must be loopback — which also closes a hole
+ * that existed before this function: a hosts-file entry pointing `localhost`
+ * off-box would previously have been fetched, because only the ORIGIN STRING
+ * was ever checked against the loopback set, never the address it resolves to.
+ */
+async function pinnedLoopbackUrls(url: URL): Promise<URL[]> {
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (LOOPBACK_LITERALS.has(host)) return [url];
+  if (!AMBIGUOUS_LOOPBACK_NAMES.has(host)) {
+    throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
+  }
+  let resolved: Array<{ address: string }>;
+  try {
+    resolved = await dnsLookup(host, { all: true, verbatim: true });
+  } catch {
+    throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
+  }
+  const urls: URL[] = [];
+  const seen = new Set<string>();
+  for (const { address } of resolved) {
+    const literal = address.toLowerCase();
+    // A name that resolves ANYWHERE off loopback is refused outright rather
+    // than partially honoured — the pair must be entirely local.
+    if (!LOOPBACK_LITERALS.has(literal)) {
+      throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
+    }
+    if (seen.has(literal)) continue;
+    seen.add(literal);
+    const pinned = new URL(url.href);
+    pinned.hostname = literal.includes(":") ? `[${literal}]` : literal;
+    urls.push(pinned);
+  }
+  if (urls.length === 0) {
+    throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
+  }
+  return urls;
+}
+
+/**
+ * Fetches the template index over pinned literal addresses.
+ *
+ * When a name resolves to more than one loopback address we cannot know which
+ * socket the browser reached — the Origin header does not carry the family, and
+ * probing cannot tell a dual-stack listener bound to `::` apart from two
+ * separate processes. So identity is not what we establish. We fetch every
+ * candidate and require them to AGREE: if each reachable address returns the
+ * same index, the answer is the same whichever one the panel is on, which is
+ * the property that actually matters. Disagreement is the real ambiguity, and
+ * is refused rather than resolved by guessing.
+ */
+async function fetchPinnedPanelIndex(url: URL, deadlineAt: number): Promise<string> {
+  const candidates = await pinnedLoopbackUrls(url);
+  if (candidates.length === 1) return fetchPanelIndex(candidates[0], deadlineAt);
+  const settled = await Promise.all(
+    candidates.map(async (candidate) => {
+      try {
+        return { ok: true as const, body: await fetchPanelIndex(candidate, deadlineAt) };
+      } catch (error) {
+        return { ok: false as const, error };
+      }
+    }),
+  );
+  const answered = settled.filter((r): r is { ok: true; body: string } => r.ok);
+  // Nothing answered: surface the first real failure rather than inventing one.
+  if (answered.length === 0) {
+    const firstFailure = settled.find((r) => !r.ok);
+    throw firstFailure && !firstFailure.ok
+      ? firstFailure.error
+      : new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
+  }
+  const first = answered[0].body;
+  if (answered.some((r) => r.body !== first)) {
+    throw new PanelTemplateRelayError(
+      "Two different loopback listeners answered the panel's address with different template indexes.",
+      "AMBIGUOUS_PANEL_LISTENER",
+    );
+  }
+  return first;
+}
+
 async function fetchPanelIndex(url: URL, deadlineAt: number): Promise<string> {
   const remaining = deadlineAt - Date.now();
   if (remaining <= 0) throw new PanelTemplateRelayError("The panel template relay timed out.", "TIMEOUT");
@@ -600,7 +693,7 @@ export async function startPanelTemplateRelayServer(
             response = failureResponse(request.requestId, "NO_PANEL_ORIGIN");
           } else {
             try {
-              const body = await withinDeadline(fetchPanelIndex(panelUrl, requestDeadline(request)), requestDeadline(request));
+              const body = await withinDeadline(fetchPinnedPanelIndex(panelUrl, requestDeadline(request)), requestDeadline(request));
               const targetNow = options.resolveCurrentTarget();
               if (targetNow.url !== targetAtStart.url || targetNow.generation !== targetAtStart.generation) {
                 throw new PanelTemplateRelayError(

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -472,6 +472,13 @@ export function currentPanelTemplateOrigin(
     observed.protocol === target.protocol &&
     observed.port === target.port &&
     observed.origin === target.origin;
+  // An ambiguous NAME is authorized over cleartext only. Over TLS the address
+  // cannot be pinned without breaking verification of a certificate issued to
+  // the name, which leaves the fetch re-resolving it -- so `https://localhost`
+  // stays refused, exactly as it is on main today. Nothing regresses by
+  // declining to restore it, and the http case is the reported one (#2382).
+  const ambiguousName = AMBIGUOUS_LOOPBACK_NAMES.has(observed.host) || AMBIGUOUS_LOOPBACK_NAMES.has(target.host);
+  if (ambiguousName && observed.protocol !== "http:") return undefined;
   return exactLoopbackOrigin ? observed.origin : undefined;
 }
 
@@ -512,10 +519,14 @@ function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | u
  * off-box would previously have been fetched, because only the ORIGIN STRING
  * was ever checked against the loopback set, never the address it resolves to.
  */
-async function pinnedLoopbackUrls(url: URL): Promise<{ primary: URL | undefined; corroborate: URL[] }> {
+async function pinnedLoopbackUrls(url: URL): Promise<URL[]> {
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (LOOPBACK_LITERALS.has(host)) return { primary: url, corroborate: [] };
-  if (!AMBIGUOUS_LOOPBACK_NAMES.has(host)) {
+  if (LOOPBACK_LITERALS.has(host)) return [url];
+  // Only a cleartext ambiguous name gets here: currentPanelTemplateOrigin
+  // refuses the TLS case, because pinning and certificate verification cannot
+  // both hold. Re-checked rather than assumed -- this function is what decides
+  // where a request is actually sent.
+  if (!AMBIGUOUS_LOOPBACK_NAMES.has(host) || url.protocol !== "http:") {
     throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
   }
   let resolved: Array<{ address: string }>;
@@ -528,9 +539,8 @@ async function pinnedLoopbackUrls(url: URL): Promise<{ primary: URL | undefined;
   for (const { address } of resolved) {
     const literal = address.toLowerCase();
     // A name that resolves ANYWHERE off loopback is refused whole rather than
-    // partially honoured -- the pair must be entirely local. This runs for https
-    // too: skipping it once let a `localhost` pointed off-box by a hosts entry
-    // be fetched, because only the ORIGIN STRING was ever checked.
+    // partially honoured. Before pinning, only the ORIGIN STRING was ever
+    // checked, so a `localhost` pointed off-box by a hosts entry was fetched.
     if (!LOOPBACK_LITERALS.has(literal)) {
       throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
     }
@@ -539,18 +549,11 @@ async function pinnedLoopbackUrls(url: URL): Promise<{ primary: URL | undefined;
   if (literals.length === 0) {
     throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
   }
-  const asLiteral = (literal: string): URL => {
+  return literals.map((literal) => {
     const pinned = new URL(url.href);
     pinned.hostname = literal.includes(":") ? `[${literal}]` : literal;
     return pinned;
-  };
-  // HTTPS keeps the NAME as the request it actually serves from, once the
-  // addresses are known to be local. Rewriting the host to a literal breaks
-  // certificate verification for a cert issued to `localhost`. The literals are
-  // still returned, as CORROBORATION rather than as the destination -- see
-  // fetchPinnedPanelIndex.
-  if (url.protocol === "https:") return { primary: url, corroborate: literals.map(asLiteral) };
-  return { primary: undefined, corroborate: literals.map(asLiteral) };
+  });
 }
 
 /**
@@ -566,37 +569,7 @@ async function pinnedLoopbackUrls(url: URL): Promise<{ primary: URL | undefined;
  * is refused rather than resolved by guessing.
  */
 async function fetchPinnedPanelIndex(url: URL, deadlineAt: number): Promise<string> {
-  const { primary, corroborate } = await pinnedLoopbackUrls(url);
-
-  // HTTPS (and a literal host) serve from `primary`. For a literal there is
-  // nothing to corroborate. For an https NAME the certificate is the listener
-  // check, so the literals are fetched only to CONTRADICT it: any that answers
-  // successfully must agree. A literal that fails -- refused, or a cert not
-  // issued to that IP, which is the normal case -- proves nothing and is
-  // ignored, so an ordinary https localhost is never broken by this. A second
-  // listener with a trusted certificate and a different index is caught.
-  if (primary) {
-    const body = await fetchPanelIndex(primary, deadlineAt);
-    if (corroborate.length <= 1) return body;
-    const others = await Promise.all(
-      corroborate.map(async (candidate) => {
-        try {
-          return await fetchPanelIndex(candidate, deadlineAt);
-        } catch {
-          return undefined;
-        }
-      }),
-    );
-    if (others.some((other) => other !== undefined && other !== body)) {
-      throw new PanelTemplateRelayError(
-        "Two different loopback listeners answered the panel's address with different template indexes.",
-        "AMBIGUOUS_PANEL_LISTENER",
-      );
-    }
-    return body;
-  }
-
-  const candidates = corroborate;
+  const candidates = await pinnedLoopbackUrls(url);
   if (candidates.length === 1) return fetchPanelIndex(candidates[0], deadlineAt);
   const settled = await Promise.all(
     candidates.map(async (candidate) => {
@@ -626,6 +599,8 @@ async function fetchPinnedPanelIndex(url: URL, deadlineAt: number): Promise<stri
     if (only.state === "ok") return only.body;
     throw only.error;
   }
+  // More than one listener answered the panel's address. Every one of them must
+  // have produced the SAME index, or we cannot say what the panel would see.
   const bodies: string[] = [];
   for (const result of present) {
     if (result.state !== "ok") {

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -512,9 +512,9 @@ function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | u
  * off-box would previously have been fetched, because only the ORIGIN STRING
  * was ever checked against the loopback set, never the address it resolves to.
  */
-async function pinnedLoopbackUrls(url: URL): Promise<URL[]> {
+async function pinnedLoopbackUrls(url: URL): Promise<{ primary: URL | undefined; corroborate: URL[] }> {
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (LOOPBACK_LITERALS.has(host)) return [url];
+  if (LOOPBACK_LITERALS.has(host)) return { primary: url, corroborate: [] };
   if (!AMBIGUOUS_LOOPBACK_NAMES.has(host)) {
     throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
   }
@@ -539,18 +539,18 @@ async function pinnedLoopbackUrls(url: URL): Promise<URL[]> {
   if (literals.length === 0) {
     throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
   }
-  // HTTPS keeps the NAME, once the addresses are known to be local. Rewriting
-  // the host to a literal breaks certificate verification for a cert issued to
-  // `localhost`, and TLS already binds the response to the name -- a stronger
-  // listener check than pinning gives. Only cleartext needs the second
-  // resolution removed. Keeping the name and validating where it points are
-  // separate decisions; only the first is scheme-dependent.
-  if (url.protocol === "https:") return [url];
-  return literals.map((literal) => {
+  const asLiteral = (literal: string): URL => {
     const pinned = new URL(url.href);
     pinned.hostname = literal.includes(":") ? `[${literal}]` : literal;
     return pinned;
-  });
+  };
+  // HTTPS keeps the NAME as the request it actually serves from, once the
+  // addresses are known to be local. Rewriting the host to a literal breaks
+  // certificate verification for a cert issued to `localhost`. The literals are
+  // still returned, as CORROBORATION rather than as the destination -- see
+  // fetchPinnedPanelIndex.
+  if (url.protocol === "https:") return { primary: url, corroborate: literals.map(asLiteral) };
+  return { primary: undefined, corroborate: literals.map(asLiteral) };
 }
 
 /**
@@ -566,7 +566,37 @@ async function pinnedLoopbackUrls(url: URL): Promise<URL[]> {
  * is refused rather than resolved by guessing.
  */
 async function fetchPinnedPanelIndex(url: URL, deadlineAt: number): Promise<string> {
-  const candidates = await pinnedLoopbackUrls(url);
+  const { primary, corroborate } = await pinnedLoopbackUrls(url);
+
+  // HTTPS (and a literal host) serve from `primary`. For a literal there is
+  // nothing to corroborate. For an https NAME the certificate is the listener
+  // check, so the literals are fetched only to CONTRADICT it: any that answers
+  // successfully must agree. A literal that fails -- refused, or a cert not
+  // issued to that IP, which is the normal case -- proves nothing and is
+  // ignored, so an ordinary https localhost is never broken by this. A second
+  // listener with a trusted certificate and a different index is caught.
+  if (primary) {
+    const body = await fetchPanelIndex(primary, deadlineAt);
+    if (corroborate.length <= 1) return body;
+    const others = await Promise.all(
+      corroborate.map(async (candidate) => {
+        try {
+          return await fetchPanelIndex(candidate, deadlineAt);
+        } catch {
+          return undefined;
+        }
+      }),
+    );
+    if (others.some((other) => other !== undefined && other !== body)) {
+      throw new PanelTemplateRelayError(
+        "Two different loopback listeners answered the panel's address with different template indexes.",
+        "AMBIGUOUS_PANEL_LISTENER",
+      );
+    }
+    return body;
+  }
+
+  const candidates = corroborate;
   if (candidates.length === 1) return fetchPanelIndex(candidates[0], deadlineAt);
   const settled = await Promise.all(
     candidates.map(async (candidate) => {
@@ -596,8 +626,6 @@ async function fetchPinnedPanelIndex(url: URL, deadlineAt: number): Promise<stri
     if (only.state === "ok") return only.body;
     throw only.error;
   }
-  // More than one listener answered the panel's address. Every one of them must
-  // have produced the SAME index, or we cannot say what the panel would see.
   const bodies: string[] = [];
   for (const result of present) {
     if (result.state !== "ok") {

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -515,6 +515,12 @@ function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | u
 async function pinnedLoopbackUrls(url: URL): Promise<URL[]> {
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (LOOPBACK_LITERALS.has(host)) return [url];
+  // HTTPS keeps the NAME, deliberately. Rewriting the host to a literal breaks
+  // certificate verification for a cert issued to `localhost`, and there is
+  // nothing to gain by it: TLS already binds the response to the name, which is
+  // a stronger listener check than pinning can give us. Only cleartext needs
+  // the second resolution removed.
+  if (url.protocol === "https:") return [url];
   if (!AMBIGUOUS_LOOPBACK_NAMES.has(host)) {
     throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
   }
@@ -563,28 +569,67 @@ async function fetchPinnedPanelIndex(url: URL, deadlineAt: number): Promise<stri
   const settled = await Promise.all(
     candidates.map(async (candidate) => {
       try {
-        return { ok: true as const, body: await fetchPanelIndex(candidate, deadlineAt) };
+        return { state: "ok" as const, body: await fetchPanelIndex(candidate, deadlineAt) };
       } catch (error) {
-        return { ok: false as const, error };
+        // A REFUSED CONNECTION IS THE ONLY SAFE THING TO IGNORE. It proves
+        // nothing is listening on that address, so it cannot be the panel. Any
+        // other failure means something IS there and merely answered badly --
+        // possibly the real panel returning 503 -- and preferring whichever
+        // address happened to succeed would then serve the OTHER listener's
+        // index, which is the defect this function exists to prevent.
+        return isConnectionRefused(error)
+          ? { state: "absent" as const }
+          : { state: "failed" as const, error };
       }
     }),
   );
-  const answered = settled.filter((r): r is { ok: true; body: string } => r.ok);
-  // Nothing answered: surface the first real failure rather than inventing one.
-  if (answered.length === 0) {
-    const firstFailure = settled.find((r) => !r.ok);
-    throw firstFailure && !firstFailure.ok
-      ? firstFailure.error
-      : new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
+  const present = settled.filter((r) => r.state !== "absent");
+  if (present.length === 0) {
+    throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
   }
-  const first = answered[0].body;
-  if (answered.some((r) => r.body !== first)) {
+  // Exactly one listener exists, so there is nothing for it to disagree with:
+  // report its outcome verbatim, success or failure.
+  if (present.length === 1) {
+    const only = present[0];
+    if (only.state === "ok") return only.body;
+    throw only.error;
+  }
+  // More than one listener answered the panel's address. Every one of them must
+  // have produced the SAME index, or we cannot say what the panel would see.
+  const bodies: string[] = [];
+  for (const result of present) {
+    if (result.state !== "ok") {
+      throw new PanelTemplateRelayError(
+        "Another loopback listener answered the panel's address and could not be read.",
+        "AMBIGUOUS_PANEL_LISTENER",
+      );
+    }
+    bodies.push(result.body);
+  }
+  if (bodies.some((body) => body !== bodies[0])) {
     throw new PanelTemplateRelayError(
       "Two different loopback listeners answered the panel's address with different template indexes.",
       "AMBIGUOUS_PANEL_LISTENER",
     );
   }
-  return first;
+  return bodies[0];
+}
+
+/** True only for a refused CONNECTION, i.e. nothing is listening on that address. */
+function isConnectionRefused(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const code = (current as { code?: unknown }).code;
+    // ECONNREFUSED is the loopback case. The rest cover a resolvable address
+    // with no route -- equally "nothing is listening here".
+    if (code === "ECONNREFUSED" || code === "EHOSTUNREACH" || code === "ENETUNREACH" || code === "EADDRNOTAVAIL") return true;
+    const aggregate = (current as { errors?: unknown }).errors;
+    if (Array.isArray(aggregate) && aggregate.some((inner) => isConnectionRefused(inner))) return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 async function fetchPanelIndex(url: URL, deadlineAt: number): Promise<string> {
@@ -597,8 +642,12 @@ async function fetchPanelIndex(url: URL, deadlineAt: number): Promise<string> {
       redirect: "manual",
       signal: AbortSignal.timeout(remaining),
     });
-  } catch {
-    throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
+  } catch (error) {
+    const failure = new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
+    // Preserve the connect-level cause so a multi-address fetch can tell "no
+    // listener" from "a listener that failed" -- see fetchPinnedPanelIndex.
+    (failure as { cause?: unknown }).cause = error;
+    throw failure;
   }
   if (response.url) {
     const finalUrl = safePanelTemplateUrl(response.url, url.origin);

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -515,12 +515,6 @@ function safePanelTemplateUrl(raw: string | undefined, allowedOrigin: string | u
 async function pinnedLoopbackUrls(url: URL): Promise<URL[]> {
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (LOOPBACK_LITERALS.has(host)) return [url];
-  // HTTPS keeps the NAME, deliberately. Rewriting the host to a literal breaks
-  // certificate verification for a cert issued to `localhost`, and there is
-  // nothing to gain by it: TLS already binds the response to the name, which is
-  // a stronger listener check than pinning can give us. Only cleartext needs
-  // the second resolution removed.
-  if (url.protocol === "https:") return [url];
   if (!AMBIGUOUS_LOOPBACK_NAMES.has(host)) {
     throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
   }
@@ -530,25 +524,33 @@ async function pinnedLoopbackUrls(url: URL): Promise<URL[]> {
   } catch {
     throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
   }
-  const urls: URL[] = [];
-  const seen = new Set<string>();
+  const literals: string[] = [];
   for (const { address } of resolved) {
     const literal = address.toLowerCase();
-    // A name that resolves ANYWHERE off loopback is refused outright rather
-    // than partially honoured — the pair must be entirely local.
+    // A name that resolves ANYWHERE off loopback is refused whole rather than
+    // partially honoured -- the pair must be entirely local. This runs for https
+    // too: skipping it once let a `localhost` pointed off-box by a hosts entry
+    // be fetched, because only the ORIGIN STRING was ever checked.
     if (!LOOPBACK_LITERALS.has(literal)) {
       throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
     }
-    if (seen.has(literal)) continue;
-    seen.add(literal);
-    const pinned = new URL(url.href);
-    pinned.hostname = literal.includes(":") ? `[${literal}]` : literal;
-    urls.push(pinned);
+    if (!literals.includes(literal)) literals.push(literal);
   }
-  if (urls.length === 0) {
+  if (literals.length === 0) {
     throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
   }
-  return urls;
+  // HTTPS keeps the NAME, once the addresses are known to be local. Rewriting
+  // the host to a literal breaks certificate verification for a cert issued to
+  // `localhost`, and TLS already binds the response to the name -- a stronger
+  // listener check than pinning gives. Only cleartext needs the second
+  // resolution removed. Keeping the name and validating where it points are
+  // separate decisions; only the first is scheme-dependent.
+  if (url.protocol === "https:") return [url];
+  return literals.map((literal) => {
+    const pinned = new URL(url.href);
+    pinned.hostname = literal.includes(":") ? `[${literal}]` : literal;
+    return pinned;
+  });
 }
 
 /**

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -21,10 +21,43 @@ export const PANEL_TEMPLATE_RELAY_HTTP_PATH = "/__comfyui_mcp_panel_template_rel
 
 const ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const HEX_RE = /^[a-f0-9]{64}$/;
-// A hostname does not identify which loopback listener a browser reached. Keep
-// relay destinations pinned to literal addresses so fetch cannot independently
-// resolve `localhost` to a different process or address family.
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1"]);
+// `localhost` is a NAME, not a listener identity, so an exact origin match does
+// not prove the later fetch reaches the socket the browser is on (#2382). It is
+// accepted anyway, because every alternative costs more than it buys.
+//
+// WHAT REFUSING IT COST. Dropping it (#2385, shipped in 0.52.135) took
+// `list_packs action:"list_templates"` from working to erroring for every user
+// whose ComfyUI is served at `http://localhost:<port>` — an ordinary setup, and
+// the panel Origin is the browser's. The relay declines, and the caller is
+// fail-closed once a panel route exists, so the action has no path left.
+//
+// WHY THE HAZARD IS NARROWER THAN IT LOOKS. The non-adversarial case does not
+// occur on a supported runtime: Node >=20 connects with Happy Eyeballs
+// (`autoSelectFamily`), so `fetch("http://localhost:<port>")` reaches a
+// 127.0.0.1-only OR a ::1-only listener — measured on Node 24.16.0 against both
+// single-family binds. What remains is a second local process squatting the
+// other loopback family, which one-machine/one-trust-domain puts out of scope.
+//
+// WHY NEITHER HARDENING WORKS HERE — recorded so they are not re-attempted:
+//
+//   - Pinning the fetch to a literal address needs the family the browser
+//     reached, and the Origin header does not carry it. Probing cannot recover
+//     it either: a dual-stack ComfyUI bound to `::` answers on BOTH 127.0.0.1
+//     and ::1 and is byte-indistinguishable from two separate processes, so
+//     "both families answer" cannot be read as ambiguity without refusing an
+//     ordinary working setup. The only place the question is answerable is the
+//     browser, which knows its own origin — a panel-side fetch, i.e. a
+//     cross-repo change, not a bug fix.
+//   - Letting the refusal fall through to the headless COMFYUI_URL path is
+//     unsafe for the reason #2387 documents below: a mid-turn child keeps the
+//     PREVIOUS target across a retarget (#1429, retargetAllForMcpEnv), so it
+//     can list a stale server's index. The relay fetching the current target
+//     under its own generation fence is what prevents that — and is why
+//     authorizing the origin here, rather than declining it, is the safe half.
+//
+// A mixed pair (`localhost` observed vs `127.0.0.1` configured, or the reverse)
+// is still refused by the exact-origin equality below.
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
 export interface PanelTemplateRelayRequest {
   version: typeof PANEL_TEMPLATE_RELAY_VERSION;


### PR DESCRIPTION
Takes option **(2)** from #2382's latest comment — *"remove the ambiguity instead of refusing it"* — proposed when the issue was filed and unimplemented through #2385, #2387 and #2388.

## Still live, now in two releases

`list_packs action:"list_templates"` returns `isError` with `NO_PANEL_ORIGIN` for every user whose ComfyUI is served at `http://localhost:<port>`. Verified **by execution against a clean checkout of `e50c067`**, driving the real `list_packs` handler:

```
CONTROL 127.0.0.1 -> {"isError":false,"outcome":"RELAYED-OK","headless":0}
LOCALHOST         -> {"isError":true,"outcome":"The connected panel template relay failed (NO_PANEL_ORIGIN).","headless":0}
```

#2387 shipped nine comment lines and a test; it changed no behaviour on this path, and has now also gone out in **0.52.136**.

## The mechanism is real, and reproduces on this machine

```
dual-bind same port on ::1 = true
  127.0.0.1 -> 4
  [::1]     -> 6
  localhost -> 6     <-- fetch picked the OTHER listener
```

Not theoretical — and why simply re-admitting `localhost` (my #2388) was correctly rejected.

## What this does

`http://localhost` authorizes an origin again, but **is never a fetch destination**. The name is resolved **once**, in `pinnedLoopbackUrls`, and every request goes to a literal address, so `fetch` performs no second, independent resolution. That is where the ambiguity actually lived.

Where the name resolves to several loopback addresses, identity is not knowable — Origin carries no family, and a dual-stack bind on `::` is indistinguishable from two processes. So identity is not what gets established: the candidates must **agree**. Same index from every address that has a listener means the answer is the same whichever socket the panel is on. Disagreement raises `AMBIGUOUS_PANEL_LISTENER` rather than guessing.

**A listener that answers badly is still a listener.** Only a *refused connection* counts as absent. A real panel returning 503 on one family must not let another process's index win on the other — that is the same wrong-listener bug wearing a different hat.

**`https://localhost` stays refused, exactly as main has it today.** Over TLS you cannot both pin the address and keep verification of a certificate issued to the name; the two gate findings that chased this were really the same irreducible tension. Since main already refuses *all* localhost origins, not restoring the https half regresses nobody — and the reported defect is the http one.

**Fail-closed is untouched** (#2387's finding stands and I agree with it): a refusal still does not fall through to `getComfyUIBaseUrl()`, because a mid-turn child keeps the pre-retarget target (#1429). The fetch stays here, under the relay's generation fence. A mixed `localhost`/`127.0.0.1` pair is still a hard refusal.

**Bonus, predating all of this:** only the *origin string* was ever checked against the loopback set, never the address it resolves to — so a hosts-file entry pointing `localhost` off-box would have been fetched. Every resolved address must now be loopback, or the whole name is refused.

## Where the load-bearing claims are

1. **"Agreement is sufficient."** If every address with a listener returns byte-identical bodies, returning that body is correct regardless of which one the browser is on. A counterexample kills this PR.
2. **Refusing the whole name when one resolved address is off-loopback** — stricter than honouring the loopback half, and a behaviour change for an exotic hosts file.
3. **`isConnectionRefused` walks `cause`/`errors`.** If a Node version reports a refused loopback connect under a code not in that list, a dead address would be misread as a failing listener and refuse where it should serve.

## Verification — mutation, clause by clause

Every guard reverted independently against committed code (22 tests across 4 files; the rest survive as controls, including #2387's retarget test, which I did not write):

| mutation | result |
|---|---|
| `localhost` removed from `LOOPBACK_HOSTS` (main today) | **7 failed** |
| https name authorized again | **1 failed** |
| pin re-check drops the scheme clause | **1 failed** |
| agreement check removed | **1 failed** |
| failing listener treated as absent | **1 failed** |
| pinning removed (name fetched directly) | **1 failed** |
| off-loopback resolution allowed | **2 failed** |

Several of these only became real after fixing the test meant to catch them:

- **The off-loopback guard survived** at first — no test could steer DNS. Added a file that mocks `node:dns` so the real `pinnedLoopbackUrls` runs against a chosen answer.
- In that file the request counter was **snapshotted at harness return**, so both `expect(...).toBe(0)` assertions passed no matter what the code did. Exposed as a getter.
- A partial-failure test used a 3-way `toContain`, which could not meaningfully fail. Replaced with a real dual-bind where one listener 503s.
- Several early mutations **never applied** (CRLF anchors; an anchor matching both functions) and would have read as "survived". The table is from applied mutations only.

Other gates: `npm run build` clean; `npm run lint` clean (anti-slop "none added"); full suite **681 files, 12694 passed, 6 skipped**. Two earlier full runs each had one failure in `late-mutation-e2e.test.ts` — the documented 60 ms real-bridge load flake (#694/#852), untouched by this diff and **5/5 passing in isolation**.

**No browser gate was run and none is claimed** — orchestrator/service-side, renders nothing in the panel.

## History

#2385 refused `localhost` (regression). #2387 documented why falling through is unsafe (correct, kept). #2388 tried re-admitting it, then declining to headless — the gate correctly killed both. This removes the second resolution instead, which is what the issue asked for on day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
