### PR TITLE
fix(2429): compact-mode list_tools category walks are not a catalog hunt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- compact-mode `list_tools` / `panel_list_tools` enumeration is not a catalog hunt (#2429)
+
 ## [0.52.141] - 2026-08-27
 
 ### MCP

--- a/src/__tests__/orchestrator/discovery-call-key.test.ts
+++ b/src/__tests__/orchestrator/discovery-call-key.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { discoveryCallKey } from "../../orchestrator/ollama-backend.js";
+
+const SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/ollama-backend.ts", import.meta.url)),
+  "utf8",
+);
+
+/**
+ * #2429 — compact-mode enumeration is not a catalog hunt.
+ *
+ * The discovery breaker keys per tool (or per `name action:"…"`). Counting
+ * `list_tools` / `panel_list_tools` by bare name treats a category walk as
+ * the Civitai-hunt wedge: each `list_tools {category}` has distinct args so
+ * the exact-repeat breaker stays at 1–2, while one discovery key climbs to 8
+ * and kills the turn. That is the log `repeats=2 discovery=9`.
+ *
+ * These tests drive the shipped `discoveryCallKey` (the loop's only keying
+ * function). They fail if list/panel_list are counted without a non-empty
+ * `search`.
+ */
+describe("discoveryCallKey (#2429)", () => {
+  it("the tool loop keys discovery through the shipped function, not a bare-name Set", () => {
+    expect(SRC).toMatch(/const discoveryKey = discoveryCallKey\(name, args\)/);
+    expect(SRC).not.toMatch(/DISCOVERY_TOOLS\.has\(name\)/);
+  });
+
+  it("does not count compact-mode enumeration: bare, empty search, or category", () => {
+    expect(discoveryCallKey("list_tools", {})).toBeUndefined();
+    expect(discoveryCallKey("list_tools", { category: "generation" })).toBeUndefined();
+    expect(discoveryCallKey("list_tools", { category: "models" })).toBeUndefined();
+    expect(discoveryCallKey("list_tools", { search: "" })).toBeUndefined();
+    expect(discoveryCallKey("list_tools", { search: "   " })).toBeUndefined();
+    expect(discoveryCallKey("panel_list_tools", {})).toBeUndefined();
+    expect(discoveryCallKey("panel_list_tools", { search: "" })).toBeUndefined();
+  });
+
+  it("still counts a keyword search on the catalog listers (the Civitai-hunt wedge)", () => {
+    expect(discoveryCallKey("list_tools", { search: "civitai" })).toBe("list_tools");
+    expect(discoveryCallKey("list_tools", { category: "models", search: "lora" })).toBe("list_tools");
+    expect(discoveryCallKey("list_tools", '{"search":"flux"}')).toBe("list_tools");
+    expect(discoveryCallKey("panel_list_tools", { search: "add node" })).toBe("panel_list_tools");
+  });
+
+  it("still keys consolidated tools on the SEARCH action, never the other actions (#839)", () => {
+    expect(discoveryCallKey("download_model", { action: "download", url: "https://h/1.safetensors" })).toBeUndefined();
+    expect(discoveryCallKey("download_model", { action: "search", query: "flux" })).toBe(
+      'download_model action:"search"',
+    );
+    expect(discoveryCallKey("search_custom_nodes", { action: "details", id: "a-pack" })).toBeUndefined();
+    expect(discoveryCallKey("search_custom_nodes", { action: "search", query: "lora" })).toBe(
+      'search_custom_nodes action:"search"',
+    );
+  });
+
+  it("does not count describe/call — those are progress, not a hunt", () => {
+    expect(discoveryCallKey("describe_tool", { name: "generate_image" })).toBeUndefined();
+    expect(discoveryCallKey("call_tool", { name: "generate_image", args: {} })).toBeUndefined();
+    expect(discoveryCallKey("panel_describe_tool", { name: "panel_add_node" })).toBeUndefined();
+  });
+});

