### PR TITLE
fix(2416): ComfyUI-Seed-API BytePlus nodes are no longer reported as local/free

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3469,6 +3469,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/src/__tests__/services/external-service-nodes-not-free.test.ts
+++ b/src/__tests__/services/external-service-nodes-not-free.test.ts
@@ -351,6 +351,9 @@ describe("#2416 ComfyUI-Seed-API BytePlus nodes are not free", () => {
   });
 
   it("THE REPORTED GRAPH: runtime is mixed, not local", async () => {
+    // Exact unfixed output from #2416:
+    // {"runtime":"local","usesApiNodes":false,"apiNodes":[],"externalApiNodes":[],
+    //  "classTypes":["Seedream4Unified","SeedancePro15Video","SaveImage"],"unknownNodes":[]}
     const out = await runtimeOf(
       ["Seedream4Unified", "SeedancePro15Video", "SaveImage"],
       {
@@ -360,14 +363,33 @@ describe("#2416 ComfyUI-Seed-API BytePlus nodes are not free", () => {
       },
     );
     expect(out.runtime).toBe("mixed");
-    expect(out.externalApiNodes).toEqual(
-      expect.arrayContaining(["Seedream4Unified", "SeedancePro15Video"]),
-    );
+    expect(out.usesApiNodes).toBe(true);
+    // Exact, not arrayContaining: SaveImage must stay off the paid list.
+    expect(out.externalApiNodes).toEqual(["Seedream4Unified", "SeedancePro15Video"]);
+    expect(out.externalProviders).toEqual(["BytePlus"]);
+    expect(out.apiNodes).toEqual([]);
+    expect(out.unknownNodes).toEqual([]);
   });
 
   it("a graph of only the LOCAL helper is still local", async () => {
+    // The reported-diff mutant (no localCategoryPrefixes) bills this by module match.
     const out = await runtimeOf(["VideoToFrames"], { VideoToFrames: SEED_FRAMES });
     expect(out.runtime).toBe("local");
+    expect(out.usesApiNodes).toBe(false);
     expect(out.externalApiNodes).toEqual([]);
+    expect(out.externalProviders).toBeUndefined();
+  });
+
+  it("the category prefix matches even when the pack directory is renamed", async () => {
+    // python_module is the clone folder. Without categoryPrefixes, a rename reads free —
+    // the same hole the fal and PoYo entries close this way.
+    const renamed = def({
+      ...SEED_IMAGE,
+      python_module: "custom_nodes.my-seed-fork",
+    } as Partial<ComfyUINodeDef>);
+    expect(isExternalServiceNode(renamed)).toBe(true);
+    const out = await runtimeOf(["Seedream4Unified"], { Seedream4Unified: renamed });
+    expect(out.runtime).toBe("api");
+    expect(out.externalProviders).toEqual(["BytePlus"]);
   });
 });

