### PR TITLE
fix(#1639): verify bare workflow aliases before success

### DIFF
--- a/src/__tests__/orchestrator/open-reconnect-false-mismatch.test.ts
+++ b/src/__tests__/orchestrator/open-reconnect-false-mismatch.test.ts
@@ -101,10 +101,19 @@ function emptyGraph() {
   return { nodes: [] as unknown[], links: [] as unknown[] };
 }
 
-function listReply(opts: { confirmed: boolean; uuid: string; path?: string }) {
+function listReply(opts: {
+  confirmed: boolean;
+  uuid: string;
+  path?: string;
+  omitActiveConfirmed?: boolean;
+}) {
   const path = opts.path ?? PATH;
   const active = { path, routing_key: `wf:${path}`, workflow_uuid: opts.uuid };
-  return { active, workflows: [{ ...active, active: true }], active_confirmed: opts.confirmed };
+  return {
+    active,
+    workflows: [{ ...active, active: true }],
+    ...(opts.omitActiveConfirmed ? {} : { active_confirmed: opts.confirmed }),
+  };
 }
 
 type GraphQuery = "answers" | "mismatch";
@@ -112,12 +121,15 @@ type GraphQuery = "answers" | "mismatch";
 function bridge(opts: {
   stamp: string;
   graphQuery: GraphQuery;
+  openResult?: "error" | "success";
   /** First N workflow_list replies are unconfirmed; then confirmed. */
   unconfirmedLists?: number;
   /** First N graph_serialize replies are the empty settling snapshot. */
   emptySerializes?: number;
   listPath?: string;
   listUuid?: string;
+  omitOpenedPath?: boolean;
+  omitActiveConfirmed?: boolean;
 }) {
   const calls: string[] = [];
   let stamp: string | undefined = opts.stamp;
@@ -136,9 +148,21 @@ function bridge(opts: {
           confirmed: listCalls > unconfirmedLists,
           uuid: listUuid,
           path: listPath,
+          omitActiveConfirmed: opts.omitActiveConfirmed,
         });
       }
-      if (cmd.cmd === "workflow_open") throw new Error(IDENTITY_PROVEN);
+      if (cmd.cmd === "workflow_open") {
+        if (opts.openResult === "success") {
+          return {
+            opened: opts.omitOpenedPath
+              ? { filename: "v3.json" }
+              : { path: PATH, filename: "v3.json" },
+            routing_key: TAB,
+            workflow_uuid: LIVE,
+          };
+        }
+        throw new Error(IDENTITY_PROVEN);
+      }
       if (cmd.cmd === "graph_query") {
         if (opts.graphQuery === "mismatch") {
           throw new Error(
@@ -186,12 +210,12 @@ afterEach(() => {
   qm.state.runningPromptId = null;
 });
 
-async function openWorkflow(opts: Parameters<typeof bridge>[0]) {
+async function openWorkflow(opts: Parameters<typeof bridge>[0], requestedPath = PATH) {
   const { b, calls, stampOf } = bridge(opts);
   const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow");
   if (!def) throw new Error("panel_open_workflow is not registered");
-  const res: ToolResult = await def.handler({ path: PATH } as never, ctx);
+  const res: ToolResult = await def.handler({ path: requestedPath } as never, ctx);
   return {
     text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
     isError: res.isError === true,
@@ -268,5 +292,102 @@ describe("panel_open_workflow does not false-mismatch the already-active canvas 
     expect(text).toMatch(/PREVIOUS workflow/);
     expect(text).toMatch(/expected routing wf:workflows\/v3\.json/);
     expect(text).toMatch(/observed routing wf:workflows\/v3\.json/);
+  });
+
+  it("a bare filename never reports active/bound success without a live active re-read (#1639)", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow(
+      {
+        stamp: PRIOR,
+        graphQuery: "answers",
+        openResult: "success",
+        listPath: "workflows/previous.json",
+        listUuid: PRIOR,
+      },
+      "v3.json",
+    );
+
+    expect(isError).toBe(true);
+    expect(calls).toContain("workflow_list");
+    expect(stamp).toBe(PRIOR);
+    expect(text).toMatch(/ACTIVE workflow now/i);
+    expect(text).toMatch(/previous\.json/);
+    expect(text).not.toMatch(/Opened/);
+  });
+
+  it("a bare filename succeeds only after the resolved path is confirmed active (#1639)", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow(
+      {
+        stamp: PRIOR,
+        graphQuery: "answers",
+        openResult: "success",
+        listPath: PATH,
+        listUuid: LIVE,
+      },
+      "v3.json",
+    );
+
+    expect(isError).toBe(false);
+    expect(calls).toContain("workflow_list");
+    expect(stamp).toBe(PRIOR);
+    expect(text).toMatch(/workflows\/v3\.json/);
+  });
+
+  it("a bare filename fails closed when the resolved active identity is unconfirmed (#1639)", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow(
+      {
+        stamp: PRIOR,
+        graphQuery: "answers",
+        openResult: "success",
+        unconfirmedLists: 1,
+        listPath: PATH,
+        listUuid: LIVE,
+      },
+      "v3.json",
+    );
+
+    expect(isError).toBe(true);
+    expect(calls).toContain("workflow_list");
+    expect(stamp).toBe(PRIOR);
+    expect(text).toMatch(/active canvas is UNKNOWN/i);
+    expect(text).not.toMatch(/Opened/);
+  });
+
+  it("a bare filename fails closed when the open reply omits its resolved path (#1639)", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow(
+      {
+        stamp: PRIOR,
+        graphQuery: "answers",
+        openResult: "success",
+        omitOpenedPath: true,
+      },
+      "v3.json",
+    );
+
+    expect(isError).toBe(true);
+    expect(calls).not.toContain("workflow_list");
+    expect(stamp).toBe(PRIOR);
+    expect(text).toMatch(/active canvas is UNKNOWN/i);
+    expect(text).toMatch(/resolved path/i);
+    expect(text).not.toMatch(/Opened/);
+  });
+
+  it("a bare filename fails closed when active_confirmed is omitted (#1639)", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow(
+      {
+        stamp: PRIOR,
+        graphQuery: "answers",
+        openResult: "success",
+        omitActiveConfirmed: true,
+        listPath: PATH,
+        listUuid: LIVE,
+      },
+      "v3.json",
+    );
+
+    expect(isError).toBe(true);
+    expect(calls).toContain("workflow_list");
+    expect(stamp).toBe(PRIOR);
+    expect(text).toMatch(/active canvas is UNKNOWN/i);
+    expect(text).not.toMatch(/Opened/);
   });
 });

