### PR TITLE
test(2392): pin the https loopback refusal through the production wiring

### DIFF
--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createServer, type Server } from "node:http";
+import { createServer as createSocketServer } from "node:net";
 import { createPanelTemplateRelayWiring } from "../../orchestrator/index.js";
 import { requestPanelTemplateIndex, startPanelTemplateRelayServer } from "../../services/panel-template-relay.js";
 
@@ -369,5 +370,94 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
 
     // NOT the v4 index, even though v4 answered perfectly well.
     await expect(requestPanelTemplateIndex()).rejects.toMatchObject({ code: "AMBIGUOUS_PANEL_LISTENER" });
+  });
+
+  // #2392. The relay may be configured over https, so the question that issue
+  // asks is whether an https `localhost` still re-resolves at request time. It
+  // does not: the production origin gate declines an ambiguous NAME over TLS,
+  // so no destination URL is ever produced and no socket is ever opened.
+  //
+  // These two drive the REAL orchestrator wiring. The existing https coverage
+  // does not: the unit test calls currentPanelTemplateOrigin directly, and the
+  // dns-pin test hands the relay a pre-authorized origin, which bypasses the
+  // gate being asserted here. Nothing until now proved that PRODUCTION reaches
+  // the refusal.
+  it("refuses an https localhost origin through the production wiring, without opening a socket (#2392)", async () => {
+    // Counting CONNECTIONS, not HTTP requests, is deliberate. A TLS fetch
+    // against this plaintext listener would fail the handshake and never become
+    // a request, so a request counter would read zero even if the fetch HAD
+    // been issued -- it would pin nothing. A connection attempt cannot hide.
+    let connections = 0;
+    const listener = createSocketServer((socket) => {
+      connections += 1;
+      socket.destroy();
+    });
+    await new Promise<void>((resolve, reject) => {
+      listener.once("error", reject);
+      listener.listen({ host: "127.0.0.1", port: 0 }, () => resolve());
+    });
+    const addr = listener.address();
+    if (!addr || typeof addr === "string") throw new Error("no bind");
+    const port = addr.port;
+    servers.push({ close: () => new Promise<void>((resolve) => { listener.close(() => resolve()); }) });
+
+    const observedOrigin = `https://localhost:${port}`;
+    const target = `${observedOrigin}/comfyapi`;
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: () => "tab-1",
+      tabServerOrigin: () => observedOrigin,
+    };
+    const wiring = createPanelTemplateRelayWiring({
+      bridge,
+      currentTarget: () => target,
+      currentTargetGeneration: () => 0,
+      secrets: new Map([[SECRET, "orchestrator::codex"]]),
+    });
+    const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    // Ordered so that each assertion below can be the one that fails. Asserting
+    // the error code first would mask the socket count: both refusal clauses
+    // raise NO_PANEL_ORIGIN, so the code is identical whether the request was
+    // declined at the gate or after a second resolution.
+    const outcome = await requestPanelTemplateIndex().then(() => undefined, (error: unknown) => error);
+    // Load-bearing: nothing was contacted, so there was no second resolution.
+    // Fails if BOTH refusal clauses go -- the fetch then reaches this listener.
+    expect(connections).toBe(0);
+    expect(outcome).toMatchObject({ code: "NO_PANEL_ORIGIN" });
+    // Load-bearing: the gate itself, through the production closures. Fails if
+    // the origin-gate clause goes, even while the deeper one still refuses.
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+  });
+
+  it("still authorizes an https LITERAL loopback origin, which has no name to re-resolve (#2392)", async () => {
+    // The refusal above is about the ambiguous NAME, not about TLS. A literal
+    // host is pinned by construction -- there is no second resolution to
+    // disagree with -- so https stays a permitted relay configuration. Without
+    // this, the refusal test above would also pass if https were banned
+    // outright, which is a different and wrong behaviour.
+    const observedOrigin = "https://127.0.0.1:8188";
+    const target = `${observedOrigin}/comfyapi`;
+    const bridge = {
+      canReach: () => true,
+      resolveFailure: () => undefined,
+      resolveSharedTabId: () => "tab-1",
+      tabServerOrigin: () => observedOrigin,
+    };
+    const wiring = createPanelTemplateRelayWiring({
+      bridge,
+      currentTarget: () => target,
+      currentTargetGeneration: () => 0,
+      secrets: new Map([[SECRET, "orchestrator::codex"]]),
+    });
+    expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBe(observedOrigin);
+    expect(wiring.resolvePanelUrl("tab-1", target)).toBe(
+      `${observedOrigin}/comfyapi/api/workflow_templates`,
+    );
   });
 });


### PR DESCRIPTION
Closes #2392

## The issue's premise is not on main

