### PR TITLE
fix(2430): replay the earlier payload on a blocked repeat call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - Ollama names the cause of a 0-tool ready and logs recovery when the surface appears (#2428)
 - disclose unreindexed host links after panel_unexpose_subgraph_input/output (#2437)
+- a blocked repeat tool call returns the earlier payload instead of an error-string-only nudge (#2430)
 
 ## [0.52.142] - 2026-08-27
 

--- a/src/__tests__/orchestrator/blocked-repeat-result.test.ts
+++ b/src/__tests__/orchestrator/blocked-repeat-result.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { blockedRepeatResult } from "../../orchestrator/ollama-backend.js";
+
+const SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/ollama-backend.ts", import.meta.url)),
+  "utf8",
+);
+
+/**
+ * #2430 — REPEAT CALL BLOCKED used to return an error string with no payload
+ * while telling the model to "use the earlier result". Small models then
+ * invent the data (observed: 24.1 GB VRAM vs 31.84 GB, and a truncated argv
+ * with an invented flag).
+ *
+ * These tests drive the shipped `blockedRepeatResult` (the loop's only
+ * blocked-repeat answer). They fail on error-string-only and pass when the
+ * earlier result is attached.
+ */
+describe("blockedRepeatResult (#2430)", () => {
+  it("the tool loop answers a blocked repeat through the shipped function", () => {
+    expect(SRC).toMatch(/blockedRepeatResult\(name, prior\?\.result\)/);
+    expect(SRC).toMatch(/result: prior\?\.result \?\? text/);
+    // The unfixed path inlined `{ text: \`REPEAT CALL BLOCKED…\`, isError: true }`
+    // at the repeats >= 2 branch. The helper is the only answer now.
+    expect(SRC).not.toMatch(/repeats >= 2\s*\?\s*\{/);
+  });
+
+  it("attaches the earlier payload instead of an error-string-only nudge", () => {
+    const prior = JSON.stringify({
+      vram_total_gb: 31.84,
+      argv: "--feature-flag show_signin_button=true --enable-manager --listen 127.0.0.1,169.254.41.48 --port 8188 --fast",
+    });
+    const out = blockedRepeatResult("get_system_stats", prior);
+    expect(out.isError).toBe(false);
+    expect(out.text).toContain(prior);
+    expect(out.text).toContain("31.84");
+    expect(out.text).toContain("show_signin_button");
+    // The unfixed path: isError + "Use the earlier result" with none of the
+    // payload. That is the confabulation trap.
+    expect(out.text.startsWith("REPEAT CALL BLOCKED")).toBe(false);
+    expect(out.text).not.toMatch(/Use the earlier result/);
+  });
+
+  it("falls back to the breaker nudge only when there is no cached payload", () => {
+    const out = blockedRepeatResult("get_system_stats", undefined);
+    expect(out.isError).toBe(true);
+    expect(out.text.startsWith("REPEAT CALL BLOCKED")).toBe(true);
+    expect(out.text).toContain("get_system_stats");
+  });
+});

--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -253,18 +253,70 @@ describe("OllamaBackend", () => {
     chatScript.push(sameCall, sameCall, sameCall, sameCall, sameCall, sameCall);
 
     const events = await collect(backend, turnsOf({ text: "find krea" }));
-    // Dispatched exactly once — repeats got the corrective nudge, not a re-run.
+    // Dispatched exactly once — repeats replay the first payload, not a re-run.
     expect(callTool).toHaveBeenCalledTimes(1);
-    // Repeat calls receive the nudge as their tool result on the wire.
-    const nudges = chatRequests
+    // Repeat calls receive the earlier result on the wire (#2430), not an
+    // error-string-only "use the earlier result" nudge.
+    const toolMsgs = chatRequests
       .flatMap((r) => r.messages)
-      .filter((m) => m.role === "tool" && String(m.content).startsWith("REPEAT CALL BLOCKED"));
-    expect(nudges.length).toBeGreaterThanOrEqual(1);
+      .filter((m) => m.role === "tool")
+      .map((m) => String(m.content));
+    const replays = toolMsgs.filter((c) => c.includes("identical call already made this turn"));
+    expect(replays.length).toBeGreaterThanOrEqual(1);
+    for (const c of replays) {
+      expect(c).toContain("result-of-list_tools");
+      expect(c.startsWith("REPEAT CALL BLOCKED")).toBe(false);
+    }
     // Turn ends with the loop-breaker, not max_tool_rounds (32 rounds later).
     expect(events.filter((e) => e.type === "result")).toEqual([
       { type: "result", ok: false, subtype: "tool_loop", turn: 1 },
     ]);
     expect(chatRequests.length).toBeLessThanOrEqual(5);
+  });
+
+  it("#2430 a blocked repeat replays the earlier payload instead of an error-string-only nudge", async () => {
+    const payload = JSON.stringify({
+      vram_total_gb: 31.84,
+      argv: "--feature-flag show_signin_button=true --enable-manager --listen 127.0.0.1,169.254.41.48 --port 8188 --fast",
+    });
+    const callTool = vi.fn(async () => ({
+      content: [{ type: "text", text: payload }],
+    }));
+    const tools = [
+      ...COMFY_META,
+      { name: "get_system_stats", description: "Stats.", inputSchema: { type: "object", properties: {} } },
+    ];
+    const client: McpToolClient = {
+      listTools: async () => ({ tools }),
+      callTool: callTool as unknown as McpToolClient["callTool"],
+      close: async () => {},
+    };
+    const backend = new OllamaBackend({ model: "gemma4:e4b", connectToolClients: async () => ({ comfyui: client }) });
+    const statsCall = [
+      {
+        message: {
+          content: "",
+          tool_calls: [{ function: { name: "get_system_stats", arguments: {} } }],
+        },
+        done: true,
+      },
+    ];
+    chatScript.push(statsCall, statsCall, [{ message: { content: "VRAM is 31.84 GB." }, done: true }]);
+
+    const events = await collect(backend, turnsOf({ text: "Get the ComfyUI system stats." }));
+    expect(callTool).toHaveBeenCalledTimes(1);
+    const toolMsgs = chatRequests
+      .flatMap((r) => r.messages)
+      .filter((m) => m.role === "tool")
+      .map((m) => String(m.content));
+    expect(toolMsgs[0]).toBe(payload);
+    expect(toolMsgs[1]).toContain(payload);
+    expect(toolMsgs[1]).toContain("31.84");
+    expect(toolMsgs[1].startsWith("REPEAT CALL BLOCKED")).toBe(false);
+    expect(toolMsgs[1]).not.toMatch(/Use the earlier result/);
+    const ends = events.filter((e) => e.type === "tool_call" && (e as { phase: string }).phase === "end");
+    expect(ends[1]).toMatchObject({ detail: { isError: false } });
+    expect(events.filter((e) => e.type === "result")).toMatchObject([{ type: "result", ok: true }]);
   });
 
   it("recovers an EMPTY final after tool rounds with one summarize nudge (never loops)", async () => {
@@ -384,8 +436,10 @@ describe("OllamaBackend", () => {
     expect(limitNudges).toEqual([]);
     const repeats = chatRequests
       .flatMap((r) => r.messages)
-      .filter((m) => m.role === "tool" && String(m.content).startsWith("REPEAT CALL BLOCKED"));
+      .filter((m) => m.role === "tool" && String(m.content).includes("identical call already made this turn"));
     expect(repeats).toHaveLength(1);
+    expect(String(repeats[0].content)).toContain("result-of-list_tools");
+    expect(String(repeats[0].content).startsWith("REPEAT CALL BLOCKED")).toBe(false);
     expect(events.filter((e) => e.type === "result")).toEqual([
       { type: "result", ok: true, turn: 1, usage: expect.anything() },
     ]);

--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -288,7 +288,7 @@ describe("OllamaBackend", () => {
     ];
     const client: McpToolClient = {
       listTools: async () => ({ tools }),
-      callTool: callTool as unknown as McpToolClient["callTool"],
+      callTool: callTool as McpToolClient["callTool"],
       close: async () => {},
     };
     const backend = new OllamaBackend({ model: "gemma4:e4b", connectToolClients: async () => ({ comfyui: client }) });

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -535,6 +535,44 @@ function stringField(args: unknown, key: "action" | "search"): string | undefine
   return typeof value === "string" ? value : undefined;
 }
 
+/** Per-turn exact-repeat record: count plus the first dispatch's payload. */
+export type RepeatCallRecord = { count: number; result?: string };
+
+/**
+ * #2430 — answer a blocked identical tool call.
+ *
+ * The previous path returned `isError: true` and a corrective string that
+ * told the model to "use the earlier result" while carrying none of it.
+ * Small models then invent plausible numbers (observed on
+ * artokun/gemma4-comfyui-mcp:12b: 24.1 GB VRAM vs the real 31.84 GB).
+ *
+ * When the first dispatch's payload is on the record, replay it with
+ * `isError: false` so the model sees data, not a failure to recover from.
+ * The tool is still not re-executed; `maxRepeats` still drives the loop
+ * breaker. The no-payload fallback keeps the old nudge so a repeat before
+ * anything was stored does not pretend there is data.
+ */
+export function blockedRepeatResult(
+  name: string,
+  priorResult: string | undefined,
+): { text: string; isError: boolean } {
+  if (priorResult !== undefined) {
+    return {
+      text:
+        `(cached — identical call already made this turn, result unchanged)\n\n${priorResult}`,
+      isError: false,
+    };
+  }
+  return {
+    text:
+      `REPEAT CALL BLOCKED: you already called ${name} with these exact arguments this turn — the result has not changed. ` +
+      `Do not call it again. Use the earlier result, or try DIFFERENT arguments or a different tool. ` +
+      `Model families like krea2 / qwen-image-edit / wan / ltxv are installer PACKS, not tools: call_tool {"name":"list_packs"} to find them, then load one. ` +
+      `If you are stuck, tell the user what you found and ask how to proceed.`,
+    isError: true,
+  };
+}
+
 function textOf(result: McpCallResult): string {
   return (result.content ?? [])
     .filter((c) => c.type === "text")
@@ -1837,10 +1875,10 @@ export class OllamaBackend implements AgentBackend {
     // Loop-breaker: small models (especially stock ones) can wedge into
     // re-issuing the SAME tool call verbatim for dozens of rounds (field:
     // 30+ identical list_tools searches hunting a pack name). Track exact
-    // (name, args) repeats per turn: 2nd+ identical call is blocked with a
-    // corrective tool result instead of dispatched; at 4 repeats the turn is
-    // ended outright.
-    const seenCalls = new Map<string, number>();
+    // (name, args) repeats per turn: 2nd+ identical call is not re-executed
+    // — it replays the first payload via blockedRepeatResult (#2430);
+    // at 4 repeats the turn is ended outright.
+    const seenCalls = new Map<string, RepeatCallRecord>();
     let maxRepeats = 0;
     // Second wedge shape (field: Discord "circles" report): the model spams a
     // DISCOVERY meta-tool with a DIFFERENT search each round (list_tools
@@ -2046,8 +2084,8 @@ export class OllamaBackend implements AgentBackend {
           const name = tc.function?.name ?? "?";
           const args = tc.function?.arguments ?? {};
           const callKey = `${name}:${typeof args === "string" ? args : JSON.stringify(args)}`;
-          const repeats = (seenCalls.get(callKey) ?? 0) + 1;
-          seenCalls.set(callKey, repeats);
+          const prior = seenCalls.get(callKey);
+          const repeats = (prior?.count ?? 0) + 1;
           maxRepeats = Math.max(maxRepeats, repeats);
           // The consolidated form first, then a catalog lister only when it
           // actually searches — so a tool whose whole surface is discovery
@@ -2061,17 +2099,7 @@ export class OllamaBackend implements AgentBackend {
           yield { type: "tool_call", name, phase: "start", detail: tc.function?.arguments };
           const { text, isError } =
             repeats >= 2
-              ? {
-                  // Every emitted tool_call still needs a paired tool result
-                  // (the wire format breaks otherwise) — answer the repeat
-                  // with a corrective nudge instead of re-running it.
-                  text:
-                    `REPEAT CALL BLOCKED: you already called ${name} with these exact arguments this turn — the result has not changed. ` +
-                    `Do not call it again. Use the earlier result, or try DIFFERENT arguments or a different tool. ` +
-                    `Model families like krea2 / qwen-image-edit / wan / ltxv are installer PACKS, not tools: call_tool {"name":"list_packs"} to find them, then load one. ` +
-                    `If you are stuck, tell the user what you found and ask how to proceed.`,
-                  isError: true,
-                }
+              ? blockedRepeatResult(name, prior?.result)
               : discoveryHits >= 4
                 ? {
                     // Searched the catalog 4+ times with no hit — the capability
@@ -2086,6 +2114,10 @@ export class OllamaBackend implements AgentBackend {
                     isError: true,
                   }
                 : await this.dispatch(name, args);
+          // Keep the first payload on the record so a later identical call
+          // can replay it (#2430). Count always advances so maxRepeats still
+          // trips the loop breaker; the cached text is never overwritten.
+          seenCalls.set(callKey, { count: repeats, result: prior?.result ?? text });
           opts.onActivity?.();
           yield { type: "tool_call", name, phase: "end", detail: { isError } };
           this.history.push({


### PR DESCRIPTION
Closes #2430.

## The hole

The exact-repeat loop-breaker answered a 2nd identical tool call with `isError: true` and a corrective string that said **"use the earlier result"** while carrying **none of it**. A small local model often cannot retrieve that result from conversation history: it has just received an error tool message where it expected data, and it recovers by inventing a plausible-looking answer.

Observed end-to-end on `artokun/gemma4-comfyui-mcp:12b`: VRAM **24.1 GB** vs the real **31.84 GB**, and a truncated argv with an invented flag (`show_signup_button` vs `show_signin_button`). The answer rendered as a normal reply — no error, no warning, no degraded badge.

## Fix

Shipped `blockedRepeatResult(name, priorResult)` is the loop's only blocked-repeat answer. `seenCalls` now keeps `{ count, result }` per `callKey`. On a repeat:

- if the first payload is on the record → replay it with `isError: false` and a short cached note
- if nothing was cached → keep the old REPEAT CALL BLOCKED nudge

The tool is still not re-executed. `maxRepeats >= 4` still ends the turn.

## Tests

Drive the shipped function. They fail on error-string-only and pass when the earlier result is attached. Loop-breaker and compact-mode category-walk tests updated so a blocked repeat is asserted to carry the payload.

Targeted vitest: **67 passed / 0 failed** (`blocked-repeat-result.test.ts` + `ollama-backend.test.ts` + `discovery-call-key.test.ts`).
