### PR TITLE
fix(2418): bound ripgrep's printed line at the source so one minified file cannot ENOBUFS the search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3469,6 +3469,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/src/__tests__/services/node-dev-rg-enobufs.test.ts
+++ b/src/__tests__/services/node-dev-rg-enobufs.test.ts
@@ -1,0 +1,74 @@
+// #2418 — `node_pack` action:"search" died with
+//   {"error":"NODE_DEV_ERROR","message":"Failed to execute rg: spawnSync rg ENOBUFS"}
+// on a workspace containing a minified one-line workflow JSON.
+//
+// `--max-count` is per FILE, so one such file can put its whole self on stdout. Measured
+// against real ripgrep 15.0.0: a 42 MB single-line file produced 33 MB of stdout, over
+// spawnSync's 32 MB maxBuffer, and the whole search failed before returning any match.
+// SEARCH_LINE_MAX could not help — clipMatchLine runs AFTER spawnSync returns.
+//
+// The fix bounds the printed line AT THE SOURCE. These pin both halves: the flags are
+// actually passed, and the preview that comes back is described honestly rather than
+// with a fabricated dropped-character count.
+import { describe, expect, it } from "vitest";
+
+import {
+  clipMatchLine,
+  READ_MAX_CHARS,
+  RIPGREP_LONG_LINE_MARKER,
+  SEARCH_LINE_MAX,
+  SEARCH_MAX_COLUMNS,
+} from "../../services/node-dev.js";
+
+describe("the printed bound is tied to the display cap (#2418)", () => {
+  it("SEARCH_MAX_COLUMNS is SEARCH_LINE_MAX, not a second free-floating number", () => {
+    // Asking ripgrep for MORE than we can display buys nothing and spends the buffer
+    // this fix exists to protect: at 4096 each long line costs ~6.5x what it does here,
+    // which is the same overflow one order of magnitude further out. Asking for LESS
+    // would make the preview shorter than the cap the refusal advertises.
+    expect(SEARCH_MAX_COLUMNS).toBe(SEARCH_LINE_MAX);
+  });
+});
+
+describe("clipMatchLine on a ripgrep-truncated preview (#2418)", () => {
+  const preview = "x".repeat(SEARCH_MAX_COLUMNS) + RIPGREP_LONG_LINE_MARKER;
+
+  it("never states a dropped-character count it could not have measured", () => {
+    const out = clipMatchLine(preview);
+    // The reported line was 42 MB. Computing +N from the PREVIEW's length would have
+    // claimed roughly +31 characters — a precise-looking number that is simply false.
+    expect(out).not.toMatch(/\+\d+ chars/);
+    expect(out).toContain("its full length was not measured");
+  });
+
+  it("still says the line continues, and names the cap that cannot be raised", () => {
+    const out = clipMatchLine(preview);
+    expect(out).toContain(`fixed ${SEARCH_LINE_MAX}-char per-line cap`);
+    expect(out).toContain(String(READ_MAX_CHARS));
+  });
+
+  it("honours SEARCH_LINE_MAX and drops ripgrep's own marker", () => {
+    const out = clipMatchLine(preview);
+    expect(out.length).toBeLessThanOrEqual(SEARCH_LINE_MAX);
+    expect(out).not.toContain(RIPGREP_LONG_LINE_MARKER);
+  });
+
+  it("an ordinary long line KEEPS the measured +N count — the #809 behaviour", () => {
+    const out = clipMatchLine("y".repeat(SEARCH_LINE_MAX * 3));
+    expect(out).toMatch(/\+\d+ chars/);
+    expect(out).toContain(`fixed ${SEARCH_LINE_MAX}-char per-line cap`);
+    expect(out.length).toBeLessThanOrEqual(SEARCH_LINE_MAX);
+  });
+
+  it("a short line is returned untouched by either path", () => {
+    expect(clipMatchLine("const a = 1;")).toBe("const a = 1;");
+  });
+
+  it("the source-truncated branch is keyed on ripgrep's marker, not on length", () => {
+    // A line UNDER the cap that still carries the marker is a preview and must be
+    // described as one; length alone would have let it through unmarked.
+    const shortPreview = "z".repeat(20) + RIPGREP_LONG_LINE_MARKER;
+    expect(shortPreview.length).toBeLessThan(SEARCH_LINE_MAX);
+    expect(clipMatchLine(shortPreview)).toContain("its full length was not measured");
+  });
+});

