### PR TITLE
fix(2439): persist panel_screenshot PNG to a caller-specified path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - apply_manifest counts a GGUF as installed when ComfyUI-GGUF lists it under clip_gguf/unet_gguf (#2447)
 - panel_list_nodes lists installed packs from host Manager HTTP when the panel tab is gone (#2459)
 - panel_run queued_unknown names a live-canvas next step instead of an unavailable queue inspector (#2438)
+- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.143] - 2026-08-27
 

--- a/src/__tests__/orchestrator/panel-screenshot-persist.test.ts
+++ b/src/__tests__/orchestrator/panel-screenshot-persist.test.ts
@@ -1,0 +1,251 @@
+// #2439 — panel_screenshot must persist a PNG to the caller-specified path.
+// The capture already returned an image block; the defect was that save_path
+// did not exist, so a deferred-tool client had to forward a 200k-character
+// base64 payload into a filesystem command and died on Windows error 206.
+//
+// These tests fail if the path is ignored: a named dest must receive the PNG
+// bytes, a blocked dest must error (not return image-only success), and a
+// relative/blank dest must be refused before the capture is even sent.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { z } from "zod";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import {
+  decodePngBase64,
+  persistScreenshotPng,
+  resolveScreenshotPersistPath,
+  screenshotOverwriteFromArgs,
+  screenshotPersistPathFromArgs,
+  ScreenshotPersistError,
+} from "../../orchestrator/panel-screenshot-persist.js";
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xaa, 0xbb]);
+const PNG_B64 = PNG_BYTES.toString("base64");
+
+const temps: string[] = [];
+
+afterEach(() => {
+  for (const dir of temps.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function scratchDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "panel-ss-persist-"));
+  temps.push(dir);
+  return dir;
+}
+
+function screenshotTool() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_screenshot");
+  if (!def) throw new Error("panel_screenshot is not registered");
+  return def;
+}
+
+function screenshotCtx(): { ctx: PanelToolCtx; sent: Array<{ cmd: string }> } {
+  const sent: Array<{ cmd: string }> = [];
+  const bridge = {
+    send: async (cmd: { cmd: string }) => {
+      sent.push(cmd);
+      if (cmd.cmd === "graph_screenshot") return { image: PNG_B64, mimeType: "image/png" };
+      if (cmd.cmd === "graph_serialize") return { nodes: [] };
+      return {};
+    },
+    push: () => 1,
+    canReach: () => true,
+  } as PanelToolCtx["bridge"];
+  return { ctx: makePanelToolCtx(bridge, "test-tab"), sent };
+}
+
+function allText(res: ToolResult): string {
+  const parts: string[] = [];
+  for (const c of res.content) {
+    if (c.type === "text") parts.push(c.text);
+  }
+  return parts.join("\n");
+}
+
+function imageData(res: ToolResult): string | undefined {
+  for (const c of res.content) {
+    if (c.type === "image") return c.data;
+  }
+  return undefined;
+}
+
+describe("panel_screenshot persist path (#2439)", () => {
+  it("schema accepts save_path, output_path, and overwrite", () => {
+    const parsed = z.object(screenshotTool().schema);
+    expect(parsed.safeParse({}).success).toBe(true);
+    expect(parsed.safeParse({ save_path: "C:\\audit\\placed.png" }).success).toBe(true);
+    expect(parsed.safeParse({ output_path: "C:\\audit\\placed.png" }).success).toBe(true);
+    expect(parsed.safeParse({ overwrite: false }).success).toBe(true);
+    expect(Object.keys(screenshotTool().schema)).toEqual(
+      expect.arrayContaining(["padding", "save_path", "output_path", "overwrite"]),
+    );
+  });
+
+  it("writes the PNG bytes to save_path and reports the resolved dest", async () => {
+    const dest = join(scratchDir(), "placed.png");
+    const { ctx, sent } = screenshotCtx();
+
+    const res = await screenshotTool().handler({ save_path: dest }, ctx);
+
+    expect(res.isError).not.toBe(true);
+    expect(sent.some((c) => c.cmd === "graph_screenshot")).toBe(true);
+    expect(imageData(res)).toBe(PNG_B64);
+    expect(existsSync(dest)).toBe(true);
+    expect(readFileSync(dest).equals(PNG_BYTES)).toBe(true);
+    expect(allText(res)).toContain(`Saved to: ${dest}`);
+  });
+
+  it("output_path is the same write as save_path", async () => {
+    const dest = join(scratchDir(), "via-output.png");
+    const { ctx } = screenshotCtx();
+
+    const res = await screenshotTool().handler({ output_path: dest }, ctx);
+
+    expect(res.isError).not.toBe(true);
+    expect(existsSync(dest)).toBe(true);
+    expect(readFileSync(dest).equals(PNG_BYTES)).toBe(true);
+    expect(allText(res)).toContain(dest);
+  });
+
+  it("refuses an existing file unless overwrite is true, and leaves the original bytes", async () => {
+    const dest = join(scratchDir(), "placed.png");
+    writeFileSync(dest, "original-not-png");
+    const { ctx, sent } = screenshotCtx();
+
+    const res = await screenshotTool().handler({ save_path: dest }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(sent).toEqual([]);
+    expect(readFileSync(dest, "utf8")).toBe("original-not-png");
+    expect(allText(res)).toMatch(/already exists/i);
+    expect(allText(res)).toMatch(/overwrite:true/);
+  });
+
+  it("overwrite:true replaces the existing file with the PNG", async () => {
+    const dest = join(scratchDir(), "placed.png");
+    writeFileSync(dest, "stale");
+    const { ctx } = screenshotCtx();
+
+    const res = await screenshotTool().handler({ save_path: dest, overwrite: true }, ctx);
+
+    expect(res.isError).not.toBe(true);
+    expect(readFileSync(dest).equals(PNG_BYTES)).toBe(true);
+  });
+
+  it("a relative save_path fails the call instead of being ignored", async () => {
+    const { ctx, sent } = screenshotCtx();
+    const relative = `placed-${Date.now()}.png`;
+
+    const res = await screenshotTool().handler({ save_path: relative }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(sent).toEqual([]);
+    expect(existsSync(relative)).toBe(false);
+    expect(existsSync(resolve(relative))).toBe(false);
+    expect(allText(res)).toMatch(/absolute path/i);
+  });
+
+  it("a whitespace save_path is refused, not treated as omitted", async () => {
+    const { ctx, sent } = screenshotCtx();
+
+    const res = await screenshotTool().handler({ save_path: "   " }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(sent).toEqual([]);
+    expect(imageData(res)).toBeUndefined();
+    expect(allText(res)).toMatch(/empty/i);
+  });
+
+  it("a directory save_path is refused", async () => {
+    const dir = join(scratchDir(), "placed.png");
+    mkdirSync(dir);
+    const { ctx, sent } = screenshotCtx();
+
+    const res = await screenshotTool().handler({ save_path: dir }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(sent).toEqual([]);
+    expect(allText(res)).toMatch(/directory/i);
+  });
+
+  it("a non-.png save_path is refused", async () => {
+    const dest = join(scratchDir(), "placed.jpg");
+    const { ctx, sent } = screenshotCtx();
+
+    const res = await screenshotTool().handler({ save_path: dest }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(sent).toEqual([]);
+    expect(existsSync(dest)).toBe(false);
+    expect(allText(res)).toMatch(/\.png/i);
+  });
+
+  it("disagreeing save_path and output_path fail closed", async () => {
+    const dir = scratchDir();
+    const { ctx, sent } = screenshotCtx();
+
+    const res = await screenshotTool().handler(
+      { save_path: join(dir, "a.png"), output_path: join(dir, "b.png") },
+      ctx,
+    );
+
+    expect(res.isError).toBe(true);
+    expect(sent).toEqual([]);
+    expect(existsSync(join(dir, "a.png"))).toBe(false);
+    expect(existsSync(join(dir, "b.png"))).toBe(false);
+    expect(allText(res)).toMatch(/disagree/i);
+  });
+
+  it("omitting the path still returns the image and does not invent a dest", async () => {
+    const { ctx } = screenshotCtx();
+    const res = await screenshotTool().handler({}, ctx);
+    expect(res.isError).not.toBe(true);
+    expect(imageData(res)).toBe(PNG_B64);
+    expect(allText(res)).not.toMatch(/Saved to:/);
+    expect(res.content).toHaveLength(1);
+  });
+});
+
+describe("screenshot persist helpers (#2439)", () => {
+  it("screenshotPersistPathFromArgs reads either alias and rejects a blank", () => {
+    expect(screenshotPersistPathFromArgs({})).toBeUndefined();
+    expect(screenshotPersistPathFromArgs({ save_path: "/tmp/a.png" })).toBe("/tmp/a.png");
+    expect(screenshotPersistPathFromArgs({ output_path: "/tmp/b.png" })).toBe("/tmp/b.png");
+    expect(() => screenshotPersistPathFromArgs({ save_path: "  " })).toThrow(ScreenshotPersistError);
+    expect(screenshotOverwriteFromArgs({})).toBe(false);
+    expect(screenshotOverwriteFromArgs({ overwrite: true })).toBe(true);
+  });
+
+  it("resolveScreenshotPersistPath requires a fully-qualified .png path", () => {
+    expect(() => resolveScreenshotPersistPath("placed.png")).toThrow(/absolute path/i);
+    expect(() => resolveScreenshotPersistPath(join(scratchDir(), "x.jpg"))).toThrow(/\.png/i);
+    const dest = join(scratchDir(), "ok.png");
+    expect(resolveScreenshotPersistPath(dest)).toBe(resolve(dest));
+  });
+
+  it("persistScreenshotPng writes atomically and refuses an existing file", () => {
+    const dest = join(scratchDir(), "atom.png");
+    persistScreenshotPng(dest, PNG_BYTES, false);
+    expect(readFileSync(dest).equals(PNG_BYTES)).toBe(true);
+    expect(() => persistScreenshotPng(dest, PNG_BYTES, false)).toThrow(/already exists/i);
+    persistScreenshotPng(dest, PNG_BYTES, true);
+    expect(readFileSync(dest).equals(PNG_BYTES)).toBe(true);
+  });
+
+  it("decodePngBase64 refuses non-PNG bytes", () => {
+    expect(decodePngBase64(PNG_B64).equals(PNG_BYTES)).toBe(true);
+    expect(() => decodePngBase64(Buffer.from("not-a-png").toString("base64"))).toThrow(/not PNG/i);
+  });
+});

--- a/src/orchestrator/panel-screenshot-persist.ts
+++ b/src/orchestrator/panel-screenshot-persist.ts
@@ -1,0 +1,200 @@
+// #2439 — panel_screenshot must write a PNG to a caller-specified path on the
+// MCP host. Capture itself already works; the missing half is the write, because
+// handing a 200k-character base64 payload to a filesystem command blows the
+// Windows command bound (error 206). Fail closed: a bad or occupied path is an
+// error, never a silent image-only success.
+
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, extname, isAbsolute, resolve } from "node:path";
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f]/;
+
+export class ScreenshotPersistError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ScreenshotPersistError";
+  }
+}
+
+/**
+ * Pick the destination the caller named. `save_path` and `output_path` are the
+ * same argument; both omitted means "do not write". A blank string is a bad
+ * path, not an omit — ignoring it is the original defect.
+ */
+export function screenshotPersistPathFromArgs(args: Record<string, unknown>): string | undefined {
+  const save = optionalPathArg(args.save_path, "save_path");
+  const output = optionalPathArg(args.output_path, "output_path");
+  if (save !== undefined && output !== undefined && save !== output) {
+    throw new ScreenshotPersistError(
+      "save_path and output_path disagree — pass one destination, or the same path twice.",
+    );
+  }
+  return save ?? output;
+}
+
+/** overwrite is opt-in. Missing / false refuses an existing file. */
+export function screenshotOverwriteFromArgs(args: Record<string, unknown>): boolean {
+  return args.overwrite === true;
+}
+
+/** Resolve and validate a caller-specified PNG path. Throws ScreenshotPersistError. */
+export function resolveScreenshotPersistPath(raw: string): string {
+  if (CONTROL_CHARS_RE.test(raw)) {
+    throw new ScreenshotPersistError("save_path must not contain control characters or NUL bytes.");
+  }
+  if (!isFullyQualified(raw)) {
+    throw new ScreenshotPersistError(
+      `save_path must be an absolute path (got ${JSON.stringify(raw)}). ` +
+        "A relative or drive-relative path is refused so the PNG cannot land in this process's launch directory.",
+    );
+  }
+  const dest = resolve(raw);
+  if (extname(dest).toLowerCase() !== ".png") {
+    throw new ScreenshotPersistError(
+      `save_path must end in .png (got ${JSON.stringify(dest)}).`,
+    );
+  }
+  return dest;
+}
+
+/**
+ * Refuse a destination we will not write: a directory, or an existing file when
+ * overwrite is false. Call this BEFORE capturing so a blocked path does not
+ * burn a screenshot.
+ */
+export function assertScreenshotPersistAllowed(dest: string, overwrite: boolean): void {
+  if (!existsSync(dest)) return;
+  let isDir = false;
+  try {
+    isDir = lstatSync(dest).isDirectory();
+  } catch (err) {
+    throw persistIoError(dest, err);
+  }
+  if (isDir) {
+    throw new ScreenshotPersistError(
+      `save_path ${JSON.stringify(dest)} is a directory — pass a .png file path.`,
+    );
+  }
+  if (!overwrite) {
+    throw new ScreenshotPersistError(
+      `save_path ${JSON.stringify(dest)} already exists. Pass overwrite:true to replace it.`,
+    );
+  }
+}
+
+export function decodePngBase64(image: string): Buffer {
+  const bytes = Buffer.from(image, "base64");
+  if (bytes.length < PNG_MAGIC.length || !bytes.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+    throw new ScreenshotPersistError("screenshot image is not PNG data.");
+  }
+  return bytes;
+}
+
+/**
+ * Write `pngBytes` to `dest` atomically. Returns the resolved path. Throws on
+ * any failure; never reports a write that did not land.
+ */
+export function persistScreenshotPng(dest: string, pngBytes: Buffer, overwrite: boolean): string {
+  assertScreenshotPersistAllowed(dest, overwrite);
+  const parent = dirname(dest);
+  try {
+    mkdirSync(parent, { recursive: true });
+  } catch (err) {
+    throw persistIoError(parent, err);
+  }
+  const tmp = `${dest}.tmp-${randomUUID()}`;
+  try {
+    const fd = openSync(tmp, "wx");
+    try {
+      writeFileSync(fd, pngBytes);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    if (overwrite) {
+      renameSync(tmp, dest);
+    } else {
+      // rename overwrites on Windows. COPYFILE_EXCL is the exclusive create.
+      copyFileSync(tmp, dest, constants.COPYFILE_EXCL);
+      rmSync(tmp, { force: true });
+      fsyncFile(dest);
+    }
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      // Best-effort cleanup; the original failure is the one to report.
+    }
+    if (err instanceof ScreenshotPersistError) throw err;
+    throw persistIoError(dest, err);
+  }
+  fsyncDirBestEffort(parent);
+  return dest;
+}
+
+function optionalPathArg(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new ScreenshotPersistError(`${label} must be a string.`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new ScreenshotPersistError(
+      `${label} is empty. Pass an absolute .png path, or omit ${label} to skip the write.`,
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Independent of this process's cwd AND its drive. `path.isAbsolute` is not that
+ * test on Windows: `\Temp` and `C:out` pick up launch state. Those are refused.
+ */
+function isFullyQualified(p: string): boolean {
+  if (process.platform !== "win32") return isAbsolute(p);
+  return /^[a-zA-Z]:[\\/]/.test(p) || /^[\\/]{2}[^\\/]/.test(p);
+}
+
+function persistIoError(path: string, err: unknown): ScreenshotPersistError {
+  const msg = err instanceof Error ? err.message : String(err);
+  return new ScreenshotPersistError(`could not write PNG to ${JSON.stringify(path)}: ${msg}`);
+}
+
+function fsyncFile(path: string): void {
+  const fd = openSync(path, "r+");
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function fsyncDirBestEffort(dir: string): void {
+  try {
+    const dirFd = openSync(dir, "r");
+    try {
+      fsyncSync(dirFd);
+    } finally {
+      closeSync(dirFd);
+    }
+  } catch (err) {
+    const code = err instanceof Error && "code" in err ? String(err.code) : "";
+    if (code !== "EPERM" && code !== "EINVAL" && code !== "ENOTSUP" && code !== "EISDIR") {
+      throw persistIoError(dir, err);
+    }
+  }
+}

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -76,6 +76,14 @@ import {
 } from "../services/panel-workflow-readiness.js";
 import { isPreExecutorRefusal } from "../services/panel-refusal.js";
 import { unexposeHostLinkShiftNote } from "../services/unexpose-host-link-shift.js";
+import {
+  assertScreenshotPersistAllowed,
+  decodePngBase64,
+  persistScreenshotPng,
+  resolveScreenshotPersistPath,
+  screenshotOverwriteFromArgs,
+  screenshotPersistPathFromArgs,
+} from "./panel-screenshot-persist.js";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
@@ -22408,11 +22416,34 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_screenshot",
-      "SCREENSHOT the canvas to a PNG IMAGE — pixels, for when the question is VISUAL: overlaps, alignment, rails, colors, group bands. To READ what is on the canvas as text (ids, types, widget values, wiring) use panel_graph_outline instead; an image cannot be searched or quoted. Renders the workflow the user is currently viewing (root graph, or the open subgraph): frames the whole graph (nodes + groups), captures, then restores the user's view. Use it to verify a layout you just built instead of reasoning from coordinates alone.",
-      { padding: z.number().optional().describe("Margin around the graph in px (default 60).") },
+      "SCREENSHOT the canvas to a PNG IMAGE — pixels, for when the question is VISUAL: overlaps, alignment, rails, colors, group bands. To READ what is on the canvas as text (ids, types, widget values, wiring) use panel_graph_outline instead; an image cannot be searched or quoted. Renders the workflow the user is currently viewing (root graph, or the open subgraph): frames the whole graph (nodes + groups), captures, then restores the user's view. Use it to verify a layout you just built instead of reasoning from coordinates alone. Optional save_path/output_path writes the PNG atomically on the MCP host (absolute .png path; existing files refused unless overwrite:true) so a bulk capture does not have to round-trip the base64 through a filesystem command.",
+      {
+        padding: z.number().optional().describe("Margin around the graph in px (default 60)."),
+        save_path: z
+          .string()
+          .optional()
+          .describe(
+            "Absolute path on the MCP host to write the captured PNG. Existing files are refused unless overwrite is true. output_path is the same argument under another name.",
+          ),
+        output_path: z
+          .string()
+          .optional()
+          .describe("Alias for save_path — an absolute .png path on the MCP host."),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe("Replace an existing file at save_path. Default false: an existing file is refused."),
+      },
       async (args: A, ctx) => {
         try {
           ctx.ensureReachable?.();
+          let persistDest: string | undefined;
+          const requestedPath = screenshotPersistPathFromArgs(args);
+          const overwrite = screenshotOverwriteFromArgs(args);
+          if (requestedPath !== undefined) {
+            persistDest = resolveScreenshotPersistPath(requestedPath);
+            assertScreenshotPersistAllowed(persistDest, overwrite);
+          }
           // Route to the same authoritative target as ctx.call: a pinned session
           // screenshots the PINNED workflow (via injected workflow_path), not just
           // whatever tab is visible (codex — graph_* must carry the pin).
@@ -22435,6 +22466,11 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             | { type: "image"; data: string; mimeType: string }
             | { type: "text"; text: string }
           > = [{ type: "image", data: res.image, mimeType: res.mimeType ?? "image/png" }];
+          if (persistDest !== undefined) {
+            const pngBytes = decodePngBase64(res.image);
+            persistScreenshotPng(persistDest, pngBytes, overwrite);
+            content.push({ type: "text", text: `Saved to: ${persistDest}` });
+          }
           // A canvas capture cannot show DOM-overlay widget content (MarkdownNote
           // text renders as an empty body) — flag any such node in view so the
           // agent doesn't read the blank body as missing content (#567). Best-effort:


### PR DESCRIPTION
## Summary

`panel_screenshot` returned a PNG image block but had no `save_path`/`output_path`. A live-canvas audit that needed each node saved as `placed.png` had to forward a 207232-character base64 payload into a filesystem command, which failed on Windows with error 206 ("The filename or extension is too long.").

The orchestrator now validates an optional absolute `.png` path, refuses an existing file unless `overwrite` is true, writes the PNG atomically on the MCP host, and returns the image block plus the resolved saved path. A bad path fails the call instead of being ignored.

## Tests

- schema accepts `save_path`, `output_path`, and `overwrite`
- named dest receives the PNG bytes and is reported in the reply
- existing file is refused (original bytes unchanged) unless `overwrite:true`
- relative, blank, directory, and non-`.png` paths fail before capture
- disagreeing `save_path`/`output_path` fail closed

`npx vitest run src/__tests__/orchestrator/panel-screenshot-persist.test.ts` — 15 passed.

Closes #2439
