### PR TITLE
fix(2459): list installed packs from host Manager HTTP when the panel tab is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - apply_manifest counts a GGUF as installed when ComfyUI-GGUF lists it under clip_gguf/unet_gguf (#2447)
+- panel_list_nodes lists installed packs from host Manager HTTP when the panel tab is gone (#2459)
 
 ## [0.52.143] - 2026-08-27
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -39,6 +39,11 @@ import {
   BRIDGE_READ_DEFAULT_TIMEOUT_MS,
   markReplyTimeout,
 } from "../../services/ui-bridge.js";
+import {
+  HOST_HTTP_LIST_NOTE,
+  setListInstalledNodesForTests,
+} from "../../services/manager-node-list.js";
+import type { InstalledNode } from "../../services/node-management.js";
 import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
 import { QueueMonitor } from "../../services/queue-monitor.js";
 import { AskAnswers } from "../../orchestrator/ask-answer-journal.js";
@@ -2575,6 +2580,98 @@ describe("panel-tools: single authoritative pin resolution (#259 wrong-tab)", ()
     const ctx = makePanelToolCtx(bridge, "test-tab", store);
     await defByName("panel_screenshot").handler({}, ctx);
     expect(sent[0]).toMatchObject({ cmd: "graph_screenshot", workflow_path: "wf-pinned-key" });
+  });
+});
+
+describe("panel_list_nodes host Manager HTTP fallback (#2459)", () => {
+  afterEach(() => setListInstalledNodesForTests(undefined));
+
+  const REPORTER_WRAP =
+    `nodes_list could not be dispatched to this session's panel tab — nothing was applied. ` +
+    `The tab may be disconnected, still reconnecting after a restart/reload, or the ` +
+    `session's binding is stale (e.g. another workflow tab is now active). Retry in a ` +
+    `moment, or rebind with panel_set_workflow_target({mode:"current"}) to follow the ` +
+    `tab that's live now. (no connected tab with id "orchestrator::claude". Connected: none)`;
+
+  const PACKS: InstalledNode[] = [
+    {
+      module: "ComfyUI-Impact-Pack",
+      cnrId: "comfyui-impact-pack",
+      version: "8.0.0",
+      enabled: true,
+    },
+  ];
+
+  function replyText(res: ToolResult): string {
+    return res.content.map((c) => (c.type === "text" ? c.text : "")).join("\n");
+  }
+
+  it("disconnected tab + live Manager HTTP → inventory, source host_http", async () => {
+    let hostCalls = 0;
+    setListInstalledNodesForTests(async () => {
+      hostCalls += 1;
+      return PACKS;
+    });
+    const { ctx, calls } = makeFakeCtx();
+    ctx.call = async (cmd) => {
+      calls.push(cmd);
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Error: ${REPORTER_WRAP}` }],
+      };
+    };
+    const res = await defByName("panel_list_nodes").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(hostCalls).toBe(1);
+    const body: unknown = JSON.parse(replyText(res));
+    expect(body).toMatchObject({
+      source: "host_http",
+      note: HOST_HTTP_LIST_NOTE,
+      installed: {
+        "ComfyUI-Impact-Pack": {
+          ver: "8.0.0",
+          cnr_id: "comfyui-impact-pack",
+          enabled: true,
+        },
+      },
+    });
+    expect(replyText(res)).not.toMatch(/could not be dispatched/);
+    expect(replyText(res)).toMatch(/not a Manager outage/i);
+    expect(replyText(res)).not.toMatch(/Manager down/i);
+    expect(calls[0]).toMatchObject({ cmd: "nodes_list" });
+  });
+
+  it("connected tab → still panel path (no host call)", async () => {
+    let hostCalls = 0;
+    setListInstalledNodesForTests(async () => {
+      hostCalls += 1;
+      throw new Error("fallback must not run");
+    });
+    const { ctx, calls } = makeFakeCtx();
+    const res = await defByName("panel_list_nodes").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(hostCalls).toBe(0);
+    expect(calls[0]).toMatchObject({ cmd: "nodes_list" });
+    expect(JSON.parse(replyText(res))).toMatchObject({ cmd: "nodes_list" });
+  });
+
+  it("disconnected tab + host HTTP failure → honest dual cause, not Manager down", async () => {
+    setListInstalledNodesForTests(async () => {
+      throw new Error("Manager customnode/installed: HTTP 503");
+    });
+    const { ctx } = makeFakeCtx();
+    ctx.call = async () => ({
+      isError: true,
+      content: [{ type: "text", text: `Error: ${REPORTER_WRAP}` }],
+    });
+    const res = await defByName("panel_list_nodes").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = replyText(res);
+    expect(text).toMatch(/could not be dispatched/i);
+    expect(text).toMatch(/no connected tab|Connected:\s*none/i);
+    expect(text).toMatch(/HTTP 503/);
+    expect(text).toMatch(/not a Manager outage inferred from tab loss/i);
+    expect(text).not.toMatch(/Manager down/i);
   });
 });
 

--- a/src/__tests__/services/manager-node-list.test.ts
+++ b/src/__tests__/services/manager-node-list.test.ts
@@ -1,0 +1,216 @@
+// #2459 — panel_list_nodes died as a tab-dispatch error when the panel tab
+// was gone, even though Manager HTTP could list installed packs. listPanelNodes
+// must serve that inventory (panel-shaped) instead of claiming a Manager outage.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { markDispatched } from "../../services/ui-bridge.js";
+import {
+  HOST_HTTP_LIST_NOTE,
+  dualCauseListFailure,
+  installedNodesToPanelMap,
+  isPanelTabDispatchFailure,
+  listPanelNodes,
+  setListInstalledNodesForTests,
+} from "../../services/manager-node-list.js";
+import type { InstalledNode } from "../../services/node-management.js";
+
+afterEach(() => setListInstalledNodesForTests(undefined));
+
+const REPORTER_WRAP =
+  `nodes_list could not be dispatched to this session's panel tab — nothing was applied. ` +
+  `The tab may be disconnected, still reconnecting after a restart/reload, or the ` +
+  `session's binding is stale (e.g. another workflow tab is now active). Retry in a ` +
+  `moment, or rebind with panel_set_workflow_target({mode:"current"}) to follow the ` +
+  `tab that's live now. (no connected tab with id "orchestrator::claude". Connected: none)`;
+
+const DISPATCH_FAIL = {
+  isError: true,
+  content: [{ type: "text", text: `Error: ${REPORTER_WRAP}` }],
+};
+
+const PACKS: InstalledNode[] = [
+  {
+    module: "ComfyUI-Impact-Pack",
+    cnrId: "comfyui-impact-pack",
+    version: "8.0.0",
+    enabled: true,
+  },
+  {
+    module: "some-git-node",
+    auxId: "user/some-git-node",
+    version: "abc1234",
+    enabled: false,
+  },
+];
+
+describe("isPanelTabDispatchFailure (#2459)", () => {
+  it("matches the reporter dispatch wrapper", () => {
+    expect(isPanelTabDispatchFailure(DISPATCH_FAIL)).toBe(true);
+    expect(isPanelTabDispatchFailure(new Error(REPORTER_WRAP))).toBe(true);
+  });
+
+  it("matches a typed pre-dispatch failure even without the wrapper phrase", () => {
+    expect(isPanelTabDispatchFailure(markDispatched(new Error("socket write failed"), false))).toBe(
+      true,
+    );
+  });
+
+  it("does not treat a live-tab Manager error or a successful listing as tab loss", () => {
+    expect(
+      isPanelTabDispatchFailure({
+        isError: true,
+        content: [{ type: "text", text: "Error: Manager customnode/installed: HTTP 500" }],
+      }),
+    ).toBe(false);
+    expect(
+      isPanelTabDispatchFailure({
+        installed: { "ComfyUI-Impact-Pack": { ver: "8.0.0", cnr_id: "comfyui-impact-pack" } },
+      }),
+    ).toBe(false);
+    expect(isPanelTabDispatchFailure(markDispatched(new Error("no connected tab"), true))).toBe(
+      false,
+    );
+  });
+});
+
+describe("installedNodesToPanelMap", () => {
+  it("inverts InstalledNode[] to the panel map keyed by module", () => {
+    expect(installedNodesToPanelMap(PACKS)).toEqual({
+      "ComfyUI-Impact-Pack": {
+        ver: "8.0.0",
+        cnr_id: "comfyui-impact-pack",
+        enabled: true,
+      },
+      "some-git-node": {
+        ver: "abc1234",
+        aux_id: "user/some-git-node",
+        enabled: false,
+      },
+    });
+  });
+});
+
+describe("listPanelNodes (#2459)", () => {
+  it("disconnected tab + live Manager HTTP → inventory, source host_http", async () => {
+    const hostCalls: number[] = [];
+    const out = await listPanelNodes({
+      panelList: async () => DISPATCH_FAIL,
+      listInstalled: async () => {
+        hostCalls.push(1);
+        return PACKS;
+      },
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(hostCalls).toHaveLength(1);
+    expect(out.value.source).toBe("host_http");
+    expect(out.value.note).toBe(HOST_HTTP_LIST_NOTE);
+    expect(out.value.note).toMatch(/not a Manager outage/i);
+    expect(out.value.note).not.toMatch(/Manager down/i);
+    expect(out.value.installed["ComfyUI-Impact-Pack"]).toEqual({
+      ver: "8.0.0",
+      cnr_id: "comfyui-impact-pack",
+      enabled: true,
+    });
+    expect(out.value.installed["some-git-node"]?.aux_id).toBe("user/some-git-node");
+  });
+
+  it("falls back when the panel throws a typed pre-dispatch failure", async () => {
+    const out = await listPanelNodes({
+      panelList: async () => {
+        throw markDispatched(
+          new Error(`no connected tab with id "orchestrator::claude". Connected: none`),
+          false,
+        );
+      },
+      listInstalled: async () => PACKS,
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(out.value.source).toBe("host_http");
+    expect(Object.keys(out.value.installed)).toEqual([
+      "ComfyUI-Impact-Pack",
+      "some-git-node",
+    ]);
+  });
+
+  it("connected tab → still panel path (no host call)", async () => {
+    const panel = {
+      installed: { "ComfyUI-Impact-Pack": { ver: "8.0.0", cnr_id: "comfyui-impact-pack" } },
+    };
+    let hostCalls = 0;
+    const out = await listPanelNodes({
+      panelList: async () => panel,
+      listInstalled: async () => {
+        hostCalls += 1;
+        throw new Error("fallback must not run");
+      },
+    });
+    expect(out).toEqual({ via: "panel", value: panel });
+    expect(hostCalls).toBe(0);
+  });
+
+  it("does not host-fallback a live-tab Manager HTTP error", async () => {
+    const managerDown = {
+      isError: true,
+      content: [{ type: "text", text: "Error: Manager customnode/installed: HTTP 500" }],
+    };
+    let hostCalls = 0;
+    const out = await listPanelNodes({
+      panelList: async () => managerDown,
+      listInstalled: async () => {
+        hostCalls += 1;
+        return PACKS;
+      },
+    });
+    expect(out).toEqual({ via: "panel", value: managerDown });
+    expect(hostCalls).toBe(0);
+  });
+
+  it("disconnected tab + host HTTP failure → honest dual cause, not Manager down", async () => {
+    const out = await listPanelNodes({
+      panelList: async () => DISPATCH_FAIL,
+      listInstalled: async () => {
+        throw new Error("Manager customnode/installed: HTTP 503");
+      },
+    });
+    expect(out.via).toBe("failed");
+    if (out.via !== "failed") throw new Error("expected failed");
+    expect(out.message).toMatch(/could not be dispatched/i);
+    expect(out.message).toMatch(/no connected tab|Connected:\s*none/i);
+    expect(out.message).toMatch(/HTTP 503/);
+    expect(out.message).toMatch(/not a Manager outage inferred from tab loss/i);
+    expect(out.message).not.toMatch(/Manager down/i);
+  });
+
+  it("rethrows a non-dispatch panel throw", async () => {
+    await expect(
+      listPanelNodes({
+        panelList: async () => {
+          throw new Error("Manager customnode/installed: HTTP 403");
+        },
+        listInstalled: async () => PACKS,
+      }),
+    ).rejects.toThrow(/HTTP 403/);
+  });
+
+  it("uses the module test seam when listInstalled is omitted", async () => {
+    setListInstalledNodesForTests(async () => PACKS);
+    const out = await listPanelNodes({
+      panelList: async () => DISPATCH_FAIL,
+    });
+    expect(out.via).toBe("fallback");
+  });
+});
+
+describe("dualCauseListFailure copy", () => {
+  it("names both tab loss and the host read, not a Manager outage from tab loss", () => {
+    const msg = dualCauseListFailure(
+      new Error(`no connected tab with id "t". Connected: none`),
+      new Error("unreadable payload"),
+    );
+    expect(msg).toMatch(/no connected tab/);
+    expect(msg).toMatch(/unreadable payload/);
+    expect(msg).toMatch(/not a Manager outage inferred from tab loss/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -67,6 +67,7 @@ import {
   getManifestPartialLeftover,
 } from "../services/manifest-partial.js";
 import { searchPanelNodes } from "../services/manager-node-search.js";
+import { listPanelNodes } from "../services/manager-node-list.js";
 import { isPanelAnsweredError } from "../services/panel-answered.js";
 import {
   readWorkflowListReadiness,
@@ -22541,9 +22542,20 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_list_nodes",
-      "List the custom-node PACKS currently installed in the user's ComfyUI (via the built-in Manager). Takes no arguments — it returns the whole installed set. Read-only. This lists packs, NOT node classes: to find out whether a specific node type is available (e.g. LTXVContextWindowsGuideAware), use comfy_cli action:\"search_nodes\", which fuzzy-searches real node classes and falls back to the connected server's live /object_info. panel_search_nodes is a third thing again — it searches INSTALLABLE packs in the registry, not what is already here.",
+      "List the custom-node PACKS currently installed in the user's ComfyUI (via the built-in Manager). Takes no arguments — it returns the whole installed set. Read-only. This lists packs, NOT node classes: to find out whether a specific node type is available (e.g. LTXVContextWindowsGuideAware), use comfy_cli action:\"search_nodes\", which fuzzy-searches real node classes and falls back to the connected server's live /object_info. panel_search_nodes is a third thing again — it searches INSTALLABLE packs in the registry, not what is already here. If the panel tab is gone, the listing is served from the ComfyUI host's Manager HTTP instead of failing as a dispatch error.",
       {},
-      async (_args, ctx) => ctx.call({ cmd: "nodes_list" }, 20000),
+      async (_args, ctx) => {
+        // #2459 — pack listing is a Manager / object_info server-state read.
+        // Try the live tab first (Manager dialect + /object_info + #1496
+        // filter). When dispatch never reaches the tab, serve the same
+        // inventory from host Manager HTTP instead of dying as tab-loss.
+        const out = await listPanelNodes({
+          panelList: () => ctx.call({ cmd: "nodes_list" }, 20000),
+        });
+        if (out.via === "panel") return out.value;
+        if (out.via === "fallback") return ok(out.value);
+        return fail(out.message);
+      },
     ),
     def(
       "panel_install_node",

--- a/src/services/manager-node-list.ts
+++ b/src/services/manager-node-list.ts
@@ -1,0 +1,139 @@
+import { dispatchOutcomeOf } from "./ui-bridge.js";
+import { listInstalledNodes, type InstalledNode } from "./node-management.js";
+
+export type ListInstalledFn = () => Promise<InstalledNode[]>;
+
+/** Panel `listedNodesResult` pack record: Manager's installed map inverted. */
+export interface ListedNodePack {
+  ver?: string;
+  cnr_id?: string;
+  aux_id?: string;
+  enabled?: boolean;
+}
+
+export interface ListedNodesHostResult {
+  installed: Record<string, ListedNodePack>;
+  source: "host_http";
+  note: string;
+}
+
+export const HOST_HTTP_LIST_NOTE =
+  "Listed from ComfyUI-Manager HTTP because this session's panel tab was not connected. " +
+  "This is the host pack inventory, not a Manager outage.";
+
+let listInstalledOverride: ListInstalledFn | undefined;
+
+/** Test seam — restore with `undefined` in afterEach. */
+export function setListInstalledNodesForTests(fn: ListInstalledFn | undefined): void {
+  listInstalledOverride = fn;
+}
+
+function textFromUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  if (!value || typeof value !== "object") return "";
+  if ("message" in value && typeof value.message === "string") return value.message;
+  if ("content" in value && Array.isArray(value.content)) {
+    return value.content
+      .map((c) =>
+        c && typeof c === "object" && "text" in c && typeof c.text === "string" ? c.text : "",
+      )
+      .join("\n");
+  }
+  return "";
+}
+
+function isErrorShaped(value: unknown): boolean {
+  return Boolean(
+    value && typeof value === "object" && "isError" in value && value.isError === true,
+  );
+}
+
+/**
+ * Pre-dispatch tab loss: typed `dispatchOutcomeOf === false`, or the
+ * callOnce wrapper / bridge text the reporter saw when Connected: none.
+ */
+export function isPanelTabDispatchFailure(value: unknown): boolean {
+  const outcome = dispatchOutcomeOf(value);
+  if (outcome === true) return false;
+  if (outcome === false) return true;
+  const text = textFromUnknown(value);
+  const looksLikeDispatch =
+    /could not be dispatched[\s\S]{0,240}panel tab/i.test(text) ||
+    /no connected tab/i.test(text) ||
+    /Connected:\s*none/i.test(text);
+  if (!looksLikeDispatch) return false;
+  if (value instanceof Error) return true;
+  if (isErrorShaped(value)) return true;
+  return typeof value === "string";
+}
+
+/** Invert `InstalledNode[]` back to the panel map keyed by module. */
+export function installedNodesToPanelMap(
+  nodes: InstalledNode[],
+): Record<string, ListedNodePack> {
+  const installed: Record<string, ListedNodePack> = {};
+  for (const n of nodes) {
+    const pack: ListedNodePack = {};
+    if (n.version !== undefined) pack.ver = n.version;
+    if (n.cnrId) pack.cnr_id = n.cnrId;
+    if (n.auxId) pack.aux_id = n.auxId;
+    if (n.enabled !== undefined) pack.enabled = n.enabled;
+    installed[n.module] = pack;
+  }
+  return installed;
+}
+
+export function dualCauseListFailure(tabErr: unknown, hostErr: unknown): string {
+  const tab = textFromUnknown(tabErr) || "panel tab was not connected";
+  const host = textFromUnknown(hostErr) || "host Manager HTTP failed";
+  return (
+    `nodes_list could not be dispatched to this session's panel tab, and the host ` +
+    `Manager HTTP pack listing also failed. Tab: ${tab} Host: ${host} ` +
+    `This is not a Manager outage inferred from tab loss alone.`
+  );
+}
+
+function resolveListInstalled(fn?: ListInstalledFn): ListInstalledFn {
+  return fn ?? listInstalledOverride ?? listInstalledNodes;
+}
+
+/**
+ * Panel `nodes_list` first. On pre-dispatch tab loss, serve the pack listing
+ * from host Manager HTTP (`listInstalledNodes`) instead of dying as a
+ * dispatch-only error. A live tab's Manager/object_info result is passed
+ * through unchanged.
+ */
+export async function listPanelNodes<T>(opts: {
+  panelList: () => Promise<T>;
+  listInstalled?: ListInstalledFn;
+}): Promise<
+  | { via: "panel"; value: T }
+  | { via: "fallback"; value: ListedNodesHostResult }
+  | { via: "failed"; message: string }
+> {
+  const runHost = async (tabErr: unknown) => {
+    try {
+      const nodes = await resolveListInstalled(opts.listInstalled)();
+      return {
+        via: "fallback" as const,
+        value: {
+          installed: installedNodesToPanelMap(nodes),
+          source: "host_http" as const,
+          note: HOST_HTTP_LIST_NOTE,
+        },
+      };
+    } catch (hostErr) {
+      return { via: "failed" as const, message: dualCauseListFailure(tabErr, hostErr) };
+    }
+  };
+
+  try {
+    const value = await opts.panelList();
+    if (!isPanelTabDispatchFailure(value)) return { via: "panel", value };
+    return await runHost(value);
+  } catch (err) {
+    if (!isPanelTabDispatchFailure(err)) throw err;
+    return await runHost(err);
+  }
+}


### PR DESCRIPTION
## Summary

`panel_list_nodes` is a Manager / `object_info` server-state read, but the MCP handler was a one-liner tab dispatch (`ctx.call({ cmd: "nodes_list" })`). When the panel tab dropped, the call died with the `callOnce` wrapper:

```
nodes_list could not be dispatched to this session's panel tab — nothing was applied...
no connected tab with id "orchestrator::claude". Connected: none...
```

The pack inventory was available on the ComfyUI host the whole time. The panel has no pack-listing host route, so this is MCP-only (panel#1955).

## Fix

Add `listPanelNodes` next to `searchPanelNodes` (#1669):

1. Try panel `nodes_list` first (keeps Manager dialect + `/object_info` fallback + #1496 filter when the tab is live).
2. On pre-dispatch failure (`dispatchOutcomeOf === false`, or the "could not be dispatched … panel tab" / `no connected tab` / `Connected: none` wrapper), call `listInstalledNodes()` (`GET /v2/customnode/installed`) and return a panel-shaped `{ installed, source: "host_http", note }`.
3. If host HTTP also fails, fail with **both** facts. Tab loss is not a Manager outage.

## Tests

- `src/__tests__/services/manager-node-list.test.ts` — helper: disconnected tab + live Manager HTTP → inventory; connected tab skips host; dual-cause host failure; live-tab Manager errors do not fallback
- `src/__tests__/orchestrator/panel-tools.test.ts` — shipped `panel_list_nodes` handler, same three cases

`npx vitest run src/__tests__/services/manager-node-list.test.ts src/__tests__/orchestrator/list-nodes-scope-description.test.ts src/__tests__/orchestrator/panel-tools.test.ts` — **442 passed**.

Closes #2459
Tracked from artokun/comfyui-mcp-panel#1955.
