### PR TITLE
fix(codex): retry active panel reads once

### DIFF
--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -57,6 +57,7 @@ const MCP_SERVERS_WITH_UNRELATED_HTTP_UP = [
 const WORKER_TRANSPORT_FAILURE =
   "Transport send error: WorkerTransport<StreamableHttpClientWorker<...>> error: " +
   "HTTP request failed sending request to http://127.0.0.1:9198/orchestrator%3A%3Acodex";
+const MUTATION_WORKER_TRANSPORT_FAILURE = `${WORKER_TRANSPORT_FAILURE} (mutation item)`;
 // The exact wrapper reported by panel_save_workflow -> immediate panel_run on
 // the affected EventNotificationTransport path. It is an outer HTTP-MCP client
 // failure, not a panel tool result; handling it must not retry panel_run.
@@ -122,6 +123,8 @@ interface Drive {
       | "panel-read-retry-timeout"
       | "panel-read-retry-cancelled"
       | "panel-mutation-no-retry"
+      | "panel-mutation-before-read-no-retry"
+      | "panel-read-retry-mutation-error"
       | "panel-unrelated-read-no-retry"
       | "panel-read-no-enter-no-retry",
   ): Promise<void>;
@@ -246,6 +249,8 @@ function startDrive(opts: {
       if (
         kind.startsWith("panel-read-retry-") ||
         kind === "panel-mutation-no-retry" ||
+        kind === "panel-mutation-before-read-no-retry" ||
+        kind === "panel-read-retry-mutation-error" ||
         kind === "panel-unrelated-read-no-retry" ||
         kind === "panel-read-no-enter-no-retry"
       ) {
@@ -262,6 +267,31 @@ function startDrive(opts: {
           notify("error", {
             itemId: mutation.id,
             error: { message: WORKER_TRANSPORT_FAILURE },
+            willRetry: true,
+          });
+        } else if (kind === "panel-mutation-before-read-no-retry") {
+          const mutation = { type: "mcpToolCall", id: "mutation-1", server: "panel", tool: "panel_set_property" };
+          const read = { type: "mcpToolCall", id: "read-1", server: "panel", tool: "panel_graph_outline" };
+          notify("item/started", { item: mutation });
+          notify("item/started", { item: read });
+          notify("error", {
+            itemId: read.id,
+            error: { message: WORKER_TRANSPORT_FAILURE },
+            willRetry: true,
+          });
+        } else if (kind === "panel-read-retry-mutation-error") {
+          const read = { type: "mcpToolCall", id: "read-1", server: "panel", tool: "panel_graph_outline" };
+          const mutation = { type: "mcpToolCall", id: "mutation-1", server: "panel", tool: "panel_set_property" };
+          notify("item/started", { item: read });
+          notify("item/started", { item: mutation });
+          notify("error", {
+            itemId: read.id,
+            error: { message: WORKER_TRANSPORT_FAILURE },
+            willRetry: true,
+          });
+          notify("error", {
+            itemId: mutation.id,
+            error: { message: MUTATION_WORKER_TRANSPORT_FAILURE },
             willRetry: true,
           });
         } else if (kind === "panel-unrelated-read-no-retry") {
@@ -544,6 +574,41 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
       ),
     ).toHaveLength(1);
 
+    await drive.finish();
+  });
+
+  it("invalidates the enter lifecycle when a mutation starts before the read (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-mutation-before-read-no-retry");
+
+    const failures = drive.events.filter(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0].message).toMatch(/did not retry the request/i);
+    expect(failures[0].message).not.toMatch(/retried this read once/i);
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    await drive.finish();
+  });
+
+  it("isolates a distinct mutation transport error from an armed read retry (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-mutation-error");
+
+    const failures = drive.events.filter(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0].message).toContain(WORKER_TRANSPORT_FAILURE);
+    expect(failures[0].message).toContain(MUTATION_WORKER_TRANSPORT_FAILURE);
+    expect(failures[0].message).toMatch(/did not retry the request/i);
+    expect(failures[0].message).not.toMatch(/retried this read once/i);
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.reloadCalls).toBe(1);
     await drive.finish();
   });
 

--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -112,12 +112,18 @@ interface Drive {
       | "scrubbed-transport"
       | "event-notification-transport"
       | "unrelated-transport"
-      | "panel-read-retry-success"
+      | "panel-read-retry-outline-success"
+      | "panel-read-retry-query-success"
       | "panel-read-retry-failure"
       | "panel-read-retry-amplified"
       | "panel-read-retry-inactive"
+      | "panel-read-retry-interleaved"
+      | "panel-read-retry-exit"
+      | "panel-read-retry-timeout"
       | "panel-read-retry-cancelled"
-      | "panel-mutation-no-retry",
+      | "panel-mutation-no-retry"
+      | "panel-unrelated-read-no-retry"
+      | "panel-read-no-enter-no-retry",
   ): Promise<void>;
   releaseInterrupt(): void;
   waitForIdle(): Promise<void>;