--- a/src/__tests__/orchestrator/panel-971-recovery-deadend.test.ts
+++ b/src/__tests__/orchestrator/panel-971-recovery-deadend.test.ts
@@ -32,7 +32,11 @@ import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js
 const textOf = (res: ToolResult): string =>
   res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
 
-function reconnectingBridge(initial: string[] = []) {
+function reconnectingBridge(
+  initial: string[] = [],
+  activePath = "demo.json",
+  resolveActiveTabId?: () => string,
+) {
   const live = new Set(initial);
   const headless = new Set<string>();
   const sent: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
@@ -45,7 +49,15 @@ function reconnectingBridge(initial: string[] = []) {
       }
       sent.push({ cmd, tabId: id });
       if (cmd.cmd === "workflow_list") {
-        return { workflows: [...live].map((t) => ({ key: t, active: true })), active: { key: id } };
+        const active = { path: activePath, routing_key: `wf:${activePath}` };
+        return {
+          workflows: [...live].map((t) =>
+            t === id
+              ? { ...active, active: true }
+              : { path: `${t}.json`, routing_key: `wf:${t}.json`, active: false },
+          ),
+          active,
+        };
       }
       return { ok: true, routedTo: id };
     },
@@ -53,11 +65,12 @@ function reconnectingBridge(initial: string[] = []) {
     canReach: (id: string) => live.has(id),
     isHeadless: (id: string) => headless.has(id),
     tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
-    resolveActiveTabId: () => {
-      if (live.size === 1) return [...live][0];
-      if (live.size === 0) throw new Error("Panel not reachable: no panel connected");
-      throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
-    },
+    resolveActiveTabId:
+      resolveActiveTabId ?? (() => {
+        if (live.size === 1) return [...live][0];
+        if (live.size === 0) throw new Error("Panel not reachable: no panel connected");
+        throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
+      }),
   } as unknown as PanelToolCtx["bridge"];
   return { bridge, live, headless, sent };
 }
