### PR TITLE
fix(2440): deliver restart confirmation approval to the pending call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
+
 ## [0.52.144] - 2026-08-27
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
+- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.144] - 2026-08-27
 
@@ -19,7 +20,6 @@ All notable changes to this project are documented here. This project adheres to
 - apply_manifest counts a GGUF as installed when ComfyUI-GGUF lists it under clip_gguf/unet_gguf (#2447)
 - panel_list_nodes lists installed packs from host Manager HTTP when the panel tab is gone (#2459)
 - panel_run queued_unknown names a live-canvas next step instead of an unavailable queue inspector (#2438)
-- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.143] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
-- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.144] - 2026-08-27
 
@@ -20,13 +19,13 @@ All notable changes to this project are documented here. This project adheres to
 - apply_manifest counts a GGUF as installed when ComfyUI-GGUF lists it under clip_gguf/unet_gguf (#2447)
 - panel_list_nodes lists installed packs from host Manager HTTP when the panel tab is gone (#2459)
 - panel_run queued_unknown names a live-canvas next step instead of an unavailable queue inspector (#2438)
+- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.143] - 2026-08-27
 
 ### MCP
 
 #### Fixed
-- a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
 - Ollama names the cause of a 0-tool ready and logs recovery when the surface appears (#2428)
 - disclose unreindexed host links after panel_unexpose_subgraph_input/output (#2437)
 - a blocked repeat tool call returns the earlier payload instead of an error-string-only nudge (#2430)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
 - Ollama names the cause of a 0-tool ready and logs recovery when the surface appears (#2428)
 - disclose unreindexed host links after panel_unexpose_subgraph_input/output (#2437)
 - a blocked repeat tool call returns the earlier payload instead of an error-string-only nudge (#2430)

--- a/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
+++ b/src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts
@@ -27,6 +27,7 @@
 import { readFileSync } from "node:fs";
 
 import { beforeEach, describe, expect, it } from "vitest";
+import { waitFor } from "../helpers/wait-for.js";
 
 import {
   appendReplyNote,
@@ -69,22 +70,32 @@ interface Harness {
   late: Map<string, unknown>;
   /** Every takeLateAskReply(id) this run made — proves WHICH id was claimed. */
   drained: string[];
+  /** Deliver a card click to the live waiter, the way the bridge does on approval. */
+  approve: (askId: string, result: unknown) => void;
 }
 
-function harness(tabId = TAB, opts: { answerCards?: boolean } = {}): Harness {
+function harness(
+  tabId = TAB,
+  opts: { answerCards?: boolean; hangMs?: number } = {},
+): Harness {
   const cards: Array<Record<string, unknown>> = [];
   const late = new Map<string, unknown>();
   const drained: string[] = [];
+  const waiters = new Map<string, Set<(result: unknown) => void>>();
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {
       if (cmd.cmd === "ask_user") {
         cards.push(cmd);
+        if (opts.answerCards) return "Yes, go ahead";
+        if (opts.hangMs != null) {
+          const hangMs = opts.hangMs;
+          return new Promise<never>((_resolve, reject) => {
+            setTimeout(() => reject(replyTimeout(tabId)), hangMs);
+          });
+        }
         // The reporter's case: the card is dispatched and painted, and no answer comes
         // back inside the caller's budget.
-        if (!opts.answerCards) throw replyTimeout(tabId);
-        // bridge.send resolves with the REPLY'S RESULT — for a card, the label the
-        // user picked — which is what isAffirmative is handed.
-        return "Yes, go ahead";
+        throw replyTimeout(tabId);
       }
       return { ok: true };
     },
@@ -94,6 +105,20 @@ function harness(tabId = TAB, opts: { answerCards?: boolean } = {}): Harness {
       const v = late.get(askId);
       late.delete(askId); // the real buffer is one-shot too
       return v;
+    },
+    subscribeLateAskReply: (askId: string, onReply: (result: unknown) => void) => {
+      let set = waiters.get(askId);
+      if (!set) {
+        set = new Set();
+        waiters.set(askId, set);
+      }
+      set.add(onReply);
+      return () => {
+        const live = waiters.get(askId);
+        if (!live) return;
+        live.delete(onReply);
+        if (live.size === 0) waiters.delete(askId);
+      };
     },
     push: () => 1,
     canReach: () => true,
@@ -110,6 +135,13 @@ function harness(tabId = TAB, opts: { answerCards?: boolean } = {}): Harness {
     cards,
     late,
     drained,
+    approve: (askId, result) => {
+      late.set(askId, result);
+      const live = waiters.get(askId);
+      if (!live) return;
+      waiters.delete(askId);
+      for (const onReply of live) onReply(result);
+    },
   };
 }
 
@@ -337,6 +369,57 @@ describe("panel#1554 a late confirmation is claimed, not discarded", () => {
     // A private "5 minutes" over in panel-tools would be a bound deciding a correctness
     // question in two places, free to drift. Pin that it is the same value.
     expect(confirmAnswerRecoveryWindowMs()).toBe(LATE_ASK_TTL_MS);
+  });
+});
+
+describe("panel#2440 an in-flight restart claims the approval, not the next call", () => {
+  beforeEach(() => resetAbandonedConfirmCards());
+
+  it("an Approve that lands while confirm is still waiting resolves THIS call", async () => {
+    const h = harness(TAB, { hangMs: 400 });
+    const pending = h.ctx.confirm(QUESTION, HEADER, 400, RECOVER);
+    await waitFor(() => expect(h.cards).toHaveLength(1));
+    const askId = String(h.cards[0].ask_id);
+    h.approve(askId, "Yes, go ahead");
+
+    expect(await pending).toBe("yes");
+    expect(h.cards).toHaveLength(1);
+    // One-shot: the same click must not satisfy a later restart.
+    expect(await h.ctx.confirm(QUESTION, HEADER, 50, RECOVER)).toBe("timeout");
+    expect(h.cards).toHaveLength(2);
+  });
+
+  it("a late DECLINE on the live card is this call's no, not a cached next-call no", async () => {
+    const h = harness(TAB, { hangMs: 400 });
+    const pending = h.ctx.confirm(QUESTION, HEADER, 400, RECOVER);
+    await waitFor(() => expect(h.cards).toHaveLength(1));
+    h.approve(String(h.cards[0].ask_id), "No, cancel");
+
+    expect(await pending).toBe("no");
+    expect(h.cards).toHaveLength(1);
+  });
+
+  it("END TO END: approving the live restart card restarts this call, not the next", async () => {
+    __panelToolsTestHooks.setHealthProbe(async () => false);
+    __panelToolsTestHooks.setPanelRebootTiming({
+      settleMs: 0,
+      budgetMs: 30,
+      intervalMs: 5,
+      probeTimeoutMs: 10,
+    });
+    try {
+      const h = harness(TAB, { hangMs: 400 });
+      const first = restartDef().handler({} as never, h.ctx);
+      await waitFor(() => expect(h.cards).toHaveLength(1));
+      h.approve(String(h.cards[0].ask_id), "Yes, go ahead");
+
+      const out = textOf(await first);
+      expect(out).not.toContain("No confirmation received within");
+      expect(h.cards).toHaveLength(1);
+    } finally {
+      __panelToolsTestHooks.setHealthProbe(null);
+      __panelToolsTestHooks.setPanelRebootTiming(null);
+    }
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -5303,6 +5303,58 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     expect(bridge.takeLateAskReply("ask-xyz")).toBeUndefined(); // drained once
   });
 
+  it("delivers a same-ask_id approval to the in-flight send even when the rid does not match (#2440)", async () => {
+    const sock = await connectPanel("tab-ask-rid", "wf");
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-ask-rid")).toBe(true));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "ask_user") {
+        sock.send(
+          JSON.stringify({
+            rid: "not-the-command-rid",
+            ask_id: msg.ask_id,
+            ok: true,
+            result: "Yes, go ahead",
+          }),
+        );
+      }
+    });
+
+    await expect(
+      bridge.send(
+        { cmd: "ask_user", ask_id: "ask-live", question: "Restart?", options: [] },
+        { tabId: "tab-ask-rid", timeoutMs: 400 },
+      ),
+    ).resolves.toBe("Yes, go ahead");
+    // Delivered to the waiter: not left solely for a later takeLateAskReply.
+    expect(bridge.takeLateAskReply("ask-live")).toBeUndefined();
+    sock.close();
+  });
+
+  it("wakes a subscribeLateAskReply waiter when the approval is buffered (#2440)", async () => {
+    const sock = await connectPanel("tab-ask-wake", "wf");
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-ask-wake")).toBe(true));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "ask_user") {
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: "Yes, go ahead" }));
+        }, 80);
+      }
+    });
+
+    const sendP = bridge.send(
+      { cmd: "ask_user", ask_id: "ask-wake", question: "Restart?", options: [] },
+      { tabId: "tab-ask-wake", timeoutMs: 30 },
+    );
+    const woken = new Promise<unknown>((resolve) => {
+      bridge.subscribeLateAskReply("ask-wake", resolve);
+    });
+    await expect(sendP).rejects.toThrow(/did not reply/i);
+    await expect(woken).resolves.toBe("Yes, go ahead");
+    sock.close();
+  });
+
   // #1352 — the same recovery for a CREDENTIAL, minus the one property that makes it
   // durable. A secret card's late answer must be claimable in memory, because a user who
   // finishes typing a moment late should still have their token applied — and it must

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -13576,6 +13576,7 @@ interface BridgeProbe {
   resolveActiveTabId?: () => string;
   resolveSharedTabId?: (scopeId?: string) => string | undefined;
   takeLateAskReply?: (askId: string) => unknown;
+  subscribeLateAskReply?: (askId: string, onReply: (result: unknown) => void) => () => void;
 }
 
 /** The only compatibility proof accepted for a legacy bare workflow open. */
