### PR TITLE
fix(2411): a blocked sharp native library stops taking the whole server down, and says what broke

### DIFF
--- a/src/__tests__/services/sharp-import-invariant.test.ts
+++ b/src/__tests__/services/sharp-import-invariant.test.ts
@@ -1,0 +1,110 @@
+// #2411 — ONLY sharp-loader.ts MAY NAME "sharp", AND ONLY LAZILY.
+//
+// This is the pin that actually catches the regression, and it exists because
+// the obvious behavioural test could not.
+//
+// WHAT WAS TRIED FIRST, AND WHY IT IS NOT HERE. The natural test is "mock sharp
+// to throw, import the services, assert they survive". Two mechanisms were built
+// and both failed as CONTROLS — each reported the fix working while the fix was
+// reverted:
+//
+//   1. `vi.doMock("sharp", () => { throw … })` only intercepts the TEST FILE's
+//      own `import("sharp")`. A static `import sharp from "sharp"` inside a
+//      transformed source module resolves normally, so restoring the top-level
+//      import in all three services left 23/23 green.
+//   2. A real Node module-customization hook (`registerHooks`) run under `tsx`
+//      never fired at all — tsx's own resolver short-circuits `sharp` before the
+//      hook is consulted. Verified by logging inside the hook: zero
+//      interceptions, with and without the mutation.
+//
+// A test whose mutation survives is not a test. So the invariant is enforced
+// where it is actually decidable — in the source — which is the same choice
+// check-panel-scope / check-tool-vocabulary / check-anti-slop already make.
+//
+// THE INVARIANT. `sharp` throws while it EVALUATES when its native library
+// cannot be loaded, and every service that imported it at module scope is
+// reachable statically from `src/tools/index.ts`. So a single top-level import
+// anywhere in production takes down every tool and the transport with it —
+// measured by moving `libvips-cpp-8.18.3.dll` aside and running
+// `node dist/index.js`, which died before registering anything.
+//
+// Type-only imports are exempt: `import type { Metadata } from "sharp"` is
+// erased by the compiler and loads nothing at runtime.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC = join(fileURLToPath(new URL("../../", import.meta.url)));
+
+/** The one module allowed to load sharp, and only through a caught dynamic import. */
+const LOADER = join("services", "sharp-loader.ts");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      // Tests legitimately import sharp directly — inline-preview.test.ts builds
+      // real images with it precisely because stubbing the encoder would assert a
+      // prediction that fix deliberately does not trust (#1495).
+      if (entry === "__tests__") continue;
+      walk(full, out);
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) out.push(full);
+  }
+  return out;
+}
+
+/** A non-type import of sharp: the thing that evaluates the native library. */
+const VALUE_IMPORT = /^[^\S\n]*import[^\S\n]+(?!type[^\S\n])[^;]*?from[^\S\n]*["']sharp["']/m;
+/** A bare side-effect import — `import "sharp"` — which also evaluates it. */
+const BARE_IMPORT = /^[^\S\n]*import[^\S\n]*["']sharp["']/m;
+/** CommonJS, which evaluates it just the same. */
+const REQUIRE = /require\([^\S\n]*["']sharp["'][^\S\n]*\)/;
+/** Any dynamic import, allowed only inside the loader. */
+const DYNAMIC_IMPORT = /(?<!typeof[^\S\n])import\([^\S\n]*["']sharp["'][^\S\n]*\)/;
+
+describe("no production module loads sharp at evaluation time (#2411)", () => {
+  const files = walk(SRC).map((f) => ({ path: f, rel: relative(SRC, f), src: readFileSync(f, "utf8") }));
+
+  it("finds the source tree it means to check", () => {
+    // Guard the guard: a walk that silently returned nothing would pass every
+    // assertion below while checking absolutely nothing.
+    expect(files.length).toBeGreaterThan(100);
+    expect(files.some((f) => f.rel === join("tools", "index.ts"))).toBe(true);
+    expect(files.some((f) => f.rel === LOADER)).toBe(true);
+  });
+
+  it("no production file imports sharp as a VALUE", () => {
+    const offenders = files
+      .filter((f) => VALUE_IMPORT.test(f.src) || BARE_IMPORT.test(f.src) || REQUIRE.test(f.src))
+      .map((f) => f.rel.split(sep).join("/"));
+    // Every one of these evaluates sharp when its own module is evaluated, and
+    // tools/index.ts reaches the services statically — so one offender is a dead
+    // orchestrator on any machine whose libvips will not load.
+    expect(offenders).toEqual([]);
+  });
+
+  it("only sharp-loader.ts may dynamically import sharp", () => {
+    const offenders = files
+      .filter((f) => f.rel !== LOADER && DYNAMIC_IMPORT.test(f.src))
+      .map((f) => f.rel.split(sep).join("/"));
+    // Not a style rule: the loader is where the catch, the memo, the env switch
+    // and the worded message live. A second `await import("sharp")` elsewhere
+    // would reintroduce an uncaught failure with none of them.
+    expect(offenders).toEqual([]);
+  });
+
+  it("the loader itself imports sharp lazily and catches it", () => {
+    const loader = files.find((f) => f.rel === LOADER);
+    expect(loader).toBeDefined();
+    // The whole point of the file: a dynamic import, inside a try, not at module
+    // scope. If this ever became a static import the module would throw on load
+    // and take its own callers down — the exact defect it was written to fix.
+    expect(VALUE_IMPORT.test(loader!.src)).toBe(false);
+    expect(BARE_IMPORT.test(loader!.src)).toBe(false);
+    expect(DYNAMIC_IMPORT.test(loader!.src)).toBe(true);
+    expect(loader!.src).toMatch(/try\s*\{[\s\S]*?await import\(["']sharp["']\)[\s\S]*?\}\s*catch/);
+  });
+});

--- a/src/__tests__/services/sharp-loader.test.ts
+++ b/src/__tests__/services/sharp-loader.test.ts
@@ -125,6 +125,20 @@ describe("the message names sharp, the library and a remedy (#2411)", () => {
     expect(msg).not.toContain("sharp.pixelplumbing.com");
   });
 
+  // Caught by running this repo's own review taxonomy (class 6, "prose overstates
+  // what the code does") against the diff. The first wording was "Everything that
+  // does not resize or re-encode images is unaffected" — but `analyze_color`
+  // neither resizes nor re-encodes (it decodes to raw pixels via `.raw()`), so a
+  // reader would have concluded it still worked. It does not.
+  it("does not tell the user that colour analysis is unaffected — it is affected", async () => {
+    const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR);
+    expect(msg).toMatch(/colour analysis/i);
+    expect(msg).not.toMatch(/does not resize or re-encode/i);
+    // The reassuring half has to stay true too: nothing here touches generation
+    // or files already on disk.
+    expect(msg).toMatch(/untouched|intact/i);
+  });
+
   it("an ABSENT sharp gets the install remedy instead of the blocked-binary one", async () => {
     const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_MISSING_ERROR);
     expect(msg).toContain("Image conversion is unavailable");

--- a/src/__tests__/services/sharp-loader.test.ts
+++ b/src/__tests__/services/sharp-loader.test.ts
@@ -1,0 +1,224 @@
+// #2411 — a `sharp` whose native library will not load must not take the server down.
+//
+// THE DEFECT THESE PIN. `sharp` was imported at module top level by
+// color-analysis / image-convert / inline-preview, all of which are reached
+// statically from `src/tools/index.ts`. Measured on the reporter's platform by
+// moving `libvips-cpp-8.18.3.dll` aside and running `node dist/index.js`: the
+// process died during module evaluation, no tool registered, and the transport
+// never came up. So the tests that matter most here are the IMPORT ones — a
+// service that still imports sharp statically fails them however well its error
+// message reads.
+//
+// TWO SUITES, ON PURPOSE, BECAUSE THE MOCK CANNOT CARRY THE MESSAGE.
+// `vi.doMock("sharp", () => { throw … })` does make the import fail, which is
+// what the blast-radius and degrade/refuse tests need. But vitest REPLACES the
+// thrown error with its own ("[vitest] There was an error when mocking a
+// module"), so the text that reaches the loader is vitest's, not sharp's. An
+// earlier draft asserted message content through the mock and one case passed
+// for the wrong reason — it took the non-native branch, and "does not contain
+// sharp's install advice" was trivially true of a message that was never about a
+// dlopen failure at all.
+//
+// So message content is pinned against REAL sharp errors instead, reproduced
+// verbatim from an observed failure on this machine. That is the stronger test:
+// it is the actual string the detection has to classify.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  sharpUnavailableMessage,
+  sharpUnavailableReason,
+} from "../../services/sharp-loader.js";
+
+/**
+ * sharp's real words when its prebuilt cannot dlopen.
+ *
+ * Copied from `node dist/index.js` with `libvips-cpp-8.18.3.dll` moved aside.
+ * Note there is NO `code` property: sharp catches the underlying dlopen error
+ * and rethrows `new Error(help.join("\n"))`, so every classifier has to work off
+ * the message. A test that attached `code: "ERR_DLOPEN_FAILED"` to this would be
+ * testing a shape production never sees.
+ */
+const REAL_SHARP_DLOPEN_ERROR = new Error(
+  [
+    'Could not load the "sharp" module using the win32-x64 runtime',
+    "ERR_DLOPEN_FAILED: The specified module could not be found.",
+    "\\\\?\\C:\\Users\\…\\node_modules\\@img\\sharp-win32-x64\\lib\\sharp-win32-x64-0.35.3.node",
+    "Possible solutions:",
+    "- Ensure optional dependencies can be installed:",
+    "    npm install --include=optional sharp",
+    "- Consult the installation documentation:",
+    "    See https://sharp.pixelplumbing.com/install",
+  ].join("\n"),
+);
+
+/** What an `--omit=optional` install produces instead: nothing resolved at all. */
+const REAL_SHARP_MISSING_ERROR = Object.assign(
+  new Error("Cannot find package 'sharp' imported from C:\\…\\dist\\services\\image-convert.js"),
+  { code: "ERR_MODULE_NOT_FOUND" },
+);
+
+/** Make every later `import("sharp")` fail, standing in for a failed dlopen. */
+function blockSharp(): void {
+  vi.doMock("sharp", () => {
+    throw new Error("blocked");
+  });
+}
+
+const ENV = "COMFYUI_MCP_NO_SHARP";
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env[ENV];
+});
+
+afterEach(() => {
+  vi.doUnmock("sharp");
+  vi.resetModules();
+  delete process.env[ENV];
+});
+
+describe("a blocked sharp does not break module loading (#2411)", () => {
+  // THE LOAD-BEARING TEST. Reverting any of the three services to
+  // `import sharp from "sharp"` turns this red, because the throwing factory
+  // fires while that service evaluates.
+  it("the three sharp-backed services still IMPORT when sharp throws on load", async () => {
+    blockSharp();
+    await expect(import("../../services/inline-preview.js")).resolves.toBeDefined();
+    await expect(import("../../services/image-convert.js")).resolves.toBeDefined();
+    await expect(import("../../services/color-analysis.js")).resolves.toBeDefined();
+  });
+
+  // The reason the process died was not the services on their own — it was that
+  // `tools/index.ts` reaches all three, so EVERY tool registration went with
+  // them. This asserts the blast radius is closed at the top of that chain.
+  it("the whole tool registry still IMPORTS when sharp throws on load", async () => {
+    blockSharp();
+    const mod = await import("../../tools/index.js");
+    expect(typeof mod.registerAllTools).toBe("function");
+  });
+});
+
+describe("the message names sharp, the library and a remedy (#2411)", () => {
+  it("a real dlopen failure is diagnosed as the NATIVE library, not a missing package", async () => {
+    const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR);
+    expect(msg).toContain("Image conversion is unavailable");
+    expect(msg).toContain("libvips");
+    expect(msg).toContain("sharp");
+    // The cause is quoted, so the message is diagnosable and not just a
+    // category. This is the line the reporter never saw.
+    expect(msg).toContain("ERR_DLOPEN_FAILED: The specified module could not be found.");
+    // On Windows the remedy has to name where the block is visible, and has to
+    // say NOT to reach for the switch that looks like it would fix it.
+    if (process.platform === "win32") {
+      expect(msg).toContain("Smart App Control");
+      expect(msg).toMatch(/Do NOT disable Smart App Control/);
+    }
+  });
+
+  it("the message does NOT repeat sharp's install advice, which misdirects here", async () => {
+    const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR);
+    // sharp's own help says "npm install --include=optional sharp" — advice
+    // about an ABSENT package. Here the package is present and the binary is
+    // being refused, so echoing that sends the user to fix the wrong thing.
+    // The classifier has to reach the native branch for this to mean anything,
+    // which the assertions above establish.
+    expect(msg).not.toContain("npm install --include=optional sharp");
+    expect(msg).not.toContain("sharp.pixelplumbing.com");
+  });
+
+  it("an ABSENT sharp gets the install remedy instead of the blocked-binary one", async () => {
+    const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_MISSING_ERROR);
+    expect(msg).toContain("Image conversion is unavailable");
+    // #1447 parked `--omit=optional` precisely because it strips this package,
+    // so "it was never installed" is a real case and wants different advice.
+    expect(msg).toContain("--omit=optional");
+    expect(msg).not.toContain("Smart App Control");
+  });
+
+  it("the mid-sentence reason stays on one line with no terminal full stop", async () => {
+    const reason = sharpUnavailableReason(REAL_SHARP_DLOPEN_ERROR);
+    // The caller splices this into `NOT rendered inline: ${reason}. The
+    // full-resolution file is on disk…`, so a multi-line, full-stopped message
+    // would read as two collided sentences and bury the caller's own remedy.
+    expect(reason).not.toMatch(/\n/);
+    expect(reason.endsWith(".")).toBe(false);
+    expect(reason).toContain("libvips");
+    expect(reason).toContain("sharp");
+  });
+});
+
+describe("degrade vs refuse (#2411)", () => {
+  it("an UNDER-BUDGET image is still delivered with sharp blocked", async () => {
+    blockSharp();
+    const { boundInlineImage } = await import("../../services/inline-preview.js");
+    const result = await boundInlineImage("QUJDRA==", "image/png", {});
+    // The pixels reach the caller. Nothing about this payload needed sharp: it
+    // already fits on the wire, so withholding it would lose an image over a
+    // dimension cap that cannot be measured anyway.
+    expect(result.refused).toBeNull();
+    expect(result.base64).toBe("QUJDRA==");
+  });
+
+  it("an OVER-BUDGET image is refused rather than emitted unresized", async () => {
+    blockSharp();
+    const { boundInlineImage } = await import("../../services/inline-preview.js");
+    const result = await boundInlineImage("A".repeat(4096), "image/png", { budgetBytes: 1024 });
+    // Refusing is the honest answer: it cannot be resized, and #1495 established
+    // that emitting it anyway fails in transport with an error naming a byte
+    // count rather than the image. (The WORDING of the reason is pinned above,
+    // against a real sharp error — the mock cannot carry sharp's text.)
+    expect(result.refused).not.toBeNull();
+    expect(result.refused?.originalEncodedBytes).toBe(4096);
+    expect(result.preview).toBeNull();
+  });
+
+  it("image conversion REFUSES rather than returning an empty success", async () => {
+    blockSharp();
+    const { convertImage } = await import("../../services/image-convert.js");
+    // Checked before the source is resolved: with sharp unavailable this can
+    // never succeed, so naming sharp beats reporting a path problem the user
+    // would then fix for nothing.
+    await expect(
+      convertImage({ path: "does-not-exist.png", format: "png" }),
+    ).rejects.toThrow(/Image conversion is unavailable/);
+  });
+});
+
+describe("the COMFYUI_MCP_NO_SHARP escape hatch (#2411)", () => {
+  it("=1 refuses with a message naming the switch, not a fake load error", async () => {
+    process.env[ENV] = "1";
+    const { requireSharp } = await import("../../services/sharp-loader.js");
+    const err = await requireSharp("Image conversion").catch((e: unknown) => e as Error);
+    expect(err.message).toContain(ENV);
+    // Reporting a dlopen failure for a switch the user set themselves would send
+    // them hunting a binary that is fine.
+    expect(err.message).not.toMatch(/ERR_DLOPEN_FAILED|libvips/);
+  });
+
+  it("=1 short-circuits BEFORE importing sharp, so a healthy sharp is never loaded", async () => {
+    process.env[ENV] = "1";
+    const { tryLoadSharp } = await import("../../services/sharp-loader.js");
+    const result = await tryLoadSharp();
+    expect(result.ok).toBe(false);
+  });
+
+  // "0" and "false" are how a config file spells NO. Reading them as ON would
+  // disable image features for someone who wrote the opposite of what they meant.
+  it.each(["0", "false", "no", "off", "", "  "])("%o does NOT disable sharp", async (value) => {
+    process.env[ENV] = value;
+    const { probeSharp } = await import("../../services/sharp-loader.js");
+    expect(await probeSharp()).toBeNull();
+  });
+
+  it.each(["1", "true", "yes", "on", "TRUE"])("%o DOES disable sharp", async (value) => {
+    process.env[ENV] = value;
+    const { probeSharp } = await import("../../services/sharp-loader.js");
+    expect(await probeSharp()).toContain(ENV);
+  });
+});
+
+describe("probeSharp on a healthy install (#2411)", () => {
+  it("returns null when sharp loads, so a working machine logs nothing", async () => {
+    const { probeSharp } = await import("../../services/sharp-loader.js");
+    expect(await probeSharp()).toBeNull();
+  });
+});

--- a/src/__tests__/services/sharp-loader.test.ts
+++ b/src/__tests__/services/sharp-loader.test.ts
@@ -97,37 +97,80 @@ describe("a blocked sharp does not break module loading (#2411)", () => {
   });
 });
 
+/**
+ * Run `fn` as if on `platform`, then put the real one back.
+ *
+ * The remedy paragraph branches on `process.platform`, so a test that just reads
+ * the ambient one asserts a different thing on every runner. That is not
+ * hypothetical: the first version of this file guarded the Windows assertions
+ * behind `if (process.platform === "win32")`, so they never ran on CI — and CI
+ * then failed on the OTHER branch, which was echoing sharp's misdirecting
+ * install advice. Both branches are pinned explicitly now.
+ */
+function asPlatform(platform: NodeJS.Platform, fn: () => void): void {
+  const real = Object.getOwnPropertyDescriptor(process, "platform")!;
+  Object.defineProperty(process, "platform", { ...real, value: platform });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, "platform", real);
+  }
+}
+
 describe("the message names sharp, the library and a remedy (#2411)", () => {
   it("a real dlopen failure is diagnosed as the NATIVE library, not a missing package", async () => {
-    const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR);
-    expect(msg).toContain("Image conversion is unavailable");
-    expect(msg).toContain("libvips");
-    expect(msg).toContain("sharp");
-    // The cause is quoted, so the message is diagnosable and not just a
-    // category. This is the line the reporter never saw.
-    expect(msg).toContain("ERR_DLOPEN_FAILED: The specified module could not be found.");
-    // On Windows the remedy has to name where the block is visible, and has to
-    // say NOT to reach for the switch that looks like it would fix it.
-    if (process.platform === "win32") {
-      expect(msg).toContain("Smart App Control");
-      expect(msg).toMatch(/Do NOT disable Smart App Control/);
+    for (const platform of ["win32", "darwin", "linux"] as NodeJS.Platform[]) {
+      asPlatform(platform, () => {
+        const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR);
+        expect(msg).toContain("Image conversion is unavailable");
+        expect(msg).toContain("libvips");
+        expect(msg).toContain("sharp");
+        // The cause is quoted, so the message is diagnosable and not just a
+        // category. This is the line the reporter never saw.
+        expect(msg).toContain("ERR_DLOPEN_FAILED: The specified module could not be found.");
+      });
     }
   });
 
-  it("the message does NOT repeat sharp's install advice, which misdirects here", async () => {
-    const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR);
-    // sharp's own help says "npm install --include=optional sharp" — advice
-    // about an ABSENT package. Here the package is present and the binary is
-    // being refused, so echoing that sends the user to fix the wrong thing.
-    // The classifier has to reach the native branch for this to mean anything,
-    // which the assertions above establish.
-    expect(msg).not.toContain("npm install --include=optional sharp");
-    expect(msg).not.toContain("sharp.pixelplumbing.com");
+  it("names Smart App Control on Windows, and does NOT elsewhere", async () => {
+    asPlatform("win32", () => {
+      const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR);
+      // The remedy has to name where the block is visible, and has to say NOT to
+      // reach for the switch that looks like it would fix it — disabling SAC is
+      // a one-way door.
+      expect(msg).toContain("Smart App Control");
+      expect(msg).toMatch(/Do NOT disable Smart App Control/);
+    });
+    for (const platform of ["darwin", "linux"] as NodeJS.Platform[]) {
+      asPlatform(platform, () => {
+        // A Windows-only remedy on macOS is noise that costs the reader trust in
+        // the rest of the message.
+        expect(sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR)).not.toContain(
+          "Smart App Control",
+        );
+      });
+    }
+  });
+
+  // CI caught this on macOS while Windows hid it: the non-Windows branch used to
+  // say "npm install --include=optional sharp", which is precisely the advice
+  // this test exists to keep out. A conditional assertion had let it through.
+  it("no platform repeats sharp's install advice, which misdirects on a LOAD failure", async () => {
+    for (const platform of ["win32", "darwin", "linux"] as NodeJS.Platform[]) {
+      asPlatform(platform, () => {
+        const msg = sharpUnavailableMessage("Image conversion", REAL_SHARP_DLOPEN_ERROR);
+        // sharp's own help says "npm install --include=optional sharp" — advice
+        // about an ABSENT package. Here the package is present and the binary is
+        // being refused, so echoing that sends the user to fix the wrong thing.
+        expect(msg).not.toContain("npm install --include=optional sharp");
+        expect(msg).not.toContain("sharp.pixelplumbing.com");
+      });
+    }
   });
 
   // Caught by running this repo's own review taxonomy (class 6, "prose overstates
   // what the code does") against the diff. The first wording was "Everything that
