### PR TITLE
fix(panel): reconcile promoted-widget writes

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -135,6 +135,8 @@ function bridge(opts: {
   workflowUuid?: string;
   /** The outer node id used by the current fake viewing scope. */
   ownerNodeId?: number;
+  /** #2394: begin the fake panel inside a subgraph for active-view scope tests. */
+  startInSubgraph?: boolean;
   /** panel#1859 — a real pre-0.15.101 panel build. It publishes no
    * `graph_identity` anywhere (neither on `viewing` nor on `subgraph_of`) and
    * its hello advertises `enforces_expected_node_type_at_write` but none of the
@@ -152,11 +154,11 @@ function bridge(opts: {
   let subgraphReads = 0;
   let postEnterGraphQueries = 0;
   let authoritativeScopeReads = 0;
-  let inSubgraph = false;
+  let inSubgraph = opts.startInSubgraph === true;
   const workflowUuid = opts.workflowUuid ?? "workflow-a";
   let currentOwnerNodeId = opts.ownerNodeId ?? 78;
-  let currentGraphIdentity = "graph:workflow-a-root";
   const targetGraphIdentity = "graph:workflow-a-container-a";
+  let currentGraphIdentity = inSubgraph ? targetGraphIdentity : "graph:workflow-a-root";
   let connectionIdentity = { generation: 1, tabSessionId: "browser-tab-a" };
   let observedPromotedScope: {
     known: true;
@@ -843,6 +845,32 @@ describe("panel_set_widget coordinated promoted-widget fixes (#2393, #2394)", ()
     expect(isError).toBe(false);
     expect(mutations).toBe(1);
     expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(0);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 82, widget: "lora_1", value }),
+    ]);
+  });
+
+  it("does not use the root-only lora_N shortcut from an active subgraph (#2394)", async () => {
+    const value = '{"on":true,"lora":"turbo.safetensors","strength":1,"strengthTwo":null}';
+    const { isError, calls, mutations } = await setWidget(
+      { node_id: 82, widget: "lora_1", value },
+      {
+        ownerNodeId: 78,
+        startInSubgraph: true,
+        firstWrite: "ok",
+        // The target is ordinary, but the active viewing scope is a subgraph.
+        promotedDetail: {
+          text:
+            '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+            '{"id":82,"type":"Power Lora Loader (rgthree)","is_subgraph":false}',
+        },
+        subgraph: new Error("Node 82 (Power Lora Loader (rgthree)) is not a subgraph"),
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(1);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
       expect.objectContaining({ node_id: 82, widget: "lora_1", value }),
     ]);

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -72,6 +72,9 @@ function bridge(opts: {
   remappedWrite?: Outcome;
   innerWrite?: Outcome;
   subgraph?: Record<string, unknown> | Error;
+  /** #2393: successive graph_get_subgraph replies, used to model a witness
+   * that is incomplete immediately after an official template load. */
+  subgraphSequence?: Array<Record<string, unknown> | Error>;
   nestedSubgraph?: Record<string, unknown> | Error;
   enterFails?: boolean;
   exitFails?: boolean;
@@ -130,6 +133,8 @@ function bridge(opts: {
   };
   omitWorkflowUuid?: boolean;
   workflowUuid?: string;
+  /** The outer node id used by the current fake viewing scope. */
+  ownerNodeId?: number;
   /** panel#1859 — a real pre-0.15.101 panel build. It publishes no
    * `graph_identity` anywhere (neither on `viewing` nor on `subgraph_of`) and
    * its hello advertises `enforces_expected_node_type_at_write` but none of the
@@ -149,7 +154,7 @@ function bridge(opts: {
   let authoritativeScopeReads = 0;
   let inSubgraph = false;
   const workflowUuid = opts.workflowUuid ?? "workflow-a";
-  let currentOwnerNodeId = 78;
+  let currentOwnerNodeId = opts.ownerNodeId ?? 78;
   let currentGraphIdentity = "graph:workflow-a-root";
   const targetGraphIdentity = "graph:workflow-a-container-a";
   let connectionIdentity = { generation: 1, tabSessionId: "browser-tab-a" };
@@ -335,10 +340,15 @@ function bridge(opts: {
           if (opts.recoveryPreflightSubgraph instanceof Error) throw opts.recoveryPreflightSubgraph;
           return withCurrentViewing(opts.recoveryPreflightSubgraph);
         }
+        if (opts.subgraphSequence && opts.subgraphSequence.length > 0) {
+          const selected = opts.subgraphSequence[Math.min(subgraphReads - 1, opts.subgraphSequence.length - 1)];
+          if (selected instanceof Error) throw selected;
+          return withCurrentViewing(selected);
+        }
         if (inSubgraph) {
           if (opts.nestedSubgraph instanceof Error) throw opts.nestedSubgraph;
           if (opts.nestedSubgraph) return withCurrentViewing(opts.nestedSubgraph);
-          if (String(cmd.node_id) !== "78") {
+          if (String(cmd.node_id) !== String(currentOwnerNodeId)) {
             throw new Error(`Node ${cmd.node_id} (OrdinaryNode) is not a subgraph`);
           }
           throw new Error("No node with id 78 in the current graph");
@@ -747,6 +757,98 @@ const CURRENT_SAFE_PROMOTED_SUBGRAPH = {
   ],
 };
 
+const QWEN_EDIT_PROMOTED_SUBGRAPH = {
+  subgraph_of: { node_id: 170, title: "Qwen Image Edit 2511 INT8" },
+  node_count: 1,
+  nodes: [
+    {
+      id: 168,
+      type: "PrimitiveBoolean",
+      widgets: { value: false },
+      inputs: [{ name: "value", type: "BOOLEAN" }],
+    },
+  ],
+  promoted_terminals: [
+    {
+      widget: "enable_turbo_mode",
+      parent_rail: { authoritative: true, widget: "enable_turbo_mode" },
+      immediate_node_id: 168,
+      immediate_widget: "value",
+      terminal_node_id: 168,
+      terminal_node_type: "PrimitiveBoolean",
+      terminal_widget: "value",
+      terminal_inputs: [{ name: "value", type: "BOOLEAN" }],
+      chain_depth: 0,
+    },
+  ],
+};
+
+const QWEN_EDIT_INCOMPLETE_PROMOTED_SUBGRAPH = {
+  ...QWEN_EDIT_PROMOTED_SUBGRAPH,
+  promoted_terminals: [
+    {
+      widget: "enable_turbo_mode",
+      error: "promoted terminal _subgraphSlot is not resolved yet",
+    },
+  ],
+};
+
+describe("panel_set_widget coordinated promoted-widget fixes (#2393, #2394)", () => {
+  it("refreshes one incomplete post-template terminal witness before the guarded inner write (#2393)", async () => {
+    const { isError, calls, mutations } = await setWidget(
+      { node_id: 170, widget: "enable_turbo_mode", value: true },
+      {
+        ownerNodeId: 170,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: {
+          text:
+            '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+            '{"id":170,"type":"SubgraphNode","is_subgraph":true}',
+        },
+        subgraph: QWEN_EDIT_PROMOTED_SUBGRAPH,
+        subgraphSequence: [
+          QWEN_EDIT_INCOMPLETE_PROMOTED_SUBGRAPH,
+          QWEN_EDIT_PROMOTED_SUBGRAPH,
+        ],
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(3);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 168, widget: "value", value: true }),
+    ]);
+  });
+
+  it("allows a missing root-level Power Lora Loader lora_N row without entering promoted mapping (#2394)", async () => {
+    const value = '{"on":true,"lora":"turbo.safetensors","strength":1,"strengthTwo":null}';
+    const { isError, calls, mutations } = await setWidget(
+      { node_id: 82, widget: "lora_1", value },
+      {
+        ownerNodeId: 82,
+        firstWrite: "ok",
+        // If the classifier regresses to graph_get_subgraph first, this is the
+        // refusal observed for a fresh root loader rather than a safe write.
+        subgraph: new Error("Node 82 (Power Lora Loader (rgthree)) is not a subgraph"),
+        promotedDetail: {
+          text:
+            '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+            '{"id":82,"type":"Power Lora Loader (rgthree)","is_subgraph":false}',
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(0);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 82, widget: "lora_1", value }),
+    ]);
+  });
+});
+
 /** The outer read lists only B. The receiver's terminal witness proves that
  * B's own promoted rail continues to the concrete endpoint, so MCP can apply
  * the three known-bad guards to the node the panel will actually mutate. */
@@ -1064,6 +1166,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(text).toMatch(/could not determine whether the addressed node is a promoted container/);
     expect(calls.map((c) => c.cmd)).toEqual([
       "graph_query",
+      "graph_query",
       "graph_get_subgraph",
     ]);
   });
@@ -1096,7 +1199,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
 
     // Still fail-closed: the guard is untouched and nothing was written.
     expect(isError).toBe(true);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_get_subgraph"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_query", "graph_get_subgraph"]);
     expect(calls.map((c) => c.cmd)).not.toContain("graph_set_widget");
     expect(mutations).toBe(0);
 
