### PR TITLE
fix(2437): disclose unreindexed host links after unexpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - Ollama names the cause of a 0-tool ready and logs recovery when the surface appears (#2428)
+- disclose unreindexed host links after panel_unexpose_subgraph_input/output (#2437)
 
 ## [0.52.142] - 2026-08-27
 

--- a/plugin/skills/panel-operations/SKILL.md
+++ b/plugin/skills/panel-operations/SKILL.md
@@ -58,6 +58,16 @@ rail and you will get it wrong. Use:
 Read `panel_query_graph`'s `rails` field (present when viewing a subgraph) to see the
 current boundary slots — what is already exposed and what still needs it.
 
+**Unexposing a boundary slot.** `panel_unexpose_subgraph_input` / `_output` remove a
+named rail slot. Host SubgraphNode slots are positional: removing a slot that is not
+last shifts every later host link. `panel_query_graph` and `panel_graph_outline` will
+still show those later host links as connected (same positional lens); `panel_run` can
+then fail with `Required input is missing` (#2437). Do not trust that connectedness.
+Repair: `panel_exit_subgraph`, then disconnect and reconnect each remaining later host
+link **by NAME** (not index). Reconnecting by name re-resolves the index. Then re-enter
+if you still need the interior. Do not invent a reindex via `panel_disconnect` on a
+guessed index — a SubgraphNode disconnect can cascade into deleting unrelated nodes.
+
 **Dissolving one.** `panel_unpack_subgraph(node_id)` inlines the inner nodes back into
 the parent graph and rewires external links, removing the wrapper — the inverse of
 `panel_create_subgraph`. All of these are undoable with Ctrl+Z.
@@ -373,4 +383,4 @@ restarts that process, so never claim such a change is live after a `panel_reloa
 ## Sources
 
 - **Official:** the panel and comfyui MCP tool descriptions in comfyui-mcp (this repo) — each tool named above is the authority on its own parameters.
-- **Empirical:** the panel agent system preamble these procedures were moved out of, plus the failure modes they were written for (issues #1398, #1551, #1708, #2234).
+- **Empirical:** the panel agent system preamble these procedures were moved out of, plus the failure modes they were written for (issues #1398, #1551, #1708, #2234, #2437).

--- a/src/__tests__/services/unexpose-host-link-shift.test.ts
+++ b/src/__tests__/services/unexpose-host-link-shift.test.ts
@@ -1,0 +1,182 @@
+// #2437 — remaining host IMAGE links look connected after unexpose, fail at queue.
+//
+// The mutation is panel-side (`graph_unexpose_subgraph_input` does not re-point
+// survivors). MCP remaining piece is the disclosure: a post-removal snapshot of
+// `node.inputs[i].link` cannot see the bug, so the note is a priori from a
+// landed `removed` object. Tests drive the shipped function AND the handlers
+// that attach it — a reimplementation in the test file would stay green if the
+// wrap were deleted.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  appendReplyNote,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import {
+  isLandedUnexpose,
+  unexposeHostLinkShiftNote,
+} from "../../services/unexpose-host-link-shift.js";
+
+const SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url)),
+  "utf8",
+);
+
+/** The reporter's exact unexpose reply: `text` at index 3, one interior link, zero host links. */
+const REPORTER_REMOVED = {
+  removed: {
+    side: "input",
+    name: "text",
+    type: "STRING",
+    slot: 3,
+    interior_links_dropped: 1,
+    host_links_dropped: 0,
+  },
+};
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function jsonResult(payload: unknown, isError = false): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function makeCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: Record<string, unknown>[] } {
+  const calls: Record<string, unknown>[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      calls.push(cmd);
+      return reply;
+    },
+    confirm: async () => "yes" as const,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  };
+  return { ctx, calls };
+}
+
+function allText(res: ToolResult): string {
+  return res.content.map((c) => (c.type === "text" ? c.text ?? "" : "")).join("\n");
+}
+
+describe("unexposeHostLinkShiftNote (#2437)", () => {
+  it("the unexpose handlers attach the shipped note, not a copy", () => {
+    expect(SRC).toMatch(/unexposeHostLinkShiftNote\(parseToolResultJson\(res\)\)/);
+    expect(SRC).toMatch(/cmd: "graph_unexpose_subgraph_input"/);
+    expect(SRC).toMatch(/cmd: "graph_unexpose_subgraph_output"/);
+  });
+
+  it("THE REPORTED CASE: text at index 3, zero host links dropped, remaining IMAGE slots shifted", () => {
+    const note = unexposeHostLinkShiftNote(REPORTER_REMOVED, ["image", "image_1", "noise_seed"]);
+    expect(note).toBeTruthy();
+    expect(note).toMatch(/artokun\/comfyui-mcp#2437/);
+    expect(note).toMatch(/"text"/);
+    expect(note).toMatch(/index 3/);
+    expect(note).toMatch(/panel_query_graph/);
+    expect(note).toMatch(/panel_graph_outline/);
+    expect(note).toMatch(/Required input is missing/);
+    expect(note).toMatch(/by NAME/);
+    expect(note).not.toMatch(/by index/);
+    expect(note).toMatch(/panel_exit_subgraph/);
+    expect(note).toContain('"image"');
+    expect(note).toContain('"image_1"');
+    expect(note).toContain('"noise_seed"');
+    // Must not claim a positional connectedness check saw the bug — that check
+    // cannot see it (owner trace).
+    expect(note).not.toMatch(/detected|divergence|snapshot showed/i);
+  });
+
+  it("still warns when later slot names are unknown — skipping is how the reporter queued", () => {
+    const note = unexposeHostLinkShiftNote(REPORTER_REMOVED);
+    expect(note).toBeTruthy();
+    expect(note).toMatch(/reconnect each remaining later host link by NAME/);
+  });
+
+  it("is silent when the caller proved there are no later slots", () => {
+    expect(unexposeHostLinkShiftNote(REPORTER_REMOVED, [])).toBeNull();
+  });
+
+  it("is silent on a refusal / missing removed (nothing landed)", () => {
+    expect(isLandedUnexpose({ error: "unknown slot" })).toBe(false);
+    expect(unexposeHostLinkShiftNote({ error: "unknown slot" })).toBeNull();
+    expect(unexposeHostLinkShiftNote(null)).toBeNull();
+    expect(unexposeHostLinkShiftNote("not json")).toBeNull();
+    expect(unexposeHostLinkShiftNote({ removed: { side: "input", name: "text" } })).toBeNull();
+  });
+
+  it("covers the output twin — host outputs are the same positional lockstep", () => {
+    const note = unexposeHostLinkShiftNote({
+      removed: { side: "output", name: "IMAGE", type: "IMAGE", slot: 0, host_links_dropped: 2 },
+    });
+    expect(note).toMatch(/boundary output slots/);
+    expect(note).toMatch(/"IMAGE"/);
+    expect(note).toMatch(/by NAME/);
+  });
+});
+
+describe("panel_unexpose_subgraph_input attaches the #2437 note", () => {
+  it("the reporter's landed reply keeps the JSON and adds the repair as its own block", async () => {
+    const { ctx, calls } = makeCtx(jsonResult(REPORTER_REMOVED));
+    const res = await defByName("panel_unexpose_subgraph_input").handler({ name: "text" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "graph_unexpose_subgraph_input", name: "text" });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]?.type).toBe("text");
+    expect(JSON.parse(res.content[0]!.text!)).toEqual(REPORTER_REMOVED);
+    expect(res.content).toHaveLength(2);
+    expect(res.content[1]?.text).toBe(unexposeHostLinkShiftNote(REPORTER_REMOVED));
+    expect(allText(res)).toMatch(/Required input is missing/);
+  });
+
+  it("a panel refusal is not decorated — nothing was removed", async () => {
+    const refusal = jsonResult("No input boundary slot \"text\"", true);
+    const { ctx } = makeCtx(refusal);
+    const res = await defByName("panel_unexpose_subgraph_input").handler({ name: "text" }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content).toHaveLength(1);
+    expect(allText(res)).not.toMatch(/#2437/);
+  });
+
+  it("the description names the repair before the agent queues", () => {
+    const def = defByName("panel_unexpose_subgraph_input");
+    expect(def.description).toMatch(/#2437/);
+    expect(def.description).toMatch(/by NAME/i);
+    expect(def.description).toMatch(/Required input is missing/);
+  });
+});
+
+describe("panel_unexpose_subgraph_output attaches the same remaining-piece note", () => {
+  it("a landed output removal is disclosed the same way", async () => {
+    const payload = {
+      removed: { side: "output", name: "IMAGE", type: "IMAGE", slot: 1, host_links_dropped: 1 },
+    };
+    const { ctx, calls } = makeCtx(jsonResult(payload));
+    const res = await defByName("panel_unexpose_subgraph_output").handler({ name: "IMAGE" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "graph_unexpose_subgraph_output", name: "IMAGE" });
+    expect(res.content).toHaveLength(2);
+    expect(res.content[1]?.text).toBe(unexposeHostLinkShiftNote(payload));
+  });
+
+  it("the description names the same positional hazard", () => {
+    expect(defByName("panel_unexpose_subgraph_output").description).toMatch(/#2437/);
+  });
+});
+
+describe("appendReplyNote keeps the JSON document at index 0", () => {
+  it("the unexpose wrap uses the exported helper, not a splice into the JSON string", () => {
+    const base = jsonResult(REPORTER_REMOVED);
+    const noted = appendReplyNote(base, unexposeHostLinkShiftNote(REPORTER_REMOVED)!);
+    expect(JSON.parse(noted.content[0]!.text!)).toEqual(REPORTER_REMOVED);
+    expect(noted.content[1]?.text).toMatch(/#2437/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -74,6 +74,7 @@ import {
   type WorkflowListReadinessRefusal,
 } from "../services/panel-workflow-readiness.js";
 import { isPreExecutorRefusal } from "../services/panel-refusal.js";
+import { unexposeHostLinkShiftNote } from "../services/unexpose-host-link-shift.js";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
@@ -562,6 +563,18 @@ function fail(err: unknown): ToolResult {
 export function appendReplyNote(res: ToolResult, note: string): ToolResult {
   if (!note) return res;
   return { ...res, content: [...res.content, { type: "text", text: note }] };
+}
+
+/**
+ * #2437 — remaining host links after unexpose are positional and not re-pointed.
+ * A post-removal snapshot of `node.inputs[i].link` cannot see the bug, so this
+ * attaches the a-priori repair (reconnect by name) to a landed `removed` reply.
+ * Refusals and unparseable bodies are left alone.
+ */
+function withUnexposeHostLinkShiftNote(res: ToolResult): ToolResult {
+  if (res.isError) return res;
+  const note = unexposeHostLinkShiftNote(parseToolResultJson(res));
+  return note ? appendReplyNote(res, note) : res;
 }
 
 /**
@@ -22477,21 +22490,25 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_unexpose_subgraph_output",
-      "REMOVE a subgraph's OUTPUT boundary slot — UN-expose it (the inverse of panel_expose_subgraph_output), so the PARENT graph's subgraph node loses that output slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). Identify the slot by the string `name` only — the boundary slot name exactly as panel_query_graph lists it under `rails.output.accepts_inputs`. A rail_node_id string such as \"-20\" is forwarded to the panel, which REFUSES it: that is the synthetic id of the whole rail, not of a slot on it. DESTRUCTIVE: the interior wire feeding the slot and any parent-graph wires on host subgraph nodes' matching slot are dropped with it — the reply's `removed.interior_links_dropped` / `removed.host_links_dropped` say how many went. An unknown name refuses and lists the slots that DO exist; nothing is removed on a refusal. Undoable with Ctrl+Z.",
+      "REMOVE a subgraph's OUTPUT boundary slot — UN-expose it (the inverse of panel_expose_subgraph_output), so the PARENT graph's subgraph node loses that output slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). Identify the slot by the string `name` only — the boundary slot name exactly as panel_query_graph lists it under `rails.output.accepts_inputs`. A rail_node_id string such as \"-20\" is forwarded to the panel, which REFUSES it: that is the synthetic id of the whole rail, not of a slot on it. DESTRUCTIVE: the interior wire feeding the slot and any parent-graph wires on host subgraph nodes' matching slot are dropped with it — the reply's `removed.interior_links_dropped` / `removed.host_links_dropped` say how many went. An unknown name refuses and lists the slots that DO exist; nothing is removed on a refusal. KNOWN HAZARD (#2437): remaining LATER host links are not reindexed. panel_query_graph / panel_graph_outline may still show them connected; panel_run can then fail with Required input is missing. After a landed removal, exit the subgraph and reconnect remaining later host links by NAME (not index). Undoable with Ctrl+Z.",
       {
         name: z.string().describe("Boundary output slot name (e.g. 'IMAGE') exactly as panel_query_graph lists it under rails.output.accepts_inputs — NOT a rail_node_id."),
       },
-      async (args: A, ctx) =>
-        ctx.call({ cmd: "graph_unexpose_subgraph_output", name: args.name }, 15000),
+      async (args: A, ctx) => {
+        const res = await ctx.call({ cmd: "graph_unexpose_subgraph_output", name: args.name }, 15000);
+        return withUnexposeHostLinkShiftNote(res);
+      },
     ),
     def(
       "panel_unexpose_subgraph_input",
-      "REMOVE a subgraph's INPUT boundary slot — UN-expose it (the inverse of panel_expose_subgraph_input), so the PARENT graph's subgraph node loses that input slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). Identify the slot by the string `name` only — the boundary slot name exactly as panel_query_graph lists it under `rails.input.provides_outputs`. A rail_node_id string such as \"-10\" is forwarded to the panel, which REFUSES it: that is the synthetic id of the whole rail, not of a slot on it. DESTRUCTIVE: the interior wire the slot fed and any parent-graph wires on host subgraph nodes' matching slot are dropped with it — the reply's `removed.interior_links_dropped` / `removed.host_links_dropped` say how many went. An unknown name refuses and lists the slots that DO exist; nothing is removed on a refusal. Undoable with Ctrl+Z.",
+      "REMOVE a subgraph's INPUT boundary slot — UN-expose it (the inverse of panel_expose_subgraph_input), so the PARENT graph's subgraph node loses that input slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). Identify the slot by the string `name` only — the boundary slot name exactly as panel_query_graph lists it under `rails.input.provides_outputs`. A rail_node_id string such as \"-10\" is forwarded to the panel, which REFUSES it: that is the synthetic id of the whole rail, not of a slot on it. DESTRUCTIVE: the interior wire the slot fed and any parent-graph wires on host subgraph nodes' matching slot are dropped with it — the reply's `removed.interior_links_dropped` / `removed.host_links_dropped` say how many went. An unknown name refuses and lists the slots that DO exist; nothing is removed on a refusal. KNOWN HAZARD (#2437): remaining LATER host links are not reindexed. panel_query_graph / panel_graph_outline may still show them connected; panel_run can then fail with Required input is missing. After a landed removal, exit the subgraph and reconnect remaining later host links by NAME (not index). Undoable with Ctrl+Z.",
       {
         name: z.string().describe("Boundary input slot name (e.g. 'model') exactly as panel_query_graph lists it under rails.input.provides_outputs — NOT a rail_node_id."),
       },
-      async (args: A, ctx) =>
-        ctx.call({ cmd: "graph_unexpose_subgraph_input", name: args.name }, 15000),
+      async (args: A, ctx) => {
+        const res = await ctx.call({ cmd: "graph_unexpose_subgraph_input", name: args.name }, 15000);
+        return withUnexposeHostLinkShiftNote(res);
+      },
     ),
     def(
       "panel_unpack_subgraph",

--- a/src/services/unexpose-host-link-shift.ts
+++ b/src/services/unexpose-host-link-shift.ts
@@ -1,0 +1,83 @@
+/**
+ * #2437 — remaining host links after `graph_unexpose_subgraph_input/output`.
+ *
+ * Host SubgraphNode slots are positional and lockstep with `subgraph.inputs` /
+ * `subgraph.outputs`. The panel executor counts host links at the OLD index,
+ * calls `removeInput`/`removeOutput`, and reports. It does not re-point the
+ * survivors. Later host slots then look connected in `panel_query_graph` /
+ * `panel_graph_outline` (same positional lens) and missing at queue time
+ * (`graphToPrompt` resolves the boundary differently).
+ *
+ * A post-removal snapshot of `node.inputs[i].link` cannot see this: it shares
+ * the mutation's dependency and agrees with the reader. This note is a priori
+ * from a landed `removed` object, not a detected divergence. The repair that
+ * re-resolves the index is disconnect + reconnect remaining later host links
+ * BY NAME. The reindex itself is panel-side (artokun/comfyui-mcp-panel#1969)
+ * and must not be improvised here: panel#668 saw a SubgraphNode disconnect
+ * cascade into deleting unrelated nodes.
+ */
+
+/** Later rail-slot names that sat AFTER the removed index (already shifted). */
+export type UnexposeLaterSlots = readonly string[] | undefined;
+
+function removedRecord(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const removed = (payload as Record<string, unknown>).removed;
+  if (!removed || typeof removed !== "object" || Array.isArray(removed)) return null;
+  return removed as Record<string, unknown>;
+}
+
+function landedSlot(removed: Record<string, unknown>): number | null {
+  if (removed.side !== "input" && removed.side !== "output") return null;
+  const slot = removed.slot;
+  return typeof slot === "number" && Number.isInteger(slot) && slot >= 0 ? slot : null;
+}
+
+/**
+ * True when the panel reported a landed unexpose (`removed.side` + integer
+ * `removed.slot`). A refusal has no `removed` and produces no note.
+ */
+export function isLandedUnexpose(payload: unknown): boolean {
+  const removed = removedRecord(payload);
+  return removed != null && landedSlot(removed) != null;
+}
+
+/**
+ * The agent-facing repair for a landed unexpose whose remaining later host
+ * links were not reindexed. `null` when there is nothing to disclose:
+ *  - not a landed `removed` object (refusal / unparseable);
+ *  - caller proved there are no later slots (`laterSlotNames` is `[]`).
+ *
+ * An UNKNOWN later list still produces the note: the cheap positional
+ * connectedness check cannot prove the survivors are valid, and skipping the
+ * note on "we did not look" is how the reporter queued a broken graph.
+ */
+export function unexposeHostLinkShiftNote(
+  payload: unknown,
+  laterSlotNames?: UnexposeLaterSlots,
+): string | null {
+  const removed = removedRecord(payload);
+  const slot = removed ? landedSlot(removed) : null;
+  if (removed == null || slot == null) return null;
+  if (laterSlotNames && laterSlotNames.length === 0) return null;
+
+  const side = removed.side === "output" ? "output" : "input";
+  const name = typeof removed.name === "string" && removed.name ? removed.name : "(unnamed)";
+  const named =
+    laterSlotNames && laterSlotNames.length > 0
+      ? ` Remaining later host ${side} slots that shifted: ${laterSlotNames.map((s) => JSON.stringify(s)).join(", ")}.`
+      : "";
+
+  return (
+    `Host links on remaining later boundary ${side} slots were not reindexed after removing ` +
+    `"${name}" at index ${slot} (artokun/comfyui-mcp#2437). Host SubgraphNode slots are ` +
+    `positional and lockstep with the rail; nothing in the panel executor re-points the ` +
+    `survivors. panel_query_graph and panel_graph_outline may still show those host links ` +
+    `as connected — they read the same positional array — but queue-time serialization ` +
+    `does not, so panel_run can fail with Required input is missing.` +
+    named +
+    ` Do not trust that connectedness. Repair: panel_exit_subgraph, then disconnect and ` +
+    `reconnect each remaining later host link by NAME (not index); reconnecting by name ` +
+    `re-resolves the index. Then re-enter if you still need the interior.`
+  );
+}


### PR DESCRIPTION
Closes #2437.

## What this is (and is not)

The mutation is panel-side. Host `SubgraphNode` slots are positional and lockstep with `subgraph.inputs`. `graph_unexpose_subgraph_input` counts host links at the **old** index, calls `removeInput`, and reports — it does not re-point survivors. After removing `text` at index 3, later IMAGE host links still look connected in `panel_query_graph` / `panel_graph_outline` (same positional lens) and fail at queue (`Required input is missing`).

A post-removal snapshot of `node.inputs[i].link` cannot see this (owner trace). Reindexing in the panel is the real fix and wants review — panel#668 saw a SubgraphNode disconnect cascade into deleting unrelated nodes. Tracked as [comfyui-mcp-panel#1969](https://github.com/artokun/comfyui-mcp-panel/issues/1969). This PR does **not** disconnect/reconnect from MCP.

## MCP remaining piece

Until the panel reindexes, the agent is told the fact the readers will lie about:

- Shipped `unexposeHostLinkShiftNote` — a priori from a landed `removed` object, not a detected divergence.
- Both unexpose handlers attach it as its own content block (`appendReplyNote`), leaving the JSON document at index 0.
- Tool descriptions and the panel-operations skill name the repair: `panel_exit_subgraph`, then disconnect and reconnect remaining later host links **by NAME**.

Refusals are not decorated. An explicit empty later-slot list (last slot, no shift) is silent; an unknown later list still warns — skipping on "we did not look" is how the reporter queued.

## Tests

Drive the shipped function and the handlers that attach it.

`npx vitest run src/__tests__/services/unexpose-host-link-shift.test.ts src/__tests__/orchestrator/panel-tools.test.ts -t "unexpose"`

**17 passed / 0 failed** (12 new + 5 existing unexpose forwards).