--- a/src/__tests__/services/external-service-nodes-not-free.test.ts
+++ b/src/__tests__/services/external-service-nodes-not-free.test.ts
@@ -287,3 +287,87 @@ describe("a paid external-service node is never reported as local/free (#1483)",
     expect(out.externalProviders).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #2416 — FloyoAI/ComfyUI-Seed-API. Same shape as PoYo: the BytePlus key lives in
+// config.ini or BYTEPLUS_API_KEY, never in a workflow input, so every generic signal
+// says free while the node spends the user's ModelArk balance.
+//
+// The fixtures are the pack's OWN categories, read from its sources rather than from
+// the report: Seed/ImageGeneration, Seed/VideoGeneration, Seed/Chat — and Seed/Video,
+// which the report did not mention and which must stay FREE.
+// ---------------------------------------------------------------------------
+
+/** The reported paid nodes. No credential input; api_node absent. */
+const SEED_IMAGE = def({
+  name: "Seedream4Unified",
+  category: "Seed/ImageGeneration",
+  python_module: "custom_nodes.ComfyUI-Seed-API",
+  input: { required: { prompt: ["STRING", {}] } },
+});
+const SEED_VIDEO = def({
+  name: "SeedancePro15Video",
+  category: "Seed/VideoGeneration",
+  python_module: "custom_nodes.ComfyUI-Seed-API",
+  input: { required: { prompt: ["STRING", {}] } },
+});
+const SEED_CHAT = def({
+  name: "SeedChatNode",
+  category: "Seed/Chat",
+  python_module: "custom_nodes.ComfyUI-Seed-API",
+  input: { required: { prompt: ["STRING", {}] } },
+});
+
+/** The pack's LOCAL helper: takes a video_url, requests.get()s it, shells out to
+ *  ffmpeg. No credential, no ModelArk call — billing it would report a free node as
+ *  paid. It matches the pack by `module`, so only the exemption keeps it free. */
+const SEED_FRAMES = def({
+  name: "VideoToFrames",
+  category: "Seed/Video",
+  python_module: "custom_nodes.ComfyUI-Seed-API",
+  input: { required: { video_url: ["STRING", {}] } },
+});
+
+describe("#2416 ComfyUI-Seed-API BytePlus nodes are not free", () => {
+  it("the three paid categories are external-service nodes", () => {
+    for (const d of [SEED_IMAGE, SEED_VIDEO, SEED_CHAT]) {
+      expect(isExternalServiceNode(d), `${d.name} must not read as free`).toBe(true);
+      expect(isApiNode(d), `${d.name} is not a Comfy partner node`).toBe(false);
+    }
+  });
+
+  it("Seed/Video stays FREE — the report's own diff would have billed it", () => {
+    // The reported fix listed only the three paid prefixes, but `module` matches the
+    // whole pack on its own, so without an exemption this local helper is swept in.
+    expect(isExternalServiceNode(SEED_FRAMES)).toBe(false);
+  });
+
+  it("the seed/video exemption does NOT swallow seed/videogeneration", () => {
+    // The exemption test is `category === p || category.startsWith(`${p}/`)`, so
+    // "seed/videogeneration" is neither equal to "seed/video" nor prefixed by
+    // "seed/video/". If that ever loosens, the paid video nodes silently go free.
+    expect(isExternalServiceNode(SEED_VIDEO)).toBe(true);
+    expect(isExternalServiceNode(SEED_FRAMES)).toBe(false);
+  });
+
+  it("THE REPORTED GRAPH: runtime is mixed, not local", async () => {
+    const out = await runtimeOf(
+      ["Seedream4Unified", "SeedancePro15Video", "SaveImage"],
+      {
+        Seedream4Unified: SEED_IMAGE,
+        SeedancePro15Video: SEED_VIDEO,
+        SaveImage: def({ name: "SaveImage", category: "image", python_module: "nodes" }),
+      },
+    );
+    expect(out.runtime).toBe("mixed");
+    expect(out.externalApiNodes).toEqual(
+      expect.arrayContaining(["Seedream4Unified", "SeedancePro15Video"]),
+    );
+  });
+
+  it("a graph of only the LOCAL helper is still local", async () => {
+    const out = await runtimeOf(["VideoToFrames"], { VideoToFrames: SEED_FRAMES });
+    expect(out.runtime).toBe("local");
+    expect(out.externalApiNodes).toEqual([]);
+  });
+});

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -147,6 +147,28 @@ const EXTERNAL_SERVICE_PACKS: readonly ExternalServicePack[] = [
   // the user's balance. The category prefix carries the match through a directory
   // rename the way the fal entries do.
   { module: "poyo-comfyui", categoryPrefixes: ["poyo ai"], provider: "PoYo" },
+  // #2416 — FloyoAI/ComfyUI-Seed-API, direct BytePlus ModelArk nodes. Same shape as
+  // PoYo above: the key lives in config.ini or BYTEPLUS_API_KEY, never in a workflow
+  // input, so declaresCredentialInput() sees nothing and api_node is false — and
+  // check_runtime answered `local` / free for nodes spending the user`s BytePlus balance.
+  //
+  // `Seed/Video` is EXEMPT and is not a typo for Seed/VideoGeneration. It holds one node,
+  // VideoToFrames, which takes a video_url, requests.get()s it and shells out to ffmpeg —
+  // no credential, no ModelArk call, so billing it would report a free node as paid. The
+  // reported fix listed only the three paid prefixes and would have swept this one in
+  // through the `module` match, which catches the whole pack on its own.
+  //
+  // The two prefixes cannot collide: the exemption test is `category === p ||
+  // category.startsWith(`${p}/`)`, and "seed/videogeneration" is neither equal to
+  // "seed/video" nor prefixed by "seed/video/". Verified against the pack`s own sources,
+  // not the report: CATEGORY is Seed/ImageGeneration, Seed/VideoGeneration, Seed/Chat and
+  // Seed/Video.
+  {
+    module: "comfyui-seed-api",
+    categoryPrefixes: ["seed/imagegeneration", "seed/videogeneration", "seed/chat"],
+    localCategoryPrefixes: ["seed/video"],
+    provider: "BytePlus",
+  },
 ];
 
 /**


### PR DESCRIPTION
Closes #2416.

## Same class as PoYo (#1855)

The BytePlus key lives in `config.ini` or `BYTEPLUS_API_KEY`, never in a workflow input, so `declaresCredentialInput()` sees nothing and `api_node` is false. Every generic signal this module has says *free* while the node spends the user's ModelArk balance — only a named entry can know better. The reporter identified that precisely.

## I did not take the reported diff, and the difference is a real defect

Categories read from the pack's **own sources**, not the report:

| file | CATEGORY | paid? |
|---|---|---|
| `nodes/byteplus_image_node.py` | `Seed/ImageGeneration` | yes |
| `nodes/byteplus_video_node.py` | `Seed/VideoGeneration` | yes |
| `nodes/byteplus_chat_node.py` | `Seed/Chat` | yes |
| `nodes/video_to_frames_node.py` | **`Seed/Video`** | **no** |

`Seed/Video` holds one node, `VideoToFrames`, which takes a `video_url`, `requests.get()`s it and shells out to ffmpeg — no credential, no ModelArk call.

The report listed only the three paid prefixes. But `packMatches` returns true on `pythonModule.includes(pack.module)`, so `module: "comfyui-seed-api"` catches **the whole pack** on its own — and the local helper would have been billed. That is the same error as the bug, pointing the other way: a free node reported as paid. `localCategoryPrefixes: ["seed/video"]` exempts it, exactly as the fal entries do for `fal/utils`.

**The two prefixes cannot collide**, and that is pinned rather than assumed: the exemption test is `category === p || category.startsWith(`${p}/`)`, so `"seed/videogeneration"` is neither equal to `"seed/video"` nor prefixed by `"seed/video/"`. If that ever loosens, the paid video nodes go silently free — which is why it has its own test.

## Mutation

| mutant | verdict |
|---|---|
| remove the entry (pre-fix) | killed — 3 failures, the paid nodes read free |
| **remove `localCategoryPrefixes` — the reported diff exactly** | killed — 3 failures, the local helper is billed |

16 controls survive the second.

## Evidence

Five tests, fixtures built from the pack's real categories, including the reported graph asserting `runtime:"mixed"` with `externalApiNodes:["Seedream4Unified","SeedancePro15Video"]` alongside a local `SaveImage` — the regression test the reporter asked for.

**Suite:** 682 files, **12795 passed**, 6 skipped. `tsc --noEmit` exit 0.

One honest note: the *first* full run showed 1 failure, which I could not attribute — the reporter output did not name it and three subsequent full runs were clean (12795/0 each). Recording it as an unattributed flake rather than claiming an unqualified green.

## Not merged

Merge gate quota-blocked (codex resets Sep 1; Copilot exhausted). Verified and queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