@@ -1143,7 +1246,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
 
     expect(isError).toBe(true);
     expect(mutations).toBe(0);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_get_subgraph"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_query", "graph_get_subgraph"]);
     // Unchanged from before panel#1869: a transport failure IS transient, so
     // "retry once stable" is honest advice there and must survive.
     expect(text).toContain("could not determine whether the addressed node is a promoted container");
@@ -1162,6 +1265,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
 
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
       "graph_query",
       "graph_get_subgraph",
       "graph_set_widget",
@@ -1240,6 +1344,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
 
     expect(isError).toBe(true);
     expect(text).toMatch(/incomplete or unresolved|missing, ambiguous, stale, or unresolved/);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(2);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
@@ -2366,9 +2471,11 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toEqual([
       "graph_query",
+      "graph_query",
       "graph_get_subgraph",
       "graph_query",
       "graph_set_widget",
+      "graph_query",
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
@@ -2378,8 +2485,8 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       "graph_set_widget",
       "graph_exit_subgraph",
     ]);
-    expect(calls[3]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
-    expect(calls[10]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
+    expect(calls[4]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
+    expect(calls[12]).toMatchObject({ expected_node_type: "OtherLoraLoader" });
     expect(text).toMatch(/validated promoted inner widget/);
   });
 
@@ -2401,9 +2508,11 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(isError).toBe(true);
     expect(calls.map((c) => c.cmd)).toEqual([
       "graph_query",
+      "graph_query",
       "graph_get_subgraph",
       "graph_query",
       "graph_set_widget",
+      "graph_query",
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
@@ -2432,9 +2541,11 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(isError).toBe(true);
     expect(calls.map((c) => c.cmd)).toEqual([
       "graph_query",
+      "graph_query",
       "graph_get_subgraph",
       "graph_query",
       "graph_set_widget",
+      "graph_query",
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
@@ -2468,7 +2579,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_get_subgraph", "graph_set_widget", "graph_query"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget", "graph_query"]);
     expect(text).toMatch(/slot:1, name:"text", label:null/);
     expect(text).toMatch(/slot:2, name:"text_1", label:"text"/);
     expect(text).toMatch(/no second write was attempted/i);
@@ -2482,14 +2593,16 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
 
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
       "graph_get_subgraph",
       "graph_set_widget",
       "graph_enter_subgraph",
+      "graph_query",
       "graph_get_subgraph",
       "graph_set_widget",
     ]);
-    expect(calls[2]).toMatchObject({ node_id: "190" });
-    expect(calls[4]).toMatchObject({ node_id: 188, widget: "text", value: "hello" });
+    expect(calls[3]).toMatchObject({ node_id: "190" });
+    expect(calls[6]).toMatchObject({ node_id: 188, widget: "text", value: "hello" });
     expect(text).toMatch(/route was re-entered and the write was retried once/i);
   });
 
