### PR TITLE
fix(2422): a patch that changed nothing on disk is no longer reported as applied

### DIFF
--- a/src/__tests__/services/node-dev.test.ts
+++ b/src/__tests__/services/node-dev.test.ts
@@ -677,3 +677,108 @@ describe("nodePackGit", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// #2422 — node_pack action:"patch" returned {success:true, stage:"apply"} for two
+// one-line hunks while an immediate readback still showed the original lines.
+//
+// `success` was `apply.status === 0` and nothing else: git's exit code, taken as
+// proof the content moved. These pin that a 0 exit alone can no longer report success.
+// ---------------------------------------------------------------------------
+
+describe("patch verifies the file actually moved (#2422)", () => {
+  const PATCH = [
+    "--- a/Pack/h3.py",
+    "+++ b/Pack/h3.py",
+    "@@ -1,1 +1,1 @@",
+    "-frame_count=5",
+    "+frame_count=9",
+    "",
+  ].join("\n");
+
+  function seed(contents: string) {
+    const pack = join(customNodes, "Pack");
+    mkdirSync(pack, { recursive: true });
+    writeFileSync(join(pack, "h3.py"), contents);
+  }
+
+  it("REFUSES when git exits 0 but every touched file is byte-identical", () => {
+    seed("frame_count=5\n");
+    // git says it worked; the disk says otherwise. This is the reported shape.
+    const { deps } = makeDeps({
+      runGit: () => ({ status: 0, stdout: "", stderr: "" }),
+    });
+    const res = applyNodePatch(PATCH, deps);
+    expect(res.success).toBe(false);
+    expect(res.stage).toBe("apply");
+    expect(res.stderr).toContain("byte-identical");
+    expect(res.stderr).toContain("NOTHING was applied");
+  });
+
+  it("REPORTS SUCCESS when the file really changed", () => {
+    seed("frame_count=5\n");
+    const { deps } = makeDeps({
+      runGit: (args) => {
+        // Only the real apply mutates; --check must not.
+        if (args[0] === "apply" && !args.includes("--check")) {
+          writeFileSync(join(customNodes, "Pack", "h3.py"), "frame_count=9\n");
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    const res = applyNodePatch(PATCH, deps);
+    expect(res.success).toBe(true);
+    expect(res.stderr).not.toContain("byte-identical");
+  });
+
+  it("counts a CREATED file as changed — absent before, present after", () => {
+    mkdirSync(join(customNodes, "Pack"), { recursive: true });
+    const { deps } = makeDeps({
+      runGit: (args) => {
+        if (args[0] === "apply" && !args.includes("--check")) {
+          writeFileSync(join(customNodes, "Pack", "h3.py"), "frame_count=9\n");
+        }
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    const res = applyNodePatch(PATCH, deps);
+    expect(res.success).toBe(true);
+  });
+
+  it("an UNREADABLE file is never counted as evidence that nothing happened", () => {
+    seed("frame_count=5\n");
+    const { deps } = makeDeps({
+      runGit: () => ({ status: 0, stdout: "", stderr: "" }),
+      readFileBuffer: () => {
+        throw new Error("EACCES");
+      },
+    });
+    // Unverifiable is not refutable: the check only refuses what it positively saw.
+    expect(applyNodePatch(PATCH, deps).success).toBe(true);
+  });
+
+  it("a non-zero apply still fails at stage apply, unchanged by this check", () => {
+    seed("frame_count=5\n");
+    const { deps } = makeDeps({
+      runGit: (args) =>
+        args.includes("--check")
+          ? { status: 0, stdout: "", stderr: "" }
+          : { status: 1, stdout: "", stderr: "patch does not apply" },
+    });
+    const res = applyNodePatch(PATCH, deps);
+    expect(res.success).toBe(false);
+    expect(res.stage).toBe("apply");
+    expect(res.stderr).toContain("patch does not apply");
+    expect(res.stderr).not.toContain("byte-identical");
+  });
+
+  it("a failing --check is still reported at stage check, never reaching the verify", () => {
+    seed("frame_count=5\n");
+    const { deps } = makeDeps({
+      runGit: () => ({ status: 1, stdout: "", stderr: "does not apply" }),
+    });
+    const res = applyNodePatch(PATCH, deps);
+    expect(res.success).toBe(false);
+    expect(res.stage).toBe("check");
+  });
+});

--- a/src/services/node-dev.ts
+++ b/src/services/node-dev.ts
@@ -1199,7 +1199,7 @@ export function applyNodePatch(
         `git apply exited 0 but every file the patch names is byte-identical to before ` +
         `it ran (${unchanged.join(", ")}), so NOTHING was applied. Reporting success here ` +
         `would have you build on an edit that is not on disk (#2422). Re-read the file ` +
-        `with node_pack (action:"read") and regenerate the patch against what it ` +
+        `with node_pack (action:"read") and rebuild the patch against what it ` +
         `actually contains — a hunk whose context has drifted is the usual cause.`,
     };
   }

--- a/src/services/node-dev.ts
+++ b/src/services/node-dev.ts
@@ -1127,6 +1127,23 @@ export function applyNodePatch(
     }
   }
 
+  // #2422 — what the touched files hold BEFORE the apply. `git apply`'s exit code is
+  // the ONLY thing this used to report, and a 0 from it was taken to mean the content
+  // changed. The report is two one-line hunks that came back {success:true,
+  // stage:"apply"} while an immediate readback still returned the original lines.
+  //
+  // Compared by CONTENT rather than by re-running the patch in reverse: `git apply
+  // --check -R` looks like the natural verifier and is wrong here, because
+  // `apply.whitespace=fix` (a git CONFIG, so ambient and per-machine) rewrites the
+  // added line, after which the reverse check fails on a patch that legitimately
+  // landed. Measured both ways before choosing. A byte comparison cannot be fooled by
+  // that: whitespace-fixed content still differs from what was there before.
+  const before = new Map<string, string | null | undefined>();
+  for (const p of touched) {
+    const { abs } = resolveInJail(p, deps, resolvedBase);
+    before.set(p, readIfPresent(abs, deps));
+  }
+
   const input = patch.endsWith("\n") ? patch : patch + "\n";
 
   // Phase 2a: git apply --check (dry run).
@@ -1151,13 +1168,56 @@ export function applyNodePatch(
     timeoutMs: GIT_TIMEOUT_MS,
     input,
   });
-  return {
-    success: apply.status === 0,
-    stage: "apply",
-    touched,
-    stdout: boundText(apply.stdout, CMD_OUTPUT_MAX, patchBoundNotice).text,
-    stderr: boundText(apply.stderr, CMD_OUTPUT_MAX, patchBoundNotice).text,
-  };
+  const applyStdout = boundText(apply.stdout, CMD_OUTPUT_MAX, patchBoundNotice).text;
+  const applyStderr = boundText(apply.stderr, CMD_OUTPUT_MAX, patchBoundNotice).text;
+  if (apply.status !== 0) {
+    return { success: false, stage: "apply", touched, stdout: applyStdout, stderr: applyStderr };
+  }
+
+  // #2422 — a 0 exit is not evidence the file moved. Say what was OBSERVED rather than
+  // what git returned: if every touched file is byte-identical to its pre-apply state,
+  // nothing was applied, and reporting success sends the caller on to build on an edit
+  // that is not there. Only an ENTIRELY unchanged set is refused: a partial apply is
+  // not possible here (git apply is all-or-nothing without --reject), and a file that
+  // changed to something other than the caller's exact intent is a different claim than
+  // this check can make.
+  const unchanged = touched.filter((p) => {
+    const { abs } = resolveInJail(p, deps, resolvedBase);
+    const was = before.get(p);
+    const now = readIfPresent(abs, deps);
+    // undefined = unreadable. Never counts as evidence that nothing happened.
+    return was !== undefined && now !== undefined && was === now;
+  });
+  if (unchanged.length === touched.length) {
+    return {
+      success: false,
+      stage: "apply",
+      touched,
+      stdout: applyStdout,
+      stderr:
+        (applyStderr ? applyStderr + "\n\n" : "") +
+        `git apply exited 0 but every file the patch names is byte-identical to before ` +
+        `it ran (${unchanged.join(", ")}), so NOTHING was applied. Reporting success here ` +
+        `would have you build on an edit that is not on disk (#2422). Re-read the file ` +
+        `with node_pack (action:"read") and regenerate the patch against what it ` +
+        `actually contains — a hunk whose context has drifted is the usual cause.`,
+    };
+  }
+
+  return { success: true, stage: "apply", touched, stdout: applyStdout, stderr: applyStderr };
+}
+
+/** #2422 — file contents, or null when absent. A patch that CREATES a file has no
+ *  before-state, and null vs a string is exactly the change that proves it landed. */
+function readIfPresent(abs: string, deps: NodeDevDeps): string | null | undefined {
+  try {
+    return deps.existsSync(abs) ? deps.readFileBuffer(abs).toString("base64") : null;
+  } catch {
+    // UNREADABLE is not UNCHANGED. undefined is incomparable by the filter above, so a
+    // file we cannot read never becomes evidence that the apply did nothing — this
+    // check only ever refuses what it positively observed.
+    return undefined;
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2422 — the reported CLASS. The trigger is not reproduced; see below.

## What was wrong

    success: apply.status === 0

git's exit code, taken as proof the content moved. Nothing read the file back. Your "Expected" is exactly the fix: *a success/apply result must mean the requested content is present on immediate readback; otherwise return a failure.*

## The verifier, and the one I rejected

`git apply --check -R` looks like the natural check — if the patch is applied, it should reverse. Measured on a real rig, it is **wrong**:

| apply mode | file after | reverse-check |
|---|---|---|
| default (`whitespace=warn`) | `baseline = 9␠␠␠` | exit 0 ✓ |
| **`apply.whitespace=fix`** | `baseline = 9` | **exit 1 ✗** |

`apply.whitespace` is a **git config** — ambient, per-machine. So a reverse-check verifier would report a false failure on every whitespace-carrying patch for anyone who has that set. A byte comparison cannot be fooled by it: whitespace-fixed content still differs from what was there before.

## Refuses only what it positively observed

- only an **entirely** unchanged set is refused — `git apply` is all-or-nothing without `--reject`, and "changed, but not to exactly what you meant" is a claim this check cannot make;
- an **unreadable** file returns `undefined` and is incomparable, so it never becomes evidence that nothing happened;
- a **created** file is absent-then-present, which is a change;
- non-zero apply and failing `--check` keep their existing stages.

## I could not reproduce your trigger

Ruled out against real git 2.54.0, each measured rather than reasoned about:

| candidate | result |
|---|---|
| one-line hunk **with** context | applies correctly |
| one-line hunk, **zero** context (`@@ -2 +2 @@`) | exit 1 — already caught at `check` |
| empty patch | exit 128 — already caught |
| LF patch against a **CRLF** file | applies correctly |
| `custom_nodes` **inside** a git repo | applies correctly |

So this closes the class — a success that is not a success — but not a mechanism I can name. **Please paste the two one-line diffs verbatim if you still have them**; with this change they will now return a failure naming the file instead of a false success, which should also make the trigger much easier to see.

## Evidence

Six tests. The pre-fix mutation (trust the exit code) kills exactly the `REFUSES` test, 51 controls surviving.

**Suite:** 682 files, **12796 passed**, 6 skipped, 0 failures. `tsc --noEmit` exit 0.

## Not merged

Merge gate quota-blocked (codex resets Sep 1; Copilot exhausted). Verified and queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
