### PR TITLE
fix(2419): Save-As re-points session routing onto the dest tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - compact-mode `list_tools` / `panel_list_tools` enumeration is not a catalog hunt (#2429)
+- Save-As re-points session routing so panel_set_todo and panel_canvas follow the dest tab (#2419)
 
 ## [0.52.141] - 2026-08-27
 

--- a/src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts
+++ b/src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts
@@ -127,7 +127,7 @@ function bridgeFor(opts?: { keepOldTab?: boolean }): PanelToolCtx["bridge"] {
       scopePin = NEW_TAB;
       return NEW_TAB;
     },
-  } as unknown as PanelToolCtx["bridge"];
+  } as PanelToolCtx["bridge"];
 }
 
 beforeEach(() => {
@@ -227,8 +227,8 @@ describe("#2419 Save-As re-points a dead SCOPE pin onto the dest canvas", () => 
 describe("#2419 Save-As routing recovery stays fail-closed when dest is ambiguous", () => {
   it("leaves routing on the old address when two live tabs match the dest path", async () => {
     const b = bridgeFor();
-    const origSend = (b as unknown as { send: PanelToolCtx["bridge"]["send"] }).send;
-    (b as unknown as { send: PanelToolCtx["bridge"]["send"] }).send = async (c, extra) => {
+    const origSend = b.send;
+    b.send = async (c, extra) => {
       const out = await origSend(c, extra);
       if (c.cmd === "workflow_save_as") {
         liveTabs = [

--- a/src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts
+++ b/src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts
@@ -1,0 +1,264 @@
+// #2419 — Save-As left panel_set_todo and panel_canvas routed to the old tab.
+//
+// After panel_save_workflow(name) created a Save-As copy and made it active,
+// graph reads/edits rebound because the command fence was refreshed from the
+// save reply (#814). Session-scoped commands still addressed the pre-save tab
+// id (`wf:…:workflows/Untitled ….json`) and failed with "no connected tab",
+// even though the only connected tab was the dest (`photo_to_anime_main`).
+//
+// The two updates are separate. The fence is already repaired. This file
+// drives the ROUTING half: re-point the session onto the dest tab when the
+// current address is dead. A live pin is left alone (#1917 / #884).
+//
+// Workaround that already worked: panel_set_workflow_target({mode:"current"}).
+// That tool is the only writer of the routing target; this makes Save-As do
+// the dead-pin recovery that workaround performs, without claiming current
+// while a live pin holds routing elsewhere.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const NEW_UUID = "11111111-2222-4333-8444-555555555555";
+const PRIOR_UUID = "99999999-8888-4777-a666-555555555555";
+const OLD_TAB = "wf:src-route:workflows/Untitled 1.json";
+const NEW_TAB = "wf:dest-route:workflows/photo_to_anime_main.json";
+const DEST_PATH = "workflows/photo_to_anime_main.json";
+const SCOPE = "orchestrator::codex";
+
+const SAVE_AS_REPLY = {
+  saved: true,
+  saved_as: true,
+  workflow: "photo_to_anime_main",
+  copied_from: "Untitled 1",
+  original_on_disk: true,
+  routing_key: "wf:workflows/photo_to_anime_main.json",
+  workflow_uuid: NEW_UUID,
+  workflow_instance_changed: true,
+};
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? (c as { text: string }).text : "")).join("\n");
+
+function toolNamed(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  return def;
+}
+
+let fence: string | undefined;
+let sent: Array<Record<string, unknown>>;
+let sentTab: string[];
+let saved: boolean;
+let liveTabs: Array<{ tab_id: string; title: string; connected_at: number }>;
+let reachable: Set<string>;
+let scopePin: string;
+let scopeRepins: Array<{ scope: string; path: string }>;
+
+function liveTabIds(): string[] {
+  return liveTabs.map((t) => t.tab_id);
+}
+
+function afterSaveAsLive(): void {
+  saved = true;
+  liveTabs = [{ tab_id: NEW_TAB, title: "photo_to_anime_main", connected_at: 1 }];
+  reachable = new Set([NEW_TAB]);
+}
+
+function bridgeFor(opts?: { keepOldTab?: boolean }): PanelToolCtx["bridge"] {
+  return {
+    send: async (c: Record<string, unknown>, extra?: { tabId?: string }) => {
+      sent.push(c);
+      sentTab.push(typeof extra?.tabId === "string" ? extra.tabId : "");
+      if (c.cmd === "workflow_save_as") {
+        if (!opts?.keepOldTab) afterSaveAsLive();
+        return SAVE_AS_REPLY;
+      }
+      if (c.cmd === "workflow_save") {
+        if (!opts?.keepOldTab) afterSaveAsLive();
+        return { saved: true, workflow: "photo_to_anime_main", ...SAVE_AS_REPLY };
+      }
+      if (c.cmd === "workflow_list") {
+        return {
+          active: {
+            path: DEST_PATH,
+            filename: "photo_to_anime_main.json",
+            routing_key: "wf:workflows/photo_to_anime_main.json",
+            workflow_uuid: NEW_UUID,
+          },
+          active_confirmed: true,
+          workflows: [
+            {
+              path: DEST_PATH,
+              filename: "photo_to_anime_main.json",
+              routing_key: "wf:workflows/photo_to_anime_main.json",
+              active: true,
+            },
+          ],
+        };
+      }
+      if (c.cmd === "set_todo") return { ok: true, items: c.items ?? [] };
+      if (c.cmd === "graph_canvas") return { ok: true, action: c.action };
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => {
+      if (id === SCOPE) return reachable.has(scopePin);
+      return reachable.has(id);
+    },
+    isHeadless: () => false,
+    tabs: () => liveTabs,
+    resolveActiveTabId: () => liveTabIds()[0] ?? NEW_TAB,
+    workflowUuidFor: () => ({ known: true, uuid: fence }),
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      fence = uuid;
+      return true;
+    },
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    tabCanMutateGraph: () => true,
+    repinScopeToWorkflow: (scope: string, path: string) => {
+      scopeRepins.push({ scope, path });
+      scopePin = NEW_TAB;
+      return NEW_TAB;
+    },
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+beforeEach(() => {
+  fence = PRIOR_UUID;
+  sent = [];
+  sentTab = [];
+  saved = false;
+  liveTabs = [{ tab_id: OLD_TAB, title: "Untitled 1", connected_at: 0 }];
+  reachable = new Set([OLD_TAB]);
+  scopePin = OLD_TAB;
+  scopeRepins = [];
+});
+
+describe("#2419 Save-As re-points a dead real-tab address onto the dest canvas", () => {
+  it("moves ctx.tabId from the retired Untitled id onto the dest tab", async () => {
+    const targets = new WorkflowTargetStore();
+    targets.set(OLD_TAB, { mode: "pinned", path: "workflows/Untitled 1.json", filename: "Untitled 1" });
+    const ctx = makePanelToolCtx(bridgeFor(), OLD_TAB, targets);
+
+    const res = await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(saved).toBe(true);
+    expect(ctx.tabId).toBe(NEW_TAB);
+    expect(ctx.tabId).not.toBe(OLD_TAB);
+    expect(targets.get(NEW_TAB)).toMatchObject({ mode: "pinned", path: "workflows/Untitled 1.json" });
+    expect(targets.get(OLD_TAB)).toEqual({ mode: "current" });
+  });
+
+  it("the next panel_set_todo and panel_canvas land on the dest tab, not the retired id", async () => {
+    const targets = new WorkflowTargetStore();
+    targets.set(OLD_TAB, { mode: "pinned", path: "workflows/Untitled 1.json" });
+    const ctx = makePanelToolCtx(bridgeFor(), OLD_TAB, targets);
+    await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    sent = [];
+    sentTab = [];
+    const todo = await toolNamed("panel_set_todo").handler(
+      { items: [{ text: "continue", status: "active" }] },
+      ctx,
+    );
+    const canvas = await toolNamed("panel_canvas").handler({ action: "fit" }, ctx);
+
+    expect(todo.isError, textOf(todo)).toBeFalsy();
+    expect(canvas.isError, textOf(canvas)).toBeFalsy();
+    expect(sent.map((c) => c.cmd)).toEqual(["set_todo", "graph_canvas"]);
+    expect(sentTab.every((id) => id === NEW_TAB)).toBe(true);
+    expect(sentTab).not.toContain(OLD_TAB);
+  });
+
+  it("does not displace a live pin — the old tab is still reachable (#1917)", async () => {
+    const ctx = makePanelToolCtx(bridgeFor({ keepOldTab: true }), OLD_TAB, new WorkflowTargetStore());
+    const res = await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(ctx.tabId).toBe(OLD_TAB);
+  });
+});
+
+describe("#2419 Save-As re-points a dead SCOPE pin onto the dest canvas", () => {
+  it("calls repinScopeToWorkflow with the dest path the save reply proved", async () => {
+    const ctx = makePanelToolCtx(bridgeFor(), SCOPE, new WorkflowTargetStore());
+    const res = await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(scopeRepins).toEqual([{ scope: SCOPE, path: DEST_PATH }]);
+    expect(scopePin).toBe(NEW_TAB);
+  });
+
+  it("the next panel_set_todo and panel_canvas then resolve through the dest pin", async () => {
+    const ctx = makePanelToolCtx(bridgeFor(), SCOPE, new WorkflowTargetStore());
+    await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    sent = [];
+    sentTab = [];
+    const todo = await toolNamed("panel_set_todo").handler(
+      { items: [{ text: "continue", status: "active" }] },
+      ctx,
+    );
+    const canvas = await toolNamed("panel_canvas").handler({ action: "fit" }, ctx);
+
+    expect(todo.isError, textOf(todo)).toBeFalsy();
+    expect(canvas.isError, textOf(canvas)).toBeFalsy();
+    expect(sent.map((c) => c.cmd)).toEqual(["set_todo", "graph_canvas"]);
+    expect(reachable.has(scopePin)).toBe(true);
+  });
+
+  it("does not call repinScopeToWorkflow when the scope pin still reaches (#1917)", async () => {
+    const ctx = makePanelToolCtx(bridgeFor({ keepOldTab: true }), SCOPE, new WorkflowTargetStore());
+    await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    expect(scopeRepins).toEqual([]);
+    expect(scopePin).toBe(OLD_TAB);
+  });
+});
+
+describe("#2419 Save-As routing recovery stays fail-closed when dest is ambiguous", () => {
+  it("leaves routing on the old address when two live tabs match the dest path", async () => {
+    const b = bridgeFor();
+    const origSend = (b as unknown as { send: PanelToolCtx["bridge"]["send"] }).send;
+    (b as unknown as { send: PanelToolCtx["bridge"]["send"] }).send = async (c, extra) => {
+      const out = await origSend(c, extra);
+      if (c.cmd === "workflow_save_as") {
+        liveTabs = [
+          { tab_id: NEW_TAB, title: "photo_to_anime_main", connected_at: 1 },
+          { tab_id: "wf:other:workflows/photo_to_anime_main.json", title: "copy", connected_at: 2 },
+        ];
+        reachable = new Set();
+      }
+      return out;
+    };
+    const ctx = makePanelToolCtx(b, OLD_TAB, new WorkflowTargetStore());
+    await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+    expect(ctx.tabId).toBe(OLD_TAB);
+  });
+});
+
+describe("#2419 WIRING: save re-points routing before the fence refresh", () => {
+  it("panel_save_workflow calls repointRoutingAfterSave immediately before refreshFenceFromOwnReply", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../orchestrator/panel-tools.ts"),
+      "utf8",
+    );
+    const saveIdx = src.indexOf('"panel_save_workflow"');
+    expect(saveIdx).toBeGreaterThan(0);
+    const saveBlock = src.slice(saveIdx, saveIdx + 9000);
+    expect(saveBlock).toMatch(
+      /repointRoutingAfterSave\(ctx, res\);\s*const fenceRebind = refreshFenceFromOwnReply\(ctx, res\)/,
+    );
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -107,7 +107,7 @@ import {
   isScopeAddress,
   shortTabId,
 } from "../services/session-scope.js";
-import type { ScopeRepinOutcome } from "./turn-origins.js";
+import { tabRouteCarriesPath, type ScopeRepinOutcome } from "./turn-origins.js";
 import {
   NODE_ID_MESSAGE,
   NODE_ID_PATTERN,
@@ -9810,6 +9810,89 @@ function refreshFenceFromOwnReply(ctx: PanelToolCtx, reply: ToolResult): Workflo
   } catch {
     return null; // never surface a throw here as worse than the existing fallback
   }
+}
+
+/**
+ * #2419 — the PATH the save reply names as the dest canvas.
+ *
+ * `routing_key` is the precise identity (`wf:<path>` handle, or a full
+ * `wf:<route>:<path>` tab id). `path` / `workflow` / `filename` are fallbacks
+ * for older replies that only named the new file. Empty / unreadable →
+ * undefined, so the caller leaves routing alone rather than guessing.
+ */
+function saveDestWorkflowPath(parsed: Record<string, unknown>): string | undefined {
+  const routing = parsed.routing_key;
+  if (typeof routing === "string" && routing.startsWith("wf:")) {
+    const rest = routing.slice(3);
+    const sep = rest.indexOf(":");
+    const pathPart =
+      sep >= 0 && rest.slice(sep + 1).includes("/") ? rest.slice(sep + 1) : rest;
+    const fromRouting = canonicalSavedWorkflowPath(pathPart);
+    if (fromRouting) return fromRouting;
+  }
+  for (const v of [parsed.path, parsed.workflow, parsed.filename]) {
+    if (typeof v !== "string") continue;
+    const trimmed = v.trim();
+    if (!trimmed) continue;
+    return canonicalSavedWorkflowPath(trimmed) ?? trimmed;
+  }
+  return undefined;
+}
+
+/** The unique live canvas tab whose route carries `destPath`, or undefined. */
+function uniqueLiveTabForSaveDest(ctx: PanelToolCtx, destPath: string): string | undefined {
+  const tabs = ctx.bridge.tabs;
+  if (typeof tabs !== "function") return undefined;
+  const live = tabs.call(ctx.bridge);
+  if (!Array.isArray(live)) return undefined;
+  const isHeadless = (id: string): boolean =>
+    typeof ctx.bridge.isHeadless === "function" && ctx.bridge.isHeadless(id);
+  const matches = live
+    .map((t) => t.tab_id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0 && !isHeadless(id))
+    .filter((id) => id === destPath || tabRouteCarriesPath(id, destPath));
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+/**
+ * #2419 — after Save-As (or a first save) mints a new tab id, the command
+ * fence is already refreshed from the reply, but session-scoped commands
+ * (`panel_set_todo`, `panel_canvas`) still address the old id.
+ *
+ * Re-point ONLY when the current routing address is dead. A live pin
+ * elsewhere is left alone — that is #1917 / #884: this recovery must not
+ * take a routing target out from under a pin another command in the same
+ * turn is relying on. Matching is on the dest path the save reply proved,
+ * and only when exactly one live canvas carries it, so this cannot silently
+ * redirect to a different workflow.
+ *
+ * Best-effort by construction: the file WAS written. A re-point that cannot
+ * happen must not retract the save.
+ */
+function repointRoutingAfterSave(ctx: PanelToolCtx, reply: ToolResult): void {
+  const parsed = parseToolResultJson(reply);
+  if (!parsed) return;
+  const destPath = saveDestWorkflowPath(parsed);
+  if (!destPath) return;
+  if (typeof ctx.bridge.canReach === "function" && ctx.bridge.canReach(ctx.tabId)) return;
+  const destTab = uniqueLiveTabForSaveDest(ctx, destPath);
+  if (!destTab) return;
+  if (isScopeAddress(ctx.tabId)) {
+    try {
+      ctx.bridge.repinScopeToWorkflow?.(ctx.tabId, destPath);
+    } catch {
+      // never worse than the pre-#2419 silence; the save already succeeded
+    }
+    return;
+  }
+  if (destTab === ctx.tabId) return;
+  const previous = ctx.tabId;
+  const pinned = ctx.workflowTarget?.get(previous);
+  if (ctx.workflowTarget && pinned?.mode === "pinned") {
+    ctx.workflowTarget.clear(previous);
+    ctx.workflowTarget.set(destTab, pinned);
+  }
+  ctx.tabId = destTab;
 }
 
 /**
@@ -21164,6 +21247,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // #814 — trust THIS reply's own proven uuid first (#800), before ever
         // attempting rebindWorkflowFence's independent workflow_list round trip,
         // which can be refused by the exact fence this repairs.
+        //
+        // #2419 — BEFORE the fence refresh so the stamp lands on the dest
+        // address. Save-As mints a new tab id; the fence repair re-stamps
+        // graph commands, but session-scoped commands (set_todo, graph_canvas)
+        // still address the old id unless routing is re-pointed. Only when
+        // the current address is dead — a live pin elsewhere is left alone
+        // (#1917 / #884).
+        repointRoutingAfterSave(ctx, res);
         const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
         let canMutateNow: boolean | undefined;
         let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement" | undefined;


### PR DESCRIPTION
## Summary
After `panel_save_workflow` Save-As, the command fence already rebound graph reads and edits to the dest workflow. Session-scoped commands (`panel_set_todo`, `panel_canvas`) still addressed the retired Untitled tab id and failed with `no connected tab`.

Save-As now re-points session routing onto the dest tab **when the current address is dead**. A live turn pin held elsewhere is left alone (#1917 / #884). Dest matching requires exactly one live canvas whose route carries the save reply's `routing_key` / path.

## Test plan
- [x] Targeted vitest: `save-as-todo-canvas-route`, `save-as-fence`, `fence-trusts-own-reply` — 27 passed
- Dead real-tab address (including pinned) moves onto dest; next `panel_set_todo` / `panel_canvas` dispatch there
- Dead scope pin calls `repinScopeToWorkflow` with the dest path
- Live pin is not displaced
- Ambiguous dest (two matching tabs) leaves routing unchanged

Closes #2419
