### PR TITLE
chore: release v0.52.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.137] - 2026-08-26
+
+### MCP
+
+#### Fixed
+- pin the relay fetch to literal loopback addresses so localhost works again (#2391)
+
+
 ## [0.52.136] - 2026-08-26
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.136",
+  "version": "0.52.137",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.136",
+      "version": "0.52.137",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.136",
+  "version": "0.52.137",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
**Cuts the P1 fix that has been sitting merged-but-unshipped.**

`08a3ad6` (#2391) fixes #2382 — `list_packs action:"list_templates"` erroring for every sidebar-backed user whose ComfyUI is served at `http://localhost:<port>`. It merged at 01:02Z and is **not in any tag**:

    git merge-base --is-ancestor 08a3ad6 v0.52.136   ->  NO
    npm view comfyui-mcp version                     ->  0.52.136

Checked the published tree directly rather than inferring — `v0.52.136` still carries `LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1"])` with none of the pinning. So the regression is live on `latest` right now, in its third release, while the fix sits on `main`.

No release PR was open, so nothing was on its way. This is that cut and nothing else.

## What is in it

    CHANGELOG.md      | 8 ++++++++
    package-lock.json | 4 ++--
    package.json      | 2 +-

Produced by `npm version patch --no-git-tag-version`, so the changelog section is the generated one, not hand-written:

```
## [0.52.137] - 2026-08-26

### MCP

#### Fixed
- pin the relay fetch to literal loopback addresses so localhost works again (#2391)
```

One `#### Fixed` heading, one entry, one merged PR — none of the duplication or misattribution that hit 0.15.105, 0.52.134 and 0.15.106 (tracked in comfyui-mcp-panel#1891).

**Verified:** `tsc --noEmit` exit 0; `08a3ad6` is an ancestor of this branch; diff is exactly the three release files with no code change of my own.

## Why I did not merge it

A release touches `package.json`, which is supply-chain gated for autopilot — the merge gate exits 2 and `AUTOPILOT_HUMAN_ACK=1` is not mine to set, by design. **@artokun this needs your merge**, and afterwards the check that matters is against the tag rather than main:

    git merge-base --is-ancestor 08a3ad6 v0.52.137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
