### PR TITLE
fix(panel): bound panel_search_nodes at MCP route

### DIFF
--- a/src/__tests__/orchestrator/panel-search-route-boundary.test.ts
+++ b/src/__tests__/orchestrator/panel-search-route-boundary.test.ts
@@ -1,0 +1,155 @@
+// #1908 — panel_search_nodes is canvas-independent, so a frozen bound canvas
+// tab must not consume the whole bridge window before the Manager query can be
+// tried on another tab or return an honest structured timeout.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __panelToolsTestHooks,
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const BOUND = "bound-frozen";
+const FALLBACK = "same-comfyui";
+
+function searchDef() {
+  const def = buildPanelToolDefs().find((entry) => entry.name === "panel_search_nodes");
+  if (!def) throw new Error("panel_search_nodes is not registered");
+  return def;
+}
+
+function parseResult(res: ToolResult): Record<string, unknown> {
+  const text = res.content.find((block) => block.type === "text")?.text;
+  if (!text) throw new Error("panel_search_nodes returned no text content");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+function routeBridge(opts: {
+  tabs: string[];
+  clientOrigins: Record<string, string | undefined>;
+  serverOrigins: Record<string, string | undefined>;
+  headless?: string[];
+  reachable?: Record<string, boolean>;
+  send: (tabId: string, cmd: Record<string, unknown>, timeoutMs: number) => Promise<Record<string, unknown>>;
+}): { bridge: PanelToolCtx["bridge"]; sent: Array<{ tabId?: string; cmd: Record<string, unknown>; timeoutMs?: number }> } {
+  const sent: Array<{ tabId?: string; cmd: Record<string, unknown>; timeoutMs?: number }> = [];
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- the fake implements only the route-boundary surface under test
+  const bridge = {
+    send: async (cmd: Record<string, unknown>, sendOpts?: { tabId?: string; timeoutMs?: number }) => {
+      sent.push({ tabId: sendOpts?.tabId, cmd, timeoutMs: sendOpts?.timeoutMs });
+      return opts.send(sendOpts?.tabId ?? "", cmd, sendOpts?.timeoutMs ?? 0);
+    },
+    tabs: () => opts.tabs.map((tab_id) => ({ tab_id, title: tab_id, connected_at: "now" })),
+    isHeadless: (tabId: string) => opts.headless?.includes(tabId) ?? false,
+    canReach: (tabId: string) => opts.reachable?.[tabId] ?? opts.tabs.includes(tabId),
+    liveTabIdFor: (tabId: string) => (opts.tabs.includes(tabId) ? tabId : undefined),
+    // Keep the spoofable client claim in the seam so the tests prove it is not
+    // sufficient for authorization.
+    tabOrigin: (tabId: string) => opts.clientOrigins[tabId],
+    tabServerOrigin: (tabId: string) => opts.serverOrigins[tabId],
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge, sent };
+}
+
+afterEach(() => {
+  __panelToolsTestHooks.setPanelSearchRouteTiming(null);
+});
+
+describe("panel_search_nodes MCP route boundary (#1908)", () => {
+  it("uses server origin proof when client hello origins conflict", async () => {
+    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 100, fallbackTriggerMs: 10 });
+    const { bridge, sent } = routeBridge({
+      tabs: [BOUND, FALLBACK],
+      clientOrigins: { [BOUND]: "http://127.0.0.1:8188", [FALLBACK]: "https://spoofed.example" },
+      serverOrigins: { [BOUND]: "http://127.0.0.1:8188/", [FALLBACK]: "http://127.0.0.1:8188" },
+      send: async (tabId, cmd) => {
+        if (tabId === BOUND) return new Promise<never>(() => undefined); // frozen listener: never starts
+        return { count: 1, results: [{ id: "KJNodes", title: "KJNodes", description: "ok" }], cmd };
+      },
+    });
+    const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
+    const started = Date.now();
+    const result = await searchDef().handler({ query: "kj", limit: 5 }, ctx);
+
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toMatchObject({
+      count: 1,
+      results: [{ id: "KJNodes" }],
+    });
+    expect(sent.map((entry) => entry.tabId)).toEqual([BOUND, FALLBACK]);
+    expect(sent[0].cmd).toMatchObject({ cmd: "nodes_search", query: "kj", limit: 5 });
+    expect(sent[0].timeoutMs).toBe(100);
+    expect(sent[1].timeoutMs).toBeLessThanOrEqual(90);
+    expect(ctx.tabId).toBe(BOUND);
+  });
+
+  it("rejects headless, unreachable, missing-proof, and mismatched-proof candidates", async () => {
+    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 60, fallbackTriggerMs: 10 });
+    const headless = "headless";
+    const unreachable = "unreachable";
+    const missingServerProof = "missing-server-proof";
+    const mismatchedServerProof = "mismatched-server-proof";
+    const { bridge, sent } = routeBridge({
+      tabs: [BOUND, headless, unreachable, missingServerProof, mismatchedServerProof],
+      clientOrigins: {
+        [BOUND]: "http://127.0.0.1:8188",
+        [headless]: "http://127.0.0.1:8188",
+        [unreachable]: "http://127.0.0.1:8188",
+        [missingServerProof]: "http://127.0.0.1:8188",
+        [mismatchedServerProof]: "http://127.0.0.1:8188",
+      },
+      serverOrigins: {
+        [BOUND]: "http://127.0.0.1:8188",
+        [headless]: "http://127.0.0.1:8188",
+        [unreachable]: "http://127.0.0.1:8188",
+        [mismatchedServerProof]: "http://127.0.0.1:8189",
+      },
+      headless: [headless],
+      reachable: { [unreachable]: false },
+      send: async () => new Promise<never>(() => undefined),
+    });
+    const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
+    const started = Date.now();
+    const result = await searchDef().handler({ query: "missing" }, ctx);
+
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toMatchObject({
+      count: 0,
+      results: [],
+      query: "missing",
+      timed_out: true,
+      panel_unresponsive: true,
+      panel_route: "bound_tab_timeout",
+    });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].tabId).toBe(BOUND);
+    expect(ctx.tabId).toBe(BOUND);
+  });
+
+  it("fails closed when the bound tab has no server origin proof", async () => {
+    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 60, fallbackTriggerMs: 10 });
+    const { bridge, sent } = routeBridge({
+      tabs: [BOUND, FALLBACK],
+      clientOrigins: { [BOUND]: "http://127.0.0.1:8188", [FALLBACK]: "http://127.0.0.1:8188" },
+      serverOrigins: { [FALLBACK]: "http://127.0.0.1:8188" },
+      send: async () => new Promise<never>(() => undefined),
+    });
+    const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
+    const result = await searchDef().handler({ query: "missing-bound-proof" }, ctx);
+
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toMatchObject({
+      query: "missing-bound-proof",
+      timed_out: true,
+      panel_unresponsive: true,
+      panel_route: "bound_tab_timeout",
+    });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].tabId).toBe(BOUND);
+  });
+});