@@ -140,11 +146,15 @@ function startDrive(opts: {
   const turnWaiters: Array<() => void> = [];
   let waitingForTurn = false;
   let releaseInterrupt: (() => void) | null = null;
+  let resolveExit: (() => void) | null = null;
+  const exitPromise = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
 
   const client = {
     notificationHandler: null as ((msg: unknown) => void) | null,
     exitError: null as Error | null,
-    exitPromise: new Promise<void>(() => {}),
+    exitPromise,
     request: vi.fn(async (method: string, params?: unknown) => {
       if (method === "thread/start" || method === "thread/resume") {
         return { thread: { id: "thread-1" }, model: "gpt-5.6-sol" };
@@ -233,52 +243,94 @@ function startDrive(opts: {
       await waitUntil(() => waitingForTurn && starts > 0);
       waitingForTurn = false;
       const turnId = `turn-${starts}`;
-      if (kind.startsWith("panel-read-retry-")) {
+      if (
+        kind.startsWith("panel-read-retry-") ||
+        kind === "panel-mutation-no-retry" ||
+        kind === "panel-unrelated-read-no-retry" ||
+        kind === "panel-read-no-enter-no-retry"
+      ) {
         const notify = (method: string, params: Record<string, unknown>) =>
           client.notificationHandler?.({ method, params: { threadId: "thread-1", turnId, ...params } });
         const enter = { type: "mcpToolCall", id: "enter-1", server: "panel", tool: "panel_enter_subgraph" };
-        notify("item/started", { item: enter });
-        notify("item/completed", { item: { ...enter, status: "completed" } });
-        const outline = { type: "mcpToolCall", id: "outline-1", server: "panel", tool: "panel_graph_outline" };
-        notify("item/started", { item: outline });
-        if (kind === "panel-read-retry-inactive") client.exitError = new Error("app-server connection closed");
-        notify("error", {
-          error: { message: WORKER_TRANSPORT_FAILURE },
-          willRetry: true,
-        });
-        if (kind === "panel-read-retry-success") {
-          notify("item/completed", { item: { ...outline, status: "completed" } });
-          notify("turn/completed", { turn: { id: turnId, status: "completed" } });
-        } else if (kind === "panel-read-retry-failure") {
+        if (kind !== "panel-read-no-enter-no-retry") {
+          notify("item/started", { item: enter });
+          notify("item/completed", { item: { ...enter, status: "completed" } });
+        }
+        if (kind === "panel-mutation-no-retry") {
+          const mutation = { type: "mcpToolCall", id: "mutation-1", server: "panel", tool: "panel_set_property" };
+          notify("item/started", { item: mutation });
           notify("error", {
-            error: { message: WORKER_TRANSPORT_FAILURE + " (retry failed)" },
-            willRetry: false,
-          });
-        } else if (kind === "panel-read-retry-amplified") {
-          // A second willRetry signal must not arm a third attempt. The backend
-          // fences the still-live turn and interrupts it once.
-          notify("error", {
-            error: { message: WORKER_TRANSPORT_FAILURE + " (retry failed)" },
+            itemId: mutation.id,
+            error: { message: WORKER_TRANSPORT_FAILURE },
             willRetry: true,
           });
-        } else if (kind === "panel-read-retry-cancelled") {
-          await backend.interrupt();
-          notify("turn/completed", { turn: { id: turnId, status: "interrupted" } });
+        } else if (kind === "panel-unrelated-read-no-retry") {
+          const unrelated = { type: "mcpToolCall", id: "unrelated-1", server: "panel", tool: "panel_view_selected" };
+          notify("item/started", { item: unrelated });
+          notify("error", {
+            itemId: unrelated.id,
+            error: { message: WORKER_TRANSPORT_FAILURE },
+            willRetry: true,
+          });
+        } else {
+          const readTool = kind === "panel-read-retry-query-success" ? "panel_query_graph" : "panel_graph_outline";
+          const read = { type: "mcpToolCall", id: "read-1", server: "panel", tool: readTool };
+          notify("item/started", { item: read });
+          if (kind === "panel-read-retry-interleaved") {
+            const mutation = { type: "mcpToolCall", id: "mutation-1", server: "panel", tool: "panel_set_property" };
+            notify("item/started", { item: mutation });
+            notify("error", {
+              itemId: read.id,
+              error: { message: WORKER_TRANSPORT_FAILURE },
+              willRetry: true,
+            });
+            // The mutation's late completion must not satisfy the read retry.
+            notify("item/completed", { item: { ...mutation, status: "completed" } });
+            notify("item/completed", { item: { ...read, status: "completed" } });
+            notify("turn/completed", { turn: { id: turnId, status: "completed" } });
+          } else {
+            if (kind === "panel-read-retry-inactive") client.exitError = new Error("app-server connection closed");
+            notify("error", {
+              itemId: read.id,
+              error: { message: WORKER_TRANSPORT_FAILURE },
+              willRetry: true,
+            });
+            if (
+              kind === "panel-read-retry-outline-success" ||
+              kind === "panel-read-retry-query-success"
+            ) {
+              notify("item/completed", { item: { ...read, status: "completed" } });
+              notify("turn/completed", { turn: { id: turnId, status: "completed" } });
+            } else if (kind === "panel-read-retry-failure") {
+              notify("error", {
+                itemId: read.id,
+                error: { message: WORKER_TRANSPORT_FAILURE + " (retry failed)" },
+                willRetry: false,
+              });
+            } else if (kind === "panel-read-retry-amplified") {
+              // A second willRetry signal must not arm a third attempt. The
+              // backend fences the still-live turn and interrupts it once.
+              notify("error", {
+                itemId: read.id,
+                error: { message: WORKER_TRANSPORT_FAILURE + " (retry failed)" },
+                willRetry: true,
+              });
+            } else if (kind === "panel-read-retry-exit") {
+              client.exitError = new Error("app-server connection closed during read retry");
+              resolveExit?.();
+            } else if (kind === "panel-read-retry-timeout") {
+              await backend.interrupt();
+            } else if (kind === "panel-read-retry-cancelled") {
+              await backend.interrupt();
+              notify("turn/completed", { turn: { id: turnId, status: "interrupted" } });
+            }
+          }
         }
-        await waitFor(() => expect(idle).toBe(true));
-      } else if (kind === "panel-mutation-no-retry") {
-        const notify = (method: string, params: Record<string, unknown>) =>
-          client.notificationHandler?.({ method, params: { threadId: "thread-1", turnId, ...params } });
-        const enter = { type: "mcpToolCall", id: "enter-1", server: "panel", tool: "panel_enter_subgraph" };
-        notify("item/started", { item: enter });
-        notify("item/completed", { item: { ...enter, status: "completed" } });
-        const mutation = { type: "mcpToolCall", id: "mutation-1", server: "panel", tool: "panel_set_property" };
-        notify("item/started", { item: mutation });
-        notify("error", {
-          error: { message: WORKER_TRANSPORT_FAILURE },
-          willRetry: true,
-        });
-        await waitFor(() => expect(idle).toBe(true));
+        if (kind === "panel-read-retry-timeout") {
+          await waitFor(() => expect(events.some((event) => event.type === "result")).toBe(true));
+        } else {
+          await waitFor(() => expect(idle).toBe(true));
+        }
       } else if (
         kind === "worker-transport" ||
         kind === "worker-transport-retry" ||
@@ -322,7 +374,7 @@ function startDrive(opts: {
       }
       // The MCP watch runs AFTER the turn result, before the run loop waits
       // for the next channel item. Idle is the barrier that it finished.
-      await waitFor(() => expect(idle).toBe(true));
+      if (kind !== "panel-read-retry-timeout") await waitFor(() => expect(idle).toBe(true));
     },
     releaseInterrupt() {
       releaseInterrupt?.();
@@ -343,7 +395,7 @@ function startDrive(opts: {
 describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
   it("retries a live panel_graph_outline once after panel_enter_subgraph (#2395)", async () => {
     const drive = startDrive({ listings: [PANEL_UP] });
-    await drive.endTurn("panel-read-retry-success");
+    await drive.endTurn("panel-read-retry-outline-success");
 
     expect(drive.reloadCalls).toBe(0);
     expect(drive.interruptCalls).toBe(0);
@@ -353,6 +405,22 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
       ),
     ).toHaveLength(0);
     expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+
+    await drive.finish();
+  });
+
+  it("retries a live panel_query_graph once after panel_enter_subgraph (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-query-success");
+
+    expect(drive.reloadCalls).toBe(0);
+    expect(drive.interruptCalls).toBe(0);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
 
     await drive.finish();
   });
@@ -395,6 +463,40 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
     await inactive.finish();
   });
 
+  it("correlates a read retry across parallel and late panel items (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-interleaved");
+
+    expect(drive.reloadCalls).toBe(0);
+    expect(drive.interruptCalls).toBe(0);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
+
+    await drive.finish();
+  });
+
+  it("preserves the original read transport error when the app-server exits during retry (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-exit");
+
+    const failures = drive.events.filter(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0].message).toContain(WORKER_TRANSPORT_FAILURE);
+    expect(failures[0].message).toMatch(/retried this read once/i);
+    expect(failures[0].message).not.toMatch(/app-server connection closed during read retry/i);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.interruptCalls).toBe(0);
+
+    await drive.finish();
+  });
+
   it("keeps cancellation semantics while a panel read retry is pending (#2395)", async () => {
     const drive = startDrive({ listings: [PANEL_UP] });
     await drive.endTurn("panel-read-retry-cancelled");
@@ -402,6 +504,23 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
     expect(drive.interruptCalls).toBe(1);
     expect(drive.events.filter((e) => e.type === "result")).toContainEqual(
       expect.objectContaining({ type: "result", ok: false, subtype: "interrupted" }),
+    );
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
+
+    await drive.finish();
+  });
+
+  it("keeps timeout cancellation semantics while a panel read retry is pending (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP], holdInterrupt: true });
+    await drive.endTurn("panel-read-retry-timeout");
+
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.events.filter((e) => e.type === "result")).toContainEqual(
+      expect.objectContaining({ type: "result", ok: true, subtype: "interrupted" }),
     );
     expect(
       drive.events.filter(
@@ -425,6 +544,26 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
       ),
     ).toHaveLength(1);
 
+    await drive.finish();
+  });
+
+  it("does not retry an unrelated panel read after panel_enter_subgraph (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-unrelated-read-no-retry");
+
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    await drive.finish();
+  });
+
+  it("does not retry an allowlisted read outside the panel_enter_subgraph lifecycle (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-no-enter-no-retry");
+
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
     await drive.finish();
   });
 

