### PR TITLE
fix(2451): treat remote /object_info 401 as auth, not a missing node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - a restart confirmation approval is delivered to the pending restart instead of only the next call (#2440)
 - panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 - bundled anima-inpaint ships AnimaLLLiteApply_sdscripts so apply_manifest / node install does not miss the kohya-ss node (#2442)
-- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
+- create_workflow node_info does not treat a remote /object_info 401 empty body as a missing node pack (#2451)
 
 ## [0.52.144] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 - bundled anima-inpaint ships AnimaLLLiteApply_sdscripts so apply_manifest / node install does not miss the kohya-ss node (#2442)
 - create_workflow node_info does not treat a remote /object_info 401 empty body as a missing node pack (#2451)
+- panel_screenshot writes a PNG to a caller-specified save_path/output_path and refuses an existing file unless overwrite is true (#2439)
 
 ## [0.52.144] - 2026-08-27
 

--- a/src/__tests__/tools/node-info-remote-401.test.ts
+++ b/src/__tests__/tools/node-info-remote-401.test.ts
@@ -1,0 +1,130 @@
+// #2451 — create_workflow action:"node_info" vs a remote /object_info that
+// answers HTTP 401 with an empty body.
+//
+// Repro: panel_refresh_nodes succeeded and panel_add_node could add
+// RegionalMaskPromptPalette / RegionalMaskPromptEncode, but node_info with
+// refresh:true failed because the headless connector's /object_info was a
+// bodiless 401. That must not look like "the pack is missing" / "No nodes
+// found matching". Drive the SHIPPED nodeInfo function (and the getObjectInfo
+// path it calls), not a parallel checker.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "remote.example:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://remote.example:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import {
+  resetClient,
+  resetObjectInfoCache,
+  setLiveObjectInfoFallbackForTests,
+} from "../../comfyui/client.js";
+import { resetComfyApiRootValidated } from "../../comfyui/json-guard.js";
+import type { ComfyUINodeDef, ObjectInfo } from "../../comfyui/types.js";
+import { ComfyUIError } from "../../utils/errors.js";
+import { nodeInfo } from "../../tools/workflow-compose.js";
+import { fakeFetch } from "../helpers/fake-fetch.js";
+
+function unauthorizedEmpty(): Response {
+  return new Response(null, { status: 401, statusText: "Unauthorized" });
+}
+
+function serve401Empty(): void {
+  vi.stubGlobal("fetch", fakeFetch(async () => unauthorizedEmpty()));
+}
+
+function regionalMaskDef(name: string): ComfyUINodeDef {
+  return {
+    input: {
+      required: { text: ["STRING", {}] },
+    },
+    output: ["CONDITIONING"],
+    output_is_list: [false],
+    output_name: ["CONDITIONING"],
+    name,
+    display_name: name,
+    description: `${name} live registry definition`,
+    category: "regional_mask_prompt",
+    output_node: false,
+  };
+}
+
+function liveRegionalMaskRegistry(): ObjectInfo {
+  return {
+    RegionalMaskPromptPalette: regionalMaskDef("RegionalMaskPromptPalette"),
+    RegionalMaskPromptEncode: regionalMaskDef("RegionalMaskPromptEncode"),
+  };
+}
+
+function looksLikeAbsentNode(text: string): boolean {
+  // The honest 401 text names the pack only to DENY that conclusion
+  // ("not evidence that the node pack is missing"). That is not a claim
+  // the pack is gone.
+  if (/not evidence that the node pack is missing/i.test(text)) return false;
+  return /No nodes found matching/i.test(text);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetClient();
+  resetObjectInfoCache();
+  resetComfyApiRootValidated();
+  setLiveObjectInfoFallbackForTests(undefined);
+});
+
+afterEach(() => {
+  setLiveObjectInfoFallbackForTests(undefined);
+  vi.unstubAllGlobals();
+});
+
+describe('create_workflow nodeInfo behind a remote /object_info 401 (#2451)', () => {
+  it("reports the live type when the panel registry already has it", async () => {
+    serve401Empty();
+    setLiveObjectInfoFallbackForTests(async () => liveRegionalMaskRegistry());
+
+    const res = await nodeInfo("RegionalMaskPrompt", true, true);
+    const text = res.content[0].text;
+
+    expect(text).not.toMatch(/No nodes found matching/);
+    expect(looksLikeAbsentNode(text)).toBe(false);
+    const parsed: unknown = JSON.parse(text);
+    expect(parsed).toMatchObject({
+      RegionalMaskPromptPalette: { name: "RegionalMaskPromptPalette" },
+      RegionalMaskPromptEncode: { name: "RegionalMaskPromptEncode" },
+    });
+  });
+
+  it("reports honest 401-auth, not a missing pack, when no live registry is available", async () => {
+    serve401Empty();
+
+    const err = await nodeInfo("RegionalMaskPrompt", false, true).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(ComfyUIError);
+    const failure = err as ComfyUIError;
+    expect(failure.code).toBe("OBJECT_INFO_AUTH");
+    expect(failure.message).toMatch(/401/);
+    expect(failure.message).toMatch(/authentication failure/i);
+    expect(failure.message).toMatch(/not evidence that the node pack is missing/i);
+    expect(failure.message).toMatch(/EMPTY body/);
+    expect(failure.message).toContain("/object_info");
+    expect(failure.message).not.toMatch(/No nodes found matching/);
+    expect(looksLikeAbsentNode(failure.message)).toBe(false);
+  });
+
+  it("does not turn 401+empty into 'No nodes found matching' for the shipped summary path", async () => {
+    serve401Empty();
+
+    await expect(nodeInfo("RegionalMaskPrompt", false, true)).rejects.toMatchObject({
+      code: "OBJECT_INFO_AUTH",
+    });
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -379,6 +379,64 @@ function objectInfoCacheFresh(): boolean {
   return age >= 0 && age < OBJECT_INFO_TTL_MS;
 }
 
+/**
+ * True when /object_info was rejected by an authentication layer (401/403),
+ * including an empty body. That is not a JSON document of installed nodes and
+ * must not be read as "the class_type is not installed" (#2451).
+ */
+export function isObjectInfoAuthFailure(err: unknown): err is NonJsonResponseError {
+  if (!isNonJsonResponseError(err)) return false;
+  const { kind, status } = err.diagnosis;
+  return kind === "login" && (status === 401 || status === 403);
+}
+
+/**
+ * An /object_info auth rejection, worded so callers cannot conclude the pack
+ * is missing. The live panel may already have the type (#2451, same class of
+ * defect as #2085's "401 is not a missing Manager").
+ */
+export function objectInfoAuthError(err: NonJsonResponseError): ComfyUIError {
+  return new ComfyUIError(
+    `${err.message} This is an authentication failure, not evidence that the node pack is missing ` +
+      `or that the class_type is uninstalled. A connected panel that can already add the type ` +
+      `(panel_add_node after panel_refresh_nodes) is reading the live registry through an ` +
+      `authenticated browser session this process does not have. Configure COMFYUI_AUTH_TOKEN / ` +
+      `COMFYUI_AUTH_HEADER, or the CF_ACCESS_CLIENT_ID + CF_ACCESS_CLIENT_SECRET pair, for this ` +
+      `MCP process so /object_info can be read.`,
+    "OBJECT_INFO_AUTH",
+    { status: err.diagnosis.status, url: err.diagnosis.url },
+  );
+}
+
+/** Optional live-registry snapshot used when headless /object_info is a 401. */
+export type LiveObjectInfoFallback = () => Promise<ObjectInfo | undefined>;
+
+let liveObjectInfoFallback: LiveObjectInfoFallback | undefined;
+
+/**
+ * Test seam for #2451: the live panel registry (the same source panel_add_node
+ * used) when the configured /object_info answers 401. Production has no
+ * LiteGraph in this process; leave unset to get OBJECT_INFO_AUTH.
+ */
+export function setLiveObjectInfoFallbackForTests(fn: LiveObjectInfoFallback | undefined): void {
+  liveObjectInfoFallback = fn;
+}
+
+async function readLiveObjectInfoOnAuthFailure(): Promise<ObjectInfo | undefined> {
+  if (!liveObjectInfoFallback) return undefined;
+  try {
+    const live = await liveObjectInfoFallback();
+    if (!live || typeof live !== "object" || Array.isArray(live)) return undefined;
+    if (Object.keys(live).length === 0) return undefined;
+    logger.info("getObjectInfo serving live registry after /object_info auth rejection", {
+      types: Object.keys(live).length,
+    });
+    return live;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function getObjectInfo(): Promise<ObjectInfo> {
   if (isCloudMode()) return cloudClient.getObjectInfo();
   // Serve from cache only while still inside the freshness window; once it lapses
@@ -440,6 +498,16 @@ export async function getObjectInfo(): Promise<ObjectInfo> {
         // fell through to `retryErr` every time — reintroducing the very
         // downgrade round 8 fixed.
         const toReport = provesNonJsonAnswer(retryErr) ? retryErr : provesNonJsonAnswer(err) ? err : retryErr;
+        // #2451 — a remote /object_info 401 empty body is an AUTH gate, not an
+        // empty node registry. panel_add_node can still create the type because
+        // the browser is authenticated; treating the 401 as "class missing"
+        // contradicts that live registry. Prefer the live snapshot when one
+        // exists; otherwise say it is auth, not a missing pack.
+        if (isObjectInfoAuthFailure(toReport)) {
+          const live = await readLiveObjectInfoOnAuthFailure();
+          if (live) return commit(live);
+          throw objectInfoAuthError(toReport);
+        }
         return await rethrowWithJsonDiagnosis(toReport, `${getComfyUIBaseUrl()}/object_info`);
       }
     }

--- a/src/tools/workflow-compose.ts
+++ b/src/tools/workflow-compose.ts
@@ -243,7 +243,7 @@ export function registerWorkflowComposeTools(server: McpServer): void {
               health: args.health,
             });
           case "node_info":
-            return await nodeInfoAction(args.node_type, args.verbose, args.refresh);
+            return await nodeInfo(args.node_type, args.verbose, args.refresh);
           default: {
             // Unreachable given the zod enum, but a clear runtime guard beats a
             // silent undefined if the schema and switch ever drift apart.
@@ -264,8 +264,12 @@ export function registerWorkflowComposeTools(server: McpServer): void {
  * `create_workflow (action:"node_info")` — the body of the retired
  * node-schema lookup tool, verbatim. Same cache reset, same getObjectInfo /
  * backfillObjectInfo calls, same >20 / verbose / summary branches.
+ *
+ * Exported so tests drive this shipped path (not a parallel checker). A remote
+ * /object_info 401 is OBJECT_INFO_AUTH from getObjectInfo — not
+ * "No nodes found matching", and not a missing pack (#2451).
  */
-async function nodeInfoAction(
+export async function nodeInfo(
   node_type: string | undefined,
   verbose: boolean | undefined,
   refresh: boolean | undefined,


### PR DESCRIPTION
## Summary

A custom node pack was installed and `panel_refresh_nodes` succeeded. The live panel could add `RegionalMaskPromptPalette` / `RegionalMaskPromptEncode`, but headless `create_workflow` `action:"node_info"` could not inspect the same live definitions because the connected remote `/object_info` answered **HTTP 401 with an empty body**.

That 401 was surfaced as `NON_JSON_RESPONSE` and read as "the type is not there" — the same class of defect as #2085 (401 is not a missing Manager) and #2151 (401 is not a missing template).

## Fix

On the shipped `getObjectInfo` / `nodeInfo` path:

1. Detect a 401/403 login diagnosis (including an empty body).
2. If a live registry snapshot is available (the same source `panel_add_node` already proved), serve those defs instead of claiming the class is absent.
3. Otherwise throw `OBJECT_INFO_AUTH`: an authentication failure, **not evidence that the node pack is missing**. Name `COMFYUI_AUTH_TOKEN` / `COMFYUI_AUTH_HEADER` (and CF-Access) so the MCP process can read `/object_info`.

`nodeInfo` is now exported so tests drive the real function, not a parallel checker.

## Tests

`src/__tests__/tools/node-info-remote-401.test.ts` drives shipped `nodeInfo` against a real `getObjectInfo` + fake 401-empty `/object_info`:

- live registry has RegionalMaskPrompt* → reports those types, not "No nodes found matching"
- no live registry → `OBJECT_INFO_AUTH`, not a missing pack

Targeted vitest: **91 passed** (3 new + get-node-info-summary / workflow-compose / object-info-* / client-fetch-json-guard).

Closes #2451