@@ -2501,8 +2614,10 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
 
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
       "graph_get_subgraph",
       "graph_set_widget",
+      "graph_query",
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
@@ -2535,7 +2650,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       { firstWrite: "ok", preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
     );
     expect(isError).toBe(false);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_get_subgraph", "graph_set_widget"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("a genuine miss is never retried", async () => {
@@ -2567,7 +2682,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       { firstWrite: "fail", preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH },
     );
     expect(isError).toBe(true);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_get_subgraph", "graph_set_widget"]);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_get_subgraph", "graph_set_widget"]);
   });
 
   it("an ambiguous inner mapping is not guessed", async () => {
@@ -2589,8 +2704,10 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(text).toMatch(/is not a promoted widget/);
     expect(text).toMatch(/ambiguously to 2 inner nodes|did not uniquely identify/);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
       "graph_get_subgraph",
       "graph_set_widget",
+      "graph_query",
       "graph_get_subgraph",
     ]);
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
@@ -2618,8 +2735,10 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(text).toMatch(/is not a promoted widget/);
     expect(text).toMatch(/graph_get_subgraph FAILED/);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
       "graph_get_subgraph",
       "graph_set_widget",
+      "graph_query",
       "graph_get_subgraph",
       "graph_get_subgraph",
     ]);