@@ -15079,7 +15080,7 @@ export function makePanelToolCtx(
     const askId = randomUUID();
     try {
       ensureReachable();
-      const reply = await bridge.send(
+      const sendP = bridge.send(
         {
           cmd: "ask_user",
           ask_id: askId,
@@ -15092,26 +15093,23 @@ export function makePanelToolCtx(
         } as { cmd: string },
         { tabId: ctx.tabId, timeoutMs: timing.deadlineMs },
       );
-      return isAffirmative(reply) ? "yes" : "no";
-    } catch (err) {
-      // Only a card-reply TIMEOUT is recoverable/honest-as-timeout: poll the late
-      // buffer, then report "timeout" if still unanswered. Any other error (no
-      // panel, transport failure) still SKIPS the destructive op — but it is reported
-      // as `unreachable`, not `no` (#1332). The user did not decline; we never got to
-      // ask them, and a caller that says "cancelled" on this is describing a decision
-      // nobody made.
-      if (isReplyTimeoutError(err)) {
-        const late = await pollLateAskReply(bridge, askId, timing, budgetEnd);
-        if (late !== undefined) return isAffirmative(late) ? "yes" : "no";
-        // panel#1554 — the card is STILL on screen and still answerable (the panel
-        // retires a card on a replaced connection, never on our timeout), and the
-        // bridge will buffer whatever the user clicks. Remember the id so the next
-        // attempt at this same confirmation drains it instead of asking again.
-        if (opts?.recoverAbandonedAnswer) {
-          rememberAbandonedConfirmCard(journalTabFor(ctx), header, question, askId);
-        }
-        return "timeout";
+      // #2440 — race the in-flight send against a late-buffer/waiter delivery so
+      // an approval that misses the original rid still resolves THIS confirm,
+      // instead of sitting in the cache for a subsequent call.
+      const outcome = await awaitConfirmReply(sendP, bridge, askId);
+      if (outcome.ok) return isAffirmative(outcome.reply) ? "yes" : "no";
+      if (!isReplyTimeoutError(outcome.err)) return "unreachable";
+      const late = await pollLateAskReply(bridge, askId, timing, budgetEnd);
+      if (late !== undefined) return isAffirmative(late) ? "yes" : "no";
+      // panel#1554 — the card is STILL on screen and still answerable (the panel
+      // retires a card on a replaced connection, never on our timeout), and the
+      // bridge will buffer whatever the user clicks. Remember the id so the next
+      // attempt at this same confirmation drains it instead of asking again.
+      if (opts?.recoverAbandonedAnswer) {
+        rememberAbandonedConfirmCard(journalTabFor(ctx), header, question, askId);
       }
+      return "timeout";
+    } catch {
       return "unreachable";
     }
   };
@@ -16228,6 +16226,50 @@ async function pollLateAskReply(
     const left = deadline - Date.now();
     if (left <= 0) return undefined;
     await sleep(Math.max(1, Math.min(timing.pollMs, left)));
+  }
+}
+
+/**
+ * #2440 — wait for THIS card's answer on every channel that can carry it, not
+ * only the rid-matched send.
+ *
+ * `bridge.send` resolves when the panel echoes the command rid. A sidebar
+ * Approve can land without that rid: the bridge then buffers it for a later
+ * takeLateAskReply / recoverAbandonedAnswer, and the original restart timed
+ * out after 90s even though the user had already clicked. Racing the send
+ * against a live waiter and the late-reply buffer delivers the click to the
+ * call that painted the card.
+ */
+async function awaitConfirmReply(
+  sendP: Promise<unknown>,
+  bridge: PanelToolCtx["bridge"],
+  askId: string,
+): Promise<{ ok: true; reply: unknown } | { ok: false; err: unknown }> {
+  const probe: BridgeProbe = bridge;
+  let done = false;
+  let unsub: (() => void) | undefined;
+
+  const fromSend = sendP.then(
+    (reply): { ok: true; reply: unknown } => ({ ok: true, reply }),
+    (err: unknown): { ok: false; err: unknown } => ({ ok: false, err }),
+  );
+
+  const fromWaiter = new Promise<{ ok: true; reply: unknown }>((resolve) => {
+    const sub = probe.subscribeLateAskReply;
+    if (typeof sub !== "function") return;
+    unsub = sub.call(bridge, askId, (reply) => {
+      if (done) return;
+      done = true;
+      resolve({ ok: true, reply });
+    });
+  });
+
+  try {
+    const winner = await Promise.race([fromSend, fromWaiter]);
+    done = true;
+    return winner;
+  } finally {
+    unsub?.();
   }
 }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1598,6 +1598,16 @@ export interface BridgeCommand {
   [key: string]: unknown;
 }
 
+function commandAskId(command: BridgeCommand): string | undefined {
+  const id = command.ask_id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+function messageAskId(msg: Record<string, unknown>): string | undefined {
+  const id = msg.ask_id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
 /** panel#1859 — the floor comes from the table the gate itself reads, so the
  * two can never disagree. With no parseable entry the sentence still names a
  * remedy; it just cannot name a number, which beats naming a wrong one. */
@@ -2215,6 +2225,13 @@ export class UiBridge {
    * caller required — after which it is durable and can be replayed or pushed.
    */
   private lateAskSink: ((askId: string, result: unknown, tabId: string) => void) | null = null;
+  /**
+   * In-flight confirm/ask waiters keyed by `ask_id` (#2440). A card approval that
+   * lands without the original command rid used to be cached only for a later
+   * takeLateAskReply(); if a restart was still waiting, that waiter timed out and
+   * the next call consumed the click. These fire first, before the late buffer.
+   */
+  private lateAskWaiters = new Map<string, Set<(result: unknown) => void>>();
   /** See setTabGoneListener. */
   private onTabGone: ((tabId: string, incarnation: string) => void) | null = null;
   /** See setTabTakenOverListener. */
@@ -3297,7 +3314,22 @@ export class UiBridge {
           // caller may still be within the MCP tools/call budget, BUFFER the
           // validated answer keyed by its ask_id so the caller can retrieve it via
           // takeLateAskReply() instead of losing it (#486). Everything else drops.
+          //
+          // #2440 — deliver to a STILL-WAITING restart/confirm first. A reply can
+          // miss `pending` (rid rewritten, timer already fired) while the tool
+          // call that painted the card is still blocked on it. Caching only for
+          // the next call left that waiter to time out after the user clicked.
           const entry = this.askRidToId.get(rid);
+          const askId = entry?.askId ?? messageAskId(msg);
+          if (askId && msg.ok) {
+            const live = this.findPendingForAskId(askId);
+            if (live) {
+              this.askRidToId.delete(rid);
+              this.settlePendingAskSuccess(live.rid, live.pending, msg.result, sock);
+              return;
+            }
+            this.wakeLateAskWaiters(askId, msg.result);
+          }
           if (entry) {
             this.askRidToId.delete(rid);
             if (msg.ok) {
@@ -3383,6 +3415,34 @@ export class UiBridge {
             rejected = attachWorkflowListReadiness(rejected, workflowListReadiness);
           }
           p.reject(rejected);
+        }
+        return;
+      }
+
+      // #2440 — a card approval that names its ask_id but not the command rid
+      // still belongs to the in-flight confirm. Deliver it to that waiter
+      // before caching it for a subsequent call.
+      const ridlessAskId = messageAskId(msg);
+      if (
+        ridlessAskId &&
+        msg.ok === true &&
+        "result" in msg &&
+        typeof msg.type !== "string"
+      ) {
+        const live = this.findPendingForAskId(ridlessAskId);
+        if (live) {
+          this.settlePendingAskSuccess(live.rid, live.pending, msg.result, sock);
+          return;
+        }
+        this.wakeLateAskWaiters(ridlessAskId, msg.result);
+        this.pruneLateAsk();
+        this.lateAskReplies.set(ridlessAskId, { result: msg.result, ts: Date.now() });
+        try {
+          if (tabId) this.lateAskSink?.(ridlessAskId, msg.result, tabId);
+        } catch (err) {
+          logger.warn(
+            `[ui-bridge] late ask-answer sink threw (the answer is still buffered): ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
         return;
       }
@@ -4871,6 +4931,67 @@ export class UiBridge {
     if (!e) return undefined;
     this.lateAskReplies.delete(askId);
     return e.result;
+  }
+
+  /**
+   * #2440 — subscribe to a card approval for `askId` so an in-flight confirm can
+   * resolve as soon as the click lands, rather than only when a later call drains
+   * the late-reply buffer. Returns an unsubscribe function.
+   */
+  subscribeLateAskReply(askId: string, onReply: (result: unknown) => void): () => void {
+    let set = this.lateAskWaiters.get(askId);
+    if (!set) {
+      set = new Set();
+      this.lateAskWaiters.set(askId, set);
+    }
+    set.add(onReply);
+    return () => {
+      const live = this.lateAskWaiters.get(askId);
+      if (!live) return;
+      live.delete(onReply);
+      if (live.size === 0) this.lateAskWaiters.delete(askId);
+    };
+  }
+
+  private wakeLateAskWaiters(askId: string, result: unknown): boolean {
+    const waiters = this.lateAskWaiters.get(askId);
+    if (!waiters || waiters.size === 0) return false;
+    this.lateAskWaiters.delete(askId);
+    for (const onReply of waiters) {
+      try {
+        onReply(result);
+      } catch (err) {
+        logger.warn(
+          `[ui-bridge] late-ask waiter threw: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return true;
+  }
+
+  private findPendingForAskId(askId: string): { rid: string; pending: Pending } | undefined {
+    for (const [rid, pending] of this.pending) {
+      if (commandAskId(pending.ctx.command) === askId) return { rid, pending };
+      const mapped = this.askRidToId.get(rid);
+      if (mapped?.askId === askId) return { rid, pending };
+    }
+    return undefined;
+  }
+
+  private settlePendingAskSuccess(
+    rid: string,
+    pending: Pending,
+    result: unknown,
+    sock: BridgeSocket,
+  ): void {
+    clearTimeout(pending.timer);
+    this.pending.delete(rid);
+    this.askRidToId.delete(rid);
+    const served = this.liveConnForTab(pending.ctx.tabId, sock);
+    served?.provenSupportedCmds.add(pending.cmd);
+    this.notePromotedScope(pending.ctx.tabId, result);
+    this.noteSiblingSuccess(pending.ctx, rid);
+    pending.resolve(result);
   }
 
   /** The incarnation currently holding `tabId` — the identity every structure


### PR DESCRIPTION
## Summary

Clicking Approve on the `panel_restart_comfyui` confirmation card could miss the original command rid. The bridge then buffered the click for a later `takeLateAskReply()`, so the in-flight restart timed out at 90s with "No confirmation received" and the **next** call consumed the already-approved state.

Deliver a same-`ask_id` approval to the live waiter first:

- If a restart/confirm send is still pending for that card, resolve it immediately.
- Wake `subscribeLateAskReply` waiters so `ctx.confirm` races the in-flight send against the click.
- Only then cache the answer for a subsequent call (#1554 late recovery still holds).

## Tests

- Approve while confirm is still waiting resolves **this** call, not the next
- A live-card decline is this call's `no`
- End-to-end `panel_restart_comfyui` does not return "No confirmation received" after Approve
- UiBridge: a reply whose rid does not match still resolves the in-flight send when `ask_id` matches
- UiBridge: `subscribeLateAskReply` fires when the approval is buffered

`npx vitest run src/__tests__/orchestrator/confirm-late-answer-recovery.test.ts src/__tests__/orchestrator/confirm-unreachable-is-not-a-decline.test.ts src/__tests__/orchestrator/panel-tools.test.ts src/__tests__/services/ui-bridge.test.ts` — 687 passed.

Closes #2440