--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -329,6 +329,67 @@ describe("OllamaBackend", () => {
   });
 
   /**
+   * #2429 — the logged failure was `repeats=2 discovery=9`. Bare identical
+   * `list_tools {}` cannot produce that (the exact-repeat breaker dies at 4
+   * first). `list_tools` also takes `category`, and walking the catalog
+   * headings is the compact-mode protocol: each call has distinct args so
+   * repeats stay at 1–2, while a bare-name counter climbs on one key and
+   * kills the turn. That is the same #839 fold the action-keying already
+   * fixed for download_model / search_custom_nodes.
+   *
+   * Unfixed counting fails this: SEARCH LIMIT from the 4th category, then
+   * tool_loop at 8/9 with no answer. Fixed: every new category dispatches,
+   * the one exact repeat is blocked, the turn completes.
+   */
+  it("#2429 compact-mode category enumeration is not a discovery hunt (repeats=2 discovery=9)", async () => {
+    const { client, callTool } = fakeMcpClient(COMFY_META);
+    const backend = new OllamaBackend({ model: "gemma4:e4b", connectToolClients: async () => ({ comfyui: client }) });
+    const list = (args: Record<string, unknown>, extra?: Record<string, unknown>) => [
+      {
+        message: {
+          content: "",
+          tool_calls: [
+            { function: { name: "list_tools", arguments: args } },
+            ...(extra ? [{ function: { name: "list_tools", arguments: extra } }] : []),
+          ],
+        },
+        done: true,
+      },
+    ];
+    // 7 distinct categories, then a round with one more AND a repeat of the
+    // first — 9 list_tools, max exact-args repeats = 2, one discovery key.
+    chatScript.push(
+      list({ category: "generation" }),
+      list({ category: "models" }),
+      list({ category: "workflows" }),
+      list({ category: "custom-nodes" }),
+      list({ category: "diagnostics" }),
+      list({ category: "server" }),
+      list({ category: "images-assets" }),
+      list({ category: "apps" }, { category: "generation" }),
+      [{ message: { content: "generate_image is in the generation category." }, done: true }],
+    );
+    const events = await collect(backend, turnsOf({ text: "what can you generate?" }));
+    // 8 distinct categories dispatched; the one exact repeat is blocked, not
+    // re-run. None of them is a keyword search, so SEARCH LIMIT must not fire.
+    expect(callTool).toHaveBeenCalledTimes(8);
+    const limitNudges = chatRequests
+      .flatMap((r) => r.messages)
+      .filter((m) => m.role === "tool" && String(m.content).startsWith("SEARCH LIMIT"));
+    expect(limitNudges).toEqual([]);
+    const repeats = chatRequests
+      .flatMap((r) => r.messages)
+      .filter((m) => m.role === "tool" && String(m.content).startsWith("REPEAT CALL BLOCKED"));
+    expect(repeats).toHaveLength(1);
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: true, turn: 1, usage: expect.anything() },
+    ]);
+    const assistant = events.filter((e) => e.type === "assistant") as Array<{ text: string }>;
+    expect(assistant).toHaveLength(1);
+    expect(assistant[0].text).toContain("generate_image");
+  });
+
+  /**
    * 0.50.0 slice 11 folded the HuggingFace model search into
    * download_model action:"search", so the discovery counter had to become
    * action-aware. Keyed on the bare name it would count a download as a catalog

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -462,6 +462,64 @@ function msgOf(err: unknown): string {
  * same reason the repeat-call key stringifies rather than reads them.
  */
 function toolCallAction(args: unknown): string | undefined {
+  return stringField(args, "action");
+}
+
+/**
+ * Discovery-breaker key for one tool call, or undefined if this call is not a
+ * catalog search.
+ *
+ * Keyed on `tool` + `action` for consolidated tools, and that is not
+ * cosmetic: 0.50.0 slice 11 folded the HuggingFace search into
+ * download_model action:"search", and the SAME tool name now also STARTS
+ * MULTI-GB DOWNLOADS. Counting the bare name would answer a fourth
+ * download_model {action:"download"} in one turn with a "SEARCH LIMIT"
+ * refusal instead of downloading, and end the turn at eight — a fold
+ * turning legitimate calls into refusals because the thing reading the
+ * name was not updated with it (#839).
+ *
+ * 0.50.0 slice 12: `search_custom_nodes` SURVIVES the fold, but it now also
+ * covers the retired pack-DETAILS lookup as action:"details" — and that name
+ * was never counted here. Keying the bare name would start counting a call
+ * that never counted, on the workflow that is CORRECT: search once, then
+ * read `details` for three or four candidate packs. The fourth would be
+ * answered with "STOP searching" while the model is doing exactly the right
+ * thing, and at eight the turn breaks. Same #839 shape as the download_model
+ * case above, so the same remedy: key the ACTION, and count only the
+ * keyword search.
+ *
+ * `list_tools` / `panel_list_tools` are the remaining instance of that fold
+ * (#2429). Compact mode's protocol is to enumerate them — including walking
+ * `list_tools {category:…}` across the catalog headings — and the
+ * exact-repeat breaker already catches a wedged identical call. Counting
+ * the bare name treats that walk as the Civitai-hunt wedge: four categories
+ * get "STOP searching", eight kill the turn with repeats still at 1–2
+ * (every category is a distinct args blob). Count them only when the call
+ * carries a non-empty `search`; that is the hunt this counter exists for.
+ */
+const DISCOVERY_SEARCH_ACTIONS = new Set([
+  'download_model action:"search"',
+  'search_custom_nodes action:"search"',
+]);
+
+export function discoveryCallKey(name: string, args: unknown): string | undefined {
+  const action = toolCallAction(args);
+  if (action !== undefined) {
+    const keyed = `${name} action:"${action}"`;
+    if (DISCOVERY_SEARCH_ACTIONS.has(keyed)) return keyed;
+  }
+  if (name === "list_tools" || name === "panel_list_tools") {
+    return catalogHasSearch(args) ? name : undefined;
+  }
+  return undefined;
+}
+
+function catalogHasSearch(args: unknown): boolean {
+  const search = stringField(args, "search");
+  return search !== undefined && search.trim().length > 0;
+}
+
+function stringField(args: unknown, key: "action" | "search"): string | undefined {
   let obj: unknown = args;
   if (typeof args === "string") {
     try {
@@ -471,8 +529,10 @@ function toolCallAction(args: unknown): string | undefined {
     }
   }
   if (!obj || typeof obj !== "object") return undefined;
-  const action = (obj as { action?: unknown }).action;
-  return typeof action === "string" ? action : undefined;
+  const value = key === "action"
+    ? (obj as { action?: unknown }).action
+    : (obj as { search?: unknown }).search;
+  return typeof value === "string" ? value : undefined;
 }
 
 function textOf(result: McpCallResult): string {
@@ -1699,34 +1759,11 @@ export class OllamaBackend implements AgentBackend {
     // DISCOVERY meta-tool with a DIFFERENT search each round (list_tools
     // {"search":"lora"} → {"search":"civitai"} → {"search":"flux"} …), hunting a
     // capability that isn't in the catalog — every call is unique so the
-    // exact-repeat breaker above never fires. Count calls per discovery tool
-    // (ignoring args); past a threshold, stop searching and tell it the truth
-    // (some capabilities live in OPTIONAL companion servers). describe_tool is
+    // exact-repeat breaker above never fires. Count calls per discovery key
+    // (see discoveryCallKey; ignoring args that are not the search);
+    // past a threshold, stop searching and tell it the truth (some
+    // capabilities live in OPTIONAL companion servers). describe_tool is
     // NOT here — describing many distinct tools is legitimate exploration.
-    //
-    // Keyed on `tool` + `action` for consolidated tools, and that is not
-    // cosmetic: 0.50.0 slice 11 folded the HuggingFace search into
-    // download_model action:"search", and the SAME tool name now also STARTS
-    // MULTI-GB DOWNLOADS. Counting the bare name would answer a fourth
-    // download_model {action:"download"} in one turn with a "SEARCH LIMIT"
-    // refusal instead of downloading, and end the turn at eight — a fold
-    // turning legitimate calls into refusals because the thing reading the
-    // name was not updated with it (#839).
-    const DISCOVERY_TOOLS = new Set([
-      "list_tools",
-      "panel_list_tools",
-      'download_model action:"search"',
-      // 0.50.0 slice 12: was the bare name. `search_custom_nodes` SURVIVES the
-      // fold, but it now also covers the retired pack-DETAILS lookup as
-      // action:"details" — and that name was never counted here. Keying the bare
-      // name would start counting a call that never counted, on the workflow
-      // that is CORRECT: search once, then read `details` for three or four
-      // candidate packs. The fourth would be answered with "STOP searching"
-      // while the model is doing exactly the right thing, and at eight the turn
-      // breaks. Same #839 shape as the download_model case above, so the same
-      // remedy: key the ACTION, and count only the keyword search.
-      'search_custom_nodes action:"search"',
-    ]);
     const discoveryCounts = new Map<string, number>();
     let emptyFinalRetried = false;
     let attachmentsStripped = false;
@@ -1925,15 +1962,11 @@ export class OllamaBackend implements AgentBackend {
           const repeats = (seenCalls.get(callKey) ?? 0) + 1;
           seenCalls.set(callKey, repeats);
           maxRepeats = Math.max(maxRepeats, repeats);
-          // The consolidated form first, then the bare name — so a tool whose
-          // whole surface is discovery still counts, while a consolidated tool
-          // counts only for the action that actually searches.
-          const action = toolCallAction(args);
-          const discoveryKey = action !== undefined && DISCOVERY_TOOLS.has(`${name} action:"${action}"`)
-            ? `${name} action:"${action}"`
-            : DISCOVERY_TOOLS.has(name)
-              ? name
-              : undefined;
+          // The consolidated form first, then a catalog lister only when it
+          // actually searches — so a tool whose whole surface is discovery
+          // still counts, a consolidated tool counts only for the action that
+          // searches, and compact-mode enumeration (bare / category) does not.
+          const discoveryKey = discoveryCallKey(name, args);
           const discoveryHits = discoveryKey
             ? (discoveryCounts.set(discoveryKey, (discoveryCounts.get(discoveryKey) ?? 0) + 1),
               discoveryCounts.get(discoveryKey)!)


### PR DESCRIPTION
Closes #2429.

## The hole in the previous analysis

The earlier attempt was right that `maxDiscovery` is per-key, and right that identical `list_tools {}` cannot produce the logged `repeats=2 discovery=9` (the exact-repeat breaker dies at 4 first). It was wrong that *the only varying argument `list_tools` takes is `search`*.

`list_tools` also takes `category` — the catalog headings. Walking those is the compact-mode protocol: each call has distinct args, so repeats stay at 1–2, while a bare-name counter climbs on one key and kills the turn.

That is the same #839 fold this file already fixed twice (`download_model` keyed on `action:"search"` so downloads don't count; `search_custom_nodes` keyed on `action:"search"` so `details` lookups don't count).

## Demonstration

A turn of 7 distinct `list_tools {category}`, then one round with a new category *and* a repeat of the first (9 calls, max exact-args repeats = 2):

- **Unfixed** (count the bare name): `tool loop broken: repeats=2 discovery=9` — the reporter's log — SEARCH LIMIT from the 4th category, turn dies with no answer.
- **Fixed**: 8 distinct categories dispatch, the one exact repeat is blocked, no SEARCH LIMIT, turn completes.

Keyword `search` is still the Civitai-hunt wedge (existing test still dies at 8).

## Fix

Shipped `discoveryCallKey(name, args)` is the loop's only keying function. `list_tools` / `panel_list_tools` count only when the call carries a non-empty `search`. Consolidated tools still key the SEARCH action.

Tests drive that function and fail on the unfixed counting.

Targeted vitest: **63 passed / 0 failed** (`discovery-call-key.test.ts` + `ollama-backend.test.ts`).
