### PR TITLE
fix(2438): stop panel_run queued_unknown from naming an unavailable queue inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - apply_manifest counts a GGUF as installed when ComfyUI-GGUF lists it under clip_gguf/unet_gguf (#2447)
 - panel_list_nodes lists installed packs from host Manager HTTP when the panel tab is gone (#2459)
+- panel_run queued_unknown names a live-canvas next step instead of an unavailable queue inspector (#2438)
 
 ## [0.52.143] - 2026-08-27
 

--- a/src/__tests__/orchestrator/panel-run-queued-unknown-guidance.test.ts
+++ b/src/__tests__/orchestrator/panel-run-queued-unknown-guidance.test.ts
@@ -1,0 +1,149 @@
+// #2438 — panel_run's queued_unknown receipt told the model to inspect a live
+// queue with `queue (action:"list")`. That tool is not on the live-canvas
+// surface, and the headless ComfyUI route may be unreachable even while the
+// panel is connected. The shipped guidance must name a real next step on THIS
+// surface: wait for an UNDETERMINED completion, do not re-run.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  __panelRunTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+
+/** The Panel/orchestrator phrasing that sent agents to a missing inspector. */
+const UNFIXED_QUEUE_LIST = 'queue (action:"list")';
+const UNFIXED_QUEUE_ACTION_LIST = "queue action:list";
+const UNFIXED_FOLLOW_PANEL = "Follow the Panel's retry_guidance";
+
+function panelRun() {
+  const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_run");
+  if (!def) throw new Error("panel_run tool not found");
+  return def;
+}
+
+function textOf(res: { content?: Array<{ type: string; text?: string }> }): string {
+  return res.content?.find((content) => content.type === "text")?.text ?? "";
+}
+
+function makeRunCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: unknown[] } {
+  const calls: unknown[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      calls.push(cmd);
+      return reply;
+    },
+    confirm: async () => "yes" as const,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  };
+  return { ctx, calls };
+}
+
+beforeEach(() => {
+  RunCompletions.reset();
+});
+
+afterEach(() => {
+  RunCompletions.reset();
+});
+
+describe("panel_run queued_unknown guidance stays on this surface (#2438)", () => {
+  it("the shipped retry_guidance string itself does not name the missing inspector", () => {
+    const shipped = __panelRunTestHooks.PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE;
+    expect(shipped).toContain("Do NOT re-run panel_run");
+    expect(shipped).toContain("UNDETERMINED completion");
+    expect(shipped).toContain("no render-queue inspection tool");
+    expect(shipped).not.toContain(UNFIXED_QUEUE_LIST);
+    expect(shipped.toLowerCase()).not.toContain(UNFIXED_QUEUE_ACTION_LIST);
+    expect(shipped).not.toContain(UNFIXED_FOLLOW_PANEL);
+  });
+
+  it("rewrites a Panel queue-list retry_guidance instead of forwarding it", () => {
+    const unfixed: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued_unknown: true,
+            retry_guidance: `Check ${UNFIXED_QUEUE_LIST} before retrying the unresolved request.`,
+          }),
+        },
+      ],
+    };
+    const rewritten = __panelRunTestHooks.applyQueuedUnknownRetryGuidance(unfixed);
+    const text = textOf(rewritten);
+    expect(text).not.toContain(`Check ${UNFIXED_QUEUE_LIST}`);
+    expect(text).not.toContain(UNFIXED_QUEUE_LIST);
+    expect(text).toContain(__panelRunTestHooks.PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE);
+    const parsed: unknown = JSON.parse(text);
+    expect(parsed).toMatchObject({
+      queued_unknown: true,
+      retry_guidance: __panelRunTestHooks.PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE,
+    });
+  });
+
+  it("id-less queued_unknown does not tell the caller to check queue action:list", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued_unknown: true,
+            error:
+              "run-to-node scope for node 35: a verified-scoped /prompt request FAILED to complete - the /prompt request itself threw (Failed to fetch).",
+            indeterminate_count: 1,
+            retry_guidance: `Check ${UNFIXED_QUEUE_LIST} before retrying.`,
+          }),
+        },
+      ],
+    };
+    const { ctx, calls } = makeRunCtx(reply);
+    const res = await panelRun().handler({ to_node_id: 35 }, ctx);
+    const text = textOf(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(calls).toHaveLength(1);
+    expect(text).not.toContain(UNFIXED_QUEUE_LIST);
+    expect(text.toLowerCase()).not.toContain(UNFIXED_QUEUE_ACTION_LIST);
+    expect(text).not.toContain(UNFIXED_FOLLOW_PANEL);
+    expect(text).toContain("[UNCERTAIN]");
+    expect(text).toContain("Do NOT re-run panel_run");
+    expect(text).toContain("no render-queue inspection tool");
+    expect(text).toContain("UNDETERMINED completion");
+    expect(text).toContain("No second panel_run was dispatched");
+  });
+
+  it("partial queued_unknown keeps known ids ticketed and still withholds the inspector", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued_unknown: true,
+            queued: true,
+            complete: false,
+            partially_queued: true,
+            queued_prompt_ids: ["p-known-1"],
+            retry_guidance: `Inspect with ${UNFIXED_QUEUE_LIST} before retrying the unresolved request.`,
+          }),
+        },
+      ],
+    };
+    const { ctx, calls } = makeRunCtx(reply);
+    const res = await panelRun().handler({ batch_count: 2, to_node_id: 9 }, ctx);
+    const text = textOf(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(calls).toHaveLength(1);
+    expect(RunCompletions.ticketFor("p-known-1")).toBeDefined();
+    expect(text).toContain("p-known-1");
+    expect(text).not.toContain(UNFIXED_QUEUE_LIST);
+    expect(text.toLowerCase()).not.toContain(UNFIXED_QUEUE_ACTION_LIST);
+    expect(text).not.toContain(UNFIXED_FOLLOW_PANEL);
+    expect(text).toContain("Do NOT re-run panel_run");
+    expect(text).toContain("UNDETERMINED completion");
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1917,14 +1917,16 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
     const { ctx, calls } = makeRunCtx(reply);
     const res = await defByName("panel_run").handler({ to_node_id: 9 }, ctx);
 
-    // A normal Panel timeout receipt must stay non-error so its explicit retry
-    // guidance survives verbatim. The handler performs no second dispatch and
-    // cannot ticket an unidentifiable completion.
+    // A normal Panel timeout receipt must stay non-error. #2438 rewrites the
+    // Panel's retry_guidance onto this surface (no live render-queue inspector)
+    // rather than forwarding it verbatim. The handler still performs no second
+    // dispatch and cannot ticket an unidentifiable completion.
     expect(res.isError).toBeFalsy();
     expect(calls).toHaveLength(1);
     const text = textOf(res);
-    expect(text).toContain("Check the ComfyUI queue before retrying anything.");
     expect(text).toContain("[UNCERTAIN]");
+    expect(text).toContain("Do NOT re-run panel_run");
+    expect(text).toContain("UNDETERMINED completion");
     expect(text).not.toContain(QUEUED_NOTE);
     expect(text).not.toContain("ComfyUI refused to queue");
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8721,6 +8721,39 @@ function isPanelQueueUncertainty(parsed: Record<string, unknown> | null): boolea
   return parsed?.queued_unknown === true;
 }
 
