### PR TITLE
chore: release v0.52.139

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.139] - 2026-08-26
+
+### MCP
+
+#### Fixed
+- fence the definitive-non-subgraph exit, via one shared check (#2410)
+- fence promoted ordinary fast path after scope probe (#2405)
+- definitive non-subgraph read must tolerate a parenthesised node type (#2402)
+
+#### Changed
+- 0.52.138 ships #2400 but does not list it (#2406)
+- panel_show_media says staging needs a LOCAL ComfyUI (#2404)
+
+
 ## [0.52.138] - 2026-08-26
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - fence the definitive-non-subgraph exit, via one shared check (#2410)
-- verify bare workflow aliases before reporting a successful open (#1639)
+- verify bare workflow aliases before reporting a successful open (#1639), via PR #2408
 - preserve and consume a proven legacy rebind exactly once (#971)
 - fence promoted ordinary fast path after scope probe (#2405)
 - definitive non-subgraph read must tolerate a parenthesised node type (#2402)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - fence the definitive-non-subgraph exit, via one shared check (#2410)
-- verify bare workflow aliases before reporting a successful open (#1639, #2408)
-- preserve and consume a proven legacy rebind exactly once (#971, #2408)
+- verify bare workflow aliases before reporting a successful open (#1639)
+- preserve and consume a proven legacy rebind exactly once (#971)
 - fence promoted ordinary fast path after scope probe (#2405)
 - definitive non-subgraph read must tolerate a parenthesised node type (#2402)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - fence the definitive-non-subgraph exit, via one shared check (#2410)
-- verify bare workflow aliases before reporting a successful open (#2408)
+- verify bare workflow aliases before reporting a successful open (#1639, #2408)
+- preserve and consume a proven legacy rebind exactly once (#971, #2408)
 - fence promoted ordinary fast path after scope probe (#2405)
 - definitive non-subgraph read must tolerate a parenthesised node type (#2402)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - fence the definitive-non-subgraph exit, via one shared check (#2410)
+- verify bare workflow aliases before reporting a successful open (#2408)
 - fence promoted ordinary fast path after scope probe (#2405)
 - definitive non-subgraph read must tolerate a parenthesised node type (#2402)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.138",
+  "version": "0.52.139",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.138",
+      "version": "0.52.139",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.138",
+  "version": "0.52.139",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Five commits have been sitting unreleased, **including two P1 correctness fences**, with no cut in flight.

```
efd0c42  fix(2409): fence the definitive-non-subgraph exit, via one shared check (#2410)   P1
ffd5d55  fix: fence promoted ordinary fast path after scope probe (#2405)                  P1
6dbab37  fix(2394): definitive non-subgraph read must tolerate a parenthesised node type (#2402)
85c4907  docs: 0.52.138 ships #2400 but does not list it (#2406)
053c8e6  docs(1906): panel_show_media says staging needs a LOCAL ComfyUI (#2404)
```

The two fences matter to users: each closes a window where a panel rebind during an `await` could let a widget write land on the same node id on a **different receiver**, silently. #2405 fixed one exit; #2410 fixed the other and collapsed both onto one shared check so the next early return cannot miss it.

## Contents

    CHANGELOG.md      | 12 ++++++++++++
    package-lock.json |  4 ++--
    package.json      |  2 +-

Generated by `npm version patch --no-git-tag-version`, so the section is the generator's, not hand-written. All five PRs cited, one `#### Fixed`, one `#### Changed`, nothing listed twice.

## Cross-checked with the guard from #2412

Ran the changelog verifier from the open #2412 branch against this cut:

    changelog: [0.52.139] lists every PR since v0.52.138, and every entry it names is reachable
    exit=0

Both directions clean — nothing merged since v0.52.138 is missing, and nothing cited is unreachable. That is the check whose absence produced the 0.52.133, 0.52.134 and 0.52.138 defects; worth having run it here even though it has not landed yet.

**Verified:** `tsc --noEmit` exit 0; diff is exactly the three release files with no code change of my own.

## Why I did not merge it

A release touches `package.json`, which is supply-chain gated for autopilot — the merge gate exits 2 and `AUTOPILOT_HUMAN_ACK=1` is not mine to set. **@artokun this needs your merge.** Afterwards the check that matters is against the tag:

    git merge-base --is-ancestor efd0c42 v0.52.139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
