### PR TITLE
fix(2428): name the cause of a 0-tool ollama ready and log recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- Ollama names the cause of a 0-tool ready and logs recovery when the surface appears (#2428)
+
 ## [0.52.142] - 2026-08-27
 
 ### MCP

--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -6,8 +6,13 @@ import {
   acceptsModelId,
   isOllamaModel,
   ollamaSystemPrompt,
+  ollamaZeroToolCause,
+  ollamaZeroToolCauseMessage,
+  ollamaToolSurfaceRecoveredMessage,
+  __resetOllamaToolSurfaceAnnouncementForTests,
   type McpToolClient,
 } from "../../orchestrator/ollama-backend.js";
+import { logger } from "../../utils/logger.js";
 import { PANEL_TOOL_MCP_TIMEOUT_MS, __panelAskTestHooks } from "../../orchestrator/panel-tools.js";
 import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
 
@@ -1585,5 +1590,106 @@ describe("panel-router retraction rides the mode-varying prompt (main↔#788 mer
     await collect(backend, turnsOf({ text: "hello" }));
     sys = chatRequests.at(-1)!.messages[0] as { role: string; content: string };
     expect(sys.content).not.toContain("CORRECTION");
+  });
+});
+
+describe("#2428 — a tool-less ollama ready names its cause", () => {
+  const infos: string[] = [];
+  const warns: string[] = [];
+
+  beforeEach(() => {
+    infos.length = 0;
+    warns.length = 0;
+    __resetOllamaToolSurfaceAnnouncementForTests();
+    vi.spyOn(logger, "info").mockImplementation((msg: string) => {
+      infos.push(msg);
+    });
+    vi.spyOn(logger, "warn").mockImplementation((msg: string) => {
+      warns.push(msg);
+    });
+  });
+
+  afterEach(() => {
+    vi.mocked(logger.info).mockRestore();
+    vi.mocked(logger.warn).mockRestore();
+    __resetOllamaToolSurfaceAnnouncementForTests();
+  });
+
+  it("ollamaZeroToolCause names never-connected vs empty-catalog and is silent only when tools exist", () => {
+    expect(ollamaZeroToolCause(null, 0)).toBe("never-connected");
+    expect(ollamaZeroToolCause(fakeMcpClient([]).client, 0)).toBe("empty-catalog");
+    expect(ollamaZeroToolCause(fakeMcpClient(COMFY_META).client, 3)).toBeNull();
+  });
+
+  it("prepare with no MCP clients is WARN degraded + never-connected, not a silent ready", async () => {
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({}),
+      mcpServers: { panel: { transport: "http", url: "http://127.0.0.1:9198/orchestrator::ollama" } },
+    });
+    await backend.prepare();
+
+    expect(warns).toContain(ollamaZeroToolCauseMessage("never-connected", "comfyui"));
+    expect(warns).toContain(ollamaZeroToolCauseMessage("never-connected", "panel"));
+    expect(
+      warns.some(
+        (line) =>
+          line.includes("degraded") &&
+          line.includes("0 comfyui tools") &&
+          line.includes("0 panel tools") &&
+          line.includes("cause: never-connected"),
+      ),
+    ).toBe(true);
+    expect(
+      infos.some((line) => line.includes("[ollama-backend] ready (") && line.includes("0 comfyui tools")),
+    ).toBe(false);
+  });
+
+  it("prepare with a connected empty catalog names empty-catalog on the degraded line", async () => {
+    const { client } = fakeMcpClient([]);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: client }),
+    });
+    await backend.prepare();
+
+    expect(warns).toContain(ollamaZeroToolCauseMessage("empty-catalog", "comfyui"));
+    expect(
+      warns.some(
+        (line) =>
+          line.includes("degraded") && line.includes("0 comfyui tools") && line.includes("cause: empty-catalog"),
+      ),
+    ).toBe(true);
+    expect(
+      infos.some((line) => line.includes("[ollama-backend] ready (") && line.includes("0 comfyui tools")),
+    ).toBe(false);
+  });
+
+  it("a later prepare that gains tools logs tool surface recovered", async () => {
+    const empty = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({}),
+    });
+    await empty.prepare();
+
+    const { client: comfy } = fakeMcpClient(COMFY_META);
+    const { client: panel } = fakeMcpClient([{ name: "panel_run", description: "Run." }]);
+    const live = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ comfyui: comfy, panel }),
+    });
+    await live.prepare();
+
+    expect(infos).toContain(
+      ollamaToolSurfaceRecoveredMessage({ comfy: 0, panel: 0 }, { comfy: COMFY_META.length, panel: 1 }),
+    );
+    expect(
+      infos.some(
+        (line) =>
+          line.includes("[ollama-backend] ready (") &&
+          line.includes(`${COMFY_META.length} comfyui tools`) &&
+          line.includes("1 panel tools"),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -629,6 +629,59 @@ export function acceptsModelId(id: string, api: "ollama" | "openai"): boolean {
   return true;
 }
 
+/** Why a session has 0 comfyui tools. Compact mode still yields 3, so 0 is never
+ *  a valid working surface — the ready line must name one of these (#2428). */
+export type OllamaZeroToolCause = "never-connected" | "empty-catalog";
+
+export function ollamaZeroToolCause(
+  comfy: McpToolClient | null,
+  comfyToolCount: number,
+): OllamaZeroToolCause | null {
+  if (comfyToolCount > 0) return null;
+  return comfy ? "empty-catalog" : "never-connected";
+}
+
+export function ollamaZeroToolCauseMessage(
+  cause: OllamaZeroToolCause,
+  surface: "comfyui" | "panel",
+): string {
+  if (cause === "empty-catalog") {
+    return surface === "comfyui"
+      ? "[ollama-backend] the comfyui MCP client connected but enumerated 0 tools (cause: empty-catalog)"
+      : "[ollama-backend] the panel MCP client connected but enumerated 0 tools (cause: empty-catalog)";
+  }
+  return surface === "comfyui"
+    ? "[ollama-backend] the comfyui MCP client was never connected — this session has NO comfyui tools (cause: never-connected)"
+    : "[ollama-backend] the panel MCP client was never connected — this session has NO live-canvas tools (cause: never-connected)";
+}
+
+export function ollamaToolSurfaceRecoveredMessage(
+  from: { comfy: number; panel: number },
+  to: { comfy: number; panel: number },
+): string {
+  return `[ollama-backend] tool surface recovered: ${from.comfy} comfyui tools, ${from.panel} panel tools → ${to.comfy} comfyui tools, ${to.panel} panel tools`;
+}
+
+/** Last (comfy, panel) counts this process announced. A later instance that
+ *  gains tools after a 0/0 announcement must say so — that is the silent
+ *  recovery in #2428. */
+let lastAnnouncedOllamaToolSurface: { comfy: number; panel: number } | null = null;
+
+export function __resetOllamaToolSurfaceAnnouncementForTests(): void {
+  lastAnnouncedOllamaToolSurface = null;
+}
+
+function logOllamaToolSurfaceRecovery(comfy: number, panel: number): void {
+  const prev = lastAnnouncedOllamaToolSurface;
+  if (!prev || prev.comfy !== 0 || prev.panel !== 0) return;
+  if (comfy === 0 && panel === 0) return;
+  logger.info(ollamaToolSurfaceRecoveredMessage(prev, { comfy, panel }));
+}
+
+function rememberOllamaToolSurface(comfy: number, panel: number): void {
+  lastAnnouncedOllamaToolSurface = { comfy, panel };
+}
+
 export class OllamaBackend implements AgentBackend {
   readonly id: BackendId;
   readonly capabilities = OLLAMA_CAPABILITIES;
@@ -752,10 +805,7 @@ export class OllamaBackend implements AgentBackend {
     }
     await this.connectTools();
     this.prepared = true;
-    logger.info(
-      `[ollama-backend] ready (${this.api === "openai" ? `openai-compatible @ ${this.host}` : `ollama ${version}`}, model ${this.model}, ${this.comfyTools.length} comfyui tools, ${this.panelTools.length} panel tools behind the router)` +
-        (this.toolModeDecision ? ` — ${this.toolModeDecision.explain}` : ""),
-    );
+    this.announcePreparedToolSurface(version);
   }
 
   protected async connectTools(): Promise<void> {
@@ -823,6 +873,43 @@ export class OllamaBackend implements AgentBackend {
       await this.panel?.close().catch(() => {});
       this.panel = null;
       this.panelTools = [];
+    }
+    // Connect failures and listing failures already warn. The never-connected
+    // path does not throw, so without this a 0/0 ready had no cause at all (#2428).
+    this.warnIfToolClientsMissing();
+    logOllamaToolSurfaceRecovery(this.comfyTools.length, this.panelTools.length);
+    rememberOllamaToolSurface(this.comfyTools.length, this.panelTools.length);
+  }
+
+  /** Name the missing surface instead of letting 0/0 look like a healthy ready. */
+  private warnIfToolClientsMissing(): void {
+    if (!this.comfy) {
+      logger.warn(ollamaZeroToolCauseMessage("never-connected", "comfyui"));
+    } else if (this.comfyTools.length === 0) {
+      logger.warn(ollamaZeroToolCauseMessage("empty-catalog", "comfyui"));
+    }
+    if (!this.panel) {
+      if (this.deps.mcpServers?.panel) {
+        logger.warn(ollamaZeroToolCauseMessage("never-connected", "panel"));
+      }
+    } else if (this.panelTools.length === 0) {
+      logger.warn(ollamaZeroToolCauseMessage("empty-catalog", "panel"));
+    }
+  }
+
+  /** 0 comfyui tools is never a valid working state (compact still yields 3).
+   *  Emit that at WARN with `degraded` + a named cause so it is greppable. */
+  private announcePreparedToolSurface(version: string): void {
+    const comfy = this.comfyTools.length;
+    const panel = this.panelTools.length;
+    const summary =
+      `${this.api === "openai" ? `openai-compatible @ ${this.host}` : `ollama ${version}`}, model ${this.model}, ${comfy} comfyui tools, ${panel} panel tools behind the router` +
+      (this.toolModeDecision ? ` — ${this.toolModeDecision.explain}` : "");
+    const cause = ollamaZeroToolCause(this.comfy, comfy);
+    if (cause) {
+      logger.warn(`[ollama-backend] degraded (${summary}) — cause: ${cause}`);
+    } else {
+      logger.info(`[ollama-backend] ready (${summary})`);
     }
   }
 


### PR DESCRIPTION
A tool-less Ollama agent could print `ready (... 0 comfyui tools, 0 panel tools ...)` with none of the existing explanatory strings, then minutes later print `ready (... 3 comfyui tools, 96 panel tools)` with no log of what changed.

`connectTools()` only warns on throw. When `this.comfy` / `this.panel` were never constructed, the list-tools `try` body did not run, the arrays stayed `[]`, and `ready` looked healthy.

### What changed
- After connect/list, warn a **named cause** for a missing surface:
  - `cause: never-connected` — client was never constructed (the silent path)
  - `cause: empty-catalog` — client connected but enumerated 0 tools
- A 0-comfyui-tool prepare is `WARN degraded`, not a healthy `ready` (compact mode still yields 3)
- When a later prepare (or respawn) goes from 0/0 to a live surface, log `tool surface recovered: 0/0 → N/M`

Tests fail if the zero-tool ready is silent and pass when the cause is named.

Closes #2428