### PR TITLE
fix(2415): align #971 rebind identities and drop the proof on a canvas move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - compact-mode `list_tools` / `panel_list_tools` enumeration is not a catalog hunt (#2429)
 - Save-As re-points session routing so panel_set_todo and panel_canvas follow the dest tab (#2419)
+- #971 legacy rebind recovers a workflows/ path, and a later canvas move drops the proof (#2415)
 
 ## [0.52.141] - 2026-08-27
 

--- a/src/__tests__/orchestrator/legacy-rebind-recovery.test.ts
+++ b/src/__tests__/orchestrator/legacy-rebind-recovery.test.ts
@@ -81,7 +81,7 @@ function reconnectingBridge(
         if (live.size === 0) throw new Error("Panel not reachable: no panel connected");
         throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
       }),
-  } as unknown as PanelToolCtx["bridge"];
+  } as PanelToolCtx["bridge"];
   return {
     bridge,
     live,

--- a/src/__tests__/orchestrator/legacy-rebind-recovery.test.ts
+++ b/src/__tests__/orchestrator/legacy-rebind-recovery.test.ts
@@ -1,0 +1,209 @@
+// #2415 — two defects that hide each other, both shipped in 7fc8920e (#2408).
+//
+// 1. The #971 recovery is unreachable for any normally-stored workflow. The
+//    proof stores canonicalSavedRecordIdentity (`wf:workflows/demo.json`) and
+//    compared it to canonicalBareSavedIdentity (`wf:demo.json`, or null for a
+//    path containing `/`). Aligning those is the obvious fix.
+// 2. Aligning (1) alone activates a fail-open: the proof is keyed to tabId +
+//    savedIdentity, neither of which moves when the canvas does. A later
+//    non-open canvas change would then accept a stale `{ok:true, routedTo}`.
+//
+// Tests drive the shipped matcher / drop and the tool path that uses them.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetPanelBaseCache } from "../../services/panel-workspace.js";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks, __openWorkflowTestHooks } =
+  await import("../../orchestrator/panel-tools.js");
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { markDispatched } from "../../services/ui-bridge.js";
+import type { ExplicitCurrentRebindProof, PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const { legacyRebindMatchesRequested, dropStaleLegacyRebindProof } = __openWorkflowTestHooks;
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+function proofOf(savedIdentity: string, tabId = "tab-b"): ExplicitCurrentRebindProof {
+  return { tabId, savedIdentity };
+}
+
+function reconnectingBridge(
+  initial: string[] = [],
+  activePath = "demo.json",
+  resolveActiveTabId?: () => string,
+) {
+  const live = new Set(initial);
+  const headless = new Set<string>();
+  const sent: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
+  let currentPath = activePath;
+  const bridge = {
+    send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+      const id = opts?.tabId;
+      if (id && !live.has(id)) {
+        const connected = [...live].map((t) => `${t.slice(0, 8)} ("${t}")`).join(", ") || "none";
+        throw markDispatched(new Error(`no connected tab with id "${id}". Connected: ${connected}`), false);
+      }
+      sent.push({ cmd, tabId: id });
+      if (cmd.cmd === "workflow_list") {
+        const active = { path: currentPath, routing_key: `wf:${currentPath}` };
+        return {
+          workflows: [...live].map((t) =>
+            t === id
+              ? { ...active, active: true }
+              : { path: `${t}.json`, routing_key: `wf:${t}.json`, active: false },
+          ),
+          active,
+        };
+      }
+      if (cmd.cmd === "workflow_new") {
+        currentPath = "Unsaved Workflow";
+        return { ok: true, routedTo: id, created: true, key: "tmp:new", routing_key: "tmp:new" };
+      }
+      return { ok: true, routedTo: id };
+    },
+    push: () => 1,
+    canReach: (id: string) => live.has(id),
+    isHeadless: (id: string) => headless.has(id),
+    tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+    resolveActiveTabId:
+      resolveActiveTabId ??
+      (() => {
+        if (live.size === 1) return [...live][0];
+        if (live.size === 0) throw new Error("Panel not reachable: no panel connected");
+        throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
+      }),
+  } as unknown as PanelToolCtx["bridge"];
+  return {
+    bridge,
+    live,
+    headless,
+    sent,
+    setActivePath: (path: string) => {
+      currentPath = path;
+    },
+  };
+}
+
+async function rebindCurrent(ctx: PanelToolCtx): Promise<ToolResult> {
+  const target = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+  return (await target.handler({ mode: "current" }, ctx)) as ToolResult;
+}
+
+async function openWorkflow(ctx: PanelToolCtx, path: string): Promise<ToolResult> {
+  const open = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow")!;
+  return (await open.handler({ path }, ctx)) as ToolResult;
+}
+
+beforeEach(() => {
+  __resetPanelBaseCache();
+  __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 300, intervalMs: 5 });
+});
+afterEach(() => {
+  __panelToolsTestHooks.setReconnectWaitTiming(null);
+});
+
+describe("legacyRebindMatchesRequested (#2415)", () => {
+  it("matches a bare filename to the stored workflows/ identity — the unreachable recovery", () => {
+    // Unfixed: `wf:workflows/demo.json` === canonicalBareSavedIdentity("demo.json")
+    // is `wf:workflows/demo.json` === `wf:demo.json`.
+    expect(legacyRebindMatchesRequested(proofOf("wf:workflows/demo.json"), "demo.json")).toBe(true);
+  });
+
+  it("matches the exact stored path", () => {
+    expect(
+      legacyRebindMatchesRequested(proofOf("wf:workflows/demo.json"), "workflows/demo.json"),
+    ).toBe(true);
+  });
+
+  it("still matches the no-slash identity the existing #971 tests use", () => {
+    expect(legacyRebindMatchesRequested(proofOf("wf:demo.json"), "demo.json")).toBe(true);
+  });
+
+  it("rejects a different file", () => {
+    expect(legacyRebindMatchesRequested(proofOf("wf:workflows/demo.json"), "other.json")).toBe(false);
+  });
+
+  it("rejects a different workflows/ path that shares the basename", () => {
+    expect(
+      legacyRebindMatchesRequested(proofOf("wf:workflows/demo.json"), "other/demo.json"),
+    ).toBe(false);
+  });
+});
+
+describe("dropStaleLegacyRebindProof (#2415)", () => {
+  it("keeps the proof when the live canvas is still that identity", () => {
+    const ctx = {
+      tabId: "tab-b",
+      lastExplicitCurrentRebind: proofOf("wf:workflows/a.json"),
+    };
+    dropStaleLegacyRebindProof(ctx, {
+      path: "workflows/a.json",
+      routing_key: "wf:workflows/a.json",
+    });
+    expect(ctx.lastExplicitCurrentRebind).toEqual(proofOf("wf:workflows/a.json"));
+  });
+
+  it("drops the proof when the live canvas moved to a different saved workflow", () => {
+    const ctx = {
+      tabId: "tab-b",
+      lastExplicitCurrentRebind: proofOf("wf:workflows/a.json"),
+    };
+    dropStaleLegacyRebindProof(ctx, {
+      path: "workflows/b.json",
+      routing_key: "wf:workflows/b.json",
+    });
+    expect(ctx.lastExplicitCurrentRebind).toBeUndefined();
+  });
+
+  it("drops the proof when the observation is not a saved identity", () => {
+    const ctx = {
+      tabId: "tab-b",
+      lastExplicitCurrentRebind: proofOf("wf:a.json"),
+    };
+    dropStaleLegacyRebindProof(ctx, { ok: true, routedTo: "tab-b" });
+    expect(ctx.lastExplicitCurrentRebind).toBeUndefined();
+  });
+});
+
+describe("the shipped #971 recovery path (#2415)", () => {
+  it("recovers a legacy open of a bare alias after rebind to a workflows/ path", async () => {
+    const { bridge } = reconnectingBridge(["tab-a", "tab-b"], "workflows/demo.json", () => "tab-b");
+    const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+
+    const rebound = await rebindCurrent(ctx);
+    expect(rebound.isError).toBeFalsy();
+    expect(ctx.tabId).toBe("tab-b");
+    expect(ctx.lastExplicitCurrentRebind).toEqual(proofOf("wf:workflows/demo.json"));
+
+    const opened = await openWorkflow(ctx, "demo.json");
+    expect(opened.isError).toBeFalsy();
+    expect(ctx.lastExplicitCurrentRebind).toBeUndefined();
+  });
+
+  it("does not accept a stale proof after a non-open canvas move", async () => {
+    // Uses the no-slash identity so the unfixed comparison WOULD match — the
+    // fail-open that aligning identities alone activates.
+    const { bridge } = reconnectingBridge(["tab-a", "tab-b"], "a.json", () => "tab-b");
+    const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+
+    expect((await rebindCurrent(ctx)).isError).toBeFalsy();
+    expect(ctx.lastExplicitCurrentRebind).toEqual(proofOf("wf:a.json"));
+
+    const created = buildPanelToolDefs().find((d) => d.name === "panel_new_workflow")!;
+    expect(((await created.handler({}, ctx)) as ToolResult).isError).toBeFalsy();
+    expect(ctx.lastExplicitCurrentRebind).toBeUndefined();
+
+    const opened = await openWorkflow(ctx, "a.json");
+    expect(opened.isError).toBe(true);
+    expect(textOf(opened)).toMatch(/resolved path|UNKNOWN/i);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9802,6 +9802,9 @@ function refreshWorkflowUuid(ctx: PanelToolCtx, value: unknown): boolean {
 function refreshFenceFromOwnReply(ctx: PanelToolCtx, reply: ToolResult): WorkflowFenceRebind | null {
   const before = currentWorkflowFence(ctx);
   const parsed = parseToolResultJson(reply);
+  // #2415 — new / save / save-as / load re-point the canvas. Drop the #971
+  // proof unless this reply still names the identity it stored.
+  dropStaleLegacyRebindProof(ctx, parsed);
   if (!parsed) return null;
   const uuid = responseWorkflowUuid(parsed);
   if (!uuid) return null;
@@ -10723,6 +10726,9 @@ async function rebindWorkflowFence(
     };
   }
   const active = corroborated.active;
+  // #2415 — a later observation of a different live canvas must drop the #971
+  // proof. tabId + savedIdentity do not move when the canvas does.
+  dropStaleLegacyRebindProof(ctx, active);
   const uuid = responseWorkflowUuid(active);
   if (!uuid) {
     return {
@@ -11416,7 +11422,7 @@ async function refreshOpenWorkflowUuid(
   // confirmed active workflow contract.
   const legacyReboundRoute =
     legacyRebind?.tabId === ctx.tabId &&
-    legacyRebind.savedIdentity === canonicalBareSavedIdentity(requestedPath) &&
+    legacyRebindMatchesRequested(legacyRebind, requestedPath) &&
     !openResult.isError &&
     parsedOpen?.ok === true &&
     parsedOpen.routedTo === ctx.tabId &&
@@ -12301,6 +12307,54 @@ function canonicalBareSavedIdentity(path: unknown): string | null {
 }
 
 /**
+ * #2415 — does this #971 proof name the workflow the caller asked to open?
+ *
+ * The proof stores `canonicalSavedRecordIdentity` (`wf:workflows/demo.json`).
+ * Comparing that to `canonicalBareSavedIdentity(requestedPath)` (`wf:demo.json`,
+ * or null for any path containing `/`) made the recovery unsatisfiable for
+ * every normally-stored workflow. Accept the stored path exactly, or a bare
+ * filename that is that path's basename. Never a different file.
+ */
+function legacyRebindMatchesRequested(
+  proof: ExplicitCurrentRebindProof,
+  requestedPath: unknown,
+): boolean {
+  const requested = canonicalSavedWorkflowPath(requestedPath);
+  if (!requested) return false;
+  if (proof.savedIdentity === `wf:${requested}`) return true;
+  const bare = canonicalBareSavedIdentity(requested);
+  if (!bare) return false;
+  const savedPath = proof.savedIdentity.startsWith("wf:") ? proof.savedIdentity.slice(3) : "";
+  if (!savedPath) return false;
+  const slash = savedPath.lastIndexOf("/");
+  const savedBare = slash >= 0 ? savedPath.slice(slash + 1) : savedPath;
+  return `wf:${savedBare}` === bare;
+}
+
+/**
+ * #2415 — drop the #971 proof when the live canvas is no longer the identity
+ * it named. The proof is keyed to tabId + savedIdentity, neither of which
+ * moves with the canvas, so a later legacy `{ok:true, routedTo}` must not
+ * inherit it. A missing/unreadable identity is also a move: the proof no
+ * longer describes a world we can name.
+ */
+function dropStaleLegacyRebindProof(
+  ctx: Pick<PanelToolCtx, "tabId" | "lastExplicitCurrentRebind">,
+  observedActive?: unknown,
+): void {
+  const proof = ctx.lastExplicitCurrentRebind;
+  if (!proof) return;
+  if (proof.tabId !== ctx.tabId) {
+    ctx.lastExplicitCurrentRebind = undefined;
+    return;
+  }
+  const now = canonicalSavedRecordIdentity(observedActive);
+  if (!now || now !== proof.savedIdentity) {
+    ctx.lastExplicitCurrentRebind = undefined;
+  }
+}
+
+/**
  * Canonical `wf:<path>` identity, but only for a complete corroborating record.
  * Command-fence replacement is stricter than pin routing: a same-path record
  * with a missing/malformed route may be partial or replayed, and must not let a
@@ -12481,6 +12535,9 @@ export const __openWorkflowTestHooks = {
   activeMatchesOpenRefreshTarget,
   activeRecordMatchesExactSavedIdentity,
   resolveOpenWorkflow,
+  /** #2415 tests drive these, not a copy. */
+  legacyRebindMatchesRequested,
+  dropStaleLegacyRebindProof,
 };
 
 const slotRef = z.union([z.string(), z.number().int().min(0)]);


### PR DESCRIPTION
Two defects that hide each other, both shipped in `7fc8920e` (#2408). They must be fixed together: aligning the identities alone converts dead fail-closed code into a live fail-open.

## 1. The recovery is unreachable

The proof stores `canonicalSavedRecordIdentity(fenceRebind.active)` (`wf:workflows/demo.json`). The comparison used `canonicalBareSavedIdentity(requestedPath)` (`wf:demo.json`, or `null` for any path containing `/`). Those are exact complements. For `workflow_open("demo.json")` the predicate is `"wf:workflows/demo.json" === "wf:demo.json"` — false for every normally-stored workflow.

An explicit rebind followed by a legacy `workflow_open` was rejected as UNKNOWN when it should have been recoverable.

## 2. The proof survives a canvas move — currently masked by (1)

The proof is consumed on the next `workflow_open` and cleared at entry to `panel_set_workflow_target`. Nothing dropped it when the active workflow changed by any other route. It is keyed to `tabId` + `savedIdentity`, neither of which moves when the canvas does.

Sequence: rebind to `a.json`; change the active workflow to `b.json` by a path that is not a `workflow_open`; a legacy `{ok:true, routedTo}` reply for `workflow_open("a.json")` would then be accepted on a proof that no longer describes the world.

## The fix

- `legacyRebindMatchesRequested` — accept the stored path exactly, or a bare filename that is that path's basename. Never a different file. Wired at the `#971` comparison site.
- `dropStaleLegacyRebindProof` — drop when a later observation is missing, unreadable, a different saved identity, or a different tab. Called from `refreshFenceFromOwnReply` (new / save / save-as / load) and `rebindWorkflowFence`.

Tests in `src/__tests__/orchestrator/legacy-rebind-recovery.test.ts` drive those shipped functions and the tool path. Mutation-checked: reverting the comparison and the two drop call sites fails both shipped-path tests. Restored: 16/16 pass (`legacy-rebind-recovery` + existing `panel-971-recovery-deadend`).

Closes #2415