### PR TITLE
docs: 0.52.138 ships #2400 but does not list it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - retry active panel reads once (#2398)
 - reconcile promoted-widget writes (#2399)
+- a promoted write is judged on its own witness entry, not the whole array (#2400)
 
 
 ## [0.52.137] - 2026-08-26


### PR DESCRIPTION
0.52.138 shipped `#2400`'s fix and does not list it. I flagged this on #2403 before it merged and said I would correct it on `main` if it landed with the gap — this is that.

    git merge-base --is-ancestor b910904 v0.52.138   ->  passes

So the code is in the published tag. Only the notes are wrong.

```
#### Fixed
- retry active panel reads once (#2398)
- reconcile promoted-widget writes (#2399)
+ - a promoted write is judged on its own witness entry, not the whole array (#2400)
```

## Second occurrence tonight, and the repos have diverged on it

0.52.133 missed #2378 in exactly this way (fixed in #2384). The window is between the release branch being cut and the PR merging; ancestry resolves itself at the merge, so the changelog is the **only** thing that can gap — and it gaps silently.

The panel repo now catches this. `scripts/check-changelog.mjs` (comfyui-mcp-panel#1894) plus the CI/publish version gate (#1902) make a mismatched or incomplete section a red build, and `v0.15.110` was the first cut to pass it cleanly.

**mcp has no equivalent.** It has `gen-changelog.mjs` and `changelog-section.mjs`, but nothing that verifies the generated section against the commits it claims to cover. That is why this recurred here and not there. Filing that separately rather than bundling it — this PR is the one-line record fix.

**Verified:** `tsc --noEmit` exit 0; entry cites the PR that actually merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
