### PR TITLE
fix(1716): a deferral request that does not qualify says which requirement it missed

### DIFF
--- a/src/__tests__/orchestrator/graph-read-during-render.test.ts
+++ b/src/__tests__/orchestrator/graph-read-during-render.test.ts
@@ -245,6 +245,92 @@ describe("graph MUTATIONS still fail fast while a prompt is running (#1639)", ()
     expect(textOf(res)).toMatch(/QUEUE BUSY/);
   });
 
+  // #1716 reopened — the fence above is CORRECT; the message was the defect. A caller
+  // that asked to defer and omitted expected_value got the byte-identical refusal an
+  // ordinary edit gets, naming neither parameter, so the documented opt-in looked
+  // broken. The test above passes either way (it only asserts QUEUE BUSY), which is
+  // why it held green through the whole life of the reported defect.
+  it("#1716 reopened: the refusal NAMES the missing expected_value", async () => {
+    startRender();
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "text", value: "a cat", defer_until_idle: true } as never,
+      ctx,
+    );
+    const text = textOf(res);
+
+    expect(sent).toEqual([]);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/defer_until_idle/);
+    expect(text).toMatch(/expected_value/);
+    expect(text).toMatch(/does not qualify/);
+    // The remedy has to be performable: naming the read that supplies the value.
+    expect(text).toMatch(/panel_query_graph/);
+  });
+
+  it("#1716 reopened: a deferral refusal is DISTINGUISHABLE from an ordinary one", async () => {
+    // This is the whole report: identical bytes whether or not deferral was requested.
+    startRender();
+    const { bridge } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+
+    const deferred = textOf(
+      await defByName("panel_set_widget").handler(
+        { node_id: 3, widget: "text", value: "a cat", defer_until_idle: true } as never,
+        ctx,
+      ),
+    );
+    const ordinary = textOf(
+      await defByName("panel_set_widget").handler(
+        { node_id: 3, widget: "text", value: "a cat" } as never,
+        ctx,
+      ),
+    );
+
+    expect(deferred).not.toBe(ordinary);
+    expect(ordinary).not.toMatch(/defer_until_idle/);
+  });
+
+  it("#1716 reopened: an ordinary edit's refusal is unchanged", async () => {
+    // The new branch is reached ONLY when defer_until_idle === true, so the message a
+    // normal caller sees must still be the #1933 one, word for word.
+    startRender();
+    const { bridge } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const text = textOf(
+      await defByName("panel_set_widget").handler(
+        { node_id: 3, widget: "text", value: "a cat" } as never,
+        ctx,
+      ),
+    );
+
+    expect(text).toMatch(/panel_set_widget was NOT sent/);
+    expect(text).toMatch(/panel_set_widget MUTATES the workflow/);
+    expect(text).toMatch(/NOT fenced/);
+    expect(text).not.toMatch(/does not qualify/);
+  });
+
+  it("#1716 reopened: a NON-SCALAR deferred value is named as the reason", async () => {
+    startRender();
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      {
+        node_id: 3,
+        widget: "text",
+        value: { not: "scalar" },
+        defer_until_idle: true,
+        expected_value: "old",
+      } as never,
+      ctx,
+    );
+
+    expect(sent).toEqual([]);
+    expect(textOf(res)).toMatch(/scalar/);
+  });
+
   it("the refusal names the reads that ARE available instead of sending the agent to poll", async () => {
     startRender("p-in-flight", "42");
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1429,14 +1429,47 @@ function isDeferredWidgetScalar(value: unknown): boolean {
  * request to reach that production classifier instead of refusing it unsent.
  */
 function graphCmdRequestsDeferredWidget(cmd: Record<string, unknown>): boolean {
-  return (
-    cmd.cmd === "graph_set_widget" &&
-    cmd.defer_until_idle === true &&
-    typeof cmd.widget === "string" &&
-    isDeferredWidgetScalar(cmd.value) &&
-    Object.prototype.hasOwnProperty.call(cmd, "expected_value") &&
-    isDeferredWidgetScalar(cmd.expected_value)
-  );
+  return deferredWidgetRequestGap(cmd) === null;
+}
+
+/**
+ * #1716 (reopened) — WHY a deferral request did not qualify, or null when it did.
+ *
+ * `defer_until_idle` and `expected_value` are BOTH optional in the tool schema, so
+ * `defer_until_idle:true` with no `expected_value` is a well-formed call that zod
+ * accepts and this gate then silently declines to exempt. The caller then received the
+ * BYTE-IDENTICAL queue-busy refusal an ordinary edit gets — a message naming neither
+ * parameter — which is what the reopened report describes: the documented opt-in
+ * appearing not to work, with nothing saying why.
+ *
+ * Stated here rather than as a zod refinement: a refinement rejects the call before it
+ * reaches the tool, and this is the only place that knows a deferral was ATTEMPTED.
+ */
+function deferredWidgetRequestGap(cmd: Record<string, unknown>): string | null {
+  if (cmd.cmd !== "graph_set_widget") return "it is not a widget write";
+  if (cmd.defer_until_idle !== true) return "defer_until_idle was not true";
+  if (typeof cmd.widget !== "string") return "no widget name was given";
+  if (!isDeferredWidgetScalar(cmd.value)) {
+    return "`value` is not a string, finite number or boolean — only scalar edits can be parked";
+  }
+  // Key PRESENCE is not enough: the tool handler always materialises the key when
+  // defer_until_idle is true (`expected_value: args.expected_value`), so an omitted
+  // argument arrives as an OWN key holding undefined. Testing hasOwnProperty alone made
+  // this branch unreachable from the only path that reaches it, and the reported case —
+  // simply not passing one — fell through to the type complaint below, which is true but
+  // tells the caller their value is the wrong TYPE rather than absent.
+  if (!Object.prototype.hasOwnProperty.call(cmd, "expected_value") || cmd.expected_value === undefined) {
+    return (
+      "`expected_value` was not supplied. Deferral is optimistic-concurrency guarded: " +
+      "the Panel re-reads the widget just before replaying the edit and refuses if it " +
+      "moved, so it needs the value you observed. Read it with panel_query_graph and " +
+      "pass it back"
+    );
+  }
+  if (!isDeferredWidgetScalar(cmd.expected_value)) {
+    return "`expected_value` is not a string, finite number or boolean";
+  }
+  return null;
 }
 
 function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | null {
@@ -1451,6 +1484,25 @@ function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | 
   if (graphCmdRequestsDeferredWidget(cmd)) return null;
   const snap = QueueMonitor.snapshot();
   if (!snap.running) return null;
+  // #1716 (reopened) — the caller ASKED to defer and the request did not qualify.
+  // Falling through to the generic refusal is what made the opt-in look broken:
+  // identical bytes whether deferral was requested or not. Name the requirement that
+  // was not met. Only reached while a prompt is actually running, so an ordinary
+  // edit's reply is byte-identical to before.
+  if (cmd.defer_until_idle === true) {
+    const gap = deferredWidgetRequestGap(cmd);
+    if (gap) {
+      const deferSubject = panelToolForGraphCmd(name) ?? "This edit";
+      return (
+        `${deferSubject} was NOT sent — nothing was applied. You asked to park this ` +
+        `edit until the queue is idle (defer_until_idle:true), but the request does ` +
+        `not qualify: ${gap}. QUEUE BUSY: a ComfyUI prompt is running` +
+        `${queueBusySnapshotNote()}, so the edit was fenced as an ordinary mutation. ` +
+        `Fix the request above and retry — or drop defer_until_idle and retry after ` +
+        `queue (action:"list") shows running: 0.`
+      );
+    }
+  }
   // #1933 — name what the CALLER called. `cmd.cmd` is the BRIDGE command
   // (observed: a `panel_set_widget` call arrives here as `graph_set_widget`),
   // and PanelToolCtx.call carries no tool identity, so the tool name is


### PR DESCRIPTION
Addresses the REOPENED half of artokun/comfyui-mcp-panel#1716 — `defer_until_idle:true` returning the byte-identical queue-busy refusal as an ordinary edit.

## The fence is right; the message was the defect

`defer_until_idle` and `expected_value` are **both optional** in the tool schema, so `defer_until_idle:true` with no `expected_value` is a call zod accepts. The queue-busy exemption requires the full protocol shape:

```ts
cmd.defer_until_idle === true &&
typeof cmd.widget === "string" &&
isDeferredWidgetScalar(cmd.value) &&
hasOwnProperty(cmd, "expected_value") && isDeferredWidgetScalar(cmd.expected_value)
```

Miss any of it and the exemption silently declines, and the caller falls through to a refusal that names **neither parameter**. That is the reopened report exactly: the documented opt-in appearing not to work, with nothing saying why.

Now the refusal names the unmet requirement and the read that supplies it. The branch is reached **only** when `defer_until_idle === true`, so an ordinary edit's refusal is byte-identical to before — pinned by its own test.

Stated at the gate rather than as a zod refinement: a refinement rejects the call before it reaches the tool, and this is the only place that knows a deferral was *attempted*.

## The existing test held green through the whole defect

```ts
it("a deferred widget request without an expected value stays fenced", …)
  expect(textOf(res)).toMatch(/QUEUE BUSY/);
```

That passes before and after this change, because it only asserts the fence fired. It documented the confusing behaviour rather than catching it. The new tests assert what the caller can actually *do* with the reply.

## My first version was wrong, and testing it is what showed that

I keyed "not supplied" on `hasOwnProperty`. But the tool handler always materialises the key when deferral is requested:

```ts
...(args.defer_until_idle === true
  ? { defer_until_idle: true, expected_value: args.expected_value }
  : {}),
```

So an omitted argument arrives as an **own key holding `undefined`** — making the not-supplied branch unreachable from the only path that reaches it. The reported case (not passing one at all) got the *type* complaint instead: true, but it tells the caller their value is the wrong type rather than absent.

`undefined` now counts as not supplied, and a mutation restoring the `hasOwnProperty`-only test fails. I would not have found this by reading; the message I got back from the test was simply the wrong one.

## Mutation

| mutant | verdict |
|---|---|
| remove the disclosure branch (pre-fix) | killed — 3 failures |
| key-presence only (**my first attempt**) | killed — 1 failure |

**Suite:** 28/28 in the render-gate file; full suite 682 files, **12794 passed**, 6 skipped. `tsc --noEmit` exit 0.

## Scope

This does not re-litigate whether the deferral itself parks correctly — panel#1775 / mcp#2238 shipped that in panel v0.15.81 / mcp v0.52.101, and the panel-side classifier is unchanged here. This is the orchestrator-side gate that was refusing qualifying-looking requests before they ever reached it.

## Not merged

Merge gate quota-blocked (codex resets Sep 1; Copilot exhausted). Verified and queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