#2392 quotes a carve-out in `pinnedLoopbackUrls`:

```ts
if (url.protocol === "https:") return [url];
```

and a comment claiming *"TLS already binds the response to the name, which is a stronger
listener check than pinning can give us."* The issue is right that the rationale is wrong —
TLS binds the response to the **name**, not the **listener** — but neither the carve-out nor
that comment exists on `main`.

`4fafc8f` ("authorize an ambiguous loopback name over cleartext only") landed at
**00:50:39Z**, **57 seconds after** the follow-up comment on #2392 at 00:49:42Z, and merged
in #2391 at 01:02:01Z. It replaced the corroboration approach entirely: an ambiguous NAME is
authorized over cleartext only, so `https://localhost` is declined at
`currentPanelTemplateOrigin` before a destination URL is ever produced. The comment there now
makes the correct argument (pinning would break verification of a cert issued to the name, so
the name is refused rather than fetched) and makes no TLS-covers-it claim.

So the issue's three factual claims are already resolved:

| #2392 claim | on `main` @ 08a3ad6 |
| --- | --- |
| `if (url.protocol === "https:") return [url];` carve-out | removed in `4fafc8f` |
| comment claims TLS covers the listener gap | rewritten; no such claim |
| `https://localhost` re-resolves at request time | refused before any fetch |

The follow-up comment also asked this issue to carry a test for the **https corroboration
branch**. That branch no longer exists, so that specific test is unwritable — this PR carries
the test for what actually shipped instead.

## What was genuinely missing

Proof that **production reaches** the refusal. The existing https coverage does not show it:

- `panel-template-relay.test.ts` calls `currentPanelTemplateOrigin` directly — a helper-level
  assertion.
- `panel-template-relay-dns-pin.test.ts` passes `resolveAllowedPanelOrigin: () => origin`,
  which **stubs out the very gate being asserted**. That test reaches `pinnedLoopbackUrls`
  with an https localhost URL precisely because the gate is bypassed.

Both stay green if the orchestrator stops consulting the gate at all. Nothing drove the real
`createPanelTemplateRelayWiring` closures over https.

## What this adds

Two tests in `panel-template-relay-production.test.ts`, which builds the **real** orchestrator
wiring.

1. **Refusal.** An `https://localhost` panel origin yields no authorized origin and no panel
   URL, the relay answers `NO_PANEL_ORIGIN`, and a raw `node:net` server on that port counts
   **zero connections**.
2. **Control.** An `https://127.0.0.1` literal origin is still authorized and still produces a
   template URL — the refusal is about the ambiguous NAME, not about TLS.

## Where the load-bearing claims are

Three things to check rather than hunt for:

- **Counting connections, not HTTP requests, is the whole point.** A TLS fetch against a
  plaintext listener fails the handshake and never becomes an HTTP request, so a request
  counter reads zero *even if the fetch was issued* — it would pin nothing. Verified: under
  the both-clauses mutation the counter reads 1.
- **Assertion order is load-bearing.** Both refusal clauses raise the same `NO_PANEL_ORIGIN`
  code, so asserting the code first masks the socket count. An earlier draft of this test had
  exactly that defect — the `connections` assertion was unreachable and pinned nothing.
- **The control exists so the refusal test cannot pass for the wrong reason.** Without it,
  banning https outright would also go green.

## Mutation evidence (each clause alone)

| mutation | result |
| --- | --- |
| delete `if (ambiguousName && observed.protocol !== "http:") return undefined;` | **FAIL** — `expected 'https://localhost:63824' to be undefined` |
| delete that **and** the `pinnedLoopbackUrls` protocol re-check | **FAIL** — `expected 1 to be +0` (a real connection reached the listener) |
| delete **only** the `pinnedLoopbackUrls` re-check | passes — correctly: that clause is unreachable while the gate holds, and the dns-pin test already pins it by stubbing the gate |
| control (`https://127.0.0.1`) | survives every mutation |

Full suite in a clean tree with its own `npm ci`: **681 files, 12696 passed, 6 skipped, 0
failed**.

## Deliberately not done

- **No connect-level `Agent({connect:{lookup}})` pin.** #2392 proposes it so `https://localhost`
  would work rather than be refused. `4fafc8f` considered and rejected that in the same hour,
  in a shipped comment. Restoring it is a scope decision for the owner, not something to
  re-litigate here under the freeze.
- **`https://localhost` remains unavailable to the relay.** It worked in the original relay
  (`a3a7ed0`, #2196/#2230), broke at #2385, and #2391 restored the cleartext case only. That
  is a real if narrow gap — noted on the issue rather than fixed here.
- **No Playwright run.** Test-only, orchestrator-side; nothing the panel renders changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