--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -111,7 +111,13 @@ interface Drive {
       | "worker-transport-retry"
       | "scrubbed-transport"
       | "event-notification-transport"
-      | "unrelated-transport",
+      | "unrelated-transport"
+      | "panel-read-retry-success"
+      | "panel-read-retry-failure"
+      | "panel-read-retry-amplified"
+      | "panel-read-retry-inactive"
+      | "panel-read-retry-cancelled"
+      | "panel-mutation-no-retry",
   ): Promise<void>;
   releaseInterrupt(): void;
   waitForIdle(): Promise<void>;
@@ -227,7 +233,53 @@ function startDrive(opts: {
       await waitUntil(() => waitingForTurn && starts > 0);
       waitingForTurn = false;
       const turnId = `turn-${starts}`;
-      if (
+      if (kind.startsWith("panel-read-retry-")) {
+        const notify = (method: string, params: Record<string, unknown>) =>
+          client.notificationHandler?.({ method, params: { threadId: "thread-1", turnId, ...params } });
+        const enter = { type: "mcpToolCall", id: "enter-1", server: "panel", tool: "panel_enter_subgraph" };
+        notify("item/started", { item: enter });
+        notify("item/completed", { item: { ...enter, status: "completed" } });
+        const outline = { type: "mcpToolCall", id: "outline-1", server: "panel", tool: "panel_graph_outline" };
+        notify("item/started", { item: outline });
+        if (kind === "panel-read-retry-inactive") client.exitError = new Error("app-server connection closed");
+        notify("error", {
+          error: { message: WORKER_TRANSPORT_FAILURE },
+          willRetry: true,
+        });
+        if (kind === "panel-read-retry-success") {
+          notify("item/completed", { item: { ...outline, status: "completed" } });
+          notify("turn/completed", { turn: { id: turnId, status: "completed" } });
+        } else if (kind === "panel-read-retry-failure") {
+          notify("error", {
+            error: { message: WORKER_TRANSPORT_FAILURE + " (retry failed)" },
+            willRetry: false,
+          });
+        } else if (kind === "panel-read-retry-amplified") {
+          // A second willRetry signal must not arm a third attempt. The backend
+          // fences the still-live turn and interrupts it once.
+          notify("error", {
+            error: { message: WORKER_TRANSPORT_FAILURE + " (retry failed)" },
+            willRetry: true,
+          });
+        } else if (kind === "panel-read-retry-cancelled") {
+          await backend.interrupt();
+          notify("turn/completed", { turn: { id: turnId, status: "interrupted" } });
+        }
+        await waitFor(() => expect(idle).toBe(true));
+      } else if (kind === "panel-mutation-no-retry") {
+        const notify = (method: string, params: Record<string, unknown>) =>
+          client.notificationHandler?.({ method, params: { threadId: "thread-1", turnId, ...params } });
+        const enter = { type: "mcpToolCall", id: "enter-1", server: "panel", tool: "panel_enter_subgraph" };
+        notify("item/started", { item: enter });
+        notify("item/completed", { item: { ...enter, status: "completed" } });
+        const mutation = { type: "mcpToolCall", id: "mutation-1", server: "panel", tool: "panel_set_property" };
+        notify("item/started", { item: mutation });
+        notify("error", {
+          error: { message: WORKER_TRANSPORT_FAILURE },
+          willRetry: true,
+        });
+        await waitFor(() => expect(idle).toBe(true));
+      } else if (
         kind === "worker-transport" ||
         kind === "worker-transport-retry" ||
         kind === "scrubbed-transport" ||
@@ -289,6 +341,93 @@ function startDrive(opts: {
 }
 
 describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
+  it("retries a live panel_graph_outline once after panel_enter_subgraph (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-success");
+
+    expect(drive.reloadCalls).toBe(0);
+    expect(drive.interruptCalls).toBe(0);
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+
+    await drive.finish();
+  });
+
+  it("preserves the first read transport error when the one retry fails (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-failure");
+
+    const failures = drive.events.filter(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0].message).toContain(WORKER_TRANSPORT_FAILURE);
+    expect(failures[0].message).toMatch(/retried this read once/i);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.interruptCalls).toBe(0);
+
+    await drive.finish();
+  });
+
+  it("does not amplify a repeated retry signal or retry when the app-server is inactive (#2395)", async () => {
+    const amplified = startDrive({ listings: [PANEL_UP] });
+    await amplified.endTurn("panel-read-retry-amplified");
+    expect(amplified.interruptCalls).toBe(1);
+    expect(amplified.reloadCalls).toBe(1);
+    expect(amplified.events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(
+      amplified.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(1);
+    await amplified.finish();
+
+    const inactive = startDrive({ listings: [PANEL_UP] });
+    await inactive.endTurn("panel-read-retry-inactive");
+    expect(inactive.interruptCalls).toBe(1);
+    expect(inactive.reloadCalls).toBe(1);
+    expect(inactive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    await inactive.finish();
+  });
+
+  it("keeps cancellation semantics while a panel read retry is pending (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-cancelled");
+
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.events.filter((e) => e.type === "result")).toContainEqual(
+      expect.objectContaining({ type: "result", ok: false, subtype: "interrupted" }),
+    );
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
+
+    await drive.finish();
+  });
+
+  it("does not retry a mutating panel tool after a transport failure (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-mutation-no-retry");
+
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(1);
+
+    await drive.finish();
+  });
+
   it("a WorkerTransport send failure forces one panel reload without retrying the turn (#1777)", async () => {
     // Codex can report the HTTP send failure while its status inventory still
     // says `panel` is connected. The observed error is the recovery trigger;

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -632,25 +632,68 @@ const PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS = new Set([
   "panel_query_graph",
 ]);
 
-type PanelMcpToolItem = { name: string; itemId?: string };
+type PanelMcpToolItem = {
+  name: string;
+  itemId: string;
+  requestKeys: readonly string[];
+  retryOf?: string;
+};
+
+function stringFieldOf(value: Record<string, unknown> | undefined, ...keys: string[]): string | undefined {
+  if (!value) return undefined;
+  for (const key of keys) {
+    if (typeof value[key] === "string" && value[key]) return value[key] as string;
+  }
+  return undefined;
+}
+
+function isMcpToolCallItem(item: Record<string, unknown> | undefined): boolean {
+  return stringFieldOf(item, "type") === "mcpToolCall";
+}
 
 function panelMcpToolItemOf(item: Record<string, unknown> | undefined): PanelMcpToolItem | null {
   const qualified = toolNameOf(item);
   if (!qualified) return null;
+  const type = stringFieldOf(item, "type");
+  if (type && type !== "mcpToolCall") return null;
   const separator = qualified.lastIndexOf(".");
   const server = separator >= 0 ? qualified.slice(0, separator) : undefined;
   const name = separator >= 0 ? qualified.slice(separator + 1) : qualified;
   // If app-server identifies the MCP server, require the configured panel
-  // server. A bare tool name is accepted for older app-server item shapes.
+  // server. An item id is required for transport correlation; the display path
+  // above still supports older items that only have a tool name.
   if (server && server !== "panel") return null;
+  const itemId = stringFieldOf(item, "id");
+  if (!itemId) return null;
+  const requestKeys = new Set<string>([itemId]);
+  for (const key of ["requestId", "request_id", "callId", "call_id"]) {
+    const value = stringFieldOf(item, key);
+    if (value) requestKeys.add(value);
+  }
+  const retryOf = stringFieldOf(item, "retryOf", "retry_of", "parentItemId", "parent_item_id");
+  if (retryOf) requestKeys.add(retryOf);
   return {
     name,
-    ...(typeof item?.id === "string" ? { itemId: item.id } : {}),
+    itemId,
+    requestKeys: [...requestKeys],
+    ...(retryOf ? { retryOf } : {}),
   };
 }
 
-function isPanelOuterTransportRetrySafe(item: PanelMcpToolItem | null): boolean {
-  return item != null && PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS.has(item.name);
+function panelMcpTransportErrorKeys(params: Record<string, unknown>): string[] {
+  const error = params.error as Record<string, unknown> | undefined;
+  const details = error?.additionalDetails as Record<string, unknown> | undefined;
+  const item = params.item as Record<string, unknown> | undefined;
+  const keys = new Set<string>();
+  for (const value of [
+    stringFieldOf(params, "itemId", "item_id", "requestId", "request_id", "callId", "call_id"),
+    stringFieldOf(item, "id", "requestId", "request_id", "callId", "call_id"),
+    stringFieldOf(error, "itemId", "item_id", "requestId", "request_id", "callId", "call_id"),
+    stringFieldOf(details, "itemId", "item_id", "requestId", "request_id", "callId", "call_id"),
+  ]) {
+    if (value) keys.add(value);
+  }
+  return [...keys];
 }
 
 /** A declared MCP server for the Codex app-server. Either a stdio command (the
@@ -1681,13 +1724,28 @@ export class CodexBackend implements AgentBackend {
     // the original panel mutation is still being retried.
     let mcpTransportFencePending = false;
     let turnFenced = false;
-    let activePanelTool: PanelMcpToolItem | null = null;
-    let panelReadRetry: {
+    type PanelMcpRequest = PanelMcpToolItem & {
+      afterEnterItemId: string | null;
+      completed: boolean;
+    };
+    type PanelReadRetry = {
       originalMessage: string;
       tool: string;
-      itemId?: string;
-      retryItemId?: string;
-    } | null = null;
+      itemIds: Set<string>;
+      requestKeys: Set<string>;
+    };
+    const panelMcpRequests = new Map<string, PanelMcpRequest>();
+    const panelRequestKeyToItem = new Map<string, string>();
+    const panelReadRetries = new Map<string, PanelReadRetry>();
+    const inFlightMcpItemIds = new Set<string>();
+    let unkeyedMcpItems = 0;
+    let lastCompletedPanelItemId: string | null = null;
+
+    // Retry contract: only an in-flight panel_graph_outline or
+    // panel_query_graph item that began immediately after a successful
+    // panel_enter_subgraph item may arm one retry. Correlation must resolve the
+    // transport error to that request; ambiguity is fail-closed. Mutations,
+    // unrelated reads, and reads outside this lifecycle use normal fencing.
 
     // LIVENESS (watchdog re-arm): re-arm PanelAgent's idle watchdog ONLY for
     // notifications that represent work or an outcome for THIS active turn. A
@@ -1764,6 +1822,74 @@ export class CodexBackend implements AgentBackend {
       this.client === liveClient &&
       liveClient.exitError == null;
 
+    const trackPanelMcpItem = (item: PanelMcpToolItem): PanelMcpRequest => {
+      const existing = panelMcpRequests.get(item.itemId);
+      if (existing) {
+        for (const key of item.requestKeys) {
+          existing.requestKeys = [...new Set([...existing.requestKeys, key])];
+          panelRequestKeyToItem.set(key, item.itemId);
+        }
+        return existing;
+      }
+      const previousPanelItem = lastCompletedPanelItemId
+        ? panelMcpRequests.get(lastCompletedPanelItemId)
+        : undefined;
+      const request: PanelMcpRequest = {
+        ...item,
+        afterEnterItemId:
+          previousPanelItem?.name === "panel_enter_subgraph" ? previousPanelItem.itemId : null,
+        completed: false,
+      };
+      panelMcpRequests.set(item.itemId, request);
+      for (const key of item.requestKeys) panelRequestKeyToItem.set(key, item.itemId);
+      return request;
+    };
+
+    const panelMcpRequestForTransportError = (
+      params: Record<string, unknown>,
+    ): PanelMcpRequest | null => {
+      const keys = panelMcpTransportErrorKeys(params);
+      if (keys.length > 0) {
+        const itemIds = new Set<string>();
+        let unknownKey = false;
+        for (const key of keys) {
+          const itemId = panelRequestKeyToItem.get(key) ?? (panelMcpRequests.has(key) ? key : undefined);
+          if (itemId) itemIds.add(itemId);
+          else unknownKey = true;
+        }
+        // An unknown explicit key must never fall back to a different request.
+        if (unknownKey || itemIds.size !== 1) return null;
+        const request = panelMcpRequests.get([...itemIds][0]);
+        return request && !request.completed ? request : null;
+      }
+
+      // Older app-server errors omit itemId. A sole in-flight MCP request is
+      // still unambiguous; any parallel or unkeyed MCP item makes it ineligible.
+      if (unkeyedMcpItems > 0 || inFlightMcpItemIds.size !== 1) return null;
+      const inFlight = [...panelMcpRequests.values()].filter((request) => !request.completed);
+      if (inFlight.length !== 1) return null;
+      const [itemId] = inFlightMcpItemIds;
+      return inFlight[0].itemId === itemId ? inFlight[0] : null;
+    };
+
+    const panelReadRetryForRequest = (
+      request: PanelMcpRequest | null,
+    ): { originItemId: string; retry: PanelReadRetry } | null => {
+      if (!request) return null;
+      for (const [originItemId, retry] of panelReadRetries) {
+        if (
+          retry.itemIds.has(request.itemId) ||
+          request.requestKeys.some((key) => retry.requestKeys.has(key))
+        ) {
+          return { originItemId, retry };
+        }
+      }
+      return null;
+    };
+
+    const firstPanelReadRetry = (): PanelReadRetry | undefined =>
+      panelReadRetries.values().next().value as PanelReadRetry | undefined;
+
     const abortActiveTurn = () => {
       interrupted = true;
       if (finishedResult) return;
@@ -1787,6 +1913,14 @@ export class CodexBackend implements AgentBackend {
         if (watched !== liveClient) return;
         // Closing the old app-server is the point of a stale-host recycle;
         // its exit must not finish the replacement turn (#2045).
+        const retry = firstPanelReadRetry();
+        if (retry) {
+          panelReadRetries.clear();
+          emitTerminalError(panelMcpTransportFailureNotice(retry.originalMessage, true), {
+            outcomeUnknown: true,
+          });
+          return;
+        }
         if (hostRecycleInFlight) return;
         emitTerminalError(
           watched.exitError ? msgOf(watched.exitError) : "codex app-server connection closed.",
@@ -2001,13 +2135,24 @@ export class CodexBackend implements AgentBackend {
           // reasoning items aren't "tools" — they're handled by the delta/commit
           // paths above — so skip them here.
           const item = params.item as Record<string, unknown> | undefined;
+          if (isMcpToolCallItem(item)) {
+            const itemId = stringFieldOf(item, "id");
+            if (itemId) inFlightMcpItemIds.add(itemId);
+            else unkeyedMcpItems += 1;
+          }
           const panelTool = panelMcpToolItemOf(item);
           if (panelTool) {
-            activePanelTool = panelTool;
-            // Some app-server versions represent the transport retry as a new
-            // item id; bind that completion to the one retry we already allowed.
-            if (panelReadRetry && panelTool.name === panelReadRetry.tool) {
-              panelReadRetry.retryItemId = panelTool.itemId;
+            const request = trackPanelMcpItem(panelTool);
+            for (const [originItemId, retry] of panelReadRetries) {
+              if (
+                request.name === retry.tool &&
+                (request.requestKeys.some((key) => retry.requestKeys.has(key)) ||
+                  request.retryOf === originItemId)
+              ) {
+                retry.itemIds.add(request.itemId);
+                for (const key of request.requestKeys) retry.requestKeys.add(key);
+                break;
+              }
             }
           }
           const name = toolNameOf(item);
@@ -2019,29 +2164,38 @@ export class CodexBackend implements AgentBackend {
           // (reasoning OR reply) then emit the canonical event: `assistant` for an
           // agentMessage, or tool_call(end) for a finished tool/command/MCP item.
           const item = params.item as Record<string, unknown> | undefined;
+          if (isMcpToolCallItem(item)) {
+            const itemId = stringFieldOf(item, "id");
+            if (itemId) inFlightMcpItemIds.delete(itemId);
+            else if (unkeyedMcpItems > 0) unkeyedMcpItems -= 1;
+          }
           const itemType = item?.type as string | undefined;
           const panelTool = panelMcpToolItemOf(item);
-          if (
-            panelReadRetry &&
-            panelTool?.name === panelReadRetry.tool &&
-            (!panelReadRetry.itemId ||
-              !panelTool.itemId ||
-              panelTool.itemId === panelReadRetry.itemId ||
-              panelTool.itemId === panelReadRetry.retryItemId)
-          ) {
-            const retryMessage = panelReadRetry.originalMessage;
-            const retryFailed = item?.status === "failed" || item?.status === "error" || item?.error != null;
-            panelReadRetry = null;
-            if (retryFailed) {
-              finishMcpTransportFailure(retryMessage, false, true);
-              break;
+          const request = panelTool ? panelMcpRequests.get(panelTool.itemId) : undefined;
+          if (request) {
+            request.completed = true;
+            const completedSuccessfully =
+              item?.status !== "failed" &&
+              item?.status !== "error" &&
+              item?.status !== "declined" &&
+              item?.error == null;
+            if (completedSuccessfully) lastCompletedPanelItemId = request.itemId;
+            else if (lastCompletedPanelItemId === request.itemId) lastCompletedPanelItemId = null;
+
+            const retryMatch = panelReadRetryForRequest(request);
+            if (retryMatch && request.name === retryMatch.retry.tool) {
+              const retryMessage = retryMatch.retry.originalMessage;
+              panelReadRetries.delete(retryMatch.originItemId);
+              if (!completedSuccessfully) {
+                finishMcpTransportFailure(retryMessage, false, true);
+                break;
+              }
+              // A successful completion proves that this request's one retry
+              // produced a tool result; do not queue the control-plane reload
+              // for the transient error recovered in-band.
+              if (panelReadRetries.size === 0) this.mcpTransportRecovery.delete("panel");
             }
-            // A successful completion proves that the app-server's one retry
-            // produced a tool result; do not queue the control-plane reload for
-            // the transient error that was recovered in-band.
-            this.mcpTransportRecovery.delete("panel");
           }
-          if (panelTool && activePanelTool?.itemId === panelTool.itemId) activePanelTool = null;
           closeStream();
           if (itemType === "agentMessage") {
             // `item.text` is normally a string, but newer app-server builds can
@@ -2078,46 +2232,54 @@ export class CodexBackend implements AgentBackend {
           // for either a later terminal error or turn/completed.
           const e = params.error ?? {};
           const message = formatCodexTurnError(e);
-          // Once a retry-safe panel read has failed, any terminal error for
-          // that turn is the retry outcome. Keep the first transport message
-          // even if the app-server wraps the second failure differently.
-          if (panelReadRetry && params.willRetry !== true) {
-            const retryMessage = panelReadRetry.originalMessage;
-            panelReadRetry = null;
-            finishMcpTransportFailure(retryMessage, false, true);
-            break;
-          }
           // The app-server's normal willRetry path is useful for provider
           // failures, but it is unsafe to allow a WorkerTransport MCP error to
           // silently replay a panel mutation. Stop this turn, remember the
           // panel transport failure for the turn-boundary reload, and make the
           // outcome/reconnect boundary explicit to the caller.
           if (this.noteMcpTransportFailure(message)) {
-            const retryAttempted = panelReadRetry;
-            const currentPanelTool = activePanelTool;
+            const request = panelMcpRequestForTransportError(params);
+            const matchedRetry = panelReadRetryForRequest(request);
+            // An uncorrelated terminal error after arming is still the only
+            // pending retry's outcome; preserve that first message. An
+            // explicitly correlated mutation never borrows a read's retry.
+            const errorKeys = panelMcpTransportErrorKeys(params);
+            const retryAttempted =
+              matchedRetry?.retry ??
+              (errorKeys.length === 0 && request == null && panelReadRetries.size === 1
+                ? firstPanelReadRetry()
+                : undefined);
             if (
               !retryAttempted &&
               params.willRetry === true &&
-              currentPanelTool != null &&
-              isPanelOuterTransportRetrySafe(currentPanelTool) &&
+              request != null &&
+              request.afterEnterItemId != null &&
+              PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS.has(request.name) &&
               appServerConnectionIsActive()
             ) {
               // The Codex app-server owns the actual HTTP client. Let its live
               // connection perform this one retry, but remember the first error
               // so a second failure cannot amplify or replace the diagnosis.
-              panelReadRetry = {
+              panelReadRetries.set(request.itemId, {
                 originalMessage: message,
-                tool: currentPanelTool.name,
-                ...(currentPanelTool.itemId ? { itemId: currentPanelTool.itemId } : {}),
-              };
+                tool: request.name,
+                itemIds: new Set([request.itemId]),
+                requestKeys: new Set(request.requestKeys),
+              });
               break;
             }
-            panelReadRetry = null;
+            panelReadRetries.clear();
             finishMcpTransportFailure(
               retryAttempted?.originalMessage ?? message,
               params.willRetry === true,
-              retryAttempted != null,
+              retryAttempted !== undefined,
             );
+            break;
+          }
+          if (panelReadRetries.size > 0 && params.willRetry !== true) {
+            const retry = firstPanelReadRetry();
+            panelReadRetries.clear();
+            finishMcpTransportFailure(retry?.originalMessage ?? message, false, retry !== undefined);
             break;
           }
           if (params.willRetry === true) break;
@@ -2132,19 +2294,19 @@ export class CodexBackend implements AgentBackend {
         }
         case "turn/completed": {
           const t = params.turn as { status?: string } | undefined;
-          if (panelReadRetry && (t?.status === "interrupted" || interrupted)) {
+          if (panelReadRetries.size > 0 && (t?.status === "interrupted" || interrupted)) {
             // User cancellation (including a watchdog timeout that successfully
             // interrupts the turn) is not a failed retry. Preserve the normal
             // interrupted result and let the existing turn-end recovery observe
             // the transport episode on its usual path.
-            panelReadRetry = null;
-          } else if (panelReadRetry) {
-            const retryMessage = panelReadRetry.originalMessage;
-            panelReadRetry = null;
+            panelReadRetries.clear();
+          } else if (panelReadRetries.size > 0) {
+            const retry = firstPanelReadRetry();
+            panelReadRetries.clear();
             // A turn completion without a successful retry item is the retry's
             // terminal outcome. Preserve the original transport error rather
             // than reporting a later wrapper or a false success.
-            finishMcpTransportFailure(retryMessage, false, true);
+            finishMcpTransportFailure(retry?.originalMessage ?? "panel MCP read retry failed", false, true);
             break;
           }
           closeStream();

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -1739,13 +1739,15 @@ export class CodexBackend implements AgentBackend {
     const panelReadRetries = new Map<string, PanelReadRetry>();
     const inFlightMcpItemIds = new Set<string>();
     let unkeyedMcpItems = 0;
-    let lastCompletedPanelItemId: string | null = null;
+    let panelEnterCandidate: { itemId: string; laterPanelRequestStarted: boolean } | null = null;
+    let immediatePanelReadAfterEnter: string | null = null;
 
-    // Retry contract: only an in-flight panel_graph_outline or
-    // panel_query_graph item that began immediately after a successful
-    // panel_enter_subgraph item may arm one retry. Correlation must resolve the
-    // transport error to that request; ambiguity is fail-closed. Mutations,
-    // unrelated reads, and reads outside this lifecycle use normal fencing.
+    // Retry contract: only the next panel request after a successful
+    // panel_enter_subgraph completion can be an eligible graph read. The
+    // one-shot sequence is consumed at request start; a mutation or unrelated
+    // panel request therefore invalidates it before a later read can qualify.
+    // Correlation must resolve the transport error to that request; ambiguity
+    // is fail-closed. Mutations and unrelated reads use normal fencing.
 
     // LIVENESS (watchdog re-arm): re-arm PanelAgent's idle watchdog ONLY for
     // notifications that represent work or an outcome for THIS active turn. A
@@ -1822,7 +1824,10 @@ export class CodexBackend implements AgentBackend {
       this.client === liveClient &&
       liveClient.exitError == null;
 
-    const trackPanelMcpItem = (item: PanelMcpToolItem): PanelMcpRequest => {
+    const trackPanelMcpItem = (
+      item: PanelMcpToolItem,
+      afterEnterItemId: string | null,
+    ): PanelMcpRequest => {
       const existing = panelMcpRequests.get(item.itemId);
       if (existing) {
         for (const key of item.requestKeys) {
@@ -1831,13 +1836,9 @@ export class CodexBackend implements AgentBackend {
         }
         return existing;
       }
-      const previousPanelItem = lastCompletedPanelItemId
-        ? panelMcpRequests.get(lastCompletedPanelItemId)
-        : undefined;
       const request: PanelMcpRequest = {
         ...item,
-        afterEnterItemId:
-          previousPanelItem?.name === "panel_enter_subgraph" ? previousPanelItem.itemId : null,
+        afterEnterItemId,
         completed: false,
       };
       panelMcpRequests.set(item.itemId, request);
@@ -2142,7 +2143,21 @@ export class CodexBackend implements AgentBackend {
           }
           const panelTool = panelMcpToolItemOf(item);
           if (panelTool) {
-            const request = trackPanelMcpItem(panelTool);
+            const isNewPanelRequest = !panelMcpRequests.has(panelTool.itemId);
+            let afterEnterItemId: string | null = null;
+            if (isNewPanelRequest) {
+              if (panelTool.name === "panel_enter_subgraph") {
+                immediatePanelReadAfterEnter = null;
+                panelEnterCandidate = { itemId: panelTool.itemId, laterPanelRequestStarted: false };
+              } else {
+                if (panelEnterCandidate) panelEnterCandidate.laterPanelRequestStarted = true;
+                if (immediatePanelReadAfterEnter && PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS.has(panelTool.name)) {
+                  afterEnterItemId = immediatePanelReadAfterEnter;
+                }
+                immediatePanelReadAfterEnter = null;
+              }
+            }
+            const request = trackPanelMcpItem(panelTool, afterEnterItemId);
             for (const [originItemId, retry] of panelReadRetries) {
               if (
                 request.name === retry.tool &&
@@ -2179,8 +2194,15 @@ export class CodexBackend implements AgentBackend {
               item?.status !== "error" &&
               item?.status !== "declined" &&
               item?.error == null;
-            if (completedSuccessfully) lastCompletedPanelItemId = request.itemId;
-            else if (lastCompletedPanelItemId === request.itemId) lastCompletedPanelItemId = null;
+            if (request.name === "panel_enter_subgraph") {
+              immediatePanelReadAfterEnter =
+                completedSuccessfully &&
+                panelEnterCandidate?.itemId === request.itemId &&
+                !panelEnterCandidate.laterPanelRequestStarted
+                  ? request.itemId
+                  : null;
+              panelEnterCandidate = null;
+            }
 
             const retryMatch = panelReadRetryForRequest(request);
             if (retryMatch && request.name === retryMatch.retry.tool) {
@@ -2240,15 +2262,10 @@ export class CodexBackend implements AgentBackend {
           if (this.noteMcpTransportFailure(message)) {
             const request = panelMcpRequestForTransportError(params);
             const matchedRetry = panelReadRetryForRequest(request);
-            // An uncorrelated terminal error after arming is still the only
-            // pending retry's outcome; preserve that first message. An
-            // explicitly correlated mutation never borrows a read's retry.
-            const errorKeys = panelMcpTransportErrorKeys(params);
-            const retryAttempted =
-              matchedRetry?.retry ??
-              (errorKeys.length === 0 && request == null && panelReadRetries.size === 1
-                ? firstPanelReadRetry()
-                : undefined);
+            // Only a correlated terminal error for the armed request is its
+            // retry outcome. A distinct mutation or unrelated request never
+            // borrows, clears, or consumes that read's retry.
+            const retryAttempted = matchedRetry?.retry;
             if (
               !retryAttempted &&
               params.willRetry === true &&
@@ -2268,9 +2285,17 @@ export class CodexBackend implements AgentBackend {
               });
               break;
             }
-            panelReadRetries.clear();
+            // A transport error for a different request must not consume or
+            // rewrite a read retry that is already armed. The mutation still
+            // fences this turn, because its dispatch/outcome is unknown, but
+            // retain the saved read error in the terminal diagnosis and leave
+            // its per-item retry state untouched.
+            const pendingRead = firstPanelReadRetry();
+            const failureMessage = pendingRead
+              ? `${pendingRead.originalMessage}\nA distinct panel MCP request also failed: ${message}`
+              : message;
             finishMcpTransportFailure(
-              retryAttempted?.originalMessage ?? message,
+              retryAttempted?.originalMessage ?? failureMessage,
               params.willRetry === true,
               retryAttempted !== undefined,
             );

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -114,10 +114,13 @@ export function isCodexPanelMcpTransportFailure(message: string, panelUrl: strin
 /** Keep a WorkerTransport failure self-contained: PanelAgent's generic turn
  * failure text says "Nothing was lost — try again", which is unsafe when a
  * mutation's dispatch/outcome was not established at this boundary. */
-function panelMcpTransportFailureNotice(message: string): string {
+function panelMcpTransportFailureNotice(message: string, retriedRead: boolean): string {
+  const retryNote = retriedRead
+    ? `The orchestrator retried this read once, but that retry also failed; the original transport error is preserved.`
+    : `The orchestrator did not retry the request.`;
   return (
     `The local panel MCP connection failed before a tool result was returned. ` +
-    `The orchestrator did not retry the request. For a render or other mutation, ` +
+    `${retryNote} For a render or other mutation, ` +
     `treat the first attempt's outcome as UNKNOWN until you inspect queue ` +
     `(action:"list") or get_history; do not re-run panel_run blindly. The panel MCP ` +
     `connection is being reloaded for the next turn. If it remains unavailable, ` +
@@ -617,6 +620,37 @@ export function toolNameOf(item: Record<string, unknown> | undefined): string | 
   // No explicit name field — use the item type as the label (commandExecution,
   // fileChange, webSearch, …) so the panel at least shows that a tool ran.
   return type ?? null;
+}
+
+// A failed HTTP MCP send is observed outside panel-mcp-http.ts, so the backend
+// has to classify the in-flight app-server item before deciding whether the
+// transport may issue its one retry. Keep this allowlist intentionally narrower
+// than the panel tool catalog: scope navigation and every mutation must never
+// be replayed from an opaque outer transport error.
+const PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS = new Set([
+  "panel_graph_outline",
+  "panel_query_graph",
+]);
+
+type PanelMcpToolItem = { name: string; itemId?: string };
+
+function panelMcpToolItemOf(item: Record<string, unknown> | undefined): PanelMcpToolItem | null {
+  const qualified = toolNameOf(item);
+  if (!qualified) return null;
+  const separator = qualified.lastIndexOf(".");
+  const server = separator >= 0 ? qualified.slice(0, separator) : undefined;
+  const name = separator >= 0 ? qualified.slice(separator + 1) : qualified;
+  // If app-server identifies the MCP server, require the configured panel
+  // server. A bare tool name is accepted for older app-server item shapes.
+  if (server && server !== "panel") return null;
+  return {
+    name,
+    ...(typeof item?.id === "string" ? { itemId: item.id } : {}),
+  };
+}
+
+function isPanelOuterTransportRetrySafe(item: PanelMcpToolItem | null): boolean {
+  return item != null && PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS.has(item.name);
 }
 
 /** A declared MCP server for the Codex app-server. Either a stdio command (the
@@ -1647,6 +1681,13 @@ export class CodexBackend implements AgentBackend {
     // the original panel mutation is still being retried.
     let mcpTransportFencePending = false;
     let turnFenced = false;
+    let activePanelTool: PanelMcpToolItem | null = null;
+    let panelReadRetry: {
+      originalMessage: string;
+      tool: string;
+      itemId?: string;
+      retryItemId?: string;
+    } | null = null;
 
     // LIVENESS (watchdog re-arm): re-arm PanelAgent's idle watchdog ONLY for
     // notifications that represent work or an outcome for THIS active turn. A
@@ -1711,6 +1752,18 @@ export class CodexBackend implements AgentBackend {
       }
     };
 
+    // `willRetry:true` is the app-server's positive signal that it still owns
+    // the active connection and can retry the failed MCP send. Keep the local
+    // state checks as well: cancellation, timeout teardown, client replacement,
+    // and disposal must not wake a retry after the turn has stopped being live.
+    const appServerConnectionIsActive = (): boolean =>
+      !interrupted &&
+      !finishedResult &&
+      !turnFenced &&
+      !this.disposed &&
+      this.client === liveClient &&
+      liveClient.exitError == null;
+
     const abortActiveTurn = () => {
       interrupted = true;
       if (finishedResult) return;
@@ -1750,14 +1803,18 @@ export class CodexBackend implements AgentBackend {
       await this.beginClientClose(fencedClient, "panel MCP transport recovery fence teardown failed");
     };
 
-    const finishMcpTransportFailure = (message: string, willRetry: boolean): void => {
+    const finishMcpTransportFailure = (
+      message: string,
+      willRetry: boolean,
+      retriedRead = false,
+    ): void => {
       if (mcpTransportFencePending || finishedResult) return;
       mcpTransportFencePending = true;
 
       // willRetry:false is already terminal at the app-server boundary. Keep
       // the existing bounded recovery path and its single local error/result.
       if (!willRetry) {
-        emitTerminalError(panelMcpTransportFailureNotice(message), { outcomeUnknown: true });
+        emitTerminalError(panelMcpTransportFailureNotice(message, retriedRead), { outcomeUnknown: true });
         return;
       }
 
@@ -1800,7 +1857,9 @@ export class CodexBackend implements AgentBackend {
         const fenceNote = interruptError
           ? " The active app-server turn could not be interrupted; its connection was closed before recovery."
           : " The active app-server turn was interrupted before recovery.";
-        emitTerminalError(panelMcpTransportFailureNotice(message) + fenceNote, { outcomeUnknown: true });
+        emitTerminalError(panelMcpTransportFailureNotice(message, retriedRead) + fenceNote, {
+          outcomeUnknown: true,
+        });
       })();
     };
 
@@ -1942,6 +2001,15 @@ export class CodexBackend implements AgentBackend {
           // reasoning items aren't "tools" — they're handled by the delta/commit
           // paths above — so skip them here.
           const item = params.item as Record<string, unknown> | undefined;
+          const panelTool = panelMcpToolItemOf(item);
+          if (panelTool) {
+            activePanelTool = panelTool;
+            // Some app-server versions represent the transport retry as a new
+            // item id; bind that completion to the one retry we already allowed.
+            if (panelReadRetry && panelTool.name === panelReadRetry.tool) {
+              panelReadRetry.retryItemId = panelTool.itemId;
+            }
+          }
           const name = toolNameOf(item);
           if (name) push({ type: "tool_call", name, phase: "start", detail: item });
           break;
@@ -1952,6 +2020,28 @@ export class CodexBackend implements AgentBackend {
           // agentMessage, or tool_call(end) for a finished tool/command/MCP item.
           const item = params.item as Record<string, unknown> | undefined;
           const itemType = item?.type as string | undefined;
+          const panelTool = panelMcpToolItemOf(item);
+          if (
+            panelReadRetry &&
+            panelTool?.name === panelReadRetry.tool &&
+            (!panelReadRetry.itemId ||
+              !panelTool.itemId ||
+              panelTool.itemId === panelReadRetry.itemId ||
+              panelTool.itemId === panelReadRetry.retryItemId)
+          ) {
+            const retryMessage = panelReadRetry.originalMessage;
+            const retryFailed = item?.status === "failed" || item?.status === "error" || item?.error != null;
+            panelReadRetry = null;
+            if (retryFailed) {
+              finishMcpTransportFailure(retryMessage, false, true);
+              break;
+            }
+            // A successful completion proves that the app-server's one retry
+            // produced a tool result; do not queue the control-plane reload for
+            // the transient error that was recovered in-band.
+            this.mcpTransportRecovery.delete("panel");
+          }
+          if (panelTool && activePanelTool?.itemId === panelTool.itemId) activePanelTool = null;
           closeStream();
           if (itemType === "agentMessage") {
             // `item.text` is normally a string, but newer app-server builds can
@@ -1988,13 +2078,46 @@ export class CodexBackend implements AgentBackend {
           // for either a later terminal error or turn/completed.
           const e = params.error ?? {};
           const message = formatCodexTurnError(e);
+          // Once a retry-safe panel read has failed, any terminal error for
+          // that turn is the retry outcome. Keep the first transport message
+          // even if the app-server wraps the second failure differently.
+          if (panelReadRetry && params.willRetry !== true) {
+            const retryMessage = panelReadRetry.originalMessage;
+            panelReadRetry = null;
+            finishMcpTransportFailure(retryMessage, false, true);
+            break;
+          }
           // The app-server's normal willRetry path is useful for provider
           // failures, but it is unsafe to allow a WorkerTransport MCP error to
           // silently replay a panel mutation. Stop this turn, remember the
           // panel transport failure for the turn-boundary reload, and make the
           // outcome/reconnect boundary explicit to the caller.
           if (this.noteMcpTransportFailure(message)) {
-            finishMcpTransportFailure(message, params.willRetry === true);
+            const retryAttempted = panelReadRetry;
+            const currentPanelTool = activePanelTool;
+            if (
+              !retryAttempted &&
+              params.willRetry === true &&
+              currentPanelTool != null &&
+              isPanelOuterTransportRetrySafe(currentPanelTool) &&
+              appServerConnectionIsActive()
+            ) {
+              // The Codex app-server owns the actual HTTP client. Let its live
+              // connection perform this one retry, but remember the first error
+              // so a second failure cannot amplify or replace the diagnosis.
+              panelReadRetry = {
+                originalMessage: message,
+                tool: currentPanelTool.name,
+                ...(currentPanelTool.itemId ? { itemId: currentPanelTool.itemId } : {}),
+              };
+              break;
+            }
+            panelReadRetry = null;
+            finishMcpTransportFailure(
+              retryAttempted?.originalMessage ?? message,
+              params.willRetry === true,
+              retryAttempted != null,
+            );
             break;
           }
           if (params.willRetry === true) break;
@@ -2008,8 +2131,23 @@ export class CodexBackend implements AgentBackend {
           break;
         }
         case "turn/completed": {
-          closeStream();
           const t = params.turn as { status?: string } | undefined;
+          if (panelReadRetry && (t?.status === "interrupted" || interrupted)) {
+            // User cancellation (including a watchdog timeout that successfully
+            // interrupts the turn) is not a failed retry. Preserve the normal
+            // interrupted result and let the existing turn-end recovery observe
+            // the transport episode on its usual path.
+            panelReadRetry = null;
+          } else if (panelReadRetry) {
+            const retryMessage = panelReadRetry.originalMessage;
+            panelReadRetry = null;
+            // A turn completion without a successful retry item is the retry's
+            // terminal outcome. Preserve the original transport error rather
+            // than reporting a later wrapper or a false success.
+            finishMcpTransportFailure(retryMessage, false, true);
+            break;
+          }
+          closeStream();
           // Mark a result emitted so a racing terminal-error path stays a no-op.
           finishedResult = true;
           push({ type: "result", ok: t?.status === "completed", ...(t?.status ? { subtype: t.status } : {}) });


### PR DESCRIPTION
## Summary

Fixes #2395

- Trace the outer Codex app-server WorkerTransport failure to the correlated panel MCP item after panel_enter_subgraph.
- Allow one in-band retry only for panel_graph_outline and panel_query_graph in the proved immediate post-enter sequence while the app-server connection remains active.
- Invalidate that sequence on any intervening panel request; keep mutations and unrelated reads on the existing fence/reload path.
- Keep per-item failures isolated and preserve the original saved read transport error when a distinct mutation fails.
- Retain cancellation, timeout, connection-exit, and no-amplification semantics.

## Validation

- Focused production-path tests: 2 files / 41 passed
- Orchestrator suite: 256 files / 4,379 tests passed
- `npm.cmd run build` passed
- `npm.cmd run lint` passed
- `git diff --check` passed

No merge or release performed.