### PR TITLE
fix(panel): disclose /models vs /object_info model mismatch

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -221,6 +221,45 @@ describe("panel-tools: panel_set_widget (empty-string clear, issue #347)", () =>
   });
 });
 
+describe("panel-tools: model inventory disclosure (#2414)", () => {
+  it("adds a positive /models-vs-/object_info disclosure without retrying the write", async () => {
+    const { ctx } = makeFakeCtx();
+    const calls: Forwarded[] = [];
+    ctx.call = async (cmd) => {
+      calls.push(cmd);
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text:
+              `Error: Value "minimax_h3_video_vae_int8_convrot.safetensors" is not a valid ` +
+              `option for combo widget "vae_name". Its option list WAS read successfully ` +
+              `and holds 22 options, none of them this value.`,
+          },
+        ],
+      };
+    };
+    ctx.modelInventoryDisclosure = async (widget, value, refusalText) => {
+      expect(widget).toBe("vae_name");
+      expect(value).toBe("minimax_h3_video_vae_int8_convrot.safetensors");
+      expect(refusalText).toContain("option list WAS read successfully");
+      return "\n\nModel inventory disclosure: /models/vae includes the value; /object_info does not.";
+    };
+
+    const res = (await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "vae_name", value: "minimax_h3_video_vae_int8_convrot.safetensors" },
+      ctx,
+    )) as ToolResult;
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]).toMatchObject({ type: "text" });
+    expect((res.content[0] as { text: string }).text).toContain("Model inventory disclosure");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ cmd: "graph_set_widget", widget: "vae_name" });
+  });
+});
+
 describe("panel-tools: fresh /object_info ack timeout (#599)", () => {
   // The refresh-before-validate FRONTEND handlers (graph_set_widget #338/#458,
   // graph_add_node #289/#458) await an authoritative /object_info fetch before

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -222,24 +222,26 @@ describe("panel-tools: panel_set_widget (empty-string clear, issue #347)", () =>
 });
 
 describe("panel-tools: model inventory disclosure (#2414)", () => {
-  it("adds a positive /models-vs-/object_info disclosure without retrying the write", async () => {
+  const COMBO_REFUSAL =
+    `Error: Value "minimax_h3_video_vae_int8_convrot.safetensors" is not a valid ` +
+    `option for combo widget "vae_name". Its option list WAS read successfully ` +
+    `and holds 22 options, none of them this value.`;
+
+  function comboRefusalCtx() {
     const { ctx } = makeFakeCtx();
     const calls: Forwarded[] = [];
     ctx.call = async (cmd) => {
       calls.push(cmd);
       return {
         isError: true,
-        content: [
-          {
-            type: "text",
-            text:
-              `Error: Value "minimax_h3_video_vae_int8_convrot.safetensors" is not a valid ` +
-              `option for combo widget "vae_name". Its option list WAS read successfully ` +
-              `and holds 22 options, none of them this value.`,
-          },
-        ],
+        content: [{ type: "text", text: COMBO_REFUSAL }],
       };
     };
+    return { ctx, calls };
+  }
+
+  it("adds a positive /models-vs-/object_info disclosure without retrying the write", async () => {
+    const { ctx, calls } = comboRefusalCtx();
     ctx.modelInventoryDisclosure = async (widget, value, refusalText) => {
       expect(widget).toBe("vae_name");
       expect(value).toBe("minimax_h3_video_vae_int8_convrot.safetensors");
@@ -254,9 +256,50 @@ describe("panel-tools: model inventory disclosure (#2414)", () => {
 
     expect(res.isError).toBe(true);
     expect(res.content[0]).toMatchObject({ type: "text" });
+    expect((res.content[0] as { text: string }).text).toContain(COMBO_REFUSAL);
     expect((res.content[0] as { text: string }).text).toContain("Model inventory disclosure");
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({ cmd: "graph_set_widget", widget: "vae_name" });
+  });
+
+  it("keeps the original refusal when the live listing is inconclusive or the probe throws", async () => {
+    const { ctx, calls } = comboRefusalCtx();
+    ctx.modelInventoryDisclosure = async () => null;
+
+    const silent = (await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "vae_name", value: "minimax_h3_video_vae_int8_convrot.safetensors" },
+      ctx,
+    )) as ToolResult;
+    expect(silent.isError).toBe(true);
+    expect((silent.content[0] as { text: string }).text).toBe(COMBO_REFUSAL);
+
+    ctx.modelInventoryDisclosure = async () => {
+      throw new Error("listing exploded");
+    };
+    const thrown = (await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "vae_name", value: "minimax_h3_video_vae_int8_convrot.safetensors" },
+      ctx,
+    )) as ToolResult;
+    expect(thrown.isError).toBe(true);
+    expect((thrown.content[0] as { text: string }).text).toBe(COMBO_REFUSAL);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("does not invent a disclosure from the shipped default probe when /models cannot corroborate", async () => {
+    const { ctx, calls } = comboRefusalCtx();
+    const res = (await defByName("panel_set_widget").handler(
+      {
+        node_id: 39,
+        widget: "vae_name",
+        value: "issue-2414-absent-from-object-info.safetensors",
+      },
+      ctx,
+    )) as ToolResult;
+
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toBe(COMBO_REFUSAL);
+    expect((res.content[0] as { text: string }).text).not.toContain("Model inventory disclosure");
+    expect(calls).toHaveLength(1);
   });
 });
 

--- a/src/__tests__/services/model-inventory-disclosure.test.ts
+++ b/src/__tests__/services/model-inventory-disclosure.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getModelInventoryDisclosure,
+  isReadableComboValueRefusal,
+} from "../../services/model-inventory-disclosure.js";
+
+const REFUSAL =
+  `Error: Value "models\\video\\minimax_h3_video_vae_int8_convrot.safetensors" is ` +
+  `not a valid option for combo widget "vae_name". Its option list WAS read ` +
+  `successfully and holds 22 options, none of them this value.`;
+
+describe("model inventory disclosure (#2414)", () => {
+  it("discloses a live /models hit without claiming /object_info availability", async () => {
+    const listCategory = vi.fn(async (category: string, options?: { timeoutMs?: number }) => {
+      expect(category).toBe("vae");
+      expect(options?.timeoutMs).toBe(2000);
+      return ["models/video/minimax_h3_video_vae_int8_convrot.safetensors"];
+    });
+
+    const note = await getModelInventoryDisclosure(
+      "vae_name",
+      "models\\video\\minimax_h3_video_vae_int8_convrot.safetensors",
+      REFUSAL,
+      listCategory,
+    );
+
+    expect(note).toContain("/models/vae");
+    expect(note).toContain("/object_info");
+    expect(note).toContain("does not establish");
+    expect(note).toContain("Nothing was written");
+    expect(note).not.toContain("filesystem");
+    expect(note).not.toContain("available to load");
+  });
+
+  it("stays silent when the live listing is absent, inconclusive, or does not contain the value", async () => {
+    for (const listing of [[], undefined]) {
+      await expect(
+        getModelInventoryDisclosure("vae_name", "missing.safetensors", REFUSAL, async () => listing),
+      ).resolves.toBeNull();
+    }
+    await expect(
+      getModelInventoryDisclosure(
+        "vae_name",
+        "present.safetensors",
+        REFUSAL,
+        async () => {
+          throw new Error("endpoint unavailable");
+        },
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("does not classify unreadable combos or ambiguous widget names as a cache mismatch", async () => {
+    expect(isReadableComboValueRefusal('The combo "vae_name" has an EMPTY option list')).toBe(false);
+    expect(isReadableComboValueRefusal("The value is not in this combo's current option list")).toBe(
+      false,
+    );
+
+    const listCategory = vi.fn(async () => ["model.safetensors"]);
+    await expect(
+      getModelInventoryDisclosure("model_name", "model.safetensors", REFUSAL, listCategory),
+    ).resolves.toBeNull();
+    await expect(
+      getModelInventoryDisclosure("toString", "model.safetensors", REFUSAL, listCategory),
+    ).resolves.toBeNull();
+    expect(listCategory).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/services/model-inventory-disclosure.test.ts
+++ b/src/__tests__/services/model-inventory-disclosure.test.ts
@@ -95,7 +95,8 @@ describe("model inventory disclosure (#2414)", () => {
   it("matches a live listing by normalized path and ignores non-string entries", async () => {
     const listCategory = vi.fn(async (category: string) => {
       expect(category).toBe("checkpoints");
-      return [12, "./models\\video\\present.safetensors"] as unknown as string[];
+      const mixed: Array<number | string> = [12, "./models\\video\\present.safetensors"];
+      return mixed as string[];
     });
 
     const note = await getModelInventoryDisclosure(

--- a/src/__tests__/services/model-inventory-disclosure.test.ts
+++ b/src/__tests__/services/model-inventory-disclosure.test.ts
@@ -51,6 +51,7 @@ describe("model inventory disclosure (#2414)", () => {
   });
 
   it("does not classify unreadable combos or ambiguous widget names as a cache mismatch", async () => {
+    expect(isReadableComboValueRefusal(REFUSAL)).toBe(true);
     expect(isReadableComboValueRefusal('The combo "vae_name" has an EMPTY option list')).toBe(false);
     expect(isReadableComboValueRefusal("The value is not in this combo's current option list")).toBe(
       false,
@@ -58,11 +59,54 @@ describe("model inventory disclosure (#2414)", () => {
 
     const listCategory = vi.fn(async () => ["model.safetensors"]);
     await expect(
+      getModelInventoryDisclosure(
+        "vae_name",
+        "model.safetensors",
+        'The combo "vae_name" has an EMPTY option list',
+        listCategory,
+      ),
+    ).resolves.toBeNull();
+    await expect(
       getModelInventoryDisclosure("model_name", "model.safetensors", REFUSAL, listCategory),
     ).resolves.toBeNull();
     await expect(
       getModelInventoryDisclosure("toString", "model.safetensors", REFUSAL, listCategory),
     ).resolves.toBeNull();
     expect(listCategory).not.toHaveBeenCalled();
+  });
+
+  it("stays silent for empty or non-string widget/value inputs", async () => {
+    const listCategory = vi.fn(async () => ["present.safetensors"]);
+    await expect(
+      getModelInventoryDisclosure("", "present.safetensors", REFUSAL, listCategory),
+    ).resolves.toBeNull();
+    await expect(
+      getModelInventoryDisclosure("vae_name", "", REFUSAL, listCategory),
+    ).resolves.toBeNull();
+    await expect(
+      getModelInventoryDisclosure(undefined, "present.safetensors", REFUSAL, listCategory),
+    ).resolves.toBeNull();
+    await expect(
+      getModelInventoryDisclosure("vae_name", undefined, REFUSAL, listCategory),
+    ).resolves.toBeNull();
+    expect(listCategory).not.toHaveBeenCalled();
+  });
+
+  it("matches a live listing by normalized path and ignores non-string entries", async () => {
+    const listCategory = vi.fn(async (category: string) => {
+      expect(category).toBe("checkpoints");
+      return [12, "./models\\video\\present.safetensors"] as unknown as string[];
+    });
+
+    const note = await getModelInventoryDisclosure(
+      "ckpt_name",
+      "models/video/present.safetensors",
+      REFUSAL.replace("vae_name", "ckpt_name"),
+      listCategory,
+    );
+
+    expect(note).toContain("/models/checkpoints");
+    expect(note).toContain("models/video/present.safetensors");
+    expect(note).toContain("Nothing was written");
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -57,6 +57,10 @@ import {
   findPackOnDisk,
   nodesInstallCommandArgs,
 } from "../services/node-management.js";
+import {
+  getModelInventoryDisclosure,
+  type ModelInventoryDisclosureProbe,
+} from "../services/model-inventory-disclosure.js";
 import { sanitizePanelUpdateNodeResult } from "../services/manager-update-error.js";
 import {
   formatQueueStatusPartialNote,
@@ -5513,6 +5517,29 @@ const SAVE_AS_NAME_CONFLICT_NOTE =
 function withSaveAsNameConflictNote(res: ToolResult): ToolResult {
   if (!isSaveAsNameConflict(res)) return res;
   return appendToolResultText(res, SAVE_AS_NAME_CONFLICT_NOTE);
+}
+
+/**
+ * #2414 — a live `/models/<category>` hit does not reconcile the panel's
+ * `/object_info` combo cache. Add the distinction only when both sides are
+ * positively observed; an unavailable listing remains an ordinary refusal.
+ */
+async function withModelInventoryDisclosure(
+  res: ToolResult,
+  widget: unknown,
+  value: unknown,
+  ctx: PanelToolCtx,
+): Promise<ToolResult> {
+  if (!res.isError) return res;
+  const probe = ctx.modelInventoryDisclosure ?? getModelInventoryDisclosure;
+  try {
+    const disclosure = await probe(widget, value, textOfToolResult(res));
+    return disclosure ? appendToolResultText(res, disclosure) : res;
+  } catch {
+    // The disclosure is advisory. Preserve the original panel refusal if its
+    // read-only corroboration fails for any reason.
+    return res;
+  }
 }
 
 // ---- #1695: bound the panel_set_widget previous/new echo --------------------
@@ -13319,6 +13346,8 @@ export interface PanelToolCtx {
   /** Notifies the completion watchdog when panel_run opens a ticket after a
    * fast completion was already observed. Optional for lightweight contexts. */
   onRunTicketOpened?: (promptIds: readonly string[]) => void;
+  /** Optional test seam for the read-only /models-vs-/object_info disclosure. */
+  modelInventoryDisclosure?: ModelInventoryDisclosureProbe;
   /** Per-tab workflow pin store (optional for tests). */
   workflowTarget?: WorkflowTargetStore;
   /**
@@ -18402,7 +18431,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           textOfToolResult(first),
           args.widget as string,
         );
-        if (!refusal || String(refusal.nodeId) !== String(args.node_id)) return first;
+        if (!refusal || String(refusal.nodeId) !== String(args.node_id)) {
+          return withModelInventoryDisclosure(first, args.widget, value, ctx);
+        }
 
         if (refusal.widget !== args.widget) {
           const remapped = await guardedWrite(args.node_id, refusal.widget);

--- a/src/services/model-inventory-disclosure.ts
+++ b/src/services/model-inventory-disclosure.ts
@@ -1,0 +1,108 @@
+import {
+  liveCategoryListing,
+  type LiveCategoryListingOptions,
+} from "./model-resolver.js";
+
+/** Only widget names whose model directory is unambiguous in current ComfyUI APIs. */
+const MODEL_CATEGORY_BY_WIDGET: Readonly<Record<string, string>> = Object.freeze({
+  ckpt_name: "checkpoints",
+  lora_name: "loras",
+  vae_name: "vae",
+  unet_name: "diffusion_models",
+  diffusion_model: "diffusion_models",
+  control_net_name: "controlnet",
+  controlnet_name: "controlnet",
+  clip_name: "text_encoders",
+  clip_name1: "text_encoders",
+  clip_name2: "text_encoders",
+  clip_name3: "text_encoders",
+  clip_name4: "text_encoders",
+  style_model_name: "style_models",
+  embedding_name: "embeddings",
+  gligen_name: "gligen",
+  hypernetwork_name: "hypernetworks",
+});
+
+const MODEL_INVENTORY_DISCLOSURE_TIMEOUT_MS = 2000;
+
+export type ModelInventoryDisclosureProbe = (
+  widget: unknown,
+  value: unknown,
+  refusalText: string,
+) => Promise<string | null>;
+
+type CategoryListing = (
+  category: string,
+  options?: LiveCategoryListingOptions,
+) => Promise<string[] | undefined>;
+
+function normalizeInventoryEntry(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\.?\//, "");
+}
+
+/**
+ * Current panel_set_widget refusals distinguish a real, readable combo list
+ * from an empty/unreadable list. Only the former can establish this mismatch.
+ */
+export function isReadableComboValueRefusal(refusalText: unknown): boolean {
+  if (typeof refusalText !== "string") return false;
+  return (
+    /not a valid option for combo widget/i.test(refusalText) &&
+    /option list was read successfully/i.test(refusalText) &&
+    /none of them this value/i.test(refusalText)
+  );
+}
+
+/**
+ * Compare the panel's strict combo refusal with the connected ComfyUI's live
+ * `/models/<category>` listing. `undefined` is deliberately inconclusive: an
+ * unavailable or non-enumerable endpoint must never become a mismatch claim.
+ */
+export async function getModelInventoryDisclosure(
+  widget: unknown,
+  value: unknown,
+  refusalText: string,
+  listCategory: CategoryListing = (category, options) =>
+    liveCategoryListing(category, options),
+): Promise<string | null> {
+  if (!isReadableComboValueRefusal(refusalText)) return null;
+  if (typeof widget !== "string") return null;
+  if (typeof value !== "string" || value.length === 0) return null;
+
+  const category = Object.prototype.hasOwnProperty.call(MODEL_CATEGORY_BY_WIDGET, widget)
+    ? MODEL_CATEGORY_BY_WIDGET[widget]
+    : undefined;
+  if (!category) return null;
+
+  let listing: string[] | undefined;
+  try {
+    listing = await listCategory(category, {
+      timeoutMs: MODEL_INVENTORY_DISCLOSURE_TIMEOUT_MS,
+    });
+  } catch {
+    return null;
+  }
+  if (!listing) return null;
+
+  const normalizedValue = normalizeInventoryEntry(value);
+  if (
+    !listing.some(
+      (entry) =>
+        typeof entry === "string" && normalizeInventoryEntry(entry) === normalizedValue,
+    )
+  ) {
+    return null;
+  }
+
+  return (
+    `\n\nModel inventory disclosure: the connected ComfyUI's "/models/${category}" ` +
+    `listing includes "${value}", but the panel's refreshed "/object_info" combo ` +
+    `did not. These are different server surfaces: "/models" visibility does not ` +
+    `establish "/object_info" availability, and the panel cannot make the server ` +
+    `rescan its model filename cache. Nothing was written. This comparison assumes ` +
+    `the MCP and panel target the same ComfyUI instance; verify that if they may differ. ` +
+    `Restart ComfyUI, or use a server-side cache-refresh mechanism provided by your ` +
+    `ComfyUI build. After "/object_info" includes the value, call panel_refresh_nodes ` +
+    `and retry.`
+  );
+}

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1092,13 +1092,23 @@ function subfolderRemainder(targetSubfolder: string): string {
  * the contract speaking, not the server's contents). Callers must treat
  * inconclusive as "no evidence", never as "no files".
  */
+export type LiveCategoryListingOptions = {
+  /** Optional bound for callers that are already inside a user-facing deadline. */
+  timeoutMs?: number;
+};
+
 export async function liveCategoryListing(
   category: string,
+  options: LiveCategoryListingOptions = {},
 ): Promise<string[] | undefined> {
   if (!category) return undefined;
   if (categoryCannotEnumerateFiles(category)) return undefined;
   try {
-    const res = await comfyApiFetch(`/models/${encodeURIComponent(category)}`);
+    const init =
+      options.timeoutMs === undefined
+        ? undefined
+        : { signal: AbortSignal.timeout(options.timeoutMs) };
+    const res = await comfyApiFetch(`/models/${encodeURIComponent(category)}`, init);
     if (!res.ok) return undefined;
     const json = (await res.json()) as unknown;
     if (!Array.isArray(json)) return undefined;


### PR DESCRIPTION
Closes #2414. Correlates strict readable panel_set_widget combo refusals with positive live /models/<category> listings for unambiguous loader widgets. Preserves the refusal, discloses that /models visibility does not establish /object_info availability, does not retry or invent a server rescan, and treats absent, unreadable, empty, ambiguous, and non-enumerable cases as inconclusive. Verification on current main: focused Vitest 2 files / 421 tests passed; npm.cmd run build passed; git diff --check passed. Root dirty files were not touched; init.py and apps_routes.py unchanged.