@@ -2644,8 +2763,10 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     );
     expect(isError).toBe(true);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
       "graph_get_subgraph",
       "graph_set_widget",
+      "graph_query",
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",
@@ -2666,8 +2787,10 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     );
     expect(isError).toBe(false);
     expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
       "graph_get_subgraph",
       "graph_set_widget",
+      "graph_query",
       "graph_get_subgraph",
       "graph_get_subgraph",
       "graph_enter_subgraph",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5909,6 +5909,53 @@ function parseQueriedNodeIdentityRow(row: unknown): QueriedNodeIdentity | null {
   return resolvedType ? { id, type: resolvedType } : null;
 }
 
+type QueriedNodeScope = "ordinary" | "container";
+
+/** Read the node's explicit container bit before attempting promoted-widget
+ * resolution. The pinpoint detail projection carries this bit even when the
+ * widget list is empty (which is how a fresh rgthree Power Lora Loader appears).
+ * Anything short of one exact, non-truncated row is deliberately indeterminate;
+ * callers retain the existing fail-closed promoted-container path in that case. */
+function parseVerifiedQueriedNodeScope(
+  payload: Record<string, unknown> | null,
+  nodeId: unknown,
+): QueriedNodeScope | null {
+  if (!payload) return null;
+  if (
+    Object.prototype.hasOwnProperty.call(payload, "truncated") &&
+    payload.truncated !== false
+  ) {
+    return null;
+  }
+
+  let row: unknown;
+  if (Object.prototype.hasOwnProperty.call(payload, "nodes")) {
+    if (!Array.isArray(payload.nodes) || payload.nodes.length !== 1) return null;
+    row = payload.nodes[0];
+  } else if (typeof payload.text === "string") {
+    // Current panel detail replies carry JSON rows in text. Accept a structured
+    // row as well, but never infer is_subgraph from compact prose.
+    for (const line of payload.text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || /^\d+ match\(es\) of \d+ in scope/.test(trimmed)) continue;
+      if (!trimmed.startsWith("{") || row !== undefined) return null;
+      try {
+        row = JSON.parse(trimmed) as unknown;
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const identity = parseQueriedNodeIdentityRow(row);
+  const requestedId = canonicalQueriedNodeId(nodeId);
+  if (!identity || !requestedId || identity.id !== requestedId) return null;
+  const isSubgraph = (row as Record<string, unknown>).is_subgraph;
+  if (typeof isSubgraph !== "boolean") return null;
+  return isSubgraph ? "container" : "ordinary";
+}
+
 /** Strict identity parser for the DaSiWa refusal gate. Unlike the older type-only
  * parser above, this accepts exactly one non-truncated row and authenticates its id. */
 function parseVerifiedQueriedNodeIdentity(
@@ -6476,6 +6523,26 @@ function promotedTerminalEvidenceError(
   return null;
 }
 
+/** A just-loaded official template can publish the terminal list before its
+ * promoted rail has settled. That is the one incomplete witness state worth a
+ * single fresh read; malformed, duplicate, or missing evidence remains a hard
+ * refusal and never becomes authorization through retry. */
+function promotedTerminalWitnessNeedsRefresh(payload: Record<string, unknown>): boolean {
+  if (!Object.prototype.hasOwnProperty.call(payload, "promoted_terminals")) return false;
+  const entries = payload.promoted_terminals;
+  if (!Array.isArray(entries)) return false;
+  return entries.some((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
+    const witness = entry as Record<string, unknown>;
+    return (
+      typeof witness.widget === "string" &&
+      witness.widget.length > 0 &&
+      typeof witness.error === "string" &&
+      witness.error.length > 0
+    );
+  });
+}
+
 /** Resolve a requested relation without ever treating an unadvertised
  * witness miss as ordinary. A valid entry is safe positive evidence for this
  * alias even during capability skew; the legacy same-name scan remains the
@@ -6495,6 +6562,20 @@ function resolvePromotedWriteTarget(
     if (witnessed) return witnessed;
   }
   return resolveLegacyInnerPromotedTarget(payload, widget, nodeId);
+}
+
+async function readPromotedTargetScope(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+): Promise<QueriedNodeScope | null> {
+  const probe = await ctx.call({
+    cmd: "graph_query",
+    ids: [nodeId],
+    fields: "detail",
+    limit: 1,
+  });
+  if (probe.isError) return null;
+  return parseVerifiedQueriedNodeScope(parseToolResultJson(probe), nodeId);
 }
 
 function currentPromotedBindingError(
@@ -6753,6 +6834,14 @@ async function preparePromotedWidgetWrite(
     }
   }
 
+  // #2394 — a root-level rgthree Power Lora Loader may have no lora_N widget
+  // yet. Prove the addressed node is an ordinary root node before asking the
+  // promoted-container classifier to resolve a target that is intentionally
+  // absent. An unreadable scope probe is not permission for an outer write;
+  // it falls through to the existing conservative graph_get_subgraph path.
+  const targetScope = await readPromotedTargetScope(ctx, nodeId);
+  if (targetScope === "ordinary") return null;
+
   const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
   if (sub.isError) {
     if (isDefinitiveNonPromotedSubgraphRead(sub)) return null;
@@ -6762,7 +6851,7 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph could not determine whether the addressed node is a promoted container",
     );
   }
-  const payload = parseToolResultJson(sub);
+  let payload = parseToolResultJson(sub);
   if (!payload || !promotedEnvelopeCarriesEvidence(payload)) {
     return promotedWriteRefusal(
       widget,
@@ -6777,6 +6866,33 @@ async function preparePromotedWidgetWrite(
       widget,
       "the current receiver advertised complete promoted-terminal witnesses but omitted the witness array",
     );
+  }
+  if (publishesCompleteTerminalWitness && promotedTerminalWitnessNeedsRefresh(payload)) {
+    // #2393 — an official template can publish the terminal list before its
+    // promoted rail has settled. Re-read exactly once, then run the same
+    // envelope, scope, mapping, and dispatch fences against that fresh reply.
+    const refreshed = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
+    if (refreshed.isError) {
+      return promotedSubgraphReadRefusal(
+        widget,
+        refreshed,
+        "the promoted-terminal witness remained incomplete or unresolved after one fresh mapping read",
+      );
+    }
+    const refreshedPayload = parseToolResultJson(refreshed);
+    if (!refreshedPayload || !promotedEnvelopeCarriesEvidence(refreshedPayload)) {
+      return promotedWriteRefusal(
+        widget,
+        "the promoted-terminal witness remained incomplete or unresolved after one fresh mapping read",
+      );
+    }
+    if (!Object.prototype.hasOwnProperty.call(refreshedPayload, "promoted_terminals")) {
+      return promotedWriteRefusal(
+        widget,
+        "the current receiver advertised complete promoted-terminal witnesses but omitted the witness array after one fresh mapping read",
+      );
+    }
+    payload = refreshedPayload;
   }
   // The recursive alias mapping is the current receiver's proof that this
   // graph_get_subgraph response can classify renamed promotions. A legacy

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5909,13 +5909,17 @@ function parseQueriedNodeIdentityRow(row: unknown): QueriedNodeIdentity | null {
   return resolvedType ? { id, type: resolvedType } : null;
 }
 
-type QueriedNodeScope = "ordinary" | "container";
+type QueriedNodeScope = {
+  activeView: "root" | "subgraph";
+  node: "ordinary" | "container";
+};
 
-/** Read the node's explicit container bit before attempting promoted-widget
- * resolution. The pinpoint detail projection carries this bit even when the
- * widget list is empty (which is how a fresh rgthree Power Lora Loader appears).
- * Anything short of one exact, non-truncated row is deliberately indeterminate;
- * callers retain the existing fail-closed promoted-container path in that case. */
+/** Read the active viewing scope and node's explicit container bit before
+ * attempting promoted-widget resolution. The pinpoint detail projection carries
+ * the node bit even when the widget list is empty (which is how a fresh rgthree
+ * Power Lora Loader appears). Anything short of one exact, non-truncated row
+ * with an explicit root/subgraph witness is deliberately indeterminate; callers
+ * retain the existing fail-closed promoted-container path in that case. */
 function parseVerifiedQueriedNodeScope(
   payload: Record<string, unknown> | null,
   nodeId: unknown,
@@ -5927,6 +5931,10 @@ function parseVerifiedQueriedNodeScope(
   ) {
     return null;
   }
+  const viewing = payload.viewing;
+  if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return null;
+  const activeView = (viewing as Record<string, unknown>).scope;
+  if (activeView !== "root" && activeView !== "subgraph") return null;
 
   let row: unknown;
   if (Object.prototype.hasOwnProperty.call(payload, "nodes")) {
@@ -5953,7 +5961,10 @@ function parseVerifiedQueriedNodeScope(
   if (!identity || !requestedId || identity.id !== requestedId) return null;
   const isSubgraph = (row as Record<string, unknown>).is_subgraph;
   if (typeof isSubgraph !== "boolean") return null;
-  return isSubgraph ? "container" : "ordinary";
+  return {
+    activeView,
+    node: isSubgraph ? "container" : "ordinary",
+  };
 }
 
 /** Strict identity parser for the DaSiWa refusal gate. Unlike the older type-only
@@ -6840,7 +6851,7 @@ async function preparePromotedWidgetWrite(
   // absent. An unreadable scope probe is not permission for an outer write;
   // it falls through to the existing conservative graph_get_subgraph path.
   const targetScope = await readPromotedTargetScope(ctx, nodeId);
-  if (targetScope === "ordinary") return null;
+  if (targetScope?.activeView === "root" && targetScope.node === "ordinary") return null;
 
   const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
   if (sub.isError) {


### PR DESCRIPTION
## Summary
- Fixes #2393 by refreshing one incomplete promoted-terminal witness after official template load, then re-running the existing identity, scope, mapping, and pre-dispatch fences.
- Fixes #2394 by proving an exact ordinary root node before allowing documented rgthree Power Lora Loader lora_N creation; promoted-container writes remain fail-closed.

## Validation
- Focused promoted-widget: 117 passed
- Focused panel-tools: 417 passed
- Build, lint, asset-counts, and git diff --check passed
- Full npm test: one unrelated timing-sensitive late-mutation e2e failure; targeted rerun passed 5/5

No release or merge performed.