### PR TITLE
fix(2447): count GGUF files listed under clip_gguf/unet_gguf as installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- apply_manifest counts a GGUF as installed when ComfyUI-GGUF lists it under clip_gguf/unet_gguf (#2447)
+
 ## [0.52.143] - 2026-08-27
 
 ### MCP

--- a/src/__tests__/services/apply-manifest-gguf-listing.test.ts
+++ b/src/__tests__/services/apply-manifest-gguf-listing.test.ts
@@ -1,0 +1,216 @@
+// #2447 — apply_manifest reported installed GGUF assets as failed/pending
+// because its existing-file validation (liveListingHasBasename) only asked
+// core /models/text_encoders and /models/unet. The same files are listed by
+// ComfyUI-GGUF under clip_gguf / unet_gguf, which list_local_models already
+// surfaces. Drive applyManifest with the REAL listing functions — not a
+// mock of the unit under test, and not a parallel checker.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConfig = vi.hoisted(() => ({
+  comfyuiPath: "/fake/ComfyUI" as string | undefined,
+  comfyuiCodePath: undefined as string | undefined,
+  remote: undefined as boolean | undefined,
+}));
+
+const h = vi.hoisted(() => ({
+  liveListings: {} as Record<string, string[] | undefined>,
+  registry: undefined as string[] | undefined,
+  fetchCalls: [] as string[],
+}));
+
+const statMock = vi.hoisted(() => vi.fn());
+const isUnderLiveModelRootsMock = vi.hoisted(() =>
+  vi.fn(async (): Promise<{ inRoots: boolean | undefined; liveRoot?: string }> => ({
+    inRoots: true,
+  })),
+);
+const resolveExistingModelFileMock = vi.hoisted(() => vi.fn());
+const listLocalModelsMock = vi.hoisted(() => vi.fn());
+const downloadModelMock = vi.hoisted(() => vi.fn());
+const listInstalledNodesMock = vi.hoisted(() => vi.fn());
+const modelsDirMock = vi.hoisted(() => vi.fn(async () => "/fake/ComfyUI/models"));
+
+vi.mock("../../config.js", () => ({
+  config: mockConfig,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyuiTargetGeneration: () => 0,
+  isRemoteMode: () => mockConfig.remote ?? !mockConfig.comfyuiPath,
+}));
+
+vi.mock("../../comfyui/client.js", () => {
+  const listingFetch = async (path: string) => {
+    h.fetchCalls.push(path);
+    if (path === "/models" || path === "/models/") {
+      const names = h.registry ?? Object.keys(h.liveListings);
+      return { ok: true, status: 200, json: async () => names };
+    }
+    const category = decodeURIComponent(path.replace(/^\/models\//, ""));
+    const listing = h.liveListings[category];
+    if (listing === undefined) return { ok: false, status: 404, json: async () => null };
+    return { ok: true, status: 200, json: async () => listing };
+  };
+  return {
+    getClient: () => ({ fetchApi: listingFetch }),
+    comfyApiFetch: listingFetch,
+    getSystemStats: vi.fn(),
+    getLogs: vi.fn(),
+  };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    stat: (...a: unknown[]) => statMock(...a),
+    mkdir: vi.fn(),
+    realpath: vi.fn(async (p: string) => p),
+    lstat: vi.fn(async () => {
+      throw new Error("missing");
+    }),
+    readFile: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", () => ({
+  existsSync: () => false,
+}));
+
+vi.mock("../../services/node-management.js", () => ({
+  installCustomNode: vi.fn(),
+  installModelViaManager: vi.fn(),
+  listInstalledNodes: (...a: unknown[]) => listInstalledNodesMock(...a),
+}));
+
+vi.mock("../../services/model-resolver.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../../services/model-resolver.js")>();
+  return {
+    ...real,
+    // Keep liveListingHasBasename / liveListingHasEntry REAL — they are the
+    // shipped validation apply_manifest uses for this bug.
+    isUnderLiveModelRoots: (...a: unknown[]) => isUnderLiveModelRootsMock(...(a as [string])),
+    resolveExistingModelFile: (...a: unknown[]) => resolveExistingModelFileMock(...(a as [string])),
+    listLocalModels: (...a: unknown[]) => listLocalModelsMock(...(a as [string])),
+    downloadModel: (...a: unknown[]) => downloadModelMock(...a),
+    shouldDispatchDownloadToManager: async () => false,
+    currentLiveModelsRoot: async () => "/fake/ComfyUI/models",
+    verifyLandedModel: async (targetPath: string) => ({
+      verifiedPath: targetPath,
+      liveVisible: "visible" as const,
+      verifiedAgainstRoot: "/fake/ComfyUI/models",
+    }),
+  };
+});
+
+vi.mock("../../services/workspace-env.js", () => ({
+  getSavedDefaultWorkspaceSync: () => undefined,
+  resolveLiveComfyUIBase: async () => undefined,
+  resolveEffectiveComfyUICodeBaseLive: async () => mockConfig.comfyuiPath,
+  resolveEffectiveComfyUIBaseLive: async () => mockConfig.comfyuiPath,
+  resolveCustomNodesScanBaseLiveStrict: async () => mockConfig.comfyuiPath,
+  getLiveServerSnapshot: async () => ({ reachable: true }),
+  resolveRootInterpreter: (root: string | undefined) => (root ? `${root}/python` : "python"),
+  resolveInstallInterpreter: async (root: string | undefined) => ({
+    python: root ? `${root}/python` : "python",
+    source: "launched",
+    reason: "test interpreter",
+  }),
+}));
+
+vi.mock("../../services/output-dir.js", () => ({
+  resolveModelsDir: (...a: unknown[]) => modelsDirMock(...(a as [])),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { applyManifest } from "../../services/manifest.js";
+
+beforeEach(() => {
+  mockConfig.comfyuiPath = "/fake/ComfyUI";
+  mockConfig.comfyuiCodePath = undefined;
+  mockConfig.remote = undefined;
+  h.liveListings = {};
+  h.registry = undefined;
+  h.fetchCalls = [];
+  statMock.mockReset().mockResolvedValue({ isFile: () => true });
+  isUnderLiveModelRootsMock.mockReset().mockResolvedValue({ inRoots: true });
+  resolveExistingModelFileMock.mockReset().mockRejectedValue(new Error("not found"));
+  listLocalModelsMock.mockReset().mockResolvedValue([]);
+  downloadModelMock.mockReset();
+  listInstalledNodesMock.mockReset().mockResolvedValue([]);
+  modelsDirMock.mockReset().mockResolvedValue("/fake/ComfyUI/models");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("apply_manifest GGUF custom-category validation (#2447)", () => {
+  it("skips wan-longer-videos-i2v GGUFs listed under clip_gguf / unet_gguf", async () => {
+    // Reproduce the reporter: files exist on disk under models/text_encoders and
+    // models/unet; core /models/text_encoders omits the GGUF; /models/unet 404s;
+    // list_local_models sees all three under clip_gguf / unet_gguf.
+    h.liveListings.text_encoders = ["umt5_xxl_fp8_e4m3fn.safetensors"];
+    h.liveListings.clip_gguf = ["umt5-xxl-encoder-Q5_K_S.gguf"];
+    h.liveListings.unet_gguf = [
+      "Wan2.2-I2V-A14B-HighNoise-Q4_K_S.gguf",
+      "Wan2.2-I2V-A14B-LowNoise-Q4_K_S.gguf",
+    ];
+    h.liveListings.vae = ["wan_2.1_vae.safetensors"];
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://huggingface.co/Aitrepreneur/FLX/resolve/main/umt5-xxl-encoder-Q5_K_S.gguf",
+            local_path: "text_encoders/umt5-xxl-encoder-Q5_K_S.gguf",
+          },
+          {
+            url: "https://huggingface.co/Aitrepreneur/FLX/resolve/main/wan_2.1_vae.safetensors",
+            local_path: "vae/wan_2.1_vae.safetensors",
+          },
+          {
+            url: "https://huggingface.co/Aitrepreneur/FLX/resolve/main/Wan2.2-I2V-A14B-HighNoise-Q4_K_S.gguf",
+            local_path: "unet/Wan2.2-I2V-A14B-HighNoise-Q4_K_S.gguf",
+          },
+          {
+            url: "https://huggingface.co/Aitrepreneur/FLX/resolve/main/Wan2.2-I2V-A14B-LowNoise-Q4_K_S.gguf",
+            local_path: "unet/Wan2.2-I2V-A14B-LowNoise-Q4_K_S.gguf",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toEqual({ applied: 0, skipped: 4, failed: 0, pending: 0 });
+    expect(result.success).toBe(true);
+    expect(downloadModelMock).not.toHaveBeenCalled();
+    expect(h.fetchCalls).toContain("/models/clip_gguf");
+    expect(h.fetchCalls).toContain("/models/unet_gguf");
+    for (const row of result.results) {
+      expect(row.status).toBe("skipped");
+      expect(row.message).toMatch(/already exists/i);
+    }
+  });
+
+  it("still fails a contained safetensors the live server does not list", async () => {
+    h.liveListings.checkpoints = ["other.safetensors"];
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/big.safetensors",
+            model_type: "checkpoints",
+            filename: "big.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ skipped: 0, failed: 1 });
+    expect(result.results[0].message).toMatch(/does not list/);
+    expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/services/live-listing-gguf.test.ts
+++ b/src/__tests__/services/live-listing-gguf.test.ts
@@ -1,0 +1,166 @@
+// #2447 — apply_manifest validates existing files via liveListingHasBasename /
+// liveListingHasEntry, which used to query ONLY the core category
+// (`/models/text_encoders`, `/models/unet`). Core listings omit .gguf
+// (supported_pt_extensions). ComfyUI-GGUF serves the same files through
+// clip_gguf / unet_gguf — the inventory list_local_models already reads.
+//
+// These tests drive those SHIPPED functions against a fake /models server.
+// A parallel checker that reimplements the mapping would pass while
+// apply_manifest kept failing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  /** Per-category `/models/<cat>` body. Missing key → HTTP 404. */
+  liveListings: {} as Record<string, string[] | undefined>,
+  /** GET /models registry. undefined → derive from liveListings keys. */
+  registry: undefined as string[] | undefined | "fail",
+  fetchCalls: [] as string[],
+}));
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: "/comfy", huggingfaceToken: undefined, civitaiApiToken: undefined },
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyuiTargetGeneration: () => 0,
+  isRemoteMode: () => false,
+}));
+
+vi.mock("../../comfyui/client.js", () => {
+  const listingFetch = async (path: string) => {
+    h.fetchCalls.push(path);
+    if (path === "/models" || path === "/models/") {
+      if (h.registry === "fail") return { ok: false, status: 500, json: async () => null };
+      const names = h.registry ?? Object.keys(h.liveListings);
+      return { ok: true, status: 200, json: async () => names };
+    }
+    const category = decodeURIComponent(path.replace(/^\/models\//, ""));
+    const listing = h.liveListings[category];
+    if (listing === undefined) return { ok: false, status: 404, json: async () => null };
+    return { ok: true, status: 200, json: async () => listing };
+  };
+  return {
+    getClient: () => ({ fetchApi: listingFetch }),
+    comfyApiFetch: listingFetch,
+    getSystemStats: vi.fn(),
+    getLogs: vi.fn(),
+  };
+});
+
+const { liveListingHasBasename, liveListingHasEntry } = await import(
+  "../../services/model-resolver.js"
+);
+
+beforeEach(() => {
+  h.liveListings = {};
+  h.registry = undefined;
+  h.fetchCalls = [];
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("liveListingHasBasename — GGUF custom categories (#2447)", () => {
+  it("treats a text-encoder GGUF listed under clip_gguf as present", async () => {
+    // The reporter's umt5-xxl-encoder-Q5_K_S.gguf: on disk under
+    // models/text_encoders, served by ComfyUI-GGUF as clip_gguf, absent from
+    // core /models/text_encoders (no .gguf in supported_pt_extensions).
+    h.liveListings.text_encoders = ["umt5_xxl_fp8_e4m3fn.safetensors"];
+    h.liveListings.clip_gguf = ["umt5-xxl-encoder-Q5_K_S.gguf"];
+
+    await expect(
+      liveListingHasBasename("text_encoders", "umt5-xxl-encoder-Q5_K_S.gguf"),
+    ).resolves.toBe(true);
+    expect(h.fetchCalls).toContain("/models/clip_gguf");
+  });
+
+  it("treats a unet GGUF listed under unet_gguf as present even when /models/unet 404s", async () => {
+    // Modern ComfyUI 404s the legacy `unet` category (renamed to diffusion_models).
+    // apply_manifest still targets models/unet/… from the wan-longer-videos-i2v
+    // pack. Unfixed this is `undefined` ("could not be asked"); with ComfyUI-GGUF
+    // the same file is in /models/unet_gguf.
+    h.liveListings.unet_gguf = [
+      "Wan2.2-I2V-A14B-HighNoise-Q4_K_S.gguf",
+      "Wan2.2-I2V-A14B-LowNoise-Q4_K_S.gguf",
+    ];
+
+    await expect(
+      liveListingHasBasename("unet", "Wan2.2-I2V-A14B-HighNoise-Q4_K_S.gguf"),
+    ).resolves.toBe(true);
+    await expect(
+      liveListingHasBasename("unet", "Wan2.2-I2V-A14B-LowNoise-Q4_K_S.gguf"),
+    ).resolves.toBe(true);
+  });
+
+  it("treats a diffusion_models GGUF listed under unet_gguf as present", async () => {
+    h.liveListings.diffusion_models = ["flux1-dev.safetensors"];
+    h.liveListings.unet_gguf = ["flux-Q4.gguf"];
+
+    await expect(liveListingHasBasename("diffusion_models", "flux-Q4.gguf")).resolves.toBe(true);
+  });
+
+  it("still returns true when the core category itself lists the .gguf", async () => {
+    h.liveListings.diffusion_models = ["new.gguf"];
+
+    await expect(liveListingHasBasename("diffusion_models", "new.gguf")).resolves.toBe(true);
+  });
+
+  it("returns false when a registered GGUF view does not list the file", async () => {
+    h.liveListings.text_encoders = ["clip.safetensors"];
+    h.liveListings.clip_gguf = ["other-encoder.gguf"];
+
+    await expect(liveListingHasBasename("text_encoders", "missing.gguf")).resolves.toBe(false);
+  });
+
+  it("does not treat a core .gguf miss as a determined negative when no GGUF view is registered", async () => {
+    // Absence from /models/text_encoders is contractual for .gguf. Without a
+    // clip_gguf category the server cannot name the file, so the answer is
+    // unknown — never "the server does not list it under text_encoders".
+    h.liveListings.text_encoders = ["clip.safetensors"];
+
+    await expect(
+      liveListingHasBasename("text_encoders", "umt5-xxl-encoder-Q5_K_S.gguf"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not consult GGUF views for a non-gguf file", async () => {
+    h.liveListings.text_encoders = ["clip.safetensors"];
+    h.liveListings.clip_gguf = ["clip.safetensors"];
+
+    await expect(liveListingHasBasename("text_encoders", "clip.safetensors")).resolves.toBe(true);
+    await expect(liveListingHasBasename("text_encoders", "missing.safetensors")).resolves.toBe(
+      false,
+    );
+    expect(h.fetchCalls.filter((p) => p.includes("clip_gguf"))).toEqual([]);
+  });
+
+  it("still finds a GGUF when GET /models fails but the alias listing answers", async () => {
+    h.registry = "fail";
+    h.liveListings.text_encoders = [];
+    h.liveListings.clip_gguf = ["umt5-xxl-encoder-Q5_K_S.gguf"];
+
+    await expect(
+      liveListingHasBasename("text_encoders", "umt5-xxl-encoder-Q5_K_S.gguf"),
+    ).resolves.toBe(true);
+  });
+});
+
+describe("liveListingHasEntry — GGUF custom categories (#2447)", () => {
+  it("matches the exact category-relative path in the GGUF view", async () => {
+    h.liveListings.text_encoders = [];
+    h.liveListings.clip_gguf = ["nested/umt5-xxl-encoder-Q5_K_S.gguf"];
+
+    await expect(
+      liveListingHasEntry("text_encoders/nested", "umt5-xxl-encoder-Q5_K_S.gguf"),
+    ).resolves.toBe(true);
+  });
+
+  it("does not satisfy a nested target from a different relative path in clip_gguf", async () => {
+    h.liveListings.text_encoders = [];
+    h.liveListings.clip_gguf = ["other/umt5-xxl-encoder-Q5_K_S.gguf"];
+
+    await expect(
+      liveListingHasEntry("text_encoders/nested", "umt5-xxl-encoder-Q5_K_S.gguf"),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -330,6 +330,20 @@ const GGUF_BACKING_DIRS: Record<string, string[]> = {
   clip_gguf: ["text_encoders", "clip"],
 };
 
+/** Reverse of GGUF_BACKING_DIRS: core folder → ComfyUI-GGUF views that alias it. */
+function ggufViewsAliasing(category: string): string[] {
+  const lower = category.toLowerCase();
+  const views: string[] = [];
+  for (const [view, backing] of Object.entries(GGUF_BACKING_DIRS)) {
+    if (backing.some((dir) => dir.toLowerCase() === lower)) views.push(view);
+  }
+  return views;
+}
+
+function isGgufFilename(filename: string): boolean {
+  return extname(filename).toLowerCase() === ".gguf";
+}
+
 /**
  * The real folder(s) a scanned category resolves to, for de-dup identity. A KNOWN
  * `*_gguf` view resolves to the physical folders it aliases (so the same file surfaced
@@ -1377,6 +1391,81 @@ function listingEntryFor(targetSubfolder: string, filename: string): string {
 }
 
 /**
+ * Categories the live server has registered (`GET /models`). Same inventory
+ * list_local_models uses to discover ComfyUI-GGUF's clip_gguf / unet_gguf.
+ * `undefined` = could not be asked.
+ */
+async function liveRegisteredCategories(): Promise<Set<string> | undefined> {
+  try {
+    const res = await comfyApiFetch("/models");
+    if (!res.ok) return undefined;
+    const json = (await res.json()) as unknown;
+    if (!Array.isArray(json)) return undefined;
+    return new Set(
+      json
+        .filter((c): c is string => typeof c === "string" && c.trim() !== "")
+        .map((c) => c.toLowerCase()),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extra `/models/<cat>` views to probe for a .gguf the core listing cannot name.
+ * Known ComfyUI-GGUF aliases of `category`, filtered to views the live server
+ * actually registered. When GET /models itself is unaskable, still probe the
+ * known aliases so a reachable `/models/clip_gguf` can confirm presence.
+ */
+async function extraGgufListingCategories(category: string): Promise<string[]> {
+  const views = ggufViewsAliasing(category);
+  if (views.length === 0) return [];
+  const registered = await liveRegisteredCategories();
+  if (registered === undefined) return views;
+  return views.filter((view) => registered.has(view.toLowerCase()));
+}
+
+function missIsContractualGgufCore(category: string, filename: string): boolean {
+  if (!isGgufFilename(filename)) return false;
+  if (isGgufCategory(category)) return false;
+  return (MODEL_SUBDIRS as readonly string[]).includes(category.toLowerCase());
+}
+
+/**
+ * Combine per-category listing answers. Any hit is present. A miss in a CORE
+ * category for a .gguf is contractual (supported_pt_extensions omits it) and is
+ * not a determined negative — that is #2447's false "does not list it under
+ * text_encoders". A miss in a registered GGUF view is determined.
+ */
+async function liveListingMatches(
+  categories: string[],
+  filename: string,
+  pred: (entry: string) => boolean,
+): Promise<boolean | undefined> {
+  let sawDeterminedMiss = false;
+  for (const cat of categories) {
+    if (!cat) continue;
+    const listing = await liveCategoryListing(cat);
+    if (listing === undefined) continue;
+    if (listing.some(pred)) return true;
+    if (missIsContractualGgufCore(cat, filename)) continue;
+    sawDeterminedMiss = true;
+  }
+  if (sawDeterminedMiss) return false;
+  return undefined;
+}
+
+async function listingCategoriesFor(
+  targetSubfolder: string,
+  filename: string,
+): Promise<string[]> {
+  const category = categoryOf(targetSubfolder);
+  if (!isGgufFilename(filename)) return [category];
+  const extra = await extraGgufListingCategories(category);
+  return extra.length === 0 ? [category] : [category, ...extra.filter((c) => c !== category)];
+}
+
+/**
  * Was this exact entry ALREADY in the live server's listing before we wrote?
  *
  * Captured BEFORE the transfer so the post-write check can tell "the server now
@@ -1385,15 +1474,21 @@ function listingEntryFor(targetSubfolder: string, filename: string): string {
  * happens to share a filename with the live install verifies as `visible` and is
  * reported as a success (codex gate, round 3). `undefined` = the server could not
  * answer, so nothing is known either way.
+ *
+ * For `.gguf`, also consults ComfyUI-GGUF's registered `*_gguf` views of the
+ * same folder (clip_gguf for text_encoders/clip, unet_gguf for unet/
+ * diffusion_models) — core `/models/<cat>` cannot name those files (#2447).
  */
 export async function liveListingHasEntry(
   targetSubfolder: string,
   filename: string,
 ): Promise<boolean | undefined> {
-  const listing = await liveCategoryListing(categoryOf(targetSubfolder));
-  if (listing === undefined) return undefined;
   const wanted = listingEntryFor(targetSubfolder, filename);
-  return listing.some((n) => normRel(n) === wanted);
+  return liveListingMatches(
+    await listingCategoriesFor(targetSubfolder, filename),
+    filename,
+    (n) => normRel(n) === wanted,
+  );
 }
 
 /**
@@ -1405,15 +1500,20 @@ export async function liveListingHasEntry(
  * exact-path check would FAIL legitimate nested installs. This is used only as an
  * ADDITIONAL requirement on the skip path — it can rule a skip out, never in on its
  * own. `undefined` = the server could not answer.
+ *
+ * For `.gguf`, a hit under the live GGUF alias of this folder counts as present
+ * (#2447) — apply_manifest's existing-file skip uses this function.
  */
 export async function liveListingHasBasename(
   category: string,
   filename: string,
 ): Promise<boolean | undefined> {
-  const listing = await liveCategoryListing(categoryOf(category));
-  if (listing === undefined) return undefined;
   const wanted = basename(filename);
-  return listing.some((n) => basename(normRel(n)) === wanted);
+  return liveListingMatches(
+    await listingCategoriesFor(category, filename),
+    filename,
+    (n) => basename(normRel(n)) === wanted,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

`apply_manifest` reported installed GGUF assets as failed/pending because its existing-file validation (`liveListingHasBasename` / `liveListingHasEntry`) only asked the core `/models/text_encoders` and `/models/unet` listings. Those omit `.gguf`. ComfyUI-GGUF serves the same files through `clip_gguf` / `unet_gguf` — the inventory `list_local_models` already reads.

On `wan-longer-videos-i2v`:

- text encoder on disk under `models/text_encoders` → core listing miss → **failed**
- Wan2.2 I2V GGUFs under `models/unet` → `/models/unet` 404 → **pending**

## Fix

Same shipped listing helpers, not a parallel checker. For `.gguf`, also probe the registered GGUF aliases of that folder. A core-category miss of a `.gguf` is contractual, not a determined negative. A matching filename in `clip_gguf` / `unet_gguf` counts as installed.

## Tests

Drive the shipped functions (fail unfixed, pass shipped). No mock of the unit under test.

- `liveListingHasBasename` / `liveListingHasEntry` against a fake `/models` server (encoder under `clip_gguf`, UNets under `unet_gguf` with `/models/unet` 404)
- `applyManifest` wan-longer-videos-i2v repro: unfixed summary was `skipped:1 failed:1 pending:2`

Closes #2447