+/**
+ * #2438 — the live-canvas surface has no render-queue inspector. Panel
+ * `retry_guidance` historically named `queue (action:"list")`, which is a
+ * headless stdio tool and may be unreachable (ECONNREFUSED) even while the
+ * panel is connected. The only safe next step on this surface is to wait for
+ * an eventual UNDETERMINED completion and not re-dispatch.
+ */
+const PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE =
+  `Do NOT re-run panel_run: the /prompt request already left the panel, and a second ` +
+  `dispatch may queue a duplicate render. This live-canvas surface has no render-queue ` +
+  `inspection tool. End your turn and wait for an eventual UNDETERMINED completion ` +
+  `event for this tab; if one arrives, treat it as this run's possible outcome rather ` +
+  `than queuing another.`;
+
+function applyQueuedUnknownRetryGuidance(res: ToolResult): ToolResult {
+  const parsed = parseToolResultJson(res);
+  if (!parsed || !isPanelQueueUncertainty(parsed)) return res;
+  if (parsed.retry_guidance === PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE) return res;
+  return {
+    ...res,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          ...parsed,
+          retry_guidance: PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE,
+        }),
+      },
+      ...res.content.slice(1),
+    ],
+  };
+}
+
 function detectRunRejection(res: ToolResult): ToolResult | null {
   // Bridge/transport/executor error: never a queue. Preserve it verbatim (#248),
   // no success note (#331). fail() already carries err.message (incl. any stack).
@@ -8730,9 +8763,9 @@ function detectRunRejection(res: ToolResult): ToolResult | null {
   if (!parsed) return null; // unparseable non-error reply — don't regress a success
 
   // #2143 — `queued_unknown` is an explicit Panel receipt, not the ComfyUI
-  // rejection channel. Its `error` field explains the timeout and its
-  // `retry_guidance` tells the caller how to settle it; keep the receipt intact
-  // and never redispatch from here.
+  // rejection channel. Its `error` field explains the timeout. Keep the
+  // receipt intact and never redispatch from here; the handler rewrites
+  // `retry_guidance` onto this surface (#2438) after this gate.
   if (isPanelQueueUncertainty(parsed)) return null;
 
   const topError = parsed.error;
@@ -8881,6 +8914,8 @@ export const __panelRunTestHooks = {
   isRetryableRunToNodeStampRace,
   isSeedRunToNodeStampRace,
   describeDroppedOutputs,
+  applyQueuedUnknownRetryGuidance,
+  PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE,
 };
 
 /** Drop a trailing .json (case-insensitive) so filename/path forms compare equal. */
@@ -16146,23 +16181,23 @@ function panelLateReceiptNote(promptId: string): string {
 }
 
 /**
- * #2143 — a normal Panel timeout receipt is neither a confirmed queue nor a
- * refusal. Keep its retry guidance in the original JSON and add only the
- * local fact that this handler did not dispatch a second run.
+ * #2143 / #2438 — a normal Panel timeout receipt is neither a confirmed queue
+ * nor a refusal. Name the next step that exists on THIS surface rather than
+ * forwarding Panel retry_guidance that points at a headless queue inspector.
  */
 function panelQueueUncertaintyNote(queuedPromptIds: readonly string[]): string {
   if (queuedPromptIds.length > 0) {
     return (
       `\n\n[UNCERTAIN] The Panel confirmed these prompt id(s) left its queue path: ` +
       `${queuedPromptIds.join(", ")}. Completion tickets were opened for them. ` +
-      `Any remaining request(s) are still uncertain; follow the Panel's retry_guidance above ` +
-      `before retrying. No second panel_run was dispatched.`
+      `Any remaining request(s) are still uncertain. ${PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE} ` +
+      `No second panel_run was dispatched.`
     );
   }
   return (
     `\n\n[UNCERTAIN] The Panel could not determine whether this run entered ComfyUI's queue. ` +
     `This is not a confirmed refusal, and no completion ticket can be opened without a prompt id. ` +
-    `Follow the Panel's retry_guidance above before retrying. No second panel_run was dispatched.`
+    `${PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE} No second panel_run was dispatched.`
   );
 }
 
@@ -20047,6 +20082,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               `If the running job is genuinely stuck, queue (action:"cancel") with clear_pending:true interrupts it AND drops pending, then escalate to restart_comfyui if it reports the job wedged.`;
           }
         }
