### PR TITLE
fix(2442): bundled anima-inpaint uses AnimaLLLiteApply_sdscripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to this project are documented here. This project adheres to
 - a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
 - panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 - bundled anima-inpaint ships AnimaLLLiteApply_sdscripts so apply_manifest / node install does not miss the kohya-ss node (#2442)
-- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.144] - 2026-08-27
 
@@ -22,6 +21,7 @@ All notable changes to this project are documented here. This project adheres to
 - apply_manifest counts a GGUF as installed when ComfyUI-GGUF lists it under clip_gguf/unet_gguf (#2447)
 - panel_list_nodes lists installed packs from host Manager HTTP when the panel tab is gone (#2459)
 - panel_run queued_unknown names a live-canvas next step instead of an unavailable queue inspector (#2438)
+- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.143] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
 - panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 - bundled anima-inpaint ships AnimaLLLiteApply_sdscripts so apply_manifest / node install does not miss the kohya-ss node (#2442)
+- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.144] - 2026-08-27
 
@@ -21,7 +22,6 @@ All notable changes to this project are documented here. This project adheres to
 - apply_manifest counts a GGUF as installed when ComfyUI-GGUF lists it under clip_gguf/unet_gguf (#2447)
 - panel_list_nodes lists installed packs from host Manager HTTP when the panel tab is gone (#2459)
 - panel_run queued_unknown names a live-canvas next step instead of an unavailable queue inspector (#2438)
-- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.143] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
 - panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
+- bundled anima-inpaint ships AnimaLLLiteApply_sdscripts so apply_manifest / node install does not miss the kohya-ss node (#2442)
 
 ## [0.52.144] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
 - panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 - bundled anima-inpaint ships AnimaLLLiteApply_sdscripts so apply_manifest / node install does not miss the kohya-ss node (#2442)
+- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.144] - 2026-08-27
 

--- a/docs/blog/anima-comfyui.mdx
+++ b/docs/blog/anima-comfyui.mdx
@@ -161,17 +161,17 @@ pack is CI-validated for reachability and size, so a link never quietly rots
 
 ANIMA's inpainting isn't a bolt-on — it's a dedicated **Anima-LLLite ControlNet**.
 LLLite ("LoRA-Lite") patches the **MODEL** directly rather than feeding standard
-ControlNet conditioning, so the pack uses a special `AnimaLLLiteApply` node from
+ControlNet conditioning, so the pack uses a special `AnimaLLLiteApply_sdscripts` node from
 `ComfyUI-Anima-LLLite` (kohya-ss). The inpaint flow is clean:
 
 1. Load an image and paint a mask over the region you want to redraw.
 2. `VAEEncode` the source image, then `SetLatentNoiseMask` with the mask.
 3. Patch the model with `anima-lllite-inpainting-v1.safetensors` via
-   `AnimaLLLiteApply`, fed the same image + mask.
+   `AnimaLLLiteApply_sdscripts`, fed the same image + mask.
 4. Sample. The masked area is regenerated from your prompt while everything
    outside it is preserved.
 
-The same `AnimaLLLiteApply` node powers ANIMA's other control modes — just swap
+The same `AnimaLLLiteApply_sdscripts` node powers ANIMA's other control modes — just swap
 the `lllite_name` and feed a preprocessed control image:
 
 | LLLite | Control source |
@@ -181,8 +181,10 @@ the `lllite_name` and feed a preprocessed control image:
 | `anima-lllite-lineart-1` | Lineart |
 | `anima-lllite-inpainting-v1` | Painted mask |
 
-> **Gotcha:** `AnimaLLLiteApply` is **not** a standard ControlNet node. If it's
-> missing, install `ComfyUI-Anima-LLLite` (the pack does this for you).
+> **Gotcha:** `AnimaLLLiteApply_sdscripts` is **not** a standard ControlNet node, and
+> it is not the core `AnimaLLLiteApply` ID (ComfyUI now owns that name with a
+> different signature). If it's missing, install `ComfyUI-Anima-LLLite` (the pack
+> does this for you).
 
 ## Train your own anime LoRA (under 6 GB)
 
@@ -277,13 +279,13 @@ painterly.
   896x1152, 832x1216, 768x1344, 640x1536).
 - **Turbo output looks washed/flat.** That's turbo at CFG 1. Switch to base mode
   (drop the turbo LoRA, 30–50 steps, CFG 4–5) for max quality.
-- **`AnimaLLLiteApply` missing.** Install `ComfyUI-Anima-LLLite` — it is not a
-  standard ControlNet node.
+- **`AnimaLLLiteApply_sdscripts` missing.** Install `ComfyUI-Anima-LLLite` — it is not a
+  standard ControlNet node, and it is not core `AnimaLLLiteApply`.
 - **CLIP loads but output is garbage.** Confirm the `CLIPLoader` `type` is
   `stable_diffusion` and the file is `qwen_3_06b_base.safetensors` (the Qwen3-0.6B
   *base*, not a chat/edit Qwen).
 - **Inpainting ignores the mask.** Make sure both `SetLatentNoiseMask` *and* the
-  inpainting `AnimaLLLiteApply` receive the painted mask.
+  inpainting `AnimaLLLiteApply_sdscripts` receive the painted mask.
 - **OOM while training.** Drop to `network_dim 8` and/or `resolution 512`, keep
   batch 1, use AdamW8bit.
 

--- a/packs/anima-img2img/manifest.yaml
+++ b/packs/anima-img2img/manifest.yaml
@@ -1,7 +1,7 @@
 # ANIMA 1.0 img2img install manifest — consumable by apply_manifest.
 # Sliced from the anima monolith's "IMAGE TO IMAGE TURBO CONTROLNET" pipeline
 # (groups un-bypassed into a standalone graph). Static-check: CONVERT-OK (unknown
-# nodes DepthAnythingV2Preprocessor / DWPreprocessor / ttN seed / AnimaLLLiteApply
+# nodes DepthAnythingV2Preprocessor / DWPreprocessor / ttN seed / AnimaLLLiteApply_sdscripts
 # need their custom-node packs installed). The depth/openpose preprocessor weights
 # (depth_anything_v2_vitl.pth, dw-ll_ucoco_384_bs5.torchscript.pt) are fetched
 # automatically by comfyui_controlnet_aux on first run.

--- a/packs/anima-img2img/pack.yaml
+++ b/packs/anima-img2img/pack.yaml
@@ -20,7 +20,7 @@ notes:
   - Run the generated installer from your ComfyUI root (folder with custom_nodes/
     and models/).
   - Sliced + un-bypassed from the monolith's "IMAGE TO IMAGE TURBO CONTROLNET".
-  - Uses the kohya-ss ComfyUI-Anima-LLLite node (AnimaLLLiteApply) for ControlNet.
+  - Uses the kohya-ss ComfyUI-Anima-LLLite node (AnimaLLLiteApply_sdscripts) for ControlNet.
   - Depth/openpose preprocessor weights (depth_anything_v2_vitl,
     dw-ll_ucoco_384) are auto-downloaded by comfyui_controlnet_aux on first run.
   - Turbo LoRA preset is the shipped default — 12 steps, CFG 1.0, er_sde/simple.

--- a/packs/anima-img2img/workflow.json
+++ b/packs/anima-img2img/workflow.json
@@ -1053,7 +1053,7 @@
     },
     {
       "id": 918,
-      "type": "AnimaLLLiteApply",
+      "type": "AnimaLLLiteApply_sdscripts",
       "pos": [
         7358.7574558388515,
         -3.442160522033436
@@ -1096,13 +1096,14 @@
       "properties": {
         "aux_id": "kohya-ss/ComfyUI-Anima-LLLite",
         "ver": "b5d431c1f7b5b35e7f0f688a71cb701cc3d018aa",
-        "Node name for S&R": "AnimaLLLiteApply"
+        "Node name for S&R": "AnimaLLLiteApply_sdscripts"
       },
       "widgets_values": [
         "anima-lllite-pose-1.safetensors",
-        1,
-        0,
-        1
+        1.0,
+        0.0,
+        1.0,
+        true
       ]
     },
     {

--- a/packs/anima-inpaint/manifest.yaml
+++ b/packs/anima-inpaint/manifest.yaml
@@ -1,7 +1,7 @@
 # ANIMA 1.0 inpainting install manifest — consumable by apply_manifest.
 # Sliced from the anima monolith's "INPAINTING CONTROLNET" pipeline (groups
 # un-bypassed into a standalone graph). Static-check: CONVERT-OK (one unknown
-# node, AnimaLLLiteApply, needs its custom-node pack installed).
+# node, AnimaLLLiteApply_sdscripts, needs its custom-node pack installed).
 # Mirror base: https://huggingface.co/Aitrepreneur/FLX/resolve/main  (third-party)
 # Official weights: https://huggingface.co/circlestone-labs/Anima
 

--- a/packs/anima-inpaint/pack.yaml
+++ b/packs/anima-inpaint/pack.yaml
@@ -20,7 +20,7 @@ notes:
   - Run the generated installer from your ComfyUI root (folder with custom_nodes/
     and models/).
   - Sliced + un-bypassed from the monolith's "INPAINTING CONTROLNET".
-  - Uses the kohya-ss ComfyUI-Anima-LLLite node (AnimaLLLiteApply) with the
+  - Uses the kohya-ss ComfyUI-Anima-LLLite node (AnimaLLLiteApply_sdscripts) with the
     anima-lllite-inpainting-v1 ControlNet.
   - Turbo LoRA preset is the shipped default — 12 steps, CFG 1.0, er_sde/simple.
 post_install:

--- a/packs/anima-inpaint/workflow.json
+++ b/packs/anima-inpaint/workflow.json
@@ -857,7 +857,7 @@
     },
     {
       "id": 1017,
-      "type": "AnimaLLLiteApply",
+      "type": "AnimaLLLiteApply_sdscripts",
       "pos": [
         3325.1531234420727,
         1834.5130513843333
@@ -899,13 +899,14 @@
       "properties": {
         "aux_id": "kohya-ss/ComfyUI-Anima-LLLite",
         "ver": "b5d431c1f7b5b35e7f0f688a71cb701cc3d018aa",
-        "Node name for S&R": "AnimaLLLiteApply"
+        "Node name for S&R": "AnimaLLLiteApply_sdscripts"
       },
       "widgets_values": [
         "anima-lllite-inpainting-v1.safetensors",
-        1,
-        0,
-        1
+        1.0,
+        0.0,
+        1.0,
+        true
       ]
     },
     {

--- a/packs/anima/pack.yaml
+++ b/packs/anima/pack.yaml
@@ -17,7 +17,7 @@ sources:
 notes:
   - Run the generated installer from your ComfyUI root (the folder containing
     custom_nodes/ and models/).
-  - Anime inpainting uses the kohya-ss ComfyUI-Anima-LLLite node (AnimaLLLiteApply).
+  - Anime inpainting uses the kohya-ss ComfyUI-Anima-LLLite node (AnimaLLLiteApply_sdscripts).
   - Turbo LoRA preset is the shipped default — 12 steps, CFG 1.0, er_sde/simple.
 post_install:
   - Restart ComfyUI (or use ComfyUI-Manager → Install missing custom nodes for

--- a/packs/anima/workflow.json
+++ b/packs/anima/workflow.json
@@ -3487,7 +3487,7 @@
     },
     {
       "id": 1017,
-      "type": "AnimaLLLiteApply",
+      "type": "AnimaLLLiteApply_sdscripts",
       "pos": [
         3325.1531234420727,
         1834.5130513843333
@@ -3529,18 +3529,19 @@
       "properties": {
         "aux_id": "kohya-ss/ComfyUI-Anima-LLLite",
         "ver": "b5d431c1f7b5b35e7f0f688a71cb701cc3d018aa",
-        "Node name for S&R": "AnimaLLLiteApply"
+        "Node name for S&R": "AnimaLLLiteApply_sdscripts"
       },
       "widgets_values": [
         "anima-lllite-inpainting-v1.safetensors",
-        1,
-        0,
-        1
+        1.0,
+        0.0,
+        1.0,
+        true
       ]
     },
     {
       "id": 918,
-      "type": "AnimaLLLiteApply",
+      "type": "AnimaLLLiteApply_sdscripts",
       "pos": [
         7358.7574558388515,
         -3.442160522033436
@@ -3583,13 +3584,14 @@
       "properties": {
         "aux_id": "kohya-ss/ComfyUI-Anima-LLLite",
         "ver": "b5d431c1f7b5b35e7f0f688a71cb701cc3d018aa",
-        "Node name for S&R": "AnimaLLLiteApply"
+        "Node name for S&R": "AnimaLLLiteApply_sdscripts"
       },
       "widgets_values": [
         "anima-lllite-pose-1.safetensors",
-        1,
-        0,
-        1
+        1.0,
+        0.0,
+        1.0,
+        true
       ]
     },
     {

--- a/plugin/skills/anima-base/SKILL.md
+++ b/plugin/skills/anima-base/SKILL.md
@@ -42,7 +42,7 @@ The "Anima Base Ultra" pack (by Aitrepreneur) installs custom nodes and download
 | ComfyUI_UltimateSDUpscale | `https://github.com/ssitu/ComfyUI_UltimateSDUpscale` | tiled upscaling |
 | ComfyUI_tinyterraNodes | `https://github.com/TinyTerra/ComfyUI_tinyterraNodes` | ttN seed |
 | comfyui_controlnet_aux | `https://github.com/Fannovel16/comfyui_controlnet_aux` | DWPreprocessor, DepthAnythingV2 |
-| **ComfyUI-Anima-LLLite** | `https://github.com/kohya-ss/ComfyUI-Anima-LLLite` | **`AnimaLLLiteApply`** (ControlNet + inpainting) |
+| **ComfyUI-Anima-LLLite** | `https://github.com/kohya-ss/ComfyUI-Anima-LLLite` | **`AnimaLLLiteApply_sdscripts`** (ControlNet + inpainting) |
 
 ### Models (download URLs from the pack's .bat / .sh)
 
@@ -91,17 +91,18 @@ The pack applies it with rgthree `Power Lora Loader`. The plain ComfyUI equivale
 ```
 The pack ships three other LoRAs you can toggle in Power Lora Loader: `anima-highres-aesthetic-boost`, `anima-preview-3-masterpieces-v5`, `anima_p3_rdbt_v0.29.b.122`. In the non-turbo groups these three are enabled and the turbo LoRA is off; in the turbo groups only the turbo LoRA is on.
 
-### AnimaLLLiteApply (ControlNet + inpainting — from ComfyUI-Anima-LLLite)
-Patches the MODEL. Anima uses LLLite-style control, not standard `ControlNetApply` conditioning. Inputs: `model`, `image`, `mask`; widget order `[lllite_name, strength, start_percent, end_percent]`; output: patched `MODEL`.
+### AnimaLLLiteApply_sdscripts (ControlNet + inpainting — from ComfyUI-Anima-LLLite)
+Patches the MODEL. Anima uses LLLite-style control, not standard `ControlNetApply` conditioning. Inputs: `model`, `image`, `mask`; widget order `[lllite_name, strength, start_percent, end_percent, preserve_wrapper]`; output: patched `MODEL`. ComfyUI core now owns the old ID `AnimaLLLiteApply` (different signature: a `MODEL_PATCH` from `ModelPatchLoader`, no mask), so this pack uses the kohya-ss node ID `AnimaLLLiteApply_sdscripts`.
 ```json
 {
-  "class_type": "AnimaLLLiteApply",
+  "class_type": "AnimaLLLiteApply_sdscripts",
   "inputs": {
     "model": ["<model>", 0],
     "image": ["<control_or_source_image>", 0],
     "mask": ["<mask>", 0],
     "lllite_name": "anima-lllite-pose-1.safetensors",
-    "strength": 1.0, "start_percent": 0.0, "end_percent": 1.0
+    "strength": 1.0, "start_percent": 0.0, "end_percent": 1.0,
+    "preserve_wrapper": true
   }
 }
 ```
@@ -191,10 +192,11 @@ The pack's "INPAINTING CONTROLNET" group loads an image with a painted mask, `VA
   "3": { "class_type": "VAELoader", "inputs": { "vae_name": "qwen_image_vae.safetensors" }},
   "4": { "class_type": "LoraLoaderModelOnly", "inputs": { "model": ["1", 0], "lora_name": "anima-turbo-lora-v0.1.safetensors", "strength_model": 1.0 }},
   "5": { "class_type": "LoadImage", "inputs": { "image": "<masked_image.png>" }},
-  "6": { "class_type": "AnimaLLLiteApply", "inputs": {
+  "6": { "class_type": "AnimaLLLiteApply_sdscripts", "inputs": {
     "model": ["4", 0], "image": ["5", 0], "mask": ["5", 1],
     "lllite_name": "anima-lllite-inpainting-v1.safetensors",
-    "strength": 1.0, "start_percent": 0.0, "end_percent": 1.0
+    "strength": 1.0, "start_percent": 0.0, "end_percent": 1.0,
+    "preserve_wrapper": true
   }},
   "7": { "class_type": "CLIPTextEncode", "inputs": { "clip": ["2", 0], "text": "<what to paint into the masked area>" }},
   "8": { "class_type": "CLIPTextEncode", "inputs": { "clip": ["2", 0], "text": "worst quality, low quality, bad anatomy, text, watermark" }},
@@ -212,7 +214,7 @@ The pack's "INPAINTING CONTROLNET" group loads an image with a painted mask, `VA
 }
 ```
 
-The other LLLite ControlNets use the same `AnimaLLLiteApply` node. Swap `lllite_name` and feed a preprocessed control image; the mask can be a full-white/blank mask when not inpainting:
+The other LLLite ControlNets use the same `AnimaLLLiteApply_sdscripts` node. Swap `lllite_name` and feed a preprocessed control image; the mask can be a full-white/blank mask when not inpainting:
 - `anima-lllite-pose-1.safetensors` ← `DWPreprocessor` (OpenPose)
 - `anima-lllite-depth-1.safetensors` ← `DepthAnythingV2Preprocessor`
 - `anima-lllite-lineart-1.safetensors` / `anima-lllite-any-test-like-1-step2000.safetensors` ← lineart / generic control
@@ -231,9 +233,9 @@ The pack upscales with `UltimateSDUpscale` (`4x_foolhardy_Remacri.pth`, 2x, deno
 
 1. **Weird/distorted images.** Use a recommended resolution (1024x1024, 896x1152, 832x1216, 768x1344, 640x1536).
 2. **Turbo result looks washed/flat.** That's turbo at CFG 1. For max quality switch to base mode (drop turbo LoRA, 30 to 50 steps, CFG 4 to 5).
-3. **`AnimaLLLiteApply` missing.** Install `ComfyUI-Anima-LLLite`; it is not a standard ControlNet node.
+3. **`AnimaLLLiteApply_sdscripts` missing.** Install `ComfyUI-Anima-LLLite`; it is not a standard ControlNet node. Do not add core `AnimaLLLiteApply` — that ID now belongs to ComfyUI and has a different input signature.
 4. **CLIP loads but output is garbage.** Confirm `CLIPLoader` `type` is `stable_diffusion` and the file is `qwen_3_06b_base.safetensors` (the Qwen3-0.6B *base*, not the chat/edit Qwen models).
-5. **Inpainting ignores the mask.** Ensure both `SetLatentNoiseMask` and the inpainting `AnimaLLLiteApply` receive the painted mask, and encode the *source* image with `VAEEncode`. Denoise 1.0 is fine because the noise mask preserves unmasked pixels.
+5. **Inpainting ignores the mask.** Ensure both `SetLatentNoiseMask` and the inpainting `AnimaLLLiteApply_sdscripts` receive the painted mask, and encode the *source* image with `VAEEncode`. Denoise 1.0 is fine because the noise mask preserves unmasked pixels.
 
 ## Training custom LoRAs
 
@@ -241,5 +243,5 @@ To train your own Anima LoRA (character/style) on <6GB VRAM, use the Citron Anim
 
 ## Sources
 
-- **Official:** model weights at https://huggingface.co/circlestone-labs/Anima; no vendor prompting guide cited.
+- **Official:** model weights at https://huggingface.co/circlestone-labs/Anima; ComfyUI-Anima-LLLite README documents the node ID `AnimaLLLiteApply_sdscripts` after the core `AnimaLLLiteApply` collision. No vendor prompting guide cited.
 - **Empirical:** tag-order / @artist prompting and sampler wiring from working graphs; Anima Style Explorer is community, not vendor docs.

--- a/src/__tests__/packs/anima-inpaint-lllite-class.test.ts
+++ b/src/__tests__/packs/anima-inpaint-lllite-class.test.ts
@@ -1,0 +1,182 @@
+// #2442 — bundled anima-inpaint serialized the stale class_type AnimaLLLiteApply.
+// ComfyUI core now owns that ID (comfy_extras/nodes_model_patch.py) with a
+// different signature (MODEL_PATCH from ModelPatchLoader, no mask). The kohya-ss
+// pack renamed its node to AnimaLLLiteApply_sdscripts; ComfyUI silently skips a
+// custom-node registration that collides with a built-in, so apply_manifest can
+// clone ComfyUI-Anima-LLLite and the graph still shows an unknown/core-colliding
+// node. extract_deps / missing-node recovery then treats AnimaLLLiteApply as
+// builtin and does not install the kohya-ss pack.
+//
+// Pin the SHIPPED files (workflow.json, pack.yaml, skill examples) and the
+// object_info alias split that makes the stale name miss the pack.
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { ComfyUINodeDef, ObjectInfo, WorkflowJSON } from "../../comfyui/types.js";
+import { loadManifestFile, resolvePackManifestFile } from "../../services/manifest.js";
+import {
+  collectClassTypes,
+  extractWorkflowDependencies,
+  type WorkflowDepsDeps,
+} from "../../services/workflow-deps.js";
+
+const STALE = "AnimaLLLiteApply";
+const CURRENT = "AnimaLLLiteApply_sdscripts";
+const PACK = "anima-inpaint";
+const PACK_DIR = join(process.cwd(), "packs", PACK);
+const SKILL = join(process.cwd(), "plugin", "skills", "anima-base", "SKILL.md");
+const LLLITE_PACKS = ["anima-inpaint", "anima", "anima-img2img"] as const;
+
+/** Quoted serialized class — matches `"AnimaLLLiteApply"` and not `_sdscripts`. */
+const STALE_QUOTED = /"AnimaLLLiteApply"/;
+
+function def(name: string, pythonModule: string): ComfyUINodeDef {
+  return {
+    input: {},
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    name,
+    display_name: name,
+    description: "",
+    category: "",
+    output_node: false,
+    python_module: pythonModule,
+  };
+}
+
+/** Live /object_info after ComfyUI 0.21+ and ComfyUI-Anima-LLLite are both loaded. */
+function liveAliases(): ObjectInfo {
+  return {
+    [STALE]: def(STALE, "comfy_extras.nodes_model_patch"),
+    [CURRENT]: def(CURRENT, "custom_nodes.ComfyUI-Anima-LLLite"),
+    KSampler: def("KSampler", "nodes"),
+  };
+}
+
+function makeDeps(objectInfo: ObjectInfo): WorkflowDepsDeps {
+  return {
+    fetchObjectInfo: vi.fn(async () => objectInfo),
+    fetchManagerMappings: vi.fn(async () => ({
+      "https://github.com/kohya-ss/ComfyUI-Anima-LLLite": [
+        [CURRENT],
+        { title: "ComfyUI-Anima-LLLite" },
+      ],
+    })),
+    fetchManagerList: vi.fn(async () => ({ channel: "default", packs: [] })),
+    queueInstall: vi.fn(async () => undefined),
+    resetQueue: vi.fn(async () => undefined),
+    startQueue: vi.fn(async () => undefined),
+    queueStatus: vi.fn(async () => ({
+      total_count: 0,
+      done_count: 0,
+      in_progress_count: 0,
+      is_processing: false,
+    })),
+  };
+}
+
+function loadUiWorkflow(pack: string) {
+  const file = join(process.cwd(), "packs", pack, "workflow.json");
+  expect(existsSync(file), file).toBe(true);
+  return JSON.parse(readFileSync(file, "utf8")) as {
+    nodes?: { id: number; type?: string; widgets_values?: unknown[] }[];
+  };
+}
+
+/** extract_deps is typed on API/prompt graphs; class types still come from UI `type`. */
+function asApi(wf: { nodes?: { id: number; type?: string }[] }): WorkflowJSON {
+  const out: WorkflowJSON = {};
+  for (const n of wf.nodes ?? []) {
+    if (n.type) out[String(n.id)] = { class_type: n.type, inputs: {} };
+  }
+  return out;
+}
+
+describe("anima-inpaint ships AnimaLLLiteApply_sdscripts (#2442)", () => {
+  it("apply_manifest pack: name still resolves and still clones ComfyUI-Anima-LLLite", async () => {
+    const file = resolvePackManifestFile(PACK);
+    expect(file, "the reported pack must resolve from the running package root").toBeTruthy();
+    expect(file).toMatch(/anima-inpaint[\\/]manifest\.ya?ml$/);
+    const manifest = await loadManifestFile(file!);
+    expect(manifest.custom_nodes.join("\n")).toMatch(/kohya-ss\/ComfyUI-Anima-LLLite/);
+  });
+
+  it("workflow.json node 1017 is the kohya-ss class, not the stale core alias", () => {
+    const parsed = loadUiWorkflow(PACK);
+    expect(Array.isArray(parsed.nodes), "UI/litegraph shape").toBe(true);
+    const types = parsed.nodes!.map((n) => n.type);
+    expect(types, "stale AnimaLLLiteApply would resolve to core and miss the pack").not.toContain(STALE);
+    expect(types).toContain(CURRENT);
+    const node = parsed.nodes!.find((n) => n.id === 1017);
+    expect(node, "inpaint LLLite is node 1017").toBeTruthy();
+    expect(node!.type).toBe(CURRENT);
+    expect(node!.widgets_values).toEqual([
+      "anima-lllite-inpainting-v1.safetensors",
+      1.0,
+      0.0,
+      1.0,
+      true,
+    ]);
+  });
+
+  it("the serialized workflow file itself does not quote the stale class", () => {
+    const text = readFileSync(join(PACK_DIR, "workflow.json"), "utf8");
+    expect(text).not.toMatch(STALE_QUOTED);
+    expect(text).toContain(`"${CURRENT}"`);
+  });
+
+  it("extract_deps against live object_info aliases installs the kohya-ss pack, not core", async () => {
+    const aliases = liveAliases();
+    const graph = asApi(loadUiWorkflow(PACK));
+    const current = await extractWorkflowDependencies(graph, makeDeps(aliases));
+    expect(collectClassTypes(graph)).toContain(CURRENT);
+    expect(collectClassTypes(graph)).not.toContain(STALE);
+
+    const byType = Object.fromEntries(current.dependencies.map((d) => [d.class_type, d]));
+    expect(byType[CURRENT]).toMatchObject({
+      builtin: false,
+      installed: true,
+      pack: "ComfyUI-Anima-LLLite",
+    });
+    expect(current.requiredPacks).toContain("ComfyUI-Anima-LLLite");
+
+    // The defect: the same live aliases classify the STALE name as builtin, so
+    // missing-node recovery never queues ComfyUI-Anima-LLLite.
+    const stale = await extractWorkflowDependencies(
+      { "1017": { class_type: STALE, inputs: {} } },
+      makeDeps(aliases),
+    );
+    expect(stale.dependencies).toEqual([
+      expect.objectContaining({
+        class_type: STALE,
+        builtin: true,
+        pack: null,
+        installed: true,
+        source: "object_info",
+      }),
+    ]);
+    expect(stale.requiredPacks).not.toContain("ComfyUI-Anima-LLLite");
+  });
+
+  it("skill examples serialize the current class_type, not the stale core alias", () => {
+    expect(existsSync(SKILL)).toBe(true);
+    const text = readFileSync(SKILL, "utf8");
+    expect(text).not.toMatch(/"class_type"\s*:\s*"AnimaLLLiteApply"/);
+    expect(text).toMatch(/"class_type"\s*:\s*"AnimaLLLiteApply_sdscripts"/);
+  });
+});
+
+describe("sibling anima LLLite graphs do not keep the stale class (#2442)", () => {
+  it.each(LLLITE_PACKS)("%s workflow.json has no quoted AnimaLLLiteApply", (pack) => {
+    const file = join(process.cwd(), "packs", pack, "workflow.json");
+    expect(existsSync(file), file).toBe(true);
+    const text = readFileSync(file, "utf8");
+    expect(text).not.toMatch(STALE_QUOTED);
+    const parsed = JSON.parse(text) as { nodes?: { type?: string }[] };
+    const lllite = (parsed.nodes ?? []).filter((n) => n.type === CURRENT || n.type === STALE);
+    expect(lllite.length, `${pack} must still ship an LLLite node`).toBeGreaterThan(0);
+    expect(lllite.every((n) => n.type === CURRENT)).toBe(true);
+  });
+});


### PR DESCRIPTION
ComfyUI core now owns `AnimaLLLiteApply` (`comfy_extras/nodes_model_patch.py`) with a different signature. The kohya-ss pack therefore registers `AnimaLLLiteApply_sdscripts`. The bundled anima-inpaint graph still serialized the stale ID, so the node showed as unknown (four UNKNOWN widgets) and extract_deps / missing-node recovery treated it as builtin core instead of installing ComfyUI-Anima-LLLite.

## Changes
- `packs/anima-inpaint/workflow.json` node 1017 is `AnimaLLLiteApply_sdscripts` with widgets `["anima-lllite-inpainting-v1.safetensors", 1.0, 0.0, 1.0, true]`
- Shared anima / anima-img2img LLLite nodes updated the same way
- pack.yaml / manifest notes, anima-base skill examples, and the ANIMA blog post use the current class
- Pack test fails on the quoted stale class and pins the live `/object_info` alias split (core `AnimaLLLiteApply` vs custom `AnimaLLLiteApply_sdscripts`)

Closes #2442