--- a/src/__tests__/orchestrator/panel-search-route-boundary.test.ts
+++ b/src/__tests__/orchestrator/panel-search-route-boundary.test.ts
@@ -29,6 +29,7 @@ function parseResult(res: ToolResult): Record<string, unknown> {
 
 function routeBridge(opts: {
   tabs: string[];
+  liveTabs?: Set<string>;
   clientOrigins?: Record<string, string | undefined>;
   serverOrigins?: Record<string, string | undefined>;
   send: (tabId: string, cmd: Record<string, unknown>, timeoutMs: number) => Promise<Record<string, unknown>>;
@@ -38,20 +39,31 @@ function routeBridge(opts: {
   probes: { tabs: ReturnType<typeof vi.fn>; tabServerOrigin: ReturnType<typeof vi.fn> };
 } {
   const sent: Array<{ tabId?: string; cmd: Record<string, unknown>; timeoutMs?: number }> = [];
-  const tabs = vi.fn(() => opts.tabs.map((tab_id) => ({ tab_id, title: tab_id, connected_at: "now" })));
+  const liveTabIds = () => [...(opts.liveTabs ?? new Set(opts.tabs))];
+  const tabs = vi.fn(() => liveTabIds().map((tab_id) => ({ tab_id, title: tab_id, connected_at: "now" })));
   const tabServerOrigin = vi.fn((tabId: string) => opts.serverOrigins?.[tabId]);
+  const resolveActiveTabId = vi.fn(() => {
+    const live = liveTabIds();
+    if (live.length !== 1) throw new Error("active tab is ambiguous");
+    return live[0];
+  });
   // Keep the tempting, weaker proof surfaces in the seam. The route must not
   // consult them: tabServerOrigin is pathless and cannot prove instance identity.
   // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- the fake implements only the route-boundary surface under test
   const bridge = {
-    send: async (cmd: Record<string, unknown>, sendOpts?: { tabId?: string; timeoutMs?: number }) => {
+    send: async (
+      cmd: Record<string, unknown>,
+      sendOpts?: { tabId?: string; timeoutMs?: number; beforeDispatch?: () => void },
+    ) => {
+      sendOpts?.beforeDispatch?.();
       sent.push({ tabId: sendOpts?.tabId, cmd, timeoutMs: sendOpts?.timeoutMs });
       return opts.send(sendOpts?.tabId ?? "", cmd, sendOpts?.timeoutMs ?? 0);
     },
     tabs,
     isHeadless: () => false,
-    canReach: (tabId: string) => opts.tabs.includes(tabId),
-    liveTabIdFor: (tabId: string) => (opts.tabs.includes(tabId) ? tabId : undefined),
+    canReach: (tabId: string) => liveTabIds().includes(tabId),
+    liveTabIdFor: (tabId: string) => (liveTabIds().includes(tabId) ? tabId : undefined),
+    resolveActiveTabId,
     tabOrigin: (tabId: string) => opts.clientOrigins?.[tabId],
     tabServerOrigin,
   } as unknown as PanelToolCtx["bridge"];
@@ -60,6 +72,7 @@ function routeBridge(opts: {
 
 afterEach(() => {
   __panelToolsTestHooks.setPanelSearchRouteTiming(null);
+  __panelToolsTestHooks.setRetrySettleMs(null);
 });
 
 describe("panel_search_nodes MCP route boundary (#1908)", () => {
@@ -176,4 +189,67 @@ describe("panel_search_nodes MCP route boundary (#1908)", () => {
       }
     },
   );
+
+  it("uses the retry-safe ctx.call envelope to rebind after a bound-tab drop", async () => {
+    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 200 });
+    __panelToolsTestHooks.setRetrySettleMs(0);
+    const liveTabs = new Set([BOUND]);
+    let attempts = 0;
+    const { bridge, sent } = routeBridge({
+      tabs: [BOUND, ALTERNATE],
+      liveTabs,
+      send: async (tabId) => {
+        attempts += 1;
+        if (attempts === 1) {
+          expect(tabId).toBe(BOUND);
+          liveTabs.delete(BOUND);
+          liveTabs.add(ALTERNATE);
+          throw new Error("no connected tab: bound transport dropped");
+        }
+        return { count: 1, results: [{ id: "rebound" }] };
+      },
+    });
+    const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
+
+    const result = await searchDef().handler({ query: "rebind" }, ctx);
+
+    expect(parseResult(result)).toMatchObject({ count: 1, results: [{ id: "rebound" }] });
+    expect(sent.map((entry) => entry.tabId)).toEqual([BOUND, ALTERNATE]);
+    expect(sent.every((entry) => entry.cmd.cmd === "nodes_search")).toBe(true);
+    expect(ctx.tabId).toBe(ALTERNATE);
+  });
+
+  it("does not issue a retry after the MCP route deadline", async () => {
+    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 20 });
+    __panelToolsTestHooks.setRetrySettleMs(0);
+    const liveTabs = new Set([BOUND]);
+    let attempts = 0;
+    const { bridge, sent } = routeBridge({
+      tabs: [BOUND, ALTERNATE],
+      liveTabs,
+      send: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          await new Promise((resolve) => setTimeout(resolve, 40));
+          liveTabs.delete(BOUND);
+          liveTabs.add(ALTERNATE);
+          throw new Error("no connected tab: late transport drop");
+        }
+        throw new Error("unexpected post-deadline retry");
+      },
+    });
+    const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
+
+    const result = await searchDef().handler({ query: "deadline" }, ctx);
+    expect(parseResult(result)).toMatchObject({
+      query: "deadline",
+      timed_out: true,
+      panel_unresponsive: true,
+      panel_route: "bound_tab_timeout",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(attempts).toBe(1);
+    expect(sent.map((entry) => entry.tabId)).toEqual([BOUND]);
+  });
 });

--- a/src/__tests__/orchestrator/panel-search-route-boundary.test.ts
+++ b/src/__tests__/orchestrator/panel-search-route-boundary.test.ts
@@ -1,8 +1,8 @@
 // #1908 — panel_search_nodes is canvas-independent, so a frozen bound canvas
-// tab must not consume the whole bridge window before the Manager query can be
-// tried on another tab or return an honest structured timeout.
+// tab must not consume the whole bridge window before the Manager query returns
+// an honest structured timeout. It must not be guessed onto another instance.
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __panelToolsTestHooks,
   buildPanelToolDefs,
@@ -13,7 +13,7 @@ import {
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const BOUND = "bound-frozen";
-const FALLBACK = "same-comfyui";
+const ALTERNATE = "unproven-alternate";
 
 function searchDef() {
   const def = buildPanelToolDefs().find((entry) => entry.name === "panel_search_nodes");
@@ -29,29 +29,33 @@ function parseResult(res: ToolResult): Record<string, unknown> {
 
 function routeBridge(opts: {
   tabs: string[];
-  clientOrigins: Record<string, string | undefined>;
-  serverOrigins: Record<string, string | undefined>;
-  headless?: string[];
-  reachable?: Record<string, boolean>;
+  clientOrigins?: Record<string, string | undefined>;
+  serverOrigins?: Record<string, string | undefined>;
   send: (tabId: string, cmd: Record<string, unknown>, timeoutMs: number) => Promise<Record<string, unknown>>;
-}): { bridge: PanelToolCtx["bridge"]; sent: Array<{ tabId?: string; cmd: Record<string, unknown>; timeoutMs?: number }> } {
+}): {
+  bridge: PanelToolCtx["bridge"];
+  sent: Array<{ tabId?: string; cmd: Record<string, unknown>; timeoutMs?: number }>;
+  probes: { tabs: ReturnType<typeof vi.fn>; tabServerOrigin: ReturnType<typeof vi.fn> };
+} {
   const sent: Array<{ tabId?: string; cmd: Record<string, unknown>; timeoutMs?: number }> = [];
+  const tabs = vi.fn(() => opts.tabs.map((tab_id) => ({ tab_id, title: tab_id, connected_at: "now" })));
+  const tabServerOrigin = vi.fn((tabId: string) => opts.serverOrigins?.[tabId]);
+  // Keep the tempting, weaker proof surfaces in the seam. The route must not
+  // consult them: tabServerOrigin is pathless and cannot prove instance identity.
   // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- the fake implements only the route-boundary surface under test
   const bridge = {
     send: async (cmd: Record<string, unknown>, sendOpts?: { tabId?: string; timeoutMs?: number }) => {
       sent.push({ tabId: sendOpts?.tabId, cmd, timeoutMs: sendOpts?.timeoutMs });
       return opts.send(sendOpts?.tabId ?? "", cmd, sendOpts?.timeoutMs ?? 0);
     },
-    tabs: () => opts.tabs.map((tab_id) => ({ tab_id, title: tab_id, connected_at: "now" })),
-    isHeadless: (tabId: string) => opts.headless?.includes(tabId) ?? false,
-    canReach: (tabId: string) => opts.reachable?.[tabId] ?? opts.tabs.includes(tabId),
+    tabs,
+    isHeadless: () => false,
+    canReach: (tabId: string) => opts.tabs.includes(tabId),
     liveTabIdFor: (tabId: string) => (opts.tabs.includes(tabId) ? tabId : undefined),
-    // Keep the spoofable client claim in the seam so the tests prove it is not
-    // sufficient for authorization.
-    tabOrigin: (tabId: string) => opts.clientOrigins[tabId],
-    tabServerOrigin: (tabId: string) => opts.serverOrigins[tabId],
+    tabOrigin: (tabId: string) => opts.clientOrigins?.[tabId],
+    tabServerOrigin,
   } as unknown as PanelToolCtx["bridge"];
-  return { bridge, sent };
+  return { bridge, sent, probes: { tabs, tabServerOrigin } };
 }
 
 afterEach(() => {
@@ -59,16 +63,11 @@ afterEach(() => {
 });
 
 describe("panel_search_nodes MCP route boundary (#1908)", () => {
-  it("uses server origin proof when client hello origins conflict", async () => {
-    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 100, fallbackTriggerMs: 10 });
+  it("starts the MCP deadline before dispatch and returns a bound-tab timeout", async () => {
+    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 60 });
     const { bridge, sent } = routeBridge({
-      tabs: [BOUND, FALLBACK],
-      clientOrigins: { [BOUND]: "http://127.0.0.1:8188", [FALLBACK]: "https://spoofed.example" },
-      serverOrigins: { [BOUND]: "http://127.0.0.1:8188/", [FALLBACK]: "http://127.0.0.1:8188" },
-      send: async (tabId, cmd) => {
-        if (tabId === BOUND) return new Promise<never>(() => undefined); // frozen listener: never starts
-        return { count: 1, results: [{ id: "KJNodes", title: "KJNodes", description: "ok" }], cmd };
-      },
+      tabs: [BOUND, ALTERNATE],
+      send: async () => new Promise<never>(() => undefined), // frozen listener: never starts
     });
     const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
     const started = Date.now();
@@ -77,79 +76,104 @@ describe("panel_search_nodes MCP route boundary (#1908)", () => {
     expect(Date.now() - started).toBeLessThan(500);
     expect(result.isError).toBeUndefined();
     expect(parseResult(result)).toMatchObject({
-      count: 1,
-      results: [{ id: "KJNodes" }],
-    });
-    expect(sent.map((entry) => entry.tabId)).toEqual([BOUND, FALLBACK]);
-    expect(sent[0].cmd).toMatchObject({ cmd: "nodes_search", query: "kj", limit: 5 });
-    expect(sent[0].timeoutMs).toBe(100);
-    expect(sent[1].timeoutMs).toBeLessThanOrEqual(90);
-    expect(ctx.tabId).toBe(BOUND);
-  });
-
-  it("rejects headless, unreachable, missing-proof, and mismatched-proof candidates", async () => {
-    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 60, fallbackTriggerMs: 10 });
-    const headless = "headless";
-    const unreachable = "unreachable";
-    const missingServerProof = "missing-server-proof";
-    const mismatchedServerProof = "mismatched-server-proof";
-    const { bridge, sent } = routeBridge({
-      tabs: [BOUND, headless, unreachable, missingServerProof, mismatchedServerProof],
-      clientOrigins: {
-        [BOUND]: "http://127.0.0.1:8188",
-        [headless]: "http://127.0.0.1:8188",
-        [unreachable]: "http://127.0.0.1:8188",
-        [missingServerProof]: "http://127.0.0.1:8188",
-        [mismatchedServerProof]: "http://127.0.0.1:8188",
-      },
-      serverOrigins: {
-        [BOUND]: "http://127.0.0.1:8188",
-        [headless]: "http://127.0.0.1:8188",
-        [unreachable]: "http://127.0.0.1:8188",
-        [mismatchedServerProof]: "http://127.0.0.1:8189",
-      },
-      headless: [headless],
-      reachable: { [unreachable]: false },
-      send: async () => new Promise<never>(() => undefined),
-    });
-    const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
-    const started = Date.now();
-    const result = await searchDef().handler({ query: "missing" }, ctx);
-
-    expect(Date.now() - started).toBeLessThan(500);
-    expect(result.isError).toBeUndefined();
-    expect(parseResult(result)).toMatchObject({
       count: 0,
       results: [],
-      query: "missing",
+      query: "kj",
       timed_out: true,
       panel_unresponsive: true,
       panel_route: "bound_tab_timeout",
+      timeout_ms: 60,
     });
     expect(sent).toHaveLength(1);
     expect(sent[0].tabId).toBe(BOUND);
+    expect(sent[0].cmd).toMatchObject({ cmd: "nodes_search", query: "kj", limit: 5 });
+    expect(sent[0].timeoutMs).toBe(60);
     expect(ctx.tabId).toBe(BOUND);
   });
 
-  it("fails closed when the bound tab has no server origin proof", async () => {
-    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 60, fallbackTriggerMs: 10 });
-    const { bridge, sent } = routeBridge({
-      tabs: [BOUND, FALLBACK],
-      clientOrigins: { [BOUND]: "http://127.0.0.1:8188", [FALLBACK]: "http://127.0.0.1:8188" },
-      serverOrigins: { [FALLBACK]: "http://127.0.0.1:8188" },
+  it.each([
+    {
+      label: "same host/port with unknown path",
+      clientOrigins: { [BOUND]: "http://127.0.0.1:8188/comfy-a", [ALTERNATE]: undefined },
+      serverOrigins: { [BOUND]: "http://127.0.0.1:8188", [ALTERNATE]: "http://127.0.0.1:8188" },
+    },
+    {
+      label: "same host/port with a different path claim",
+      clientOrigins: {
+        [BOUND]: "http://127.0.0.1:8188/comfy-a",
+        [ALTERNATE]: "http://127.0.0.1:8188/comfy-b",
+      },
+      serverOrigins: { [BOUND]: "http://127.0.0.1:8188", [ALTERNATE]: "http://127.0.0.1:8188" },
+    },
+    {
+      label: "missing server proof",
+      clientOrigins: {
+        [BOUND]: "http://127.0.0.1:8188/comfy-a",
+        [ALTERNATE]: "http://127.0.0.1:8188/comfy-a",
+      },
+      serverOrigins: { [BOUND]: "http://127.0.0.1:8188", [ALTERNATE]: undefined },
+    },
+  ])("does not use an alternate tab for $label", async ({ clientOrigins, serverOrigins }) => {
+    __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 60 });
+    const { bridge, sent, probes } = routeBridge({
+      tabs: [BOUND, ALTERNATE],
+      clientOrigins,
+      serverOrigins,
       send: async () => new Promise<never>(() => undefined),
     });
     const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
-    const result = await searchDef().handler({ query: "missing-bound-proof" }, ctx);
+    const result = await searchDef().handler({ query: "unproven" }, ctx);
 
-    expect(result.isError).toBeUndefined();
     expect(parseResult(result)).toMatchObject({
-      query: "missing-bound-proof",
+      query: "unproven",
       timed_out: true,
       panel_unresponsive: true,
       panel_route: "bound_tab_timeout",
     });
-    expect(sent).toHaveLength(1);
-    expect(sent[0].tabId).toBe(BOUND);
+    expect(sent.map((entry) => entry.tabId)).toEqual([BOUND]);
+    expect(probes.tabs).not.toHaveBeenCalled();
+    expect(probes.tabServerOrigin).not.toHaveBeenCalled();
+    expect(ctx.tabId).toBe(BOUND);
   });
+
+  it.each(["resolves", "rejects"] as const)(
+    "consumes a late bridge reply that %s without an unhandled rejection",
+    async (outcome) => {
+      __panelToolsTestHooks.setPanelSearchRouteTiming({ budgetMs: 20 });
+      let resolveLate!: (value: Record<string, unknown>) => void;
+      let rejectLate!: (error: Error) => void;
+      const late = new Promise<Record<string, unknown>>((resolve, reject) => {
+        resolveLate = resolve;
+        rejectLate = reject;
+      });
+      const { bridge, sent } = routeBridge({
+        tabs: [BOUND],
+        send: async () => late,
+      });
+      const ctx = makePanelToolCtx(bridge, BOUND, new WorkflowTargetStore());
+      const unhandled = vi.fn();
+      process.on("unhandledRejection", unhandled);
+      try {
+        const result = await searchDef().handler({ query: "late" }, ctx);
+        expect(parseResult(result)).toMatchObject({
+          query: "late",
+          timed_out: true,
+          panel_unresponsive: true,
+          panel_route: "bound_tab_timeout",
+        });
+        expect(sent.map((entry) => entry.tabId)).toEqual([BOUND]);
+
+        if (outcome === "resolves") {
+          resolveLate({ count: 1, results: [{ id: "late-reply" }] });
+        } else {
+          rejectLate(new Error("late bridge rejection"));
+        }
+        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(unhandled).not.toHaveBeenCalled();
+      } finally {
+        process.off("unhandledRejection", unhandled);
+      }
+    },
+  );
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1262,9 +1262,7 @@ export const __panelToolsTestHooks = {
     saveTimeoutSettleGraceMsOverride = ms;
   },
   /** Shrink the #1908 route-boundary budget for frozen-tab tests. */
-  setPanelSearchRouteTiming(
-    timing: { budgetMs: number; fallbackTriggerMs: number } | null,
-  ): void {
+  setPanelSearchRouteTiming(timing: { budgetMs: number } | null): void {
     panelSearchRouteTimingOverride = timing;
   },
   isRetrySafeCmd,
@@ -1295,18 +1293,14 @@ function sleep(ms: number): Promise<void> {
 // #1908 — `nodes_search` is a canvas-independent Manager read, but the old
 // handler still sent it through the session's bound canvas tab. A frozen tab
 // never starts the Panel-side deadline because its listener never runs, so the
-// route itself needs a finite budget and a safe same-ComfyUI fallback.
+// route itself needs a finite budget. There is no safe alternate-tab instance
+// proof in the bridge contract, so this route remains bound to the session tab.
 export const PANEL_SEARCH_ROUTE_BUDGET_MS = 18_000;
-const PANEL_SEARCH_FALLBACK_TRIGGER_MS = 5_000;
-let panelSearchRouteTimingOverride: {
-  budgetMs: number;
-  fallbackTriggerMs: number;
-} | null = null;
+let panelSearchRouteTimingOverride: { budgetMs: number } | null = null;
 
-function panelSearchRouteTiming(): { budgetMs: number; fallbackTriggerMs: number } {
+function panelSearchRouteTiming(): { budgetMs: number } {
   return panelSearchRouteTimingOverride ?? {
     budgetMs: PANEL_SEARCH_ROUTE_BUDGET_MS,
-    fallbackTriggerMs: PANEL_SEARCH_FALLBACK_TRIGGER_MS,
   };
 }
 
@@ -15572,84 +15566,6 @@ function panelSearchAttempt(
   });
 }
 
-/** Wait briefly for the bound tab before deciding whether a same-origin fallback is needed. */
-function waitForPanelSearchAttempt(
-  attempt: Promise<PanelSearchAttempt>,
-  timeoutMs: number,
-): Promise<{ kind: "settled"; attempt: PanelSearchAttempt } | { kind: "trigger" }> {
-  const wait = Math.max(0, Math.floor(timeoutMs));
-  return new Promise((resolve) => {
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      resolve({ kind: "trigger" });
-    }, wait);
-    void attempt.then((result) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve({ kind: "settled", attempt: result });
-    });
-  });
-}
-
-function normalizedPanelSearchServerOrigin(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const origin = value.trim();
-  return origin === "" ? undefined : origin.replace(/\/+$/, "");
-}
-
-/**
- * Pick one alternate interactive tab only when the bridge has matching,
- * server-observed handshake-origin proof for both tabs. Client hello metadata
- * (`tabOrigin`) is not an authorization signal and is deliberately not
- * consulted here.
- */
-function panelSearchFallbackTab(ctx: PanelToolCtx, boundTab: string): string | undefined {
-  const b: BridgeProbe = ctx.bridge;
-  if (
-    typeof b.tabs !== "function" ||
-    typeof b.isHeadless !== "function" ||
-    typeof b.canReach !== "function" ||
-    typeof b.tabServerOrigin !== "function"
-  ) {
-    return undefined;
-  }
-  let boundServerOrigin: string | undefined;
-  try {
-    boundServerOrigin = normalizedPanelSearchServerOrigin(b.tabServerOrigin(boundTab));
-  } catch {
-    return undefined;
-  }
-  if (!boundServerOrigin) return undefined;
-  let live: Array<{ tab_id: string }>;
-  try {
-    live = b.tabs();
-  } catch {
-    return undefined;
-  }
-  if (!Array.isArray(live)) return undefined;
-
-  // `tabs()` preserves most-recent hello last; try the newest alternate first.
-  for (const tab of [...live].reverse()) {
-    const candidate = typeof tab?.tab_id === "string" ? tab.tab_id : "";
-    if (!candidate || candidate === boundTab) continue;
-    try {
-      if (b.isHeadless(candidate)) continue;
-      if (!b.canReach(candidate)) continue;
-      const candidateServerOrigin = normalizedPanelSearchServerOrigin(b.tabServerOrigin(candidate));
-      // Handshake Origin is pathless; use the existing canonical scheme/host/port
-      // comparison, which rejects malformed or DNS-ambiguous values closed.
-      if (!sameHttpOrigin(candidateServerOrigin, boundServerOrigin)) continue;
-    } catch {
-      continue;
-    }
-    return candidate;
-  }
-  return undefined;
-}
-
 function panelSearchBoundTab(ctx: PanelToolCtx): string | undefined {
   const b: BridgeProbe = ctx.bridge;
   try {
@@ -15662,7 +15578,6 @@ function panelSearchBoundTab(ctx: PanelToolCtx): string | undefined {
 
 function panelSearchTimeoutResult(
   query: string,
-  attemptedTabs: number,
   budgetMs: number,
 ): Record<string, unknown> {
   return {
@@ -15671,33 +15586,32 @@ function panelSearchTimeoutResult(
     query,
     timed_out: true,
     panel_unresponsive: true,
-    panel_route: attemptedTabs > 1 ? "same_comfyui_fallback_timeout" : "bound_tab_timeout",
+    panel_route: "bound_tab_timeout",
     timeout_ms: budgetMs,
     reason: "No panel reply was observed before the MCP route budget expired.",
     message:
       "Node-registry search could not complete because the bound ComfyUI panel tab did not " +
       "answer. This is not evidence that the requested pack is missing. The MCP route " +
-      "only retries this canvas-independent search on another tab proven to front the same " +
-      "ComfyUI instance; retry after a panel tab responds.",
+      "does not retarget this request to another tab without a stronger instance proof; retry " +
+      "after the bound panel tab responds.",
   };
 }
 
 function panelSearchAttemptResult(
   attempt: PanelSearchAttempt,
   query: string,
-  attemptedTabs: number,
   budgetMs: number,
 ): ToolResult {
   if (attempt.kind === "reply") return ok(attempt.value);
   if (attempt.kind === "error") return fail(attempt.error);
-  return ok(panelSearchTimeoutResult(query, attemptedTabs, budgetMs));
+  return ok(panelSearchTimeoutResult(query, budgetMs));
 }
 
 /**
  * Route the Manager read with an MCP-owned deadline. Lightweight test bridges
- * and older compatibility contexts keep the existing `ctx.call` path; the
- * production UiBridge path is the one that can enumerate origins and safely
- * address a second panel tab without changing the session's binding.
+ * and older compatibility contexts keep the existing `ctx.call` path when no
+ * concrete bound tab can be resolved. No alternate tab is eligible here: the
+ * available bridge origin fields do not prove a path-aware ComfyUI instance.
  */
 async function panelSearchAtRouteBoundary(
   ctx: PanelToolCtx,
@@ -15705,11 +15619,13 @@ async function panelSearchAtRouteBoundary(
   query: string,
 ): Promise<ToolResult> {
   const b: BridgeProbe = ctx.bridge;
+  // Lightweight compatibility contexts do not expose the live-tab inventory
+  // used by the route-owned send. Keep their existing ctx.call path; this is
+  // still the session's bound route, never an alternate-tab fallback.
   const supportsRouteBoundary =
     typeof b?.tabs === "function" &&
     typeof b.isHeadless === "function" &&
-    typeof b.canReach === "function" &&
-    typeof b.tabServerOrigin === "function";
+    typeof b.canReach === "function";
   if (!supportsRouteBoundary) return ctx.call(cmd, 20000);
 
   const boundTab = panelSearchBoundTab(ctx);
@@ -15717,44 +15633,11 @@ async function panelSearchAtRouteBoundary(
 
   const timing = panelSearchRouteTiming();
   const budgetMs = Math.max(1, Math.floor(timing.budgetMs));
-  const deadline = Date.now() + budgetMs;
-  const attemptedTabs = [boundTab];
-  const primary = panelSearchAttempt(ctx, boundTab, cmd, budgetMs);
-  const first = await waitForPanelSearchAttempt(
-    primary,
-    Math.min(budgetMs, Math.max(0, Math.floor(timing.fallbackTriggerMs))),
+  return panelSearchAttemptResult(
+    await panelSearchAttempt(ctx, boundTab, cmd, budgetMs),
+    query,
+    budgetMs,
   );
-  if (first.kind === "settled") {
-    return panelSearchAttemptResult(first.attempt, query, attemptedTabs.length, budgetMs);
-  }
-
-  const fallbackTab = panelSearchFallbackTab(ctx, boundTab);
-  if (!fallbackTab) {
-    return panelSearchAttemptResult(await primary, query, attemptedTabs.length, budgetMs);
-  }
-  attemptedTabs.push(fallbackTab);
-  const remaining = Math.max(1, deadline - Date.now());
-  const fallback = panelSearchAttempt(ctx, fallbackTab, cmd, remaining);
-
-  // A slow-but-alive bound tab may still answer while the alternate is probing.
-  // Prefer the first successful reply; do not let an early transport error from
-  // one tab hide a valid answer from the other.
-  const pending = new Set<Promise<PanelSearchAttempt>>([primary, fallback]);
-  let lastError: unknown;
-  let sawError = false;
-  while (pending.size > 0) {
-    const winner = await Promise.race(
-      [...pending].map(async (attempt) => ({ attempt, result: await attempt })),
-    );
-    pending.delete(winner.attempt);
-    if (winner.result.kind === "reply") return ok(winner.result.value);
-    if (winner.result.kind === "error") {
-      lastError = winner.result.error;
-      sawError = true;
-    }
-  }
-  if (sawError) return fail(lastError);
-  return ok(panelSearchTimeoutResult(query, attemptedTabs.length, budgetMs));
 }
 
 /** Re-resolve the desktop redirect target after a transient drop — returns the fresh
@@ -22434,8 +22317,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         const out = await searchPanelNodes({
           // #1908 — this read is independent of the canvas, so a frozen bound
           // tab must not own the whole bridge window. The route helper keeps
-          // the session binding unchanged and may address one same-ComfyUI
-          // interactive tab after the MCP-owned trigger deadline.
+          // the session binding unchanged and applies an MCP-owned deadline;
+          // it never guesses another ComfyUI instance.
           panelSearch: () =>
             panelSearchAtRouteBoundary(ctx, { cmd: "nodes_search", query, limit }, query),
           query,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -15523,59 +15523,6 @@ async function dispatchToTab(
   }
 }
 
-type PanelSearchAttempt =
-  | { kind: "reply"; value: unknown }
-  | { kind: "error"; error: unknown }
-  | { kind: "timeout" };
-
-/**
- * #1908 — bound a `nodes_search` send at the MCP route, independently of the
- * Panel listener. The Panel's own timer is installed by that listener, so it
- * cannot help when the bound browser tab is frozen before it handles the frame.
- * This timer is deliberately external and every promise settles locally, so a
- * late reply from the abandoned read cannot hold the tool open or become an
- * unhandled rejection.
- */
-function panelSearchAttempt(
-  ctx: PanelToolCtx,
-  tabId: string,
-  cmd: Record<string, unknown>,
-  timeoutMs: number,
-): Promise<PanelSearchAttempt> {
-  const budget = Math.max(1, Math.floor(timeoutMs));
-  return new Promise((resolve) => {
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout>;
-    const finish = (attempt: PanelSearchAttempt): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(attempt);
-    };
-    timer = setTimeout(() => finish({ kind: "timeout" }), budget);
-
-    // `bridge.send` normally rejects its own bounded timeout. The route timer
-    // above is still authoritative: it also covers a frozen-listener test seam
-    // or any future transport that never settles its send promise.
-    void Promise.resolve()
-      .then(() => ctx.bridge.send(cmd as { cmd: string }, { tabId, timeoutMs: budget }))
-      .then(
-        (value) => finish({ kind: "reply", value }),
-        (error) => finish(isReplyTimeoutTagged(error) ? { kind: "timeout" } : { kind: "error", error }),
-      );
-  });
-}
-
-function panelSearchBoundTab(ctx: PanelToolCtx): string | undefined {
-  const b: BridgeProbe = ctx.bridge;
-  try {
-    if (isScopeAddress(ctx.tabId)) return b.resolveSharedTabId?.(ctx.tabId);
-    return b.liveTabIdFor?.(ctx.tabId) ?? ctx.tabId;
-  } catch {
-    return undefined;
-  }
-}
-
 function panelSearchTimeoutResult(
   query: string,
   budgetMs: number,
@@ -15597,21 +15544,18 @@ function panelSearchTimeoutResult(
   };
 }
 
-function panelSearchAttemptResult(
-  attempt: PanelSearchAttempt,
-  query: string,
-  budgetMs: number,
-): ToolResult {
-  if (attempt.kind === "reply") return ok(attempt.value);
-  if (attempt.kind === "error") return fail(attempt.error);
-  return ok(panelSearchTimeoutResult(query, budgetMs));
-}
-
 /**
  * Route the Manager read with an MCP-owned deadline. Lightweight test bridges
- * and older compatibility contexts keep the existing `ctx.call` path when no
- * concrete bound tab can be resolved. No alternate tab is eligible here: the
+ * and older compatibility contexts keep the existing `ctx.call` path when they
+ * cannot expose the live-tab inventory. No alternate tab is eligible here: the
  * available bridge origin fields do not prove a path-aware ComfyUI instance.
+ *
+ * The bounded call deliberately stays inside `makePanelToolCtx`. That preserves
+ * its `liveTabIdFor`/`ensureReachable` resolution and the existing retry-safe
+ * reconnect/rebind envelope for `nodes_search`. The synchronous guard is passed
+ * through to UiBridge's final dispatch boundary, so a retry that wakes after the
+ * MCP deadline is refused before it can write a second frame. The call promise is
+ * observed on both outcomes after the route returns, consuming a late settlement.
  */
 async function panelSearchAtRouteBoundary(
   ctx: PanelToolCtx,
@@ -15628,16 +15572,36 @@ async function panelSearchAtRouteBoundary(
     typeof b.canReach === "function";
   if (!supportsRouteBoundary) return ctx.call(cmd, 20000);
 
-  const boundTab = panelSearchBoundTab(ctx);
-  if (!boundTab) return ctx.call(cmd, 20000);
-
   const timing = panelSearchRouteTiming();
   const budgetMs = Math.max(1, Math.floor(timing.budgetMs));
-  return panelSearchAttemptResult(
-    await panelSearchAttempt(ctx, boundTab, cmd, budgetMs),
-    query,
-    budgetMs,
-  );
+  const deadline = Date.now() + budgetMs;
+
+  return new Promise<ToolResult>((resolve) => {
+    let settled = false;
+    const finish = (result: ToolResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(
+      () => finish(ok(panelSearchTimeoutResult(query, budgetMs))),
+      budgetMs,
+    );
+
+    // Start the ctx.call promise before yielding to the event loop. Its internal
+    // retry/rebind path remains active even if this route promise times out, but
+    // the guard below prevents any post-deadline retry from reaching the socket.
+    const call = ctx.call(cmd, budgetMs, undefined, () => {
+      if (Date.now() >= deadline) {
+        throw new Error("panel_search_nodes route deadline expired before dispatch");
+      }
+    });
+    void call.then(
+      (result) => finish(result),
+      (error) => finish(fail(error)),
+    );
+  });
 }
 
 /** Re-resolve the desktop redirect target after a transient drop — returns the fresh

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1261,6 +1261,12 @@ export const __panelToolsTestHooks = {
   setSaveTimeoutSettleGraceMs(ms: number | null): void {
     saveTimeoutSettleGraceMsOverride = ms;
   },
+  /** Shrink the #1908 route-boundary budget for frozen-tab tests. */
+  setPanelSearchRouteTiming(
+    timing: { budgetMs: number; fallbackTriggerMs: number } | null,
+  ): void {
+    panelSearchRouteTimingOverride = timing;
+  },
   isRetrySafeCmd,
   isTransientReconnectError,
   isWorkerTransportSendError,
@@ -1284,6 +1290,24 @@ export const __panelToolsTestHooks = {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+// #1908 — `nodes_search` is a canvas-independent Manager read, but the old
+// handler still sent it through the session's bound canvas tab. A frozen tab
+// never starts the Panel-side deadline because its listener never runs, so the
+// route itself needs a finite budget and a safe same-ComfyUI fallback.
+export const PANEL_SEARCH_ROUTE_BUDGET_MS = 18_000;
+const PANEL_SEARCH_FALLBACK_TRIGGER_MS = 5_000;
+let panelSearchRouteTimingOverride: {
+  budgetMs: number;
+  fallbackTriggerMs: number;
+} | null = null;
+
+function panelSearchRouteTiming(): { budgetMs: number; fallbackTriggerMs: number } {
+  return panelSearchRouteTimingOverride ?? {
+    budgetMs: PANEL_SEARCH_ROUTE_BUDGET_MS,
+    fallbackTriggerMs: PANEL_SEARCH_FALLBACK_TRIGGER_MS,
+  };
 }
 
 // ── Post-reconnect retry-once for idempotent panel commands ──────────────────
@@ -13277,6 +13301,8 @@ interface BridgeProbe {
   isHeadless?: (tabId: string) => boolean;
   canReach?: (tabId: string) => boolean;
   tabs?: () => Array<{ tab_id: string }>;
+  liveTabIdFor?: (tabId: string) => string | undefined;
+  tabServerOrigin?: (tabId: string) => string | undefined;
   resolveActiveTabId?: () => string;
   resolveSharedTabId?: (scopeId?: string) => string | undefined;
   takeLateAskReply?: (askId: string) => unknown;
@@ -15501,6 +15527,234 @@ async function dispatchToTab(
     }
     return fail(err);
   }
+}
+
+type PanelSearchAttempt =
+  | { kind: "reply"; value: unknown }
+  | { kind: "error"; error: unknown }
+  | { kind: "timeout" };
+
+/**
+ * #1908 — bound a `nodes_search` send at the MCP route, independently of the
+ * Panel listener. The Panel's own timer is installed by that listener, so it
+ * cannot help when the bound browser tab is frozen before it handles the frame.
+ * This timer is deliberately external and every promise settles locally, so a
+ * late reply from the abandoned read cannot hold the tool open or become an
+ * unhandled rejection.
+ */
+function panelSearchAttempt(
+  ctx: PanelToolCtx,
+  tabId: string,
+  cmd: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<PanelSearchAttempt> {
+  const budget = Math.max(1, Math.floor(timeoutMs));
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const finish = (attempt: PanelSearchAttempt): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(attempt);
+    };
+    timer = setTimeout(() => finish({ kind: "timeout" }), budget);
+
+    // `bridge.send` normally rejects its own bounded timeout. The route timer
+    // above is still authoritative: it also covers a frozen-listener test seam
+    // or any future transport that never settles its send promise.
+    void Promise.resolve()
+      .then(() => ctx.bridge.send(cmd as { cmd: string }, { tabId, timeoutMs: budget }))
+      .then(
+        (value) => finish({ kind: "reply", value }),
+        (error) => finish(isReplyTimeoutTagged(error) ? { kind: "timeout" } : { kind: "error", error }),
+      );
+  });
+}
+
+/** Wait briefly for the bound tab before deciding whether a same-origin fallback is needed. */
+function waitForPanelSearchAttempt(
+  attempt: Promise<PanelSearchAttempt>,
+  timeoutMs: number,
+): Promise<{ kind: "settled"; attempt: PanelSearchAttempt } | { kind: "trigger" }> {
+  const wait = Math.max(0, Math.floor(timeoutMs));
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve({ kind: "trigger" });
+    }, wait);
+    void attempt.then((result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ kind: "settled", attempt: result });
+    });
+  });
+}
+
+function normalizedPanelSearchServerOrigin(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const origin = value.trim();
+  return origin === "" ? undefined : origin.replace(/\/+$/, "");
+}
+
+/**
+ * Pick one alternate interactive tab only when the bridge has matching,
+ * server-observed handshake-origin proof for both tabs. Client hello metadata
+ * (`tabOrigin`) is not an authorization signal and is deliberately not
+ * consulted here.
+ */
+function panelSearchFallbackTab(ctx: PanelToolCtx, boundTab: string): string | undefined {
+  const b: BridgeProbe = ctx.bridge;
+  if (
+    typeof b.tabs !== "function" ||
+    typeof b.isHeadless !== "function" ||
+    typeof b.canReach !== "function" ||
+    typeof b.tabServerOrigin !== "function"
+  ) {
+    return undefined;
+  }
+  let boundServerOrigin: string | undefined;
+  try {
+    boundServerOrigin = normalizedPanelSearchServerOrigin(b.tabServerOrigin(boundTab));
+  } catch {
+    return undefined;
+  }
+  if (!boundServerOrigin) return undefined;
+  let live: Array<{ tab_id: string }>;
+  try {
+    live = b.tabs();
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(live)) return undefined;
+
+  // `tabs()` preserves most-recent hello last; try the newest alternate first.
+  for (const tab of [...live].reverse()) {
+    const candidate = typeof tab?.tab_id === "string" ? tab.tab_id : "";
+    if (!candidate || candidate === boundTab) continue;
+    try {
+      if (b.isHeadless(candidate)) continue;
+      if (!b.canReach(candidate)) continue;
+      const candidateServerOrigin = normalizedPanelSearchServerOrigin(b.tabServerOrigin(candidate));
+      // Handshake Origin is pathless; use the existing canonical scheme/host/port
+      // comparison, which rejects malformed or DNS-ambiguous values closed.
+      if (!sameHttpOrigin(candidateServerOrigin, boundServerOrigin)) continue;
+    } catch {
+      continue;
+    }
+    return candidate;
+  }
+  return undefined;
+}
+
+function panelSearchBoundTab(ctx: PanelToolCtx): string | undefined {
+  const b: BridgeProbe = ctx.bridge;
+  try {
+    if (isScopeAddress(ctx.tabId)) return b.resolveSharedTabId?.(ctx.tabId);
+    return b.liveTabIdFor?.(ctx.tabId) ?? ctx.tabId;
+  } catch {
+    return undefined;
+  }
+}
+
+function panelSearchTimeoutResult(
+  query: string,
+  attemptedTabs: number,
+  budgetMs: number,
+): Record<string, unknown> {
+  return {
+    count: 0,
+    results: [],
+    query,
+    timed_out: true,
+    panel_unresponsive: true,
+    panel_route: attemptedTabs > 1 ? "same_comfyui_fallback_timeout" : "bound_tab_timeout",
+    timeout_ms: budgetMs,
+    reason: "No panel reply was observed before the MCP route budget expired.",
+    message:
+      "Node-registry search could not complete because the bound ComfyUI panel tab did not " +
+      "answer. This is not evidence that the requested pack is missing. The MCP route " +
+      "only retries this canvas-independent search on another tab proven to front the same " +
+      "ComfyUI instance; retry after a panel tab responds.",
+  };
+}
+
+function panelSearchAttemptResult(
+  attempt: PanelSearchAttempt,
+  query: string,
+  attemptedTabs: number,
+  budgetMs: number,
+): ToolResult {
+  if (attempt.kind === "reply") return ok(attempt.value);
+  if (attempt.kind === "error") return fail(attempt.error);
+  return ok(panelSearchTimeoutResult(query, attemptedTabs, budgetMs));
+}
+
+/**
+ * Route the Manager read with an MCP-owned deadline. Lightweight test bridges
+ * and older compatibility contexts keep the existing `ctx.call` path; the
+ * production UiBridge path is the one that can enumerate origins and safely
+ * address a second panel tab without changing the session's binding.
+ */
+async function panelSearchAtRouteBoundary(
+  ctx: PanelToolCtx,
+  cmd: Record<string, unknown>,
+  query: string,
+): Promise<ToolResult> {
+  const b: BridgeProbe = ctx.bridge;
+  const supportsRouteBoundary =
+    typeof b?.tabs === "function" &&
+    typeof b.isHeadless === "function" &&
+    typeof b.canReach === "function" &&
+    typeof b.tabServerOrigin === "function";
+  if (!supportsRouteBoundary) return ctx.call(cmd, 20000);
+
+  const boundTab = panelSearchBoundTab(ctx);
+  if (!boundTab) return ctx.call(cmd, 20000);
+
+  const timing = panelSearchRouteTiming();
+  const budgetMs = Math.max(1, Math.floor(timing.budgetMs));
+  const deadline = Date.now() + budgetMs;
+  const attemptedTabs = [boundTab];
+  const primary = panelSearchAttempt(ctx, boundTab, cmd, budgetMs);
+  const first = await waitForPanelSearchAttempt(
+    primary,
+    Math.min(budgetMs, Math.max(0, Math.floor(timing.fallbackTriggerMs))),
+  );
+  if (first.kind === "settled") {
+    return panelSearchAttemptResult(first.attempt, query, attemptedTabs.length, budgetMs);
+  }
+
+  const fallbackTab = panelSearchFallbackTab(ctx, boundTab);
+  if (!fallbackTab) {
+    return panelSearchAttemptResult(await primary, query, attemptedTabs.length, budgetMs);
+  }
+  attemptedTabs.push(fallbackTab);
+  const remaining = Math.max(1, deadline - Date.now());
+  const fallback = panelSearchAttempt(ctx, fallbackTab, cmd, remaining);
+
+  // A slow-but-alive bound tab may still answer while the alternate is probing.
+  // Prefer the first successful reply; do not let an early transport error from
+  // one tab hide a valid answer from the other.
+  const pending = new Set<Promise<PanelSearchAttempt>>([primary, fallback]);
+  let lastError: unknown;
+  let sawError = false;
+  while (pending.size > 0) {
+    const winner = await Promise.race(
+      [...pending].map(async (attempt) => ({ attempt, result: await attempt })),
+    );
+    pending.delete(winner.attempt);
+    if (winner.result.kind === "reply") return ok(winner.result.value);
+    if (winner.result.kind === "error") {
+      lastError = winner.result.error;
+      sawError = true;
+    }
+  }
+  if (sawError) return fail(lastError);
+  return ok(panelSearchTimeoutResult(query, attemptedTabs.length, budgetMs));
 }
 
 /** Re-resolve the desktop redirect target after a transient drop — returns the fresh
@@ -22178,7 +22432,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         const query = String(args.query ?? "");
         const limit = typeof args.limit === "number" ? args.limit : undefined;
         const out = await searchPanelNodes({
-          panelSearch: () => ctx.call({ cmd: "nodes_search", query, limit }, 20000),
+          // #1908 — this read is independent of the canvas, so a frozen bound
+          // tab must not own the whole bridge window. The route helper keeps
+          // the session binding unchanged and may address one same-ComfyUI
+          // interactive tab after the MCP-owned trigger deadline.
+          panelSearch: () =>
+            panelSearchAtRouteBoundary(ctx, { cmd: "nodes_search", query, limit }, query),
           query,
           limit,
         });


### PR DESCRIPTION
Companion implementation for artokun/comfyui-mcp-panel#1908. The Panel-side deadline starts only after the bound listener runs; a frozen tab can therefore hold ctx.call until the bridge timeout. This change adds an MCP-owned 18s route budget with a 5s trigger, probes one reachable interactive alternate only when both tabs have matching non-empty server-observed tabServerOrigin handshake origins, preserves ctx.tabId/session binding, and returns a structured timeout when no safe alternate answers. The client-controlled tabOrigin hello claim is deliberately ignored for authorization. Headless, unreachable, missing-proof, malformed, or mismatched candidates fail closed. Lightweight bridges without the route-proof surface retain the legacy ctx.call compatibility path. Regression coverage simulates a listener that never runs, conflicting client/server origins, candidate rejection, and missing bound proof. Files: src/orchestrator/panel-tools.ts and src/__tests__/orchestrator/panel-search-route-boundary.test.ts. Validation: npm.cmd run lint; focused route tests (3 passed); combined panel-search/panel-tools Vitest (422 passed); full npm.cmd run test:vitest (682 files, 12744 passed, 6 skipped). No init.py or apps_routes.py changes and no network operations were introduced there. Independent review required; do not merge automatically. The Panel PR remains independently gated. This companion must not close comfyui-mcp#1908, which is unrelated.