### PR TITLE
fix(1937): the panel router runs the call when its payload is under `parameters`

### DIFF
--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -653,6 +653,349 @@ describe("OllamaBackend", () => {
     }
   });
 
+  // #1937 — ChatGPT's multi_tool_use.parallel names each recipient's payload
+  // `parameters`, and after the first call in a batch the model copies that key
+  // inward instead of `args`. #1824 fixed the headless `call_tool` facade for
+  // exactly this; the panel router was left on `args ?? arguments` alone, so the
+  // real payload was dropped and `panel_set_widget` was invoked with `{}` —
+  // reaching the panel MCP server's strict schema as
+  // "MCP error -32602: Input validation error ... received undefined at node_id;
+  //  expected string, received undefined at widget", with the arguments the model
+  // actually wrote sitting one key away.
+  it("panel_call_tool runs the call when the payload is under `parameters` instead of `args` (#1937)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_set_widget", description: "Set a widget value." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "panel_call_tool",
+                  arguments: {
+                    name: "panel_set_widget",
+                    parameters: { node_id: 30, widget: "frame_load_cap", value: 192 },
+                  },
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "set." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "set frame_load_cap to 192" }));
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_set_widget", arguments: { node_id: 30, widget: "frame_load_cap", value: 192 } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
+  });
+
+  // The reporter's wire shape, not a convenient one: the ChatGPT backend hands
+  // `dispatch` the Responses API's `function_call.arguments` — a JSON STRING — so
+  // the wrapper key arrives inside text that dispatch parses first. Pinned
+  // separately because a fix that only ever saw a pre-parsed object would look
+  // green while the path that actually reported the bug stayed broken.
+  it("panel_call_tool accepts a `parameters` payload arriving as a JSON string (#1937)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_set_widget", description: "Set a widget value." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "panel_call_tool",
+                  arguments:
+                    '{"name":"panel_set_widget","parameters":{"node_id":30,"widget":"frame_load_cap","value":192}}',
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "set." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "set frame_load_cap to 192" }));
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_set_widget", arguments: { node_id: 30, widget: "frame_load_cap", value: 192 } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
+  });
+
+  it("panel_call_tool prefers `args` over a colliding `parameters` wrapper (#1937)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_set_widget", description: "Set a widget value." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "panel_call_tool",
+                  arguments: {
+                    name: "panel_set_widget",
+                    args: { node_id: 30, widget: "from_args", value: 1 },
+                    parameters: { node_id: 99, widget: "from_parameters", value: 2 },
+                  },
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "set." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "set it" }));
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_set_widget", arguments: { node_id: 30, widget: "from_args", value: 1 } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
+  });
+
+  it("unwraps a self-nested envelope whose INNER payload is under `parameters` (#1937)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_set_widget", description: "Set a widget value." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "panel_call_tool",
+                  arguments: {
+                    name: "panel_call_tool",
+                    args: {
+                      name: "panel_set_widget",
+                      parameters: { node_id: 30, widget: "frame_load_cap", value: 192 },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "set." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "set it" }));
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_set_widget", arguments: { node_id: 30, widget: "frame_load_cap", value: 192 } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
+  });
+
+  // The same wrapper key, one hop away: the FORGIVING DIRECT DISPATCH path below
+  // the router exists because models call a panel tool by its bare name, and
+  // `multi_tool_use.parallel` names THAT payload `parameters` too. Forwarded raw
+  // it hits the panel server's strict schema as an unrecognized key AND two
+  // missing required fields.
+  it("a bare-name panel call unwraps a lone `parameters` wrapper (#1937)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_set_widget", description: "Set a widget value." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "panel_set_widget",
+                  arguments: { parameters: { node_id: 30, widget: "frame_load_cap", value: 192 } },
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "set." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "set frame_load_cap to 192" }));
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_set_widget", arguments: { node_id: 30, widget: "frame_load_cap", value: 192 } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
+  });
+
+  // The unwrap must never eat a payload the tool actually declares. panel_add_mcp
+  // takes a real `args` array today, and a tool taking `parameters` must reach its
+  // handler with that key intact — otherwise the recovery silently deletes a
+  // legitimate argument.
+  it("does NOT unwrap `parameters` when the panel tool declares it (#1937)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      {
+        name: "panel_takes_parameters",
+        description: "A tool whose own schema has a parameters field.",
+        inputSchema: { type: "object", properties: { parameters: { type: "object" } } },
+      },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "panel_takes_parameters",
+                  arguments: { parameters: { depth: 3 } },
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "ok." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "run it" }));
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_takes_parameters", arguments: { parameters: { depth: 3 } } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
+  });
+
+  // The headless surface has the same bare-name hole. #1824 fixed the `call_tool`
+  // FACADE, which is all a compact-mode client can reach — but in full mode every
+  // comfy tool is registered directly, so the wrapper lands on the tool itself and
+  // the facade's alias never runs.
+  it("a bare-name comfy call unwraps a lone `parameters` wrapper (#1937)", async () => {
+    const { client: comfy, callTool: comfyCall } = fakeMcpClient([
+      { name: "download_model", description: "Download a model." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "download_model",
+                  arguments: { parameters: { action: "status", id: "dl-7" } },
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "checked." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "check the download" }));
+    expect(comfyCall).toHaveBeenCalledWith({
+      name: "download_model",
+      arguments: { action: "status", id: "dl-7" },
+    });
+  });
+
+  // A wrapper key alongside real fields is NOT a wrapper — it is a model that
+  // spelled most of the call correctly. Unwrapping there would throw the sibling
+  // fields away, so the payload must pass through untouched and let the tool's
+  // own schema speak.
+  it("does NOT unwrap `parameters` when it sits alongside other keys (#1937)", async () => {
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel, callTool: panelCall } = fakeMcpClient([
+      { name: "panel_set_widget", description: "Set a widget value." },
+    ]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "panel_set_widget",
+                  arguments: { node_id: 30, parameters: { widget: "frame_load_cap", value: 192 } },
+                },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "ok." }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "set it" }));
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_set_widget", arguments: { node_id: 30, parameters: { widget: "frame_load_cap", value: 192 } } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
+  });
+
   it("panel_call_tool without a name field says what is missing instead of 'Unknown panel tool '''", async () => {
     const { client: comfy } = fakeMcpClient(COMFY_META);
     const { client: panel, callTool: panelCall } = fakeMcpClient([

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -487,6 +487,42 @@ function firstSentence(text: string, maxLen = 160): string {
   return line.length <= maxLen ? line : `${line.slice(0, maxLen - 1).trimEnd()}…`;
 }
 
+/**
+ * #1937 — undo ChatGPT's `multi_tool_use.parallel` payload wrapper on a call that
+ * named its tool DIRECTLY (no router envelope to hold the alias).
+ *
+ * The wrapper names each recipient's payload `parameters`, and after the first
+ * call in a batch the model copies that key inward. `panel_call_tool` can absorb
+ * that as an alias for `args` because the payload is a field of the envelope; a
+ * bare-name call has no envelope, so `{parameters: {...}}` IS the whole argument
+ * object and reaches the tool's own schema — where panel_* tools are `.strict()`
+ * (#754) and answer with an unrecognized key plus every required field missing.
+ * That is #1824's defect at the one call site its fix could not reach.
+ *
+ * Deliberately narrow, because the cost of over-reaching is deleting a real
+ * argument rather than surfacing a confusing error:
+ *  - the payload's ONLY key must be `parameters` — a wrapper key beside real
+ *    fields is a call the model mostly spelled right, and unwrapping would throw
+ *    those siblings away;
+ *  - its value must be a plain object, never an array or scalar;
+ *  - the target tool must not declare `parameters` itself. No tool in either
+ *    surface does today (only `panel_add_mcp` claims one of these names, `args`,
+ *    which this never touches), so the check is a latch against a future one.
+ * Anything else passes through untouched and lets the tool's schema speak.
+ */
+function unwrapParametersWrapper(
+  args: Record<string, unknown>,
+  inputSchema: unknown,
+): Record<string, unknown> {
+  const keys = Object.keys(args);
+  if (keys.length !== 1 || keys[0] !== "parameters") return args;
+  const inner = args.parameters;
+  if (inner === null || typeof inner !== "object" || Array.isArray(inner)) return args;
+  const props = (inputSchema as { properties?: Record<string, unknown> } | null | undefined)?.properties;
+  if (props && Object.prototype.hasOwnProperty.call(props, "parameters")) return args;
+  return inner as Record<string, unknown>;
+}
+
 /** Does this id look like a model this backend can run? PanelAgent
  *  unconditionally passes the panel's Claude model as opts.model — this guard
  *  keeps the configured model in charge unless the panel explicitly picked one
@@ -808,9 +844,10 @@ export class OllamaBackend implements AgentBackend {
     }
 
     try {
-      if (this.comfyTools.some((t) => t.name === name)) {
+      const comfyTool = this.comfyTools.find((t) => t.name === name);
+      if (comfyTool) {
         if (!this.comfy) return { text: "comfyui tools are unavailable in this session.", isError: true };
-        const res = await this.comfy.callTool({ name, arguments: args });
+        const res = await this.comfy.callTool({ name, arguments: unwrapParametersWrapper(args, comfyTool.inputSchema) });
         return { text: textOf(res), isError: !!res.isError };
       }
       if (name === "panel_list_tools") {
@@ -842,7 +879,15 @@ export class OllamaBackend implements AgentBackend {
       if (name === "panel_call_tool") {
         if (!this.panel) return { text: "panel tools are unavailable in this session.", isError: true };
         let wanted = typeof args.name === "string" ? args.name : typeof args.tool_name === "string" ? (args.tool_name as string) : "";
-        let inner: unknown = args.args ?? args.arguments ?? {};
+        // #1937 — `parameters` is the THIRD accepted spelling of the payload, for
+        // the same reason #1824 added it to the headless `call_tool`: ChatGPT's
+        // multi_tool_use.parallel names each recipient's payload `parameters`, and
+        // after the first call in a batch the model copies that key inward. With
+        // only `args ?? arguments` here the real payload was dropped and the panel
+        // tool ran with `{}` — surfacing as `MCP error -32602: Input validation
+        // error … received undefined at node_id`, an error about arguments the
+        // model had in fact written, one key away. `args` still wins a collision.
+        let inner: unknown = args.args ?? args.arguments ?? args.parameters ?? {};
         // #1297 — ROUTER SELF-NESTING: a malformed call wraps the real invocation
         // in a second router envelope (panel_call_tool {"name": "panel_call_tool",
         // "args": {"name": "<tool>", "args": {...}}}). The old reply — "Unknown
@@ -868,7 +913,7 @@ export class OllamaBackend implements AgentBackend {
           const nestedName = nested && typeof nested.name === "string" ? nested.name : "";
           if (wanted === "panel_call_tool" && nested && this.panelTools.some((t) => t.name === nestedName)) {
             wanted = nestedName;
-            inner = nested.args ?? nested.arguments ?? {};
+            inner = nested.args ?? nested.arguments ?? nested.parameters ?? {};
             unwrapped = true;
           } else {
             return {
@@ -925,11 +970,14 @@ export class OllamaBackend implements AgentBackend {
       // real panel tool, run it on the panel client; anything else is handed to
       // the compact server's call_tool, whose unknown-name error carries
       // close-match suggestions the model can recover from.
-      if (this.panel && this.panelTools.some((t) => t.name === name)) {
+      const panelTool = this.panel ? this.panelTools.find((t) => t.name === name) : undefined;
+      if (this.panel && panelTool) {
         // Same #325 timeout as the panel_call_tool router path above.
-        const res = await this.panel.callTool({ name, arguments: args }, undefined, {
-          timeout: PANEL_TOOL_MCP_TIMEOUT_MS,
-        });
+        const res = await this.panel.callTool(
+          { name, arguments: unwrapParametersWrapper(args, panelTool.inputSchema) },
+          undefined,
+          { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+        );
         return { text: textOf(res), isError: !!res.isError };
       }
       if (this.comfy && this.comfyTools.some((t) => t.name === "call_tool")) {


### PR DESCRIPTION
Reported as **artokun/comfyui-mcp-panel#1937** (P2, `via-panel`, reporter on comfyui-mcp `0.52.139` / panel `0.15.113`). Filed against the panel repo, but the defect is entirely here: `multi_tool`, `panel_call_tool` and the string `a node id must be an integer` all have **zero** hits across the panel pack — `panel_set_widget`'s schema and its router are both in this repo.

## What the reporter saw

`panel_set_widget` through ChatGPT's parallel/multi-tool wrapper failed as though `node_id` and `widget` had never been sent, while the identical arguments succeeded through a plain `panel_call_tool`:

```
MCP error -32602: Input validation error for panel_set_widget:
a node id must be an integer … received undefined at node_id;
expected string, received undefined at widget
```

## Root cause — this is #1824, at the call sites its fix could not reach

`multi_tool_use.parallel` names each recipient's payload `parameters`, and after the first call in a batch the model copies that key inward instead of `args`. #1824 diagnosed exactly this and added `parameters` as an alias — but only to the headless `call_tool` facade in `src/tools/compact.ts:293`.

The panel router in `ollama-backend.ts` (shared by the ChatGPT, Grok, Qwen and Ollama backends — `chatgpt-oauth-backend.ts:442` calls straight into `dispatch`) still read `args.args ?? args.arguments`. So the payload was dropped and the panel tool was invoked with `{}`, reaching the panel MCP server's `.strict()` schema (#754) as the error above — about arguments the model had in fact written, sitting one key away.

Reproduced before touching the fix, driving the real backend through the existing scripted-`/api/chat` harness. The pre-fix run shows the payload being deleted, not mangled:

```
  1st vi.fn() call:
  [
    {
-     "arguments": {
-       "node_id": 30,
-       "value": 192,
-       "widget": "frame_load_cap",
-     },
+     "arguments": {},
      "name": "panel_set_widget",
```

## The change

Four places the key can arrive, not just the one that was reported:

1. **`panel_call_tool` envelope** — `parameters` becomes the third accepted spelling. `args` still wins a collision (pinned by its own test), exactly mirroring compact.ts.
2. **The #1297 self-nested envelope's INNER payload** — same rule, or the recovery added for #1297 hands the unwrapped call an empty object.
3. **Bare-name dispatch of a panel tool**, and 4. **of a comfy tool**. The "FORGIVING DIRECT DISPATCH" block exists because models call an inner tool by its bare name; in full mode every comfy tool is registered directly, so the facade's alias never runs there at all. These have no envelope to hold an alias — `{parameters: {...}}` **is** the whole argument object — so `unwrapParametersWrapper` undoes it.

## Where to look hardest — `unwrapParametersWrapper`

This is the load-bearing part, and the only place the change can do harm: over-reaching here **deletes a real argument** instead of surfacing a confusing error. It fires only when all three hold:

- `parameters` is the payload's **sole** key — a wrapper key beside real fields is a call the model mostly spelled right, and unwrapping would throw the siblings away;
- its value is a plain object (never an array or scalar);
- the target tool does not declare `parameters` itself.

On that last latch: I enumerated both surfaces rather than assuming. Across all **96** panel tool defs and the comfy catalog, the only tool claiming any of these names is `panel_add_mcp`, which declares **`args`** — a key this helper never touches. So no tool collides today; the schema check is there so a future one cannot.

The router path (1 & 2) deliberately gets a plain alias with no such guard, because `parameters` is not a router-envelope key at all — there is nothing there to be ambiguous with.

## Verification

- **Reproduced by execution first**, then fixed — the diff above is the pre-fix run.
- **Every hunk mutation-verified.** Six mutations, each reverting one hunk in isolation, each re-running the file; all six **KILLED**, each by a *different* test, so no hunk is dead code and no test is satisfied by a sibling call site:

  | mutation | result | test that went red |
  |---|---|---|
  | drop `?? args.parameters` (router) | KILLED | *…payload is under `parameters` instead of `args`* **and** *…arriving as a JSON string* |
  | drop `?? nested.parameters` | KILLED | *unwraps a self-nested envelope whose INNER payload is under `parameters`* |
  | panel bare-name forwards `args` raw | KILLED | *a bare-name panel call unwraps a lone `parameters` wrapper* |
  | comfy bare-name forwards `args` raw | KILLED | *a bare-name comfy call unwraps a lone `parameters` wrapper* |
  | lone-key guard removed | KILLED | *does NOT unwrap `parameters` when it sits alongside other keys* |
  | schema latch removed | KILLED | *does NOT unwrap `parameters` when the panel tool declares it* |

  The harness restores from an in-memory snapshot (never `git checkout`), asserts the file is byte-identical afterwards, and re-runs to confirm green.
- **The reporter's wire shape is pinned separately.** The ChatGPT backend hands `dispatch` the Responses API's `function_call.arguments` — a JSON **string** — so one test feeds the wrapper as text rather than a pre-parsed object. Without it, a fix that only ever saw an object would look green while the path that actually reported the bug stayed broken.
- Full suite: **682 files, 12798 passed, 6 skipped**. `npm run lint` clean (tsc + anti-slop: "none added").

## What I did NOT do

**No browser gate.** This is orchestrator tool-dispatch and renders nothing; more to the point the panel's Playwright suite drives a `MockBridge`, so it fakes the orchestrator and structurally *cannot* cover a change on this side. I am claiming no browser coverage rather than implying it.

**No live-canvas run.** No ComfyUI was allocated to this run, so the end-to-end path is proved through the backend harness (which drives the real `dispatch` and a real MCP client shim), not against a running rig.

The panel issue does not auto-close across repos; I will close **comfyui-mcp-panel#1937** by hand once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
