### PR TITLE
fix(2427): treat Manager dependency-reapply exit 0 as a handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- restart_comfyui treats a Manager dependency-reapply exit 0 as a handoff and replays the saved launch once (#2427)
 - compact-mode `list_tools` / `panel_list_tools` enumeration is not a catalog hunt (#2429)
 - Save-As re-points session routing so panel_set_todo and panel_canvas follow the dest tab (#2419)
 - #971 legacy rebind recovers a workflows/ path, and a later canvas move drops the proof (#2415)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ All notable changes to this project are documented here. This project adheres to
 - Ollama names the cause of a 0-tool ready and logs recovery when the surface appears (#2428)
 - disclose unreindexed host links after panel_unexpose_subgraph_input/output (#2437)
 - a blocked repeat tool call returns the earlier payload instead of an error-string-only nudge (#2430)
+- restart_comfyui treats a Manager dependency-reapply exit 0 as a handoff and replays the saved launch once (#2427)
 
 ## [0.52.142] - 2026-08-27
 
 ### MCP
 
 #### Fixed
-- restart_comfyui treats a Manager dependency-reapply exit 0 as a handoff and replays the saved launch once (#2427)
 - compact-mode `list_tools` / `panel_list_tools` enumeration is not a catalog hunt (#2429)
 - Save-As re-points session routing so panel_set_todo and panel_canvas follow the dest tab (#2419)
 - #971 legacy rebind recovers a workflows/ path, and a later canvas move drops the proof (#2415)

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -96,6 +96,8 @@ import {
   __processControlTestHooks,
   clearRestartDispatch,
   getRestartDispatchRecord,
+  isManagerDependencyReapplyHandoff,
+  MANAGER_DEPENDENCY_REAPPLY_MARKER,
   parseListenerPidFromNetstat,
   preflightLocalRestart,
   PROCESS_WIDE_RESTART_DISPATCH_TOKEN,
@@ -552,6 +554,223 @@ describe("process-control startup readiness", () => {
     expect(result.message).toMatch(/EXITED \(exit code 0\)/);
     expect(result.message).toMatch(/could not be confirmed as the process this call launched/i);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("is a Manager dependency-reapply handoff only for exit 0 after the marker (#2427)", () => {
+    __processControlTestHooks.setLaunchLogText(
+      `loading custom nodes\n${MANAGER_DEPENDENCY_REAPPLY_MARKER}\n`,
+    );
+    expect(
+      isManagerDependencyReapplyHandoff({ exit: { code: 0, signal: null } }),
+    ).toBe(true);
+    expect(
+      isManagerDependencyReapplyHandoff({ exit: { code: 1, signal: null } }),
+    ).toBe(false);
+    expect(
+      isManagerDependencyReapplyHandoff({ exit: { code: 0, signal: "SIGTERM" } }),
+    ).toBe(false);
+    expect(isManagerDependencyReapplyHandoff({ exit: { code: 0, signal: null }, launchLogPath: "unused.log" })).toBe(true);
+
+    __processControlTestHooks.setLaunchLogText(undefined);
+    expect(
+      isManagerDependencyReapplyHandoff({ exit: { code: 0, signal: null } }),
+    ).toBe(false);
+
+    __processControlTestHooks.setLaunchLogText("ordinary startup, no manager restart\n");
+    expect(
+      isManagerDependencyReapplyHandoff({ exit: { code: 0, signal: null } }),
+    ).toBe(false);
+  });
+
+  it("replays the saved launch once after Manager's dependency-reapply exit 0 (#2427)", async () => {
+    // The reporter's shape: Manager prints the reapply marker, the child we
+    // launched exits 0, nothing is serving, and a later action:"start" brings
+    // the API up immediately. Treating that handoff as startup:"failed" /
+    // started:false is the bug; replaying the saved command once is the repair.
+    vi.useFakeTimers();
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    setLaunchInfo();
+    __processControlTestHooks.setLaunchLogText(
+      `Install done.\n${MANAGER_DEPENDENCY_REAPPLY_MARKER}\n`,
+    );
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    const fetchMock = vi.fn(async () => {
+      if (children.length <= 1) {
+        children[0]?.emit("exit", 0, null);
+        throw new Error("ECONNREFUSED");
+      }
+      return { ok: true } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startComfyUI();
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await pending;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(result.started).toBe(true);
+    expect(result.ready).toBe(true);
+    expect(result.startup).not.toBe("failed");
+    expect(result.message).not.toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).not.toMatch(/not a slow start/i);
+    expect(result.message).toMatch(/dependency-reapply handoff/);
+    expect(result.message).toContain(MANAGER_DEPENDENCY_REAPPLY_MARKER);
+  });
+
+  it("does not treat a Manager reapply handoff as started:false when the replay is still starting (#2427)", async () => {
+    vi.useFakeTimers();
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    setLaunchInfo();
+    __processControlTestHooks.setLaunchLogText(MANAGER_DEPENDENCY_REAPPLY_MARKER);
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    const fetchMock = vi.fn(async () => {
+      if (children.length <= 1) {
+        children[0]?.emit("exit", 0, null);
+      }
+      throw new Error("ECONNREFUSED");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startComfyUI();
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await pending;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    // The replayed child is still alive — this is #367 unconfirmed, not a failed
+    // relaunch of the Manager handoff child.
+    expect(result.started).toBe(true);
+    expect(result.ready).toBe(false);
+    expect(result.startup).toBe("unconfirmed");
+    expect(result.message).not.toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).toContain(MANAGER_DEPENDENCY_REAPPLY_MARKER);
+  });
+
+  it("replays the saved launch only once even if the Manager marker fires again (#2427)", async () => {
+    vi.useFakeTimers();
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    setLaunchInfo();
+    __processControlTestHooks.setLaunchLogText(MANAGER_DEPENDENCY_REAPPLY_MARKER);
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    const fetchMock = vi.fn(async () => {
+      children[children.length - 1]?.emit("exit", 0, null);
+      throw new Error("ECONNREFUSED");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startComfyUI();
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await pending;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(result.started).toBe(false);
+    expect(result.ready).toBe(false);
+    expect(result.startup).toBe("failed");
+    expect(result.message).toMatch(/dependency-reapply handoff/);
+    expect(result.message).toMatch(/replayed once/i);
+    expect(result.message).not.toMatch(/THIS RELAUNCH FAILED/);
+  });
+
+  it("does not replay a clean exit 0 that lacks the Manager reapply marker (#2427)", async () => {
+    vi.useFakeTimers();
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    setLaunchInfo();
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    const fetchMock = vi.fn(async () => {
+      children[0]?.emit("exit", 0, null);
+      throw new Error("ECONNREFUSED");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startComfyUI();
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await pending;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.started).toBe(false);
+    expect(result.startup).toBe("failed");
+    expect(result.message).toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).not.toMatch(/dependency-reapply/);
+  });
+
+  it("does not replay a crash that happens to print the Manager marker (#2427)", async () => {
+    vi.useFakeTimers();
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    setLaunchInfo();
+    __processControlTestHooks.setLaunchLogText(MANAGER_DEPENDENCY_REAPPLY_MARKER);
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    const fetchMock = vi.fn(async () => {
+      children[0]?.emit("exit", 1, null);
+      throw new Error("ECONNREFUSED");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startComfyUI();
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await pending;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.started).toBe(false);
+    expect(result.startup).toBe("failed");
+    expect(result.message).toMatch(/EXITED \(exit code 1\)/);
+    expect(result.message).toMatch(/THIS RELAUNCH FAILED/);
+  });
+
+  it("follows a replacement listener after the Manager handoff instead of spawning a second copy (#2427)", async () => {
+    vi.useFakeTimers();
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    setLaunchInfo();
+    __processControlTestHooks.setLaunchLogText(MANAGER_DEPENDENCY_REAPPLY_MARKER);
+    const children: FakeChild[] = [];
+    let spawnCount = 0;
+    mockSpawn.mockImplementation(() => {
+      spawnCount += 1;
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes("lsof")) {
+        // Proven free only before the first spawn; after Manager exits, a
+        // replacement already owns the port.
+        if (spawnCount === 0) throw noListener();
+        return "p7777\nn127.0.0.1:8188\n";
+      }
+      if (cmd.includes("netstat")) {
+        if (spawnCount === 0) return "";
+        return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       7777";
+      }
+      return "";
+    });
+    let fetches = 0;
+    const fetchMock = vi.fn(async () => {
+      fetches += 1;
+      if (fetches <= 3) {
+        children[0]?.emit("exit", 0, null);
+        throw new Error("ECONNREFUSED");
+      }
+      return { ok: true } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = startComfyUI();
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await pending;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.ready).toBe(true);
+    expect(result.message).not.toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).toContain(MANAGER_DEPENDENCY_REAPPLY_MARKER);
   });
 
   it("reports child process spawn errors without throwing", async () => {

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -143,6 +143,7 @@ vi.mock("../../services/instance-witness.js", async () => ({
 import { detectStabilityMatrix } from "../../services/launcher-env.js";
 import {
   __processControlTestHooks,
+  MANAGER_DEPENDENCY_REAPPLY_MARKER,
   preflightLocalRestart,
   restartComfyUI,
   startComfyUI,
@@ -2815,6 +2816,47 @@ n127.0.0.1:8188
     const serialized = JSON.parse(JSON.stringify(result));
     expect(serialized.startup).toBe("unconfirmed");
     expect(serialized.listener_ownership).toBe("unconfirmed");
+
+    killSpy.mockRestore();
+  });
+
+  it("replays the saved launch after Manager's dependency-reapply exit 0 (#2427)", async () => {
+    // Distinct from #2009: the port is NOT serving after Manager's clean handoff.
+    // restart_comfyui used to wait out the budget and return started:false /
+    // "could not be started" even though a subsequent action:"start" came up
+    // immediately. Replay the saved command once instead of treating the
+    // handoff as a terminal relaunch failure.
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    usePlainInstall();
+    mockLivePortThenFree();
+    const children = spawnCapturingChildren();
+    __processControlTestHooks.setLaunchLogText(MANAGER_DEPENDENCY_REAPPLY_MARKER);
+    let fetches = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        fetches++;
+        if (children.length <= 1) {
+          children[0]?.emit("exit", 0, null);
+          throw new Error("ECONNREFUSED");
+        }
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(result.ready).toBe(true);
+    expect(result.startup).not.toBe("failed");
+    expect(result.message).not.toMatch(/could not be started/i);
+    expect(result.message).not.toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).toMatch(/dependency-reapply handoff/);
+    expect(fetches).toBeGreaterThan(3);
 
     killSpy.mockRestore();
   });

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1435,6 +1435,160 @@ function describeLaunchedChildExit(
   return ` The process this call launched EXITED (${exitCause(exit)}), so THIS RELAUNCH FAILED — it was not a slow start. No readiness probe got a healthy response, the last one included.`;
 }
 
+/**
+ * ComfyUI-Manager prints this then exits 0 so a supervisor can re-exec after
+ * installing custom-node dependencies (#2427). Distinct from the #2009 trampoline
+ * shape: that wrapper leaves a listener behind. This handoff does not.
+ */
+export const MANAGER_DEPENDENCY_REAPPLY_MARKER =
+  "Restarting to reapply dependency installation";
+
+/** Test seam: process-control tests mock `node:fs`, so a real launch log cannot
+ *  be opened or read there. Production always reads the file. */
+let launchLogTextOverride: string | undefined;
+
+function readLaunchLogText(logPath: string | undefined): string | undefined {
+  if (launchLogTextOverride !== undefined) return launchLogTextOverride;
+  if (!logPath) return undefined;
+  try {
+    return readFileSync(logPath, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Clean exit 0 after Manager's dependency-reapply line — a handoff, not a crash. */
+export function isManagerDependencyReapplyHandoff(opts: {
+  exit?: { code: number | null; signal: NodeJS.Signals | null };
+  launchLogPath?: string;
+}): boolean {
+  if (!opts.exit) return false;
+  if (opts.exit.signal != null) return false;
+  if (opts.exit.code !== 0) return false;
+  const text = readLaunchLogText(opts.launchLogPath);
+  return text != null && text.includes(MANAGER_DEPENDENCY_REAPPLY_MARKER);
+}
+
+function describeManagerDependencyReapplyFailure(opts: {
+  readiness: StartupReadinessResult;
+  replayed: boolean;
+  launchLogPath?: string;
+}): string {
+  const followup = opts.replayed
+    ? `The saved launch command was replayed once, but no readiness probe got a healthy response in ${opts.readiness.waited_ms}ms (${opts.readiness.attempts}/${opts.readiness.max_tries} probes).`
+    : "No replacement listener answered, and the saved launch command was not replayed because the port was not proven free.";
+  return (
+    ` ComfyUI-Manager printed "${MANAGER_DEPENDENCY_REAPPLY_MARKER}" and the process this call launched EXITED (exit code 0) — a dependency-reapply handoff, not a crash. ` +
+    followup +
+    describeLaunchLog(opts.launchLogPath)
+  );
+}
+
+interface ManagerHandoffFollowup {
+  launched: SpawnedComfyUI;
+  launchedChildExit?: { code: number | null; signal: NodeJS.Signals | null };
+  launchedSpawnFailed: boolean;
+  readiness: StartupReadinessResult;
+  replayed: boolean;
+}
+
+/**
+ * After Manager's dependency-reapply exit 0: follow a replacement listener if one
+ * already owns the port; otherwise replay the saved launch command ONCE. A second
+ * copy is refused unless the port is proven free — that is the ownership argument
+ * for this being a start, not a double-launch (#2427).
+ */
+async function followManagerDependencyReapplyHandoff(opts: {
+  info: ProcessInfo;
+  port: number;
+  probeUrl: string;
+  launched: SpawnedComfyUI;
+  launchedChildExit?: { code: number | null; signal: NodeJS.Signals | null };
+  readiness: StartupReadinessResult;
+}): Promise<ManagerHandoffFollowup> {
+  const portState = probePortOwner(opts.port);
+  if (portState.state === "owned") {
+    // Something rebound. Wait for THAT listener; do not spawn a second copy.
+    const follow = await waitForApiReady({
+      ...getStartupReadinessConfig(),
+      probeUrl: opts.probeUrl,
+    });
+    return {
+      launched: opts.launched,
+      launchedChildExit: opts.launchedChildExit,
+      launchedSpawnFailed: false,
+      readiness: follow,
+      replayed: false,
+    };
+  }
+  if (portState.state !== "free") {
+    logger.info(
+      "ComfyUI-Manager dependency-reapply handoff observed, but the port was not proven free — not spawning a second copy",
+      { port: opts.port, portState: portState.state },
+    );
+    return {
+      launched: opts.launched,
+      launchedChildExit: opts.launchedChildExit,
+      launchedSpawnFailed: false,
+      readiness: opts.readiness,
+      replayed: false,
+    };
+  }
+
+  logger.info(
+    "ComfyUI-Manager exited after a dependency-reapply handoff; replaying the saved launch command once",
+  );
+  const replayed = spawnFromProcessInfo(opts.info);
+  if (!replayed) {
+    return {
+      launched: opts.launched,
+      launchedChildExit: opts.launchedChildExit,
+      launchedSpawnFailed: false,
+      readiness: opts.readiness,
+      replayed: false,
+    };
+  }
+
+  let launchedChildExit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+  let launchedSpawnFailed = false;
+  const spawnError = captureChildProcessError(replayed.child);
+  replayed.child.once("exit", (code, signal) => {
+    launchedChildExit = { code, signal };
+  });
+  replayed.child.once("error", () => {
+    launchedSpawnFailed = true;
+  });
+  replayed.child.unref();
+  superviseChild(replayed.child, opts.info);
+  if (!opts.info.isDesktopApp || opts.info.selfRelaunch) {
+    adoptLaunchedChild(replayed.child);
+  }
+
+  const replayResult = await Promise.race([
+    waitForApiReady({
+      ...getStartupReadinessConfig(),
+      probeUrl: opts.probeUrl,
+    }).then((readiness) => ({ readiness })),
+    spawnError.then((error) => ({ spawn_error: error })),
+  ]);
+  if ("spawn_error" in replayResult) {
+    return {
+      launched: replayed,
+      launchedChildExit,
+      launchedSpawnFailed: true,
+      readiness: opts.readiness,
+      replayed: true,
+    };
+  }
+  return {
+    launched: replayed,
+    launchedChildExit,
+    launchedSpawnFailed,
+    readiness: replayResult.readiness,
+    replayed: true,
+  };
+}
+
 /** Whole seconds, never rounded down to a "within 0s" that reads as no wait. */
 function seconds(ms: number): number {
   return Math.max(1, Math.round(ms / 1000));
@@ -4285,7 +4439,7 @@ export async function startComfyUI(anchor?: {
     argv: info.argv.join(" "),
   });
 
-  const launched = spawnFromProcessInfo(info);
+  let launched = spawnFromProcessInfo(info);
   if (!launched) {
     return {
       started: false,
@@ -4401,8 +4555,8 @@ export async function startComfyUI(anchor?: {
   // `launchedChildStillRunning` is tri-state on purpose: `undefined` is "cannot
   // tell", and it must not be spent as either answer, so it falls on the
   // unconfirmed side with the uncertainty stated. Only a DEFINITE death fails.
-  const childAlive = launchedChildStillRunning(launched.child);
-  const childIsGone =
+  let childAlive = launchedChildStillRunning(launched.child);
+  let childIsGone =
     launchedSpawnFailed || launchedChildExit != null || childAlive === false;
   // #2009: the launched PID exiting is NOT proof the server is down. A Windows
   // portable / venv trampoline / wrapper exits 0 after handing off, and the last
@@ -4428,6 +4582,56 @@ export async function startComfyUI(anchor?: {
         probe_url: readiness.probe_url,
       };
     }
+  }
+  // #2427: Manager's "Restarting to reapply dependency installation" + exit 0 is
+  // a handoff, not a crash. #2009's extra look covers a wrapper that left a
+  // listener behind; this marker means Manager expected a supervisor to re-exec
+  // and nothing is coming unless we replay the saved launch once — or follow a
+  // replacement that already rebound. Either way this first child's death is
+  // not `started:false`.
+  let managerHandoffSeen = false;
+  let managerHandoffReplayed = false;
+  if (
+    !readiness.ready &&
+    !launchedSpawnFailed &&
+    isManagerDependencyReapplyHandoff({
+      exit: launchedChildExit,
+      launchLogPath: launched.launchLogPath,
+    })
+  ) {
+    managerHandoffSeen = true;
+    const followup = await followManagerDependencyReapplyHandoff({
+      info,
+      port,
+      probeUrl: readiness.probe_url,
+      launched,
+      launchedChildExit,
+      readiness,
+    });
+    launched = followup.launched;
+    launchedChildExit = followup.launchedChildExit;
+    launchedSpawnFailed = followup.launchedSpawnFailed;
+    readiness = followup.readiness;
+    managerHandoffReplayed = followup.replayed;
+    if (!targetFenceMatchesCurrent(targetFence)) {
+      return {
+        started: false,
+        ready: readiness.ready,
+        startup: "unconfirmed",
+        readiness,
+        message:
+          `The ComfyUI target changed while following a ComfyUI-Manager dependency-reapply handoff at ${targetFence.baseUrl}. ` +
+          "The target-specific launch result is unconfirmed; no success is claimed for the new target.",
+        target_fence: targetFence,
+        target_stable: false,
+        auto_restart: supervisorResult(info),
+        launch_env: launchEnvInfo(info),
+        listener_ownership: unclassifiedOwnership(),
+      };
+    }
+    childAlive = launchedChildStillRunning(launched.child);
+    childIsGone =
+      launchedSpawnFailed || launchedChildExit != null || childAlive === false;
   }
   if (!readiness.ready) {
     const env = launchEnvInfo(info);
@@ -4463,7 +4667,14 @@ export async function startComfyUI(anchor?: {
           // the microtask window between the readiness result resolving and this
           // line reading the flag — an interleaving no test can schedule. The branch
           // costs nothing and removes a self-contradictory verdict if it ever runs.
-          (launchedSpawnFailed && !launchedChildExit
+          (managerHandoffSeen
+            ? `ComfyUI process was launched, but no readiness probe got a healthy response in ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes).` +
+              describeManagerDependencyReapplyFailure({
+                readiness,
+                replayed: managerHandoffReplayed,
+                launchLogPath: launched.launchLogPath,
+              })
+            : (launchedSpawnFailed && !launchedChildExit
             ? `The ComfyUI process could not be spawned, and no readiness probe got a healthy response in ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes). THIS RELAUNCH FAILED — it was not a slow start.`
             : `ComfyUI process was launched, but no readiness probe got a healthy response in ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes).` +
               (launchedChildExit
@@ -4473,7 +4684,7 @@ export async function startComfyUI(anchor?: {
           // nothing else is the least actionable thing a failed launch can say,
           // and it left a reporter offline with no way to diagnose it. The child
           // had already explained itself; the output was going to `ignore`.
-          describeLaunchLog(launched.launchLogPath) +
+          describeLaunchLog(launched.launchLogPath)) +
           ' Re-check with get_system_stats (action:"health") before assuming nothing is serving the port — an external launcher or supervisor may have brought one back since.' +
           (env ? ` Launch environment: ${env.note}.` : "") +
           launchEnvWarning(info),
@@ -4512,6 +4723,9 @@ export async function startComfyUI(anchor?: {
         `COMFYUI_STARTUP_CHECK_MAX_TRIES (currently ${readiness.max_tries} ` +
         `${readiness.max_tries === 1 ? "probe" : "probes"}, one every ` +
         `${describeInterval(readiness.interval_ms)}).` +
+        (managerHandoffReplayed
+          ? ` ComfyUI-Manager previously handed off after "${MANAGER_DEPENDENCY_REAPPLY_MARKER}"; this call replayed the saved launch command once and that process is still starting.`
+          : "") +
         (env ? ` Launch environment: ${env.note}.` : "") +
         launchEnvWarning(info),
       pid: launched.child.pid,
@@ -4665,6 +4879,11 @@ export async function startComfyUI(anchor?: {
       // produced it — it may be the server that was already there.
       (!portObservedFreeBeforeLaunch && ownership !== "ours"
         ? ` NOTE: the port was never observed free before launching, so this call cannot claim to have started the server that is answering.`
+        : "") +
+      (managerHandoffSeen
+        ? managerHandoffReplayed
+          ? ` ComfyUI-Manager had printed "${MANAGER_DEPENDENCY_REAPPLY_MARKER}" and exited 0; this call followed that dependency-reapply handoff by replaying the saved launch command once.`
+          : ` ComfyUI-Manager had printed "${MANAGER_DEPENDENCY_REAPPLY_MARKER}" and exited 0; this call followed that dependency-reapply handoff.`
         : "") +
       launchEnvWarning(info),
     pid: newPid ?? undefined,
@@ -6423,6 +6642,12 @@ export const __processControlTestHooks = {
     processExistsOverride = null;
     deliberateStop = false;
     restartDispatchRecords.clear();
+    launchLogTextOverride = undefined;
+  },
+  /** Inject launch-log text so tests can drive the Manager reapply marker without
+   *  a real file (#2427). `undefined` restores the production file reader. */
+  setLaunchLogText(text: string | undefined): void {
+    launchLogTextOverride = text;
   },
   /** Inject a fake parent-pid reader so the lineage check can be driven without a
    *  real process tree. */


### PR DESCRIPTION
## Summary

`restart_comfyui` treated ComfyUI-Manager's expected dependency-reapply exit as a terminal relaunch failure.

After installing a custom node, Manager prints `Restarting to reapply dependency installation` and the child we launched exits 0. That is a **handoff**, not a crash: Manager expects a supervisor to re-exec. A process this tool spawned directly has no supervisor, so the 60s readiness budget found nothing and the tool returned `started:false` / `startup:"failed"` even though a subsequent `action:"start"` brought the API up immediately.

Distinct from #2009 (PR #2025): that fix covers a wrapper that **leaves a listener behind**. Main had no knowledge of this Manager marker. The extra look after a dead child still correctly fails when nothing is serving — which is this case.

## Fix

When the launched child exits 0 after the Manager marker:

1. **Say what was observed** — a clean exit after that line is a handoff, not `THIS RELAUNCH FAILED`.
2. **Follow a replacement listener** if one already owns the port (no second copy).
3. **Replay the saved launch command once** if the port is proven free — the same start the reporter's follow-up `action:"start"` already did.
4. Never retry more than once, and never spawn onto a port that is owned or unknown.

Ownership: the caller asked for a restart; the child handed off and died; nothing is serving; starting it once is what "restart" means. A second ComfyUI on a still-bound port is refused.

## Tests

- Detector: marker + exit 0 only (not exit 1, not signal, not missing marker).
- `startComfyUI` replays once and reports `started:true` when the replay answers.
- Replay still starting → `startup:"unconfirmed"`, not `started:false`.
- Marker firing again does not spawn a third copy.
- Exit 0 without the marker, and exit 1 with the marker, still fail as crashes.
- An already-owned replacement is followed instead of double-launched.
- `restartComfyUI` same handoff → replay path.

Targeted vitest: `src/__tests__/services/process-control.test.ts` and `restart-launcher-env.test.ts` (`-t "2427|2009|DIED before the API"`). Full `process-control.test.ts`: 60 passed.

Closes #2427