--- a/src/__tests__/services/node-dev.test.ts
+++ b/src/__tests__/services/node-dev.test.ts
@@ -53,6 +53,7 @@ import {
   // #809
   MIN_OUTPUT_CHARS,
   SEARCH_LINE_MAX,
+  SEARCH_MAX_COLUMNS,
   SEARCH_MAX_RESULTS,
   LIST_MAX_ENTRIES,
   defaultDeps,
@@ -332,6 +333,29 @@ describe("searchNodePacks", () => {
     });
     searchNodePacks({ query: "x", maxResults: 5 }, deps);
     expect(seen[0][seen[0].indexOf("--max-count") + 1]).toBe("6");
+  });
+
+  // #2418 — `--max-count` is per FILE, so ONE minified one-line workflow JSON can put
+  // its whole self on stdout. Measured against real ripgrep 15.0.0: a 42 MB single-line
+  // file produced 33 MB of output, past spawnSync's 32 MB maxBuffer, and the search died
+  // ENOBUFS before returning a single match. SEARCH_LINE_MAX cannot help — clipMatchLine
+  // runs after spawnSync has already returned, so the bound has to be asked of ripgrep.
+  it("bounds each printed line AT THE SOURCE so one minified file cannot ENOBUFS it", () => {
+    const seen: string[][] = [];
+    const { deps } = makeDeps({
+      hasRipgrep: () => true,
+      runRipgrep: (args) => {
+        seen.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    searchNodePacks({ query: "x" }, deps);
+    expect(seen[0]).toContain("--max-columns");
+    expect(seen[0][seen[0].indexOf("--max-columns") + 1]).toBe(String(SEARCH_MAX_COLUMNS));
+    // PREVIEW, not bare --max-columns: bare yields "[Omitted long matching line]" (28
+    // chars), which is UNDER SEARCH_LINE_MAX, so clipMatchLine would skip its marker and
+    // the caller would get neither the content nor any disclosure that it was cut.
+    expect(seen[0]).toContain("--max-columns-preview");
   });
 
   it("does NOT claim truncation when the match count is exactly max_results", () => {

--- a/src/services/node-dev.ts
+++ b/src/services/node-dev.ts
@@ -84,6 +84,23 @@ export const READ_MAX_CHARS = 24_000;
 export const LONG_LINE_CHUNK = 1_000;
 /** Per-match line cap for search results. */
 export const SEARCH_LINE_MAX = 600;
+/**
+ * #2418 — what ripgrep is allowed to PRINT for one line, before we ever see it.
+ *
+ * `--max-count` is per FILE, so a single minified one-line workflow JSON under
+ * custom_nodes can put its whole self on stdout: measured 33 MB of output from one
+ * 42 MB file, which overflows spawnSync's 32 MB maxBuffer and fails the whole search
+ * with ENOBUFS. SEARCH_LINE_MAX cannot help — it is applied by clipMatchLine AFTER
+ * spawnSync has already returned, which is far too late.
+ *
+ * Set to SEARCH_LINE_MAX so ripgrep prints a preview no larger than what we display.
+ * With `--max-columns-preview` it emits that many columns plus its own
+ * ` [... omitted end of long line]` marker, so the field still arrives LONGER than
+ * SEARCH_LINE_MAX and clipMatchLine still marks it — the #809 disclosure survives.
+ */
+export const SEARCH_MAX_COLUMNS = SEARCH_LINE_MAX;
+/** ripgrep's own elision suffix under `--max-columns-preview` (#2418). */
+export const RIPGREP_LONG_LINE_MARKER = " [... omitted end of long line]";
 /** Bound on any subprocess (git / patch) stdout+stderr surfaced to the caller. */
 export const CMD_OUTPUT_MAX = 12_000;
 /**
@@ -750,8 +767,25 @@ export interface SearchResult {
 }
 
 /** #809: a hard 600-char slice with no marker read as if the line simply ended there.
- *  Mark it, and say the cap is fixed so nobody retries a parameter that can't move it. */
+ *  Mark it, and say the cap is fixed so nobody retries a parameter that can't move it.
+ *
+ *  #2418 — when ripgrep already truncated the line (`--max-columns`), the text we hold
+ *  is a PREVIEW, not the line. Its length says nothing about the real one, so the
+ *  `+N chars` count would be a fabricated number: on the reported 42 MB line it would
+ *  have claimed roughly +31. State that the line is longer than the cap, which is all
+ *  that was actually observed. Detected from ripgrep's own elision suffix rather than
+ *  from a flag threaded through the call, so a preview reaching this from any path is
+ *  described correctly. */
 export function clipMatchLine(text: string): string {
+  const sourceTruncated = text.endsWith(RIPGREP_LONG_LINE_MARKER);
+  if (sourceTruncated) {
+    const preview = text.slice(0, text.length - RIPGREP_LONG_LINE_MARKER.length);
+    const note =
+      `…(line continues past the fixed ${SEARCH_LINE_MAX}-char per-line cap; its full ` +
+      `length was not measured — read more of it with node_pack (action:"read"), itself ` +
+      `bounded by its own max_chars, max ${READ_MAX_CHARS})`;
+    return preview.slice(0, Math.max(0, SEARCH_LINE_MAX - note.length)) + note;
+  }
   if (text.length <= SEARCH_LINE_MAX) return text;
   // The marker is spent from the SAME cap it describes (codex gate), so reserve its
   // worst-case size — the emitted field still honours SEARCH_LINE_MAX.
@@ -831,6 +865,13 @@ function searchWithRipgrep(
     // same +1.
     "--max-count",
     String(cap + 1),
+    // #2418 — bound each printed line AT THE SOURCE. Without this a minified
+    // one-line JSON overflows spawnSync's maxBuffer and the whole search dies
+    // ENOBUFS before a single match is returned. `--max-columns-preview` keeps a
+    // usable prefix instead of ripgrep's bare `[Omitted long matching line]`.
+    "--max-columns",
+    String(SEARCH_MAX_COLUMNS),
+    "--max-columns-preview",
   ];
   if (!options.caseSensitive) args.push("-i");
   if (options.glob) args.push("-g", options.glob);


### PR DESCRIPTION
Closes #2418.

## Reproduced against real ripgrep, not asserted from the source

`--max-count` is per **file**, so one minified one-line workflow JSON can put its whole self on stdout. Built a 42 MB single-line file containing the query and ran the shipped argv:

| args | result |
|---|---|
| current | **ENOBUFS**, 33,619,968 bytes buffered |
| `+ --max-columns 600 --max-columns-preview` | exit 0, **645 bytes**, 631-char usable preview |

`SEARCH_LINE_MAX` cannot help: `clipMatchLine` runs *after* `spawnSync` has returned. The bound has to be asked of ripgrep.

Raising `maxBuffer` was rejected — a larger minified file just moves the cliff.

## Why preview, and not bare `--max-columns`

Measured both:

    --max-columns 600            -> "[Omitted long matching line]"   (28 chars)
    --max-columns 600 + preview  -> 631 chars, ending " [... omitted end of long line]"

28 chars is **under** `SEARCH_LINE_MAX`, so `clipMatchLine`'s #809 marker would not fire — the caller would get neither the content nor any sign it was cut. That is precisely the defect #809 exists to prevent, reintroduced through the back door. With preview the field arrives *over* the cap, so the disclosure path is still reached.

## The count `clipMatchLine` would otherwise have invented

Its `+N chars` is computed from the text it holds. On a preview that text is 631 chars — so on the reported 42 MB line it would have reported roughly **+31 characters**. A precise-looking number that is simply false, in a marker whose whole purpose is telling the caller how much they are missing.

The preview branch says the line continues past the cap and that its full length **was not measured**, which is all that was observed. It is keyed on ripgrep's own elision suffix rather than on length, so a preview arriving *under* the cap is still described correctly, and an ordinary long line keeps its measured count unchanged.

## Mutation results — 5 mutants, each killed by exactly one test

| mutant | verdict |
|---|---|
| drop `--max-columns` (ENOBUFS returns) | killed |
| drop `--max-columns-preview` | killed |
| untie `SEARCH_MAX_COLUMNS` from the display cap | killed |
| remove the honest-marker branch | killed |
| key that branch on length, not the marker | killed |

The third **survived the first round** — I had trimmed that assertion out while splitting the tests, so the tie was unpinned. Re-added rather than waved off as equivalent: at 4096 each long line costs ~6.5× the buffer, which is the same overflow one order of magnitude further out.

**Suite:** 683 files, **12798 passed**, 6 skipped, 0 failures. `tsc --noEmit` exit 0.

## Not fixed here

Ripgrep's output **order is not stable across runs** — three runs of identical args disagreed with each other. So which matches survive truncation is already nondeterministic, independently of this change. `--sort path` makes it deterministic but disables ripgrep's parallelism; that is a different trade and belongs in its own issue rather than riding along here.

## Not merged

Merge gate quota-blocked (codex resets Sep 1; Copilot exhausted). Verified and queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
