### PR TITLE
fix(2393): a promoted write is judged on its OWN witness entry, not the whole array

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -2970,3 +2970,197 @@ describe("panel_set_widget promoted write against a pre-#2314 panel build (panel
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
 });
+
+/**
+ * #2393 — the promoted-terminal witness veto was WHOLE-ARRAY.
+ *
+ * `promotedTerminalEvidenceError` refused a write when ANY entry in
+ * `promoted_terminals` repeated a widget name or carried an error, even when the
+ * alias being written had its own complete, error-free entry. The official
+ * Qwen-Image-Edit-2511 INT8 template hits that on every promoted write to
+ * subgraph node 170, and it is structural rather than transient:
+ *
+ *   - node 170's proxyWidgets carries ["151","prompt"] AND ["149","prompt"] —
+ *     two inner nodes whose inner widget is named `prompt` — while exactly one
+ *     host input (`prompt`/`positive_prompt`) claims that alias. The panel's
+ *     `promotedHostAliasRecords` binds the first relation onto the existing
+ *     unbound record and APPENDS a record for the second, and
+ *     `promotedTerminalWitnesses` publishes one entry per record with no
+ *     de-duplication. The array therefore always repeats `prompt`.
+ *   - node 170 also names `lora_name`, `seed` and `control_after_generate` in
+ *     proxyWidgets with no matching host input, which adds error entries.
+ *
+ * Neither depends on timing, so re-reading `graph_get_subgraph` returns the
+ * identical array — the write has to be decided on the requested alias's own
+ * evidence or it can never succeed.
+ *
+ * The fixtures below use `quality_prompt` as the requested alias because that is
+ * what this file's shared subgraph harness resolves; the SHAPE (one clean entry
+ * for the requested alias, damage on a different alias) is node 170's.
+ */
+describe("#2393 promoted-terminal witness is judged on the requested alias", () => {
+  const ownEntry = CURRENT_SAFE_PROMOTED_SUBGRAPH.promoted_terminals[0];
+  const withTerminals = (promoted_terminals: unknown[]) => ({
+    ...CURRENT_SAFE_PROMOTED_SUBGRAPH,
+    promoted_terminals,
+  });
+
+  it("writes when a DIFFERENT alias is duplicated (node 170's two `prompt` relations)", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([
+          ownEntry,
+          { ...ownEntry, widget: "prompt" },
+          { ...ownEntry, widget: "prompt" },
+        ]),
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget").length).toBeGreaterThan(0);
+  });
+
+  it("writes when a DIFFERENT alias carries an error (node 170's `control_after_generate`)", async () => {
+    const { isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([
+          ownEntry,
+          {
+            widget: "control_after_generate",
+            error:
+              "properties.proxyWidgets named a promoted relation that had no live " +
+              "node.widgets/_subgraphSlot projection",
+          },
+        ]),
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget").length).toBeGreaterThan(0);
+  });
+
+  it("still refuses when the REQUESTED alias is the duplicated one", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([ownEntry, { ...ownEntry }]),
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was ambiguous/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("still refuses when the REQUESTED alias's own entry carries the error", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([
+          { widget: "quality_prompt", error: "the immediate promotion was unresolved" },
+        ]),
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was incomplete or unresolved/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("still refuses a MISS against a damaged array — the P0 the whole-array rule protected", async () => {
+    // `ordinary` is absent from the witness. Absence is read as "not promoted,
+    // write it outer", and only a WHOLE array can prove that absence is real —
+    // so an unrelated error must still veto here, exactly as before. This is the
+    // control for the two allow-cases above: same damage, different question.
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "ordinary", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([
+          ownEntry,
+          { widget: "control_after_generate", error: "no live projection" },
+        ]),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was incomplete or unresolved/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("still refuses a MISS against a duplicated array", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "ordinary", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([
+          ownEntry,
+          { ...ownEntry, widget: "prompt" },
+          { ...ownEntry, widget: "prompt" },
+        ]),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was ambiguous/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  // Structural damage must not become writable just because the requested alias
+  // reads clean. It does not — but the refusal comes from FURTHER UP than the
+  // narrowed check: `parsePromotedTerminalEntries` returns null for a non-record
+  // entry or an empty widget name, so `validatePromotedSubgraphEnvelope` rejects
+  // the whole envelope before `promotedTerminalEvidenceError` is ever reached.
+  // These two pin the OBSERVED refusal rather than the one the narrowed function
+  // would have produced, so they stay true if that ordering is ever revisited.
+  // (The structural pass inside `promotedTerminalEvidenceError` is retained as
+  // defence in depth for direct callers; on this path it is unreachable, and
+  // these tests deliberately do not claim otherwise.)
+  it("refuses on STRUCTURAL damage even though the requested alias looks clean", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([ownEntry, "not-an-object"]),
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("refuses when an entry has no usable widget name, requested alias notwithstanding", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([ownEntry, { widget: "" }]),
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6556,17 +6556,21 @@ function promotedTerminalEvidenceError(
       return "the current receiver's promoted-terminal witness was unavailable";
     }
   }
-  // Decide on the requested alias's OWN entries when it has any. Duplicated or
-  // errored evidence for this alias is still a hard refusal for this write.
+  // ONE entry for the requested alias is the only case this narrows: that entry
+  // is complete evidence about this write, and it decides it.
   const own = (entries as Array<Record<string, unknown>>).filter(
     (entry) => (entry.widget as string).toLowerCase() === wanted,
   );
-  if (own.length > 1) return "the promoted-terminal witness was ambiguous";
   if (own.length === 1) {
     return own[0].error ? "the promoted-terminal witness was incomplete or unresolved" : null;
   }
-  // A MISS. Only a whole array can prove that absence means "ordinary widget",
-  // so the original whole-array rule stands unchanged here.
+  // Everything else falls to the ORIGINAL whole-array rule, unchanged:
+  //   - a MISS (own.length === 0), because absence is read as "ordinary widget,
+  //     write it outer" and only a whole array can prove that absence is real;
+  //   - a requested alias appearing MORE THAN ONCE, which the loop below refuses
+  //     when it reaches the repeat. An explicit `own.length > 1` branch here was
+  //     tried and removed: mutating it away left every test green, because the
+  //     loop already covers it. Redundant guards read as load-bearing.
   const seen = new Set<string>();
   for (const entry of entries as Array<Record<string, unknown>>) {
     const key = (entry.widget as string).toLowerCase();

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6510,14 +6510,43 @@ function promotedTerminalAliasCount(
  * malformed, duplicate, or unresolved entry also makes the whole successful
  * subgraph response incomplete: an unrelated requested alias cannot use the
  * remaining entries as proof that it was ordinary. Do not ignore that evidence
- * and revive the old same-name scan into an outer write. */
+ * and revive the old same-name scan into an outer write.
+ *
+ * #2393 — that reasoning is sound for a requested alias the witness MISSES, and
+ * only for that case. A miss is read as "ordinary, write it outer", so a miss
+ * can only be trusted from an array that is whole. But when the array carries
+ * COMPLETE, error-free evidence for the requested alias itself, the write is
+ * decided by that entry alone; evidence about some OTHER alias is not evidence
+ * about this one, and vetoing on it refuses a promotion the receiver resolved.
+ *
+ * The official Qwen-Image-Edit-2511 INT8 template is the reported instance and
+ * it is structural, not transient. Subgraph node 170 carries the proxyWidgets
+ * relations ["151","prompt"] and ["149","prompt"] — two inner nodes whose inner
+ * widget is named `prompt` — while exactly one host input (`prompt`/
+ * `positive_prompt`) claims that alias. `promotedHostAliasRecords` binds the
+ * first relation onto the existing unbound record and APPENDS for the second,
+ * and `promotedTerminalWitnesses` publishes one entry per record with no
+ * de-duplication, so the array always repeats `prompt`. Node 170 also declares
+ * `lora_name`, `seed` and `control_after_generate` in proxyWidgets with no
+ * matching host input, which adds error entries in the shape where the parent's
+ * rails are not projected. Under the old whole-array rule EITHER of those
+ * vetoed `enable_turbo_mode`, whose own entry resolves cleanly — and re-reading
+ * returns the identical array, so no retry could clear it.
+ *
+ * Structural damage still fails closed globally: an array that is not an array,
+ * or an entry that is not an object or has no usable widget name, means nothing
+ * in it can be trusted to name what it is about — including the entry that
+ * appears to be the requested one. */
 function promotedTerminalEvidenceError(
   payload: Record<string, unknown>,
+  widget: string,
 ): string | null {
   if (!Object.prototype.hasOwnProperty.call(payload, "promoted_terminals")) return null;
   const entries = payload.promoted_terminals;
   if (!Array.isArray(entries)) return "the current receiver's promoted-terminal witness was unavailable";
-  const seen = new Set<string>();
+  const wanted = widget.toLowerCase();
+  // Structural pass first: a malformed array cannot be narrowed, because the
+  // requested alias may be exactly the entry that failed to parse.
   for (const entry of entries) {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
       return "the current receiver's promoted-terminal witness was unavailable";
@@ -6526,10 +6555,24 @@ function promotedTerminalEvidenceError(
     if (typeof witness.widget !== "string" || witness.widget.length === 0) {
       return "the current receiver's promoted-terminal witness was unavailable";
     }
-    const key = witness.widget.toLowerCase();
+  }
+  // Decide on the requested alias's OWN entries when it has any. Duplicated or
+  // errored evidence for this alias is still a hard refusal for this write.
+  const own = (entries as Array<Record<string, unknown>>).filter(
+    (entry) => (entry.widget as string).toLowerCase() === wanted,
+  );
+  if (own.length > 1) return "the promoted-terminal witness was ambiguous";
+  if (own.length === 1) {
+    return own[0].error ? "the promoted-terminal witness was incomplete or unresolved" : null;
+  }
+  // A MISS. Only a whole array can prove that absence means "ordinary widget",
+  // so the original whole-array rule stands unchanged here.
+  const seen = new Set<string>();
+  for (const entry of entries as Array<Record<string, unknown>>) {
+    const key = (entry.widget as string).toLowerCase();
     if (seen.has(key)) return "the promoted-terminal witness was ambiguous";
     seen.add(key);
-    if (witness.error) return "the promoted-terminal witness was incomplete or unresolved";
+    if (entry.error) return "the promoted-terminal witness was incomplete or unresolved";
   }
   return null;
 }
@@ -6966,7 +7009,7 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity",
     );
   }
-  const terminalEvidenceError = promotedTerminalEvidenceError(payload);
+  const terminalEvidenceError = promotedTerminalEvidenceError(payload, widget);
   if (terminalEvidenceError) return promotedWriteRefusal(widget, terminalEvidenceError);
   const inner = resolvePromotedWriteTarget(
     payload,


### PR DESCRIPTION
Re #2393. That issue was auto-closed by #2399 (`8abbbf6`), but **the cause is still on main** — see the mutation evidence below. This is rebased on top of that merge and is complementary to it, not a competing fix.

### What refuses the write

`panel_set_widget` on a promoted subgraph widget refuses with **"the promoted-terminal witness was incomplete or unresolved"** (or "was ambiguous"), no `graph_set_widget` dispatched. `promotedTerminalEvidenceError` vetoes on the **whole array** — any repeated widget name, or any `error` entry, anywhere in `promoted_terminals`, including entries about a completely different alias:

```ts
if (seen.has(key)) return "the promoted-terminal witness was ambiguous";
seen.add(key);
if (witness.error) return "the promoted-terminal witness was incomplete or unresolved";
```

So `enable_turbo_mode` on subgraph node 170 is refused even though its own witness entry resolves cleanly.

### Why a retry cannot reach it

#2399 added a single fresh `graph_get_subgraph` gated on `promotedTerminalWitnessNeedsRefresh`, premised on the incompleteness being transient. For this template the array is identical on every read:

1. **A guaranteed duplicate.** Node 170s `proxyWidgets` carries `["151","prompt"]` **and** `["149","prompt"]` — two inner nodes whose inner widget is named `prompt` — while exactly one host input claims that alias (`prompt`/`positive_prompt`; the negative one is `prompt_1`/`negative_prompt`, which does not match `prompt`). In the panel, `promotedHostAliasRecords` `existingUnbound` fast path only matches a record with **no relation yet**, so the first relation binds and the second **appends**; `promotedTerminalWitnesses` publishes one entry per record with **no de-duplication**.
2. **Unmatched relations.** `lora_name`, `seed` and `control_after_generate` are named in `proxyWidgets` with no matching host input — node 170 serializes 9 of the definitions 11 input slots, and `control_after_generate` is not a subgraph input at all — adding `error` entries in the shape where the parent rails are not projected.

Measured, not inferred: I extracted the panels **real** `promotedHostAliasRecords` verbatim from the shipped bundle, drove it with the real `promotedInputAliases`, and ran it over node 170 as serialized in the shipped `image_qwen_image_edit_2511_int8.json`:

| `node.widgets` | records | error entries | duplicated aliases | requested alias clean? |
|---|---|---|---|---|
| unprojected | 21 | 3 (`lora_name`, `seed`, `control_after_generate`) | 2 | yes |
| projected (6 rails) | 112 | 0 | 12 | yes |

### The change

Decide on the **requested alias**:

- exactly one entry for it, no error → authorized on its own evidence
- duplicated, or its own entry errors → refused, as before
- **absent** → the whole-array rule is **unchanged**

### The load-bearing part — attack this first

The third case is the whole point of the original rule and it is untouched. A **miss** is read as "ordinary widget, write it outer", so a miss can only be trusted from an array that is whole; narrowing it would revive the old same-name scan into an outer write, which is the P0 that comment protects. Evidence about *another* alias was never evidence about *this* one — that is the only inference removed here.

Also worth attacking: this removes exactly one veto. Everything downstream is intact — `resolvePromotedWriteTarget` must still resolve the target, `inner.parentRail` must still be proven authoritative, `currentPromotedScopeError` and the dispatch fences still run.

Second: structural damage (not an array; an entry that is not an object or has no usable widget name) still fails closed, but **not here** — `parsePromotedTerminalEntries` rejects those first and `validatePromotedSubgraphEnvelope` refuses the envelope, so the structural pass inside this function is unreachable on the write path. I kept it (removing it would be an unrelated behaviour change) and the tests deliberately pin the refusal that is **actually observed** rather than the one this function would have produced.

### Verification

Rebased onto `8abbbf6`; both changes coexist with no conflict. `npx tsc --noEmit` clean. `promoted-widget.test.ts`: **126/126** (my 8 plus the 3 #2399 added). Full suite before the rebase: 12703 passed, 1 pre-existing `late-mutation-e2e` load flake that passes in isolation and is untouched by this diff.

**Mutation-verified on top of #2399s merged fix** — neuter only the one-line call-site change:

```
KILLED: writes when a DIFFERENT alias is duplicated
KILLED: writes when a DIFFERENT alias carries an error
Tests  2 failed | 124 passed (126)
```

If the merged refresh covered this case those two would have survived. They do not, and all 124 controls — including #2399s three tests — stay green.

Full battery:

| mutation | killed |
|---|---|
| remove the own-entry decision | both allow-tests; 121 controls survive |
| stop passing `widget` at the call site | both allow-tests; 124 controls survive (post-rebase) |
| ignore an error on the requested aliass own entry | that guard test |
| remove the whole-array MISS fallback | all three miss/duplicate guard tests |

An explicit `own.length > 1` branch I first wrote **survived** mutation — the fallback loop already refuses that — so it was removed rather than left looking load-bearing.

Codex gate on the rebased SHA `713d83e`: **SHIP**, "No P0/P1 correctness or safety defect found."

### What I did NOT do

**No live-rig verification.** ComfyUI on :8188 went down mid-session and this run had no instance to allocate, so `panel_set_widget` against the real template was never executed — by this PR or by #2399. Everything above is from the shipped panel bundle and the shipped template, not from a live write. The duplicate-`prompt` finding is the part that holds regardless of any runtime model, since it is visible in the template JSON itself.

The check that would settle it: `panel_set_widget(node_id=170, widget="enable_turbo_mode", value=true)` should dispatch instead of refusing, and a genuinely non-promoted widget on node 170 should still be refused rather than written outer.