@@ -71,8 +84,7 @@ afterEach(() => {
 });
 
 it("#971 the last-active case works — this is the path the design documents", async () => {
-  const { bridge } = reconnectingBridge(["tab-a", "tab-b"]);
-  (bridge as unknown as { resolveActiveTabId: () => string }).resolveActiveTabId = () => "tab-b";
+  const { bridge } = reconnectingBridge(["tab-a", "tab-b"], "demo.json", () => "tab-b");
   const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
   expect(await ctx.awaitReachable!()).toBe(false);
 
@@ -84,6 +96,43 @@ it("#971 the last-active case works — this is the path the design documents", 
 
   const open = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow")!;
   expect(((await open.handler({ path: "demo.json" }, ctx)) as ToolResult).isError).toBeFalsy();
+});
+
+it("#971 consumes the proof when an unrelated bare alias is attempted", async () => {
+  const { bridge } = reconnectingBridge(["tab-a", "tab-b"], "demo.json", () => "tab-b");
+  const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+
+  const target = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+  expect(((await target.handler({ mode: "current" }, ctx)) as ToolResult).isError).toBeFalsy();
+
+  const open = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow")!;
+  const unrelated = (await open.handler({ path: "other.json" }, ctx)) as ToolResult;
+  expect(unrelated.isError).toBe(true);
+  expect(textOf(unrelated)).toMatch(/resolved path|UNKNOWN/i);
+
+  // The mismatched open consumed the one-shot proof before dispatching. A later
+  // alias cannot inherit it, even though the bridge still returns the legacy
+  // {ok:true,routedTo} shape.
+  const second = (await open.handler({ path: "demo.json" }, ctx)) as ToolResult;
+  expect(second.isError).toBe(true);
+  expect(textOf(second)).toMatch(/resolved path|UNKNOWN/i);
+});
+
+it("#971 consumes the proof after one successful legacy bare open", async () => {
+  const { bridge } = reconnectingBridge(["tab-a", "tab-b"]);
+  (bridge as unknown as { resolveActiveTabId: () => string }).resolveActiveTabId = () => "tab-b";
+  const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+
+  const target = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+  expect(((await target.handler({ mode: "current" }, ctx)) as ToolResult).isError).toBeFalsy();
+
+  const open = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow")!;
+  const first = (await open.handler({ path: "demo.json" }, ctx)) as ToolResult;
+  expect(first.isError).toBeFalsy();
+
+  const second = (await open.handler({ path: "other.json" }, ctx)) as ToolResult;
+  expect(second.isError).toBe(true);
+  expect(textOf(second)).toMatch(/resolved path|UNKNOWN/i);
 });
 
 it("#971 with NO last-active tab, the prescribed recovery is a dead end", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4851,7 +4851,7 @@ describe("#716 workflow UUID refresh after reconnect/open/re-pin", () => {
     const ctx: PanelToolCtx = {
       call: async (cmd) =>
         cmd.cmd === "workflow_list"
-          ? { content: [{ type: "text", text: JSON.stringify({ active: { path: resolved, routing_key: "wf:workflows/a/foo.json", workflow_uuid: LIVE_UUID } }) }] }
+          ? { content: [{ type: "text", text: JSON.stringify({ active_confirmed: true, active: { path: resolved, routing_key: "wf:workflows/a/foo.json", workflow_uuid: LIVE_UUID } }) }] }
           : { content: [{ type: "text", text: JSON.stringify({ opened: { path: resolved }, routing_key: "wf:workflows/a/foo.json", workflow_uuid: LIVE_UUID }) }] },
       confirm: async () => "yes" as const,
       bridge: { refreshWorkflowUuid: refresh } as unknown as PanelToolCtx["bridge"],

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8831,7 +8831,7 @@ function activeMatchesOpenRefreshTarget(active: unknown, path: string): boolean 
 export type OpenActiveReading = "same" | "different" | "indeterminate";
 
 /** #887 — what the post-open corroborating read OBSERVED, when it contradicts the open. */
-export type OpenDriftNotice = { drifted: true; activeLabel: string };
+export type OpenDriftNotice = { drifted: true; activeLabel: string; unverified?: boolean };
 
 /**
  * Would this active record plausibly BE the requested workflow? Used only to
@@ -11234,11 +11234,107 @@ async function refreshOpenWorkflowUuid(
   // alias/basename to a path, but that reply must never retroactively turn the
   // alias into a UUID-refresh authorization. Require the reply to corroborate
   // the original exact saved identity before consulting the live active record.
+  const requestedSavedPath = canonicalSavedWorkflowPath(requestedPath);
+  const requestedIsBareAlias =
+    !!requestedSavedPath && !requestedSavedPath.includes("/");
   const requestedIdentity = canonicalRequestedSavedIdentity(requestedPath);
   const openedIdentity = openedPath
     ? canonicalSavedRecordIdentity({ path: openedPath, routing_key: parsedOpen?.routing_key })
     : null;
+  if (requestedIsBareAlias) {
+    // A bare filename is only a selector. It is not safe to let a native
+    // success through unless the panel both resolved it to a saved path and
+    // gave us a fresh, explicitly confirmed active observation. In particular,
+    // an omitted `opened.path` is not a resolution, and an omitted
+    // `active_confirmed` is not confirmation (#1639).
+    if (!openedPath || !canonicalRequestedSavedIdentity(openedPath)) {
+      return {
+        drifted: true,
+        unverified: true,
+        activeLabel: "the panel did not return a resolved path for this filename",
+      };
+    }
+    let list: Record<string, unknown> | null = null;
+    try {
+      const res = await ctx.call({ cmd: "workflow_list" }, 6000);
+      if (!res?.isError) list = parseToolResultJson(res);
+    } catch {
+      list = null;
+    }
+    if (!list || list.active_confirmed !== true) {
+      return {
+        drifted: true,
+        unverified: true,
+        activeLabel: "the panel did not return a freshly confirmed active workflow after resolving this filename",
+      };
+    }
+    const resolvedIdentity = canonicalSavedRecordIdentity({
+      path: openedPath,
+      routing_key: parsedOpen?.routing_key,
+    });
+    const activeIdentity = canonicalSavedRecordIdentity(list.active);
+    if (resolvedIdentity && activeIdentity === resolvedIdentity) {
+      // The re-read proves which resolved path is active, but the caller only
+      // supplied an alias. Preserve #716's no-adoption rule.
+      return null;
+    }
+    if (activeIdentity) {
+      return { drifted: true, activeLabel: describeActiveRecord(list.active) };
+    }
+    return {
+      drifted: true,
+      unverified: true,
+      activeLabel: "the panel returned an unconfirmed active workflow after resolving this filename",
+    };
+  }
   if (!requestedIdentity || requestedIdentity !== openedIdentity) {
+    // A bare filename is an alias, not a saved identity. The panel's `opened.path`
+    // is the resolution of that alias; once it is available, corroborate THAT exact
+    // path against a fresh active-list read before allowing the caller to treat the
+    // success as an active-canvas success. Without this branch, the alias exits here
+    // before any live observation and a stale previous tab can be reported as active
+    // and bound (#1639).
+    const resolvedIdentity = openedPath ? canonicalRequestedSavedIdentity(openedPath) : null;
+    if (!requestedIdentity && resolvedIdentity) {
+      let list: Record<string, unknown> | null = null;
+      try {
+        const res = await ctx.call({ cmd: "workflow_list" }, 6000);
+        if (!res?.isError) list = parseToolResultJson(res);
+      } catch {
+        list = null;
+      }
+      if (!list) {
+        return {
+          drifted: true,
+          unverified: true,
+          activeLabel: "the panel did not return a confirmed active workflow after resolving this filename",
+        };
+      }
+      if (list.active_confirmed !== true) {
+        return {
+          drifted: true,
+          unverified: true,
+          activeLabel: "the panel returned an unconfirmed active workflow after resolving this filename",
+        };
+      }
+      const activeIdentity = canonicalSavedRecordIdentity(list.active);
+      if (activeIdentity === resolvedIdentity) {
+        // The re-read proves which resolved path is active, but the caller only
+        // supplied an alias. Preserve #716's no-adoption rule: an alias may be
+        // observed for the #1639 wrong-canvas guard, never promoted into a new
+        // command-fence UUID by the reply-resolved path.
+        return null;
+      }
+      if (activeIdentity) {
+        return { drifted: true, activeLabel: describeActiveRecord(list.active) };
+      }
+      return {
+        drifted: true,
+        unverified: true,
+        activeLabel: "the panel returned an unconfirmed active workflow after resolving this filename",
+      };
+    }
+
     // #812 — the SAVED corroboration above can never succeed for an unsaved
     // target (there is no path), so try the parallel UNSAVED identity: the
     // caller's literal token against the panel's own proven routing_key for
@@ -11573,6 +11669,14 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
       // act is typically a write. The session's fence is untouched (nothing was
       // adopted), so the tab that IS active keeps its own protection.
       if (drift) {
+        if (drift.unverified) {
+          return fail(
+            `workflow_open: ${path} was reported applied, but the panel could not prove that ` +
+              `${drift.activeLabel}. The active canvas is UNKNOWN, so this open is not a ` +
+              `success and this session's workflow identity was NOT re-pointed. Inspect ` +
+              `panel_list_workflows before reading or writing the graph.`,
+          );
+        }
         return fail(
           `workflow_open: ${path} was opened, but ${drift.activeLabel} is the ACTIVE workflow now — ` +
             `the panel confirmed this on a re-read after the open completed. This session's ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9857,6 +9857,8 @@ export type WorkflowFenceRebind =
       before: FenceRead;
       kind: "no_uuid" | "uncorroborated";
       why: string;
+      /** The corroborated active record, when it was readable but carried no UUID. */
+      active?: Record<string, unknown>;
       /** #1292 — how hard we already tried, so the remedy can stop telling a
        *  caller to do the thing this function just did. Present only on the
        *  `uncorroborated` path, which is the one that rechecks. `settles` is
@@ -10548,6 +10550,7 @@ async function rebindWorkflowFence(
       before,
       kind: "no_uuid",
       why: "the active workflow record carries no usable workflow_uuid",
+      active,
     };
   }
   // "already current" requires a KNOWN prior fence equal to the live uuid. An
@@ -11223,16 +11226,18 @@ async function refreshOpenWorkflowUuid(
   ctx: PanelToolCtx,
   requestedPath: string,
   openResult: ToolResult,
+  legacyRebind?: ExplicitCurrentRebindProof,
 ): Promise<OpenDriftNotice | null> {
   const parsedOpen = parseToolResultJson(openResult);
   // #971 compatibility: older/lightweight bridges may return only an explicit
-  // transport route for a successful open. This proof is deliberately one-shot
-  // and is consumed below; it is never a substitute for the modern bare-alias
-  // `opened.path` + confirmed active workflow contract.
-  const reboundTab = ctx.lastExplicitCurrentRebindTab;
-  ctx.lastExplicitCurrentRebindTab = undefined;
+  // transport route for a successful open. The proof is supplied by the one
+  // immediately following open only after the caller consumed it before any
+  // await; it is never a substitute for the modern bare-alias `opened.path` +
+  // confirmed active workflow contract.
   const legacyReboundRoute =
-    reboundTab === ctx.tabId &&
+    legacyRebind?.tabId === ctx.tabId &&
+    legacyRebind.savedIdentity === canonicalBareSavedIdentity(requestedPath) &&
+    !openResult.isError &&
     parsedOpen?.ok === true &&
     parsedOpen.routedTo === ctx.tabId &&
     (typeof ctx.bridge.canReach !== "function" || ctx.bridge.canReach(ctx.tabId));
@@ -11607,6 +11612,11 @@ function noReachableTabFail(cmd: string, ctx?: PanelToolCtx): ToolResult {
 }
 
 async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<ToolResult> {
+  // #971 — consume the explicit-current proof BEFORE the first await. This
+  // makes it one-shot even when this open fails, and prevents a concurrent or
+  // later open from inheriting a proof belonging to an earlier operation.
+  const legacyRebind = ctx.lastExplicitCurrentRebind;
+  ctx.lastExplicitCurrentRebind = undefined;
   // #402: after a full ComfyUI restart the browser tab re-registers a few seconds
   // later. Awaiting a stable binding BEFORE dispatching a mutating workflow_open
   // (nothing is sent yet — no double-apply risk) means the command reaches a live
@@ -11675,7 +11685,7 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
       );
     }
     {
-      const drift = await refreshOpenWorkflowUuid(ctx, path, res);
+      const drift = await refreshOpenWorkflowUuid(ctx, path, res, legacyRebind);
       // #887 — the read above is the ONLY observation in this whole path taken
       // after a real round trip, so it is the only thing that can catch the active
       // pointer having settled elsewhere. It already declined to adopt the uuid;
@@ -12102,6 +12112,12 @@ function canonicalRequestedSavedIdentity(path: unknown): string | null {
   // command fence must bind. It may still resolve a legacy pin, but must never
   // authorize replacing its existing UUID stamp.
   return canonicalPath && canonicalPath.includes("/") ? `wf:${canonicalPath}` : null;
+}
+
+/** Canonical identity for a bare saved-workflow selector, for one-shot #971 proof matching. */
+function canonicalBareSavedIdentity(path: unknown): string | null {
+  const canonicalPath = canonicalSavedWorkflowPath(path);
+  return canonicalPath && !canonicalPath.includes("/") ? `wf:${canonicalPath}` : null;
 }
 
 /**
@@ -13266,6 +13282,12 @@ interface BridgeProbe {
   takeLateAskReply?: (askId: string) => unknown;
 }
 
+/** The only compatibility proof accepted for a legacy bare workflow open. */
+export interface ExplicitCurrentRebindProof {
+  tabId: string;
+  savedIdentity: string;
+}
+
 export interface PanelToolCtx {
   /** Forward a command to the panel and wrap the reply as a tool result. An
    *  optional observer receives the bridge request id after the frame is written,
@@ -13360,11 +13382,12 @@ export interface PanelToolCtx {
   awaitReachable?: (budgetMs?: number) => Promise<boolean>;
   /**
    * One-shot proof for the legacy #971 recovery path. A current-mode recovery
-   * that actually moved an orphaned session records the exact tab it selected;
-   * the next legacy workflow_open may use a matching transport route echo as
-   * compatibility evidence, but never as a workflow-identity/UUID source.
+   * that actually moved an orphaned session records the exact tab and the
+   * corroborated saved identity it selected; only the immediately following
+   * matching legacy workflow_open may use its transport route echo as
+   * compatibility evidence, never as a workflow-identity/UUID source.
    */
-  lastExplicitCurrentRebindTab?: string;
+  lastExplicitCurrentRebind?: ExplicitCurrentRebindProof;
   /** Snapshot of the current panel registration. The browser-tab session id is
    * separate from the workflow-derived routing tab id, which another browser
    * tab may reuse for the same saved workflow. */
@@ -21046,10 +21069,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (mode === "pinned" && !(path ?? "").trim()) {
           return fail("Provide path when pinning — use panel_list_workflows to list open workflows.");
         }
-        // A prior explicit recovery proof must not survive another current-mode
-        // targeting call. It is valid only for the open immediately following
-        // the rebind that produced it.
-        if (mode === "current") ctx.lastExplicitCurrentRebindTab = undefined;
+        // A prior explicit recovery proof must not survive another targeting
+        // call. It is valid only for the open immediately following the rebind
+        // that produced it.
+        ctx.lastExplicitCurrentRebind = undefined;
         // mode:'current' is the explicit, user/agent-initiated "rebind me to the
         // tab that's live now" consent signal. Self-heal a session whose captured
         // tab id was orphaned (reconnect/reload/workflow-switch) BEFORE writing the
@@ -21062,8 +21085,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // on a successful turn-pin recovery. Track that separately from the
         // real-tab rebind note below.
         let currentModeTurnRepinned = false;
+        let explicitCurrentRebindBefore: string | undefined;
         if (mode === "current" && ctx.rebindToActiveTab) {
           const before = ctx.tabId;
+          explicitCurrentRebindBefore = before;
           const recoveringScope = isScopeAddress(before);
           // Hold the send() wait BEFORE the first await so a same-batch sibling
           // that already hit the null pin waits instead of minting #884.
@@ -21151,7 +21176,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Detect the rebind regardless of whether awaitReachable or rebindToActiveTab
           // performed it (either mutates ctx.tabId), so the note is never swallowed.
           if (!deferredBind && ctx.tabId !== before) {
-            ctx.lastExplicitCurrentRebindTab = ctx.tabId;
             // #934 — `.slice(0, 8)` renders EVERY `wf:workflows/…` tab as the
             // literal "wf:workf", so this note read "Rebound this session from
             // tab wf:workf onto the active tab wf:workf" for a rebind between two
@@ -21314,6 +21338,23 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             const moved = ctx.workflowTarget.set(ctx.tabId, { mode: "current" });
             ctx.bridge.push({ type: "workflow_target", target: moved }, ctx.tabId);
             rebindNote += ` The panel dropped mid-call: this session moved from tab ${tabBeforeProbe} onto tab ${ctx.tabId}, and mode:"current" was applied there too.`;
+          }
+        }
+        // #971 — preserve the old-panel recovery only when the current-mode
+        // operation itself corroborated the saved identity now selected. The
+        // proof is consumed by the next open before its first await, so a failed
+        // open, a different alias, or a later open cannot inherit it.
+        if (
+          mode === "current" &&
+          !deferredBind &&
+          explicitCurrentRebindBefore !== undefined &&
+          ctx.tabId !== explicitCurrentRebindBefore &&
+          fenceRebind &&
+          "active" in fenceRebind
+        ) {
+          const savedIdentity = canonicalSavedRecordIdentity(fenceRebind.active);
+          if (savedIdentity) {
+            ctx.lastExplicitCurrentRebind = { tabId: ctx.tabId, savedIdentity };
           }
         }
         // panel#1529 — "Graph tools will target that workflow" is a CLAIM ABOUT

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11225,6 +11225,17 @@ async function refreshOpenWorkflowUuid(
   openResult: ToolResult,
 ): Promise<OpenDriftNotice | null> {
   const parsedOpen = parseToolResultJson(openResult);
+  // #971 compatibility: older/lightweight bridges may return only an explicit
+  // transport route for a successful open. This proof is deliberately one-shot
+  // and is consumed below; it is never a substitute for the modern bare-alias
+  // `opened.path` + confirmed active workflow contract.
+  const reboundTab = ctx.lastExplicitCurrentRebindTab;
+  ctx.lastExplicitCurrentRebindTab = undefined;
+  const legacyReboundRoute =
+    reboundTab === ctx.tabId &&
+    parsedOpen?.ok === true &&
+    parsedOpen.routedTo === ctx.tabId &&
+    (typeof ctx.bridge.canReach !== "function" || ctx.bridge.canReach(ctx.tabId));
   const opened = parsedOpen?.opened;
   const openedPath =
     opened && typeof opened === "object" && typeof (opened as { path?: unknown }).path === "string"
@@ -11247,7 +11258,15 @@ async function refreshOpenWorkflowUuid(
     // gave us a fresh, explicitly confirmed active observation. In particular,
     // an omitted `opened.path` is not a resolution, and an omitted
     // `active_confirmed` is not confirmation (#1639).
-    if (!openedPath || !canonicalRequestedSavedIdentity(openedPath)) {
+    if (!openedPath) {
+      if (legacyReboundRoute) return null;
+      return {
+        drifted: true,
+        unverified: true,
+        activeLabel: "the panel did not return a resolved path for this filename",
+      };
+    }
+    if (!canonicalRequestedSavedIdentity(openedPath)) {
       return {
         drifted: true,
         unverified: true,
@@ -13339,6 +13358,13 @@ export interface PanelToolCtx {
    * Optional so lightweight test contexts can omit it.
    */
   awaitReachable?: (budgetMs?: number) => Promise<boolean>;
+  /**
+   * One-shot proof for the legacy #971 recovery path. A current-mode recovery
+   * that actually moved an orphaned session records the exact tab it selected;
+   * the next legacy workflow_open may use a matching transport route echo as
+   * compatibility evidence, but never as a workflow-identity/UUID source.
+   */
+  lastExplicitCurrentRebindTab?: string;
   /** Snapshot of the current panel registration. The browser-tab session id is
    * separate from the workflow-derived routing tab id, which another browser
    * tab may reuse for the same saved workflow. */
@@ -21020,6 +21046,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (mode === "pinned" && !(path ?? "").trim()) {
           return fail("Provide path when pinning — use panel_list_workflows to list open workflows.");
         }
+        // A prior explicit recovery proof must not survive another current-mode
+        // targeting call. It is valid only for the open immediately following
+        // the rebind that produced it.
+        if (mode === "current") ctx.lastExplicitCurrentRebindTab = undefined;
         // mode:'current' is the explicit, user/agent-initiated "rebind me to the
         // tab that's live now" consent signal. Self-heal a session whose captured
         // tab id was orphaned (reconnect/reload/workflow-switch) BEFORE writing the
@@ -21121,6 +21151,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Detect the rebind regardless of whether awaitReachable or rebindToActiveTab
           // performed it (either mutates ctx.tabId), so the note is never swallowed.
           if (!deferredBind && ctx.tabId !== before) {
+            ctx.lastExplicitCurrentRebindTab = ctx.tabId;
             // #934 — `.slice(0, 8)` renders EVERY `wf:workflows/…` tab as the
             // literal "wf:workf", so this note read "Rebound this session from
             // tab wf:workf onto the active tab wf:workf" for a rebind between two


### PR DESCRIPTION
Refs #1639\n\n## Summary\n- Re-read the panel active workflow after a successful bare-filename workflow_open resolves to a saved path.\n- Fail closed when the resolved active identity is different, unconfirmed, or unreadable; leave the existing workflow fence unchanged.\n- Preserve #716: an alias may be observed, but its reply-resolved path never promotes a new workflow-fence UUID. Exact-path opens and graph read/render fencing are unchanged.\n- Add production-handler tests for stale active, confirmed resolved target, and unconfirmed active cases.\n\n## Validation\n- Full Vitest: 681 files, 12,723 passed, 6 skipped.\n- Focused #1639/render tests: green.\n- Build, lint, and diff checks: green.\n- Rebased on origin/main ffd5d55, including #2402/#2404/#2405; this diff does not touch the promoted-widget/subgraph path.