+        // #2438 — rewrite Panel retry_guidance BEFORE the notes are spliced so
+        // a headless `queue (action:"list")` inspector is not left in the JSON
+        // for a surface that cannot call it.
+        if (panelQueueUncertain) res = applyQueuedUnknownRetryGuidance(res);
         if (res.content?.[0]?.type === "text") {
           return {
             ...res,


### PR DESCRIPTION
## Summary

`panel_run` returned `queued_unknown` after a browser-side scoped `/prompt` fetch threw, and its retry guidance told the model to inspect the live render queue with `queue (action:"list")`.

That tool is not on the live-canvas surface. In the reported session the headless ComfyUI route was also `ECONNREFUSED`, so there was no safe inspector — only waiting for an eventual UNDETERMINED completion and not retrying.

This rewrites `retry_guidance` onto this surface instead of forwarding the Panel's queue-list instruction:

- Do not re-run `panel_run` (the request already left the panel; a second dispatch may duplicate)
- This live-canvas surface has no render-queue inspection tool
- End the turn and wait for an UNDETERMINED completion event for this tab

The duplicate fence is unchanged.

## Tests

- `src/__tests__/orchestrator/panel-run-queued-unknown-guidance.test.ts` — fails if the unfixed `queue (action:"list")` / `queue action:list` guidance is forwarded; passes on the shipped next step
- `#2143` queued_unknown receipt stays non-error and no longer preserves the Panel inspector instruction
- `#1728` late-prompt reconciliation still tickets without redispatch

`npx vitest run src/__tests__/orchestrator/panel-run-queued-unknown-guidance.test.ts src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts` — 12 passed.

Closes #2438