-  // does not resize or re-encode images is unaffected" — but `analyze_color`
+  // does not resize or re-encode images is unaffected" — but analysing colour
   // neither resizes nor re-encodes (it decodes to raw pixels via `.raw()`), so a
   // reader would have concluded it still worked. It does not.
   it("does not tell the user that colour analysis is unaffected — it is affected", async () => {

--- a/src/__tests__/services/sharp-loader.test.ts
+++ b/src/__tests__/services/sharp-loader.test.ts
@@ -22,6 +22,9 @@
 // So message content is pinned against REAL sharp errors instead, reproduced
 // verbatim from an observed failure on this machine. That is the stronger test:
 // it is the actual string the detection has to classify.
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   sharpUnavailableMessage,
@@ -237,6 +240,18 @@ describe("degrade vs refuse (#2411)", () => {
     await expect(
       convertImage({ path: "does-not-exist.png", format: "png" }),
     ).rejects.toThrow(/Image conversion is unavailable/);
+  });
+
+  it("colour analysis REFUSES rather than returning an empty success", async () => {
+    blockSharp();
+    const path = join(mkdtempSync(join(tmpdir(), "cmcp-2411-color-")), "pixel.png");
+    writeFileSync(path, "not-an-image");
+    const { analyzeColor } = await import("../../services/color-analysis.js");
+    // Colour analysis has to decode pixels; without sharp it has nothing to
+    // hand back, so a refusal naming the library beats an empty success. The
+    // file is only here so the path resolver does not fail first — convert
+    // loads sharp before resolving the source; this path does not.
+    await expect(analyzeColor({ path })).rejects.toThrow(/Colour analysis is unavailable/);
   });
 });
 

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -29,6 +29,7 @@ import {
 import { banner, labelRows, numberedSteps } from "./i18n/terminal-layout.js";
 import { STDIO_HANDSHAKE_INSTRUCTIONS } from "./handshake-instructions.js";
 import { orchestratorLogPath } from "./services/orchestrator-log.js";
+import { probeSharp } from "./services/sharp-loader.js";
 
 /** A RunPod proxy can only reach a listener exposed beyond loopback. */
 function advertisedOriginForBind(host: string, port: number): string | undefined {
@@ -49,6 +50,30 @@ function advertisedOriginForBind(host: string, port: number): string | undefined
  * never block or crash startup. Opt out with COMFYUI_MCP_PANEL_AUTOINSTALL=0.
  * The explicit `install_comfyui(action:'panel', panel_action:'update')` tool refreshes nightly on demand.
  */
+/**
+ * #2411 — SAY IT AT STARTUP, NOT ON THE FIRST RENDER OF A LONG SESSION.
+ *
+ * Before this, a `sharp` whose native library would not load crashed the process
+ * during module evaluation; now it degrades, which means it can also go unnoticed
+ * until someone asks for a preview an hour in. One warning at boot is what turns
+ * that into a fact the user already has.
+ *
+ * Deliberately after the transport is up and deliberately non-blocking: this is
+ * diagnostics, and a diagnostic that can delay or fail startup is a worse defect
+ * than the one it reports.
+ */
+function probeSharpOnLoad(): void {
+  void probeSharp()
+    .then((warning) => {
+      if (warning) logger.warn(warning);
+    })
+    .catch(() => {
+      // probeSharp() already swallows the load failure and returns it as text;
+      // reaching here means the probe ITSELF broke, which is not worth a second
+      // warning about a feature the user may never touch.
+    });
+}
+
 function ensurePanelOnLoad(): void {
   if (!isLocalMode()) return;
   void ensurePanelInstalled()
@@ -675,6 +700,8 @@ async function main() {
   // After the server is up deliberately: adoption re-issues real transfers, so it
   // must not delay or endanger the transport coming up.
   adoptOrphanedDownloadsOnLoad();
+  // ...and say ONCE, at startup, if sharp's native library will not load (#2411).
+  probeSharpOnLoad();
 }
 
 main().catch((err) => {

--- a/src/services/color-analysis.ts
+++ b/src/services/color-analysis.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { isAbsolute, resolve, sep } from "node:path";
-import sharp from "sharp";
+import { requireSharp } from "./sharp-loader.js";
 import { AssetRegistry } from "./asset-registry.js";
 import { getOutputImage } from "./image-management.js";
 import { resolveOutputDir } from "./output-dir.js";
@@ -134,6 +134,9 @@ async function resolveSafePath(path: string): Promise<string> {
 }
 
 async function toRaw(bytes: Buffer): Promise<RawPixels> {
+  // #2411 — loaded HERE, not at module scope. A blocked libvips used to throw
+  // while this file evaluated, which took every tool registration down with it.
+  const sharp = await requireSharp("Colour analysis");
   const { data, info } = await sharp(bytes, { limitInputPixels: 100_000_000 })
     .removeAlpha()
     .toColourspace("srgb")
@@ -327,6 +330,7 @@ async function renderHistogram(raw: RawPixels): Promise<{ data: string; mimeType
   draw(rHist, 220, 60, 60);
   draw(gHist, 60, 200, 80);
   draw(bHist, 80, 130, 240);
+  const sharp = await requireSharp("Colour analysis");
   const png = await sharp(buf, { raw: { width: W, height: H, channels: 3 } })
     .png()
     .toBuffer();

--- a/src/services/image-convert.ts
+++ b/src/services/image-convert.ts
@@ -1,6 +1,6 @@
 import { lstat, mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
-import sharp from "sharp";
+import { requireSharp, type SharpModule } from "./sharp-loader.js";
 import { AssetRegistry } from "./asset-registry.js";
 import { getOutputImage } from "./image-management.js";
 import { resolveOutputDir } from "./output-dir.js";
@@ -219,10 +219,15 @@ async function resolveSource(opts: ConvertImageOptions): Promise<SourceImage> {
   };
 }
 
+// #2411 — the sharp factory arrives as an ARGUMENT rather than a module binding,
+// so this file no longer loads a native library while it evaluates. `convertImage`
+// is the one caller and does the loading, which keeps the refusal message next to
+// the action the user actually asked for.
 function buildEncoder(
+  sharp: SharpModule,
   input: Buffer,
   opts: ConvertImageOptions,
-): ReturnType<typeof sharp> {
+): ReturnType<SharpModule> {
   const image = sharp(input, { limitInputPixels: limitInputPixels() });
   if (opts.format === "png") {
     return image.png({ quality: opts.quality });
@@ -263,8 +268,9 @@ export async function convertImage(
   }
   validateEncodeOptions(opts);
 
+  const sharp = await requireSharp("Image conversion");
   const source = await resolveSource(opts);
-  const converted = await buildEncoder(source.bytes, opts).toBuffer();
+  const converted = await buildEncoder(sharp, source.bytes, opts).toBuffer();
   const mimeType = MIME_BY_FORMAT[opts.format];
   const outPath = opts.out_path
     ? await resolveWritableOutputPath(opts.out_path)

--- a/src/services/inline-preview.ts
+++ b/src/services/inline-preview.ts
@@ -1,5 +1,5 @@
-import sharp from "sharp";
 import type { Metadata } from "sharp";
+import { sharpUnavailableReason, tryLoadSharp } from "./sharp-loader.js";
 
 /**
  * #1495 — BOUND WHAT GOES ON THE WIRE, NOT WHAT GOES ON DISK.
@@ -144,6 +144,36 @@ export async function boundInlineImage(
   const limitInputPixels = Math.max(1, opts.maxInputPixels ?? DEFAULT_MAX_INPUT_PIXELS);
   const maxDecodedBytes = Math.max(1, opts.maxDecodedBytes ?? DEFAULT_MAX_DECODED_BYTES);
   const originalEncodedBytes = base64.length;
+
+  // #2411 — RESOLVE SHARP BEFORE TOUCHING IT, AND DEGRADE RATHER THAN DIE.
+  //
+  // This used to be a module-scope `import sharp from "sharp"`, so a native
+  // library Windows refused to load threw while the file evaluated and took the
+  // whole tool registry with it. Loading here makes the failure catchable, and
+  // this function is the one sharp caller that can still do something useful
+  // without it: an image already under budget goes out untouched.
+  const loaded = await tryLoadSharp();
+  if (!loaded.ok) {
+    if (originalEncodedBytes <= budget) {
+      // Identical to the `metadata()`-threw branch below, which has always
+      // delivered an under-budget image rather than withhold it. What is lost is
+      // the DIMENSION check — a long thin image can encode small and still
+      // exceed a consumer's dimension limit — but that check was already best
+      // effort, and refusing a payload that fits in order to enforce it would
+      // withhold pixels over a cap we cannot measure.
+      return { base64, mimeType, preview: null, refused: null };
+    }
+    // Over budget with no way to resize. Refusing is honest: emitting ~267 MB of
+    // base64 is what #1495 established fails in transport, where the error names
+    // a byte count and not the image.
+    return {
+      base64,
+      mimeType,
+      preview: null,
+      refused: { reason: sharpUnavailableReason(loaded.err), originalEncodedBytes },
+    };
+  }
+  const sharp = loaded.sharp;
 
   let width: number | null = null;
   let height: number | null = null;

--- a/src/services/sharp-loader.ts
+++ b/src/services/sharp-loader.ts
@@ -136,7 +136,7 @@ export function sharpUnavailableMessage(feature: string, err: unknown): string {
     : "the `sharp` module could not be loaded";
   const advice = native
     ? process.platform === "win32"
-      ? "On Windows this is usually the binary being REFUSED rather than missing. Check, in order: " +
+      ? "On Windows the binary is as often REFUSED as it is missing, so check both. In order: " +
         'Windows Security > App & browser control for a "Part of this app has been blocked" entry ' +
         "naming libvips-cpp-<version>.dll (Smart App Control refuses binaries it cannot attribute to " +
         "a known publisher); then your antivirus quarantine; then reinstall with " +
@@ -151,8 +151,9 @@ export function sharpUnavailableMessage(feature: string, err: unknown): string {
     `${feature} is unavailable: ${cause}.\n` +
     `  ${detail}\n` +
     `${advice}\n` +
-    "Everything that does not resize or re-encode images is unaffected, and files already written " +
-    `to disk are intact. Set ${SHARP_DISABLE_ENV}=1 to skip these features quietly instead.`
+    "Only the features that DECODE image pixels are affected — inline previews, conversion and " +
+    "colour analysis. Generation, queueing and every file already written to disk are untouched. " +
+    `Set ${SHARP_DISABLE_ENV}=1 to skip the affected features quietly instead.`
   );
 }
 
@@ -193,11 +194,6 @@ export function sharpUnavailableReason(err: unknown): string {
  */
 let cached: { ok: true; sharp: SharpModule } | { ok: false; err: unknown } | null = null;
 
-/** Drop the memoised outcome. Exists for tests; production loads once. */
-export function resetSharpLoaderForTests(): void {
-  cached = null;
-}
-
 /**
  * The sharp factory, or the reason it is unavailable.
  *
@@ -235,10 +231,12 @@ export async function requireSharp(feature: string): Promise<SharpModule> {
 /**
  * One line for the startup log when sharp cannot load, or `null` when it can.
  *
- * A probe exists because the alternative is finding out during the first render
- * of a long session, which is exactly how #2411 cost an hour. It deliberately
- * returns the line instead of logging it, so the caller owns the level and the
- * tests do not have to capture a logger.
+ * A probe exists because this change makes the failure SURVIVABLE, and a
+ * survivable failure is one nobody notices until the first operation that needs
+ * it. (Not because it explains #2411's lost hour — see the header: a blocked
+ * sharp yields no server at all, so it cannot have.) It deliberately returns the
+ * line instead of logging it, so the caller owns the level and the tests do not
+ * have to capture a logger.
  */
 export async function probeSharp(): Promise<string | null> {
   const result = await tryLoadSharp();

--- a/src/services/sharp-loader.ts
+++ b/src/services/sharp-loader.ts
@@ -143,8 +143,11 @@ export function sharpUnavailableMessage(feature: string, err: unknown): string {
         "`npm install -g comfyui-mcp@latest` in case the extraction was interrupted. " +
         "Do NOT disable Smart App Control to work around this — on Windows that is a one-way switch " +
         "you cannot turn back on without reinstalling the OS."
-      : "Reinstall sharp's platform binaries with `npm install --include=optional sharp`, or " +
-        "reinstall with `npm install -g comfyui-mcp@latest`."
+      : "The package is present and its binary is being refused or is unusable, so check in this " +
+        "order: a quarantine flag or security policy on the .node/dylib (macOS Gatekeeper, SELinux, " +
+        "an endpoint agent); an architecture mismatch between Node and the prebuilt (arm64 vs x64); " +
+        "then reinstall with `npm install -g comfyui-mcp@latest` in case the extraction was " +
+        "interrupted."
     : "sharp's optional platform package is probably absent — `--omit=optional` removes it. " +
       "Reinstall with `npm install -g comfyui-mcp@latest`.";
   return (

--- a/src/services/sharp-loader.ts
+++ b/src/services/sharp-loader.ts
@@ -1,0 +1,247 @@
+// #2411 — SHARP'S NATIVE LIBRARY CAN BE UNLOADABLE, AND NOTHING SAID SO.
+//
+// `sharp` was imported at module top level by three services:
+//
+//     src/services/color-analysis.ts
+//     src/services/image-convert.ts
+//     src/services/inline-preview.ts
+//
+// All three are reached, statically, from `src/tools/index.ts` — which registers
+// EVERY tool. So a `sharp` that throws while it evaluates does not disable image
+// features; it takes the whole orchestrator down before any of our code runs.
+// Measured on this machine by moving `libvips-cpp-8.18.3.dll` aside and booting
+// `dist/index.js`:
+//
+//     Error: Could not load the "sharp" module using the win32-x64 runtime
+//     ERR_DLOPEN_FAILED: The specified module could not be found.
+//         at …/dist/index.js:17:5
+//
+// No tool registers, the server never starts, and the message names neither
+// comfyui-mcp nor the feature the user lost. This is the same defect class as
+// #1318 (a half-extracted dependency reported as a resolver path), and it gets
+// the same treatment: load it where the failure can be CAUGHT, and translate the
+// observable state into a sentence naming the library and the remedy.
+//
+// WHAT THIS DOES NOT CLAIM. #2411 was reported alongside a Windows Smart App
+// Control toast blocking `libvips-cpp-8.18.6.dll`, and SAC is a plausible cause
+// on that machine — but `ERR_DLOPEN_FAILED` is equally what an antivirus
+// quarantine, a partial extraction, or a genuinely absent optional dependency
+// produces. Following #1318's rule, the message states what was OBSERVED (the
+// native library would not load, plus the loader's own words) and lists the
+// causes worth checking. It does not assert which one happened.
+//
+// The reporter's own correlation — that this produced their undeliverable
+// completions ("no prompt id … origin is UNDETERMINED") — is NOT supported by
+// the measurement above: a blocked sharp yields no server at all, so a session
+// whose renders succeeded and whose panel displayed outputs was not running a
+// blocked sharp. Naming the failure is still the right fix; the symptom it will
+// actually prevent is a dead orchestrator, not a missing contact sheet.
+
+/**
+ * The callable `sharp` factory, typed without importing it.
+ *
+ * A type-only reference is erased at compile time, so naming the module here
+ * cannot reintroduce the load this file exists to defer.
+ */
+export type SharpModule = typeof import("sharp").default;
+
+/**
+ * Opt out of every sharp-backed feature without uninstalling anything.
+ *
+ * Set when the native library cannot be made loadable and the noise is worse
+ * than the missing feature: the services below then refuse with the same worded
+ * message instead of attempting a load that is known to fail.
+ */
+export const SHARP_DISABLE_ENV = "COMFYUI_MCP_NO_SHARP";
+
+/** Marks "the user turned it off", so the message says that and not a fake load error. */
+const DISABLED_SENTINEL = Symbol("sharp disabled by env");
+
+/** Is the escape hatch set to something meaning "yes"? */
+function disabledByEnv(): boolean {
+  const raw = process.env[SHARP_DISABLE_ENV];
+  if (raw === undefined) return false;
+  const v = raw.trim().toLowerCase();
+  // An empty value is how a shell spells "unset it", and "0"/"false" are how a
+  // config file spells "no". Treating either as ON would disable image features
+  // for anyone who wrote `COMFYUI_MCP_NO_SHARP=0` to mean the opposite.
+  return v !== "" && v !== "0" && v !== "false" && v !== "no" && v !== "off";
+}
+
+/**
+ * Did this failure come from the NATIVE library, rather than from sharp's
+ * JavaScript being absent?
+ *
+ * The two want different remedies — a dlopen failure is a blocked or damaged
+ * binary, while a resolution failure is a dependency that was never installed
+ * (`--omit=optional` does exactly this, which is why #1447 parked it). Detection
+ * is deliberately loose: it only picks WHICH paragraph of advice to print, and
+ * both paragraphs name sharp, so a misclassification costs a line of irrelevant
+ * advice rather than a wrong diagnosis.
+ */
+function isNativeLoadFailure(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  if (code === "ERR_DLOPEN_FAILED") return true;
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /ERR_DLOPEN_FAILED|Could not load the "sharp" module|\.node\b/.test(msg);
+}
+
+/** The first line of whatever the loader said, for quoting back verbatim. */
+function firstLine(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  const line = msg
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  return line ?? "no error message";
+}
+
+/**
+ * The dlopen detail line, when sharp's help text carries one.
+ *
+ * sharp concatenates its own headline, then each underlying error as
+ * `${code}: ${message}`, then a "Possible solutions:" block that is about
+ * INSTALLING sharp — advice which is actively misleading when the package is
+ * installed correctly and the binary is being refused. Lifting just the cause
+ * line keeps what diagnoses and drops what misdirects.
+ */
+function dlopenDetail(err: unknown): string | null {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  for (const raw of msg.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("ERR_DLOPEN_FAILED:")) return line;
+  }
+  return null;
+}
+
+/**
+ * What to tell a user whose sharp will not load, for the feature they asked for.
+ *
+ * `feature` names the thing that is unavailable in the caller's own vocabulary
+ * ("Colour analysis", "Image conversion"), because a message that says only
+ * "sharp is unavailable" leaves the reader to work out which of their requests
+ * died — which is the gap #2411 is about.
+ */
+export function sharpUnavailableMessage(feature: string, err: unknown): string {
+  if (err === DISABLED_SENTINEL) {
+    return (
+      `${feature} is unavailable: image processing is switched off by ` +
+      `${SHARP_DISABLE_ENV}. Unset it to re-enable sharp-backed features.`
+    );
+  }
+  const native = isNativeLoadFailure(err);
+  const detail = dlopenDetail(err) ?? firstLine(err);
+  const cause = native
+    ? "its native library (libvips, loaded through `sharp`) could not be loaded"
+    : "the `sharp` module could not be loaded";
+  const advice = native
+    ? process.platform === "win32"
+      ? "On Windows this is usually the binary being REFUSED rather than missing. Check, in order: " +
+        'Windows Security > App & browser control for a "Part of this app has been blocked" entry ' +
+        "naming libvips-cpp-<version>.dll (Smart App Control refuses binaries it cannot attribute to " +
+        "a known publisher); then your antivirus quarantine; then reinstall with " +
+        "`npm install -g comfyui-mcp@latest` in case the extraction was interrupted. " +
+        "Do NOT disable Smart App Control to work around this — on Windows that is a one-way switch " +
+        "you cannot turn back on without reinstalling the OS."
+      : "Reinstall sharp's platform binaries with `npm install --include=optional sharp`, or " +
+        "reinstall with `npm install -g comfyui-mcp@latest`."
+    : "sharp's optional platform package is probably absent — `--omit=optional` removes it. " +
+      "Reinstall with `npm install -g comfyui-mcp@latest`.";
+  return (
+    `${feature} is unavailable: ${cause}.\n` +
+    `  ${detail}\n` +
+    `${advice}\n` +
+    "Everything that does not resize or re-encode images is unaffected, and files already written " +
+    `to disk are intact. Set ${SHARP_DISABLE_ENV}=1 to skip these features quietly instead.`
+  );
+}
+
+/**
+ * The same diagnosis as {@link sharpUnavailableMessage}, sized to be dropped
+ * into the MIDDLE of someone else's sentence.
+ *
+ * `boundInlineImage` hands its reason to a caller that wraps it as
+ * `NOT rendered inline: ${reason}. The full-resolution file is on disk…`, so the
+ * standalone form — several lines, its own remedy paragraph, a closing full stop
+ * — would read as two collided messages and push the caller's own remedy off the
+ * end. This starts lower-case and carries no terminal punctuation.
+ */
+export function sharpUnavailableReason(err: unknown): string {
+  if (err === DISABLED_SENTINEL) {
+    return `image processing is switched off by ${SHARP_DISABLE_ENV}, so no preview could be built`;
+  }
+  const detail = dlopenDetail(err) ?? firstLine(err);
+  const what = isNativeLoadFailure(err)
+    ? "sharp's native library (libvips) could not be loaded"
+    : "the sharp module could not be loaded";
+  return (
+    `${what} (${detail}), so the image could not be resized to fit — ` +
+    "this is an install/permissions problem with that binary, not a problem with the render"
+  );
+}
+
+/**
+ * Cached outcome of the one load attempt.
+ *
+ * Caching the FAILURE matches Node's own ESM semantics — a module that throws
+ * while evaluating stays errored in the module map and re-throws the identical
+ * error on every later `import()` — so this adds no constraint that was not
+ * already there. It only avoids re-deriving the wrapped message per call.
+ *
+ * The env check is NOT cached with it: reading `process.env` each time keeps the
+ * switch honest for tests that set and clear it around a case.
+ */
+let cached: { ok: true; sharp: SharpModule } | { ok: false; err: unknown } | null = null;
+
+/** Drop the memoised outcome. Exists for tests; production loads once. */
+export function resetSharpLoaderForTests(): void {
+  cached = null;
+}
+
+/**
+ * The sharp factory, or the reason it is unavailable.
+ *
+ * For paths that DEGRADE — an inline preview that can be skipped while the
+ * underlying file is still delivered. Callers that cannot proceed at all should
+ * use {@link requireSharp}, which throws the same worded message.
+ */
+export async function tryLoadSharp(): Promise<
+  { ok: true; sharp: SharpModule } | { ok: false; err: unknown }
+> {
+  if (disabledByEnv()) return { ok: false, err: DISABLED_SENTINEL };
+  if (cached) return cached;
+  try {
+    const mod = await import("sharp");
+    cached = { ok: true, sharp: mod.default };
+  } catch (err) {
+    cached = { ok: false, err };
+  }
+  return cached;
+}
+
+/**
+ * The sharp factory, or a thrown Error naming the library and the remedy.
+ *
+ * The throw is what a caller that cannot degrade wants: `get_image
+ * action:"convert"` has nothing to hand back if it cannot re-encode, and an
+ * empty success would be worse than a refusal that says why.
+ */
+export async function requireSharp(feature: string): Promise<SharpModule> {
+  const result = await tryLoadSharp();
+  if (result.ok) return result.sharp;
+  throw new Error(sharpUnavailableMessage(feature, result.err));
+}
+
+/**
+ * One line for the startup log when sharp cannot load, or `null` when it can.
+ *
+ * A probe exists because the alternative is finding out during the first render
+ * of a long session, which is exactly how #2411 cost an hour. It deliberately
+ * returns the line instead of logging it, so the caller owns the level and the
+ * tests do not have to capture a logger.
+ */
+export async function probeSharp(): Promise<string | null> {
+  const result = await tryLoadSharp();
+  if (result.ok) return null;
+  return sharpUnavailableMessage("Image resizing, conversion and colour analysis", result.err);
+}


### PR DESCRIPTION
Closes #2411

## What I measured, and how it changes the report

The reporter correlated a Smart App Control block on `libvips-cpp-8.18.6.dll` with a session of undeliverable completions. I reproduced the block directly — moved `libvips-cpp-8.18.3.dll` aside in an isolated worktree's `node_modules` and ran the real `node dist/index.js`:

```
Error: Could not load the "sharp" module using the win32-x64 runtime
ERR_DLOPEN_FAILED: The specified module could not be found.
    at …/dist/index.js:17:5
```

**The process dies during module evaluation. No tool registers and the transport never comes up.** All three sharp-backed services are reached statically from `src/tools/index.ts`, which registers *every* tool.

That is worse than reported — and it means **the reporter's own correlation cannot be right**. A blocked sharp yields no orchestrator at all, so a session whose renders succeeded and whose panel displayed outputs was not running a blocked sharp. The triage comment flagged this as unverified; it is now measured. Their *constraint* was right even though their premise was not: sharp unavailability must be named.

**I did not touch the `sharp` version pin.** Per the triage, the load-bearing fix is "name any sharp unavailability", not "pin past this one" — and a `package.json` dependency change is human-gated in this pipeline. Worth noting the lockfile currently resolves sharp 0.35.3 → libvips **8.18.3**, the version the report calls good, so the drift is in npx cache resolution rather than in this repo's pin. That decision is left open deliberately.

## The fix

`src/services/sharp-loader.ts` — load sharp lazily behind a catchable boundary, memoise the outcome, and translate the failure into a sentence naming the library, the cause and the remedy. Same treatment #1318 gave a half-extracted dependency.

Then **degrade where the caller can still deliver, refuse where it cannot**:

| path | with sharp blocked |
|---|---|
| server boot | boots; one `WARN` naming sharp/libvips/remedy |
| inline image **under** budget | delivered untouched — needed no resize |
| inline image **over** budget | refused, reason names sharp (emitting it unresized fails in transport, #1495) |
| `get_image action:"convert"` | refuses, names sharp |
| `get_image action:"analyze_color"` | refuses, names sharp |

`COMFYUI_MCP_NO_SHARP=1` skips it all quietly. `=0`/`false`/`no`/`off` deliberately do **not** disable.

The Windows remedy says explicitly **not** to disable Smart App Control — it is a one-way switch.

## Where the load-bearing claim is — please look here

**The message does not assert Smart App Control.** `ERR_DLOPEN_FAILED` is equally an AV quarantine, a partial extraction, or an absent optional dep (`--omit=optional`, cf. #1447). Following #1318's rule it states the observation and lists causes to check. If you think it still reads as a diagnosis, that is the line to push on.

**Two test mechanisms failed as controls before the third worked — I want this checked.**

1. `vi.doMock("sharp", () => { throw … })` only intercepts the *test file's own* `import("sharp")`. A static `import sharp from "sharp"` inside a transformed source module resolves normally. **Reverting all three services left 23/23 green.**
2. A real `registerHooks` loader hook never fired under `tsx` — its resolver short-circuits `sharp` first. Verified by logging inside the hook: zero interceptions, with and without the mutation.

Both reported the fix working while it was reverted. An earlier draft also had a case passing *for the wrong reason* — it took the non-native branch, making "does not contain sharp's install advice" trivially true.

So message content is pinned against **real** sharp error strings (note: sharp's error carries **no `code`** — it rethrows `new Error(help.join("\n"))`, so classification is message-based), and the import invariant is pinned in the **source**, as `check-panel-scope` / `check-tool-vocabulary` / `check-anti-slop` already do.

## Mutation testing

| mutation | result |
|---|---|
| restore top-level import in `color-analysis` | **caught** |
| restore top-level import in `image-convert` | **caught** |
| restore top-level import in `inline-preview` | **caught** |
| all three together | **caught**, names all three |
| loader drops its `try`/`catch` | **caught** |
| loader rewritten equivalently | passes (no false positive) |

## Verification

- Full suite: **12811 passed**, 1 pre-existing failure (`late-mutation-e2e`, the known 60 ms wall-clock flake) — passes alone 5/5, and my diff does not touch it.
- `lint` (tsc + anti-slop: **none added**), `check:vocabulary`, `check:unknown-collapse`, `i18n:check`, `check:changelog` — all green.
- End-to-end on the built `dist`, real boot path: healthy boot warns nothing; blocked boot **boots and warns**; `NO_SHARP=1` names the switch.

**No browser verification: this changes no panel code** (`src/services/*`, `src/boot.ts`, tests only). The `via-panel` label describes where the report came from, not where the fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
