### PR TITLE
docs(1933): panel_list_nodes says it lists PACKS, and names the tool that finds a node class

### DIFF
--- a/src/__tests__/orchestrator/list-nodes-scope-description.test.ts
+++ b/src/__tests__/orchestrator/list-nodes-scope-description.test.ts
@@ -1,0 +1,75 @@
+// comfyui-mcp-panel#1933 — `panel_list_nodes({search:"LTXVContextWindowsGuideAware"})`
+// was rejected with "this tool takes no arguments", and the reporter concluded the
+// schema and the documentation disagreed.
+//
+// They did not. The schema is `{}` and the tool is correct: it lists installed PACKS.
+// What was missing is that the description never said a pack is not a node class, and
+// never named the tool that answers the question actually being asked. An accurate
+// rejection that points nowhere costs the caller the same time as a wrong one.
+//
+// Three tools sit close enough together to be confused, and this pins that the
+// description distinguishes them:
+//   panel_list_nodes   — packs ALREADY installed        (no arguments)
+//   panel_search_nodes — packs INSTALLABLE from registry
+//   comfy_cli action:"search_nodes" — real node CLASSES, with a live /object_info fallback
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(
+  new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+/** The def(...) block for one tool, from its name literal to the next def boundary. */
+function toolBlock(name: string): string {
+  const at = SRC.indexOf(`"${name}",`);
+  expect(at, `${name} not found — re-anchor this pin`).toBeGreaterThan(0);
+  return SRC.slice(at, at + 2000);
+}
+
+describe("panel_list_nodes says what it lists (panel#1933)", () => {
+  const block = toolBlock("panel_list_nodes");
+
+  it("still takes no arguments — the schema was never the defect", () => {
+    // The fix is documentation. If someone later adds a `search` argument, this pin
+    // should fail so the description is revisited with it rather than left stale.
+    expect(block).toMatch(/"panel_list_nodes",[\s\S]{0,1200}?\n\s*\{\},/);
+  });
+
+  it("says it lists PACKS, not node classes", () => {
+    expect(block).toMatch(/PACKS/);
+    expect(block).toMatch(/NOT node classes/i);
+  });
+
+  it("names the tool that DOES find a node class", () => {
+    // The reporter's actual question was whether one node type was available. Naming
+    // the answer is the whole point; a rejection with no redirect is what cost them.
+    expect(block).toContain('comfy_cli action:\\"search_nodes\\"');
+  });
+
+  it("distinguishes the third neighbour, which searches INSTALLABLE packs", () => {
+    expect(block).toContain("panel_search_nodes");
+    expect(block).toMatch(/INSTALLABLE/);
+  });
+
+  it("states it takes no arguments, so the rejection is predictable", () => {
+    expect(block).toMatch(/[Tt]akes no arguments/);
+  });
+});
+
+describe("the tools the description redirects to actually exist", () => {
+  // A redirect to a tool that does not exist is the same defect as no redirect, and
+  // worse: it reads as actionable. check:vocabulary enforces this repo-wide for tool
+  // NAME literals; this pins the two this description depends on specifically, so a
+  // rename cannot quietly strand the sentence.
+  it("comfy_cli is a registered tool name", () => {
+    expect(SRC.includes("comfy_cli") || readFileSync(
+      new URL("../../tools/comfy-cli.ts", import.meta.url),
+      "utf8",
+    ).includes('"comfy_cli"')).toBe(true);
+  });
+
+  it("panel_search_nodes is defined in this same surface", () => {
+    expect(SRC).toContain('"panel_search_nodes",');
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -22187,7 +22187,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_list_nodes",
-      "List the custom-node packs currently installed in the user's ComfyUI (via the built-in Manager). Read-only.",
+      "List the custom-node PACKS currently installed in the user's ComfyUI (via the built-in Manager). Takes no arguments — it returns the whole installed set. Read-only. This lists packs, NOT node classes: to find out whether a specific node type is available (e.g. LTXVContextWindowsGuideAware), use comfy_cli action:\"search_nodes\", which fuzzy-searches real node classes and falls back to the connected server's live /object_info. panel_search_nodes is a third thing again — it searches INSTALLABLE packs in the registry, not what is already here.",
       {},
       async (_args, ctx) => ctx.call({ cmd: "nodes_list" }, 20000),
     ),


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#1933.

## The schema and the docs did not disagree

The report concluded they were out of sync. They are not: the schema is `{}` and the tool is correct — it lists installed **packs**. `LTXVContextWindowsGuideAware` is a node **class**, so no argument on this tool could have answered the question being asked.

What was missing is that the description never said a pack is not a node class, and never named the tool that *does* answer it. **An accurate rejection that points nowhere costs the caller exactly what a wrong one does** — that is the defect, and it is a real one.

## Three neighbours, now separated

| tool | answers |
|---|---|
| `panel_list_nodes` | packs **already installed** (no arguments) |
| `panel_search_nodes` | packs **installable** from the registry |
| `comfy_cli action:"search_nodes"` | real node **classes**, with a live `/object_info` fallback |

The third is what the reporter needed. It fuzzy-searches actual ComfyUI node classes and, when comfy-cli is absent, falls back to searching the connected server's own `/object_info` — so it works on exactly the "is this node type here?" question.

## No behaviour change

Description text and a test file. The schema is untouched.

## What the pins are for

- **The schema is still `{}`.** If someone later adds a real `search` argument, that pin fails, so the description gets revisited *with* it rather than left stale describing a tool that has changed.
- **The tools it redirects to exist.** A redirect to a missing tool is the same defect as no redirect and reads as more actionable. `check:vocabulary` enforces this repo-wide for tool-name literals and passes here — naming `comfy_cli` and `panel_search_nodes` is validated, not assumed.

## Evidence

7 pins green. `tsc --noEmit` exit 0, `check:vocabulary` exit 0.

**Suite:** 683 files, **12796 passed**, 6 skipped. One failure in the full run — `late-mutation-e2e.test.ts`, asserting a 60 ms reply window — is the known load flake under parallel execution; **5/5 passing in isolation**, and untouched by a description string.

## Not merged

Merge gate quota-blocked (codex resets Sep 1; Copilot exhausted). Verified and queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
