### PR TITLE
fix(2356): report live segmented .seg staging instead of withholding progress

### DIFF
--- a/src/__tests__/tools/download-cancel-partial.test.ts
+++ b/src/__tests__/tools/download-cancel-partial.test.ts
@@ -21,7 +21,12 @@ import { basename, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { findResumablePartial, stagedPartialPathForUrl } from "../../services/download-cache.js";
+import {
+  findResumablePartial,
+  observeSegmentScratchAtPath,
+  stagedPartialPathForUrl,
+} from "../../services/download-cache.js";
+import { segmentScratchPath } from "../../services/download-segments.js";
 
 const URL_A = "https://huggingface.co/Comfy-Org/flux2-dev/resolve/main/flux2_dev_fp8mixed.safetensors";
 const URL_B = "https://huggingface.co/Comfy-Org/other/resolve/main/mistral_3_small.safetensors";
@@ -103,6 +108,24 @@ describe("findResumablePartial reports what is ACTUALLY staged (#1370)", () => {
     await stagePartialFor(URL_B, 8192);
     expect(await findResumablePartial(URL_A)).toBeNull();
     expect((await findResumablePartial(URL_B))?.bytes).toBe(8192);
+  });
+
+  it("a growing .seg scratch is not a resumable .partial (#2356 recurrence)", async () => {
+    // Segmented downloads write a holey `<partial>.seg` and only publish a
+    // contiguous prefix onto `.partial` on success/cancel. Treating the scratch
+    // as resumable would restate this issue as silent corruption.
+    await useTempCache();
+    const partial = stagedPartialPathForUrl(URL_A);
+    await mkdir(dirname(partial), { recursive: true });
+    await writeFile(segmentScratchPath(partial), Buffer.alloc(4096, 1));
+    expect(await findResumablePartial(URL_A)).toBeNull();
+    const scratch = await observeSegmentScratchAtPath(partial);
+    expect(scratch).toEqual({
+      state: "present",
+      path: segmentScratchPath(partial),
+      bytes: 4096,
+      modifiedMs: expect.any(Number),
+    });
   });
 
   it("a ZERO-BYTE partial is reported as absent", async () => {

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -602,6 +602,64 @@ describe('download_model action:"status"', () => {
     }
   });
 
+  it("keeps durable .partial as the byte authority when a leftover .seg also exists (#2356)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "model-management-2356-partial-wins-"));
+    const cache = await mkdtemp(join(tmpdir(), "model-management-2356-partial-wins-cache-"));
+    const savedCache = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+    const url = "https://example.com/partial-wins.safetensors";
+    const id = "status-2356-partial-wins";
+    const progressId = "progress-2356-partial-wins";
+    process.env.COMFYUI_DOWNLOAD_CACHE_DIR = cache;
+    setProgressDir(dir);
+    try {
+      const identity = downloadCacheIdentity(url);
+      await mkdir(dirname(identity.partialPath), { recursive: true });
+      await writeFile(identity.partialPath, Buffer.alloc(100));
+      await writeFile(segmentScratchPath(identity.partialPath), Buffer.alloc(900));
+      await writeFile(
+        join(dir, `control-job-${id}-session.json`),
+        JSON.stringify({
+          id,
+          trayId: "tray-2356-partial-wins",
+          progressId,
+          partialPath: identity.partialPath,
+          url,
+          target_subfolder: "checkpoints",
+          status: "downloading",
+          via_manager: false,
+          partial_identity: { version: 1, cache_key: identity.cacheKey, auth_mode: "none" },
+          started_at: Date.now() - 60_000,
+          updated: Date.now(),
+        }),
+      );
+      await writeFile(
+        join(dir, `${progressId}-snapshot.json`),
+        JSON.stringify({
+          id: progressId,
+          name: "partial-wins.safetensors",
+          downloaded: 900,
+          total: 1_000,
+          bytes_per_sec: 10,
+          status: "downloading",
+          updated: Date.now(),
+        }),
+      );
+
+      const { downloadStatus } = makeServer();
+      const text = (await downloadStatus({ id })).content[0].text;
+      expect(text).toContain("(10%)");
+      expect(text).not.toContain("(90%)");
+      expect(text).toContain("reconciled to the durable .partial");
+      expect(text).not.toContain("live segmented staging");
+    } finally {
+      setProgressDir("");
+      if (savedCache === undefined) delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+      else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = savedCache;
+      await rm(dir, { recursive: true, force: true });
+      await rm(cache, { recursive: true, force: true });
+    }
+  });
+
   it("cancel recovery with a live .seg does not claim the re-issue starts from zero (#2356 recurrence)", async () => {
     const dir = await mkdtemp(join(tmpdir(), "model-management-2356-seg-cancel-"));
     const cache = await mkdtemp(join(tmpdir(), "model-management-2356-seg-cancel-cache-"));
@@ -612,7 +670,8 @@ describe('download_model action:"status"', () => {
     process.env.COMFYUI_DOWNLOAD_CACHE_DIR = cache;
     setProgressDir(dir);
     try {
-      const partial = downloadCacheIdentity(url).partialPath;
+      const identity = downloadCacheIdentity(url);
+      const partial = identity.partialPath;
       await mkdir(dirname(partial), { recursive: true });
       await writeFile(partial, Buffer.alloc(0));
       await writeFile(segmentScratchPath(partial), Buffer.alloc(2048));
@@ -627,7 +686,7 @@ describe('download_model action:"status"', () => {
           target_subfolder: "checkpoints",
           status: "cancelled",
           via_manager: false,
-          partial_identity: { version: 1, cache_key: "seg-cancel-test", auth_mode: "none" },
+          partial_identity: { version: 1, cache_key: identity.cacheKey, auth_mode: "none" },
           started_at: Date.now() - 60_000,
           updated: Date.now(),
         }),
@@ -644,6 +703,55 @@ describe('download_model action:"status"', () => {
       else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = savedCache;
       await rm(dir, { recursive: true, force: true });
       await rm(cache, { recursive: true, force: true });
+    }
+  });
+
+  it("action:cancel during segmented staging does not claim a restart from zero (#2356 recurrence)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "model-management-2356-seg-cancel-live-"));
+    const savedCache = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+    process.env.COMFYUI_DOWNLOAD_CACHE_DIR = dir;
+    const url = "https://example.com/seg-cancel-live.safetensors";
+    const identity = downloadCacheIdentity(url);
+    const partial = identity.partialPath;
+    setProgressDir(dir);
+    resetDownloadJobs();
+    downloadModelMock.mockImplementationOnce(async (...args: unknown[]) => {
+      (args[10] as (path: string) => void)(partial);
+      const signal = args[6] as AbortSignal;
+      return await new Promise<string>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new DOMException("cancelled", "AbortError")), {
+          once: true,
+        });
+      });
+    });
+    try {
+      await mkdir(dirname(partial), { recursive: true });
+      await writeFile(partial, Buffer.alloc(0));
+      await writeFile(segmentScratchPath(partial), Buffer.alloc(2048));
+      const { downloadModel, cancelDownload } = makeServer();
+      const downloading = downloadModel({
+        url,
+        target_subfolder: "checkpoints",
+      });
+      await vi.waitFor(() => expect(downloadModelMock).toHaveBeenCalled());
+      const [job] = listDownloadJobs();
+      expect(job).toBeTruthy();
+
+      const cancelled = await cancelDownload({ id: job.id, tray_id: job.trayId });
+      expect(cancelled.content[0].text).toContain("being aborted");
+      expect(cancelled.content[0].text).toContain("segmented staging is present");
+      expect(cancelled.content[0].text).toContain("does not start from the beginning");
+      expect(cancelled.content[0].text).not.toContain("starts from the beginning");
+      const text = (await downloading).content[0].text;
+      expect(text).toContain("segmented staging is present");
+      expect(text).toContain("does not start from the beginning");
+      expect(text).not.toContain("starts from the beginning");
+    } finally {
+      resetDownloadJobs();
+      setProgressDir("");
+      if (savedCache === undefined) delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+      else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = savedCache;
+      await rm(dir, { recursive: true, force: true });
     }
   });
 

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -55,6 +55,7 @@ import { setProgressDir } from "../../services/download-progress.js";
 import * as progressModule from "../../services/download-progress.js";
 import { listDownloadJobs, resetDownloadJobs, startDownloadJob } from "../../services/download-jobs.js";
 import { downloadCacheIdentity } from "../../services/download-cache.js";
+import { segmentScratchPath } from "../../services/download-segments.js";
 import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -534,6 +535,113 @@ describe('download_model action:"status"', () => {
       else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = savedCache;
       if (savedStall === undefined) delete process.env.COMFYUI_DOWNLOAD_STALL_TIMEOUT_S;
       else process.env.COMFYUI_DOWNLOAD_STALL_TIMEOUT_S = savedStall;
+      await rm(dir, { recursive: true, force: true });
+      await rm(cache, { recursive: true, force: true });
+    }
+  });
+
+  it("reports live segmented .seg staging instead of withholding progress (#2356 recurrence)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "model-management-2356-seg-"));
+    const cache = await mkdtemp(join(tmpdir(), "model-management-2356-seg-cache-"));
+    const savedCache = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+    const savedStall = process.env.COMFYUI_DOWNLOAD_STALL_TIMEOUT_S;
+    const url = "https://huggingface.co/Comfy-Org/test/resolve/main/segmented.safetensors";
+    const id = "status-2356-seg";
+    const progressId = "progress-2356-seg";
+    process.env.COMFYUI_DOWNLOAD_CACHE_DIR = cache;
+    process.env.COMFYUI_DOWNLOAD_STALL_TIMEOUT_S = "0";
+    setProgressDir(dir);
+    try {
+      const partial = downloadCacheIdentity(url).partialPath;
+      await mkdir(dirname(partial), { recursive: true });
+      await writeFile(segmentScratchPath(partial), Buffer.alloc(1024));
+      await writeFile(
+        join(dir, `control-job-${id}-session.json`),
+        JSON.stringify({
+          id,
+          trayId: "tray-2356-seg",
+          progressId,
+          partialPath: partial,
+          url,
+          target_subfolder: "diffusion_models",
+          status: "downloading",
+          via_manager: false,
+          partial_identity: { version: 1, cache_key: "seg-test", auth_mode: "none" },
+          started_at: Date.now() - 32 * 60_000,
+          updated: Date.now(),
+        }),
+      );
+      await writeFile(
+        join(dir, `${progressId}-snapshot.json`),
+        JSON.stringify({
+          id: progressId,
+          name: "segmented.safetensors",
+          downloaded: 4.23 * 1024 ** 3,
+          total: 19.53 * 1024 ** 3,
+          bytes_per_sec: 8_000_000,
+          status: "downloading",
+          updated: Date.now(),
+        }),
+      );
+
+      const { downloadStatus } = makeServer();
+      const text = (await downloadStatus({ id })).content[0].text;
+      expect(text).toContain("live segmented staging");
+      expect(text).toContain("does not start from the beginning");
+      expect(text).toMatch(/4\.23\/19\.53 GB \(21%\)/);
+      expect(text).not.toContain("PROGRESS UNAVAILABLE");
+      expect(text).not.toContain("no readable durable .partial is present yet");
+    } finally {
+      setProgressDir("");
+      if (savedCache === undefined) delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+      else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = savedCache;
+      if (savedStall === undefined) delete process.env.COMFYUI_DOWNLOAD_STALL_TIMEOUT_S;
+      else process.env.COMFYUI_DOWNLOAD_STALL_TIMEOUT_S = savedStall;
+      await rm(dir, { recursive: true, force: true });
+      await rm(cache, { recursive: true, force: true });
+    }
+  });
+
+  it("cancel recovery with a live .seg does not claim the re-issue starts from zero (#2356 recurrence)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "model-management-2356-seg-cancel-"));
+    const cache = await mkdtemp(join(tmpdir(), "model-management-2356-seg-cancel-cache-"));
+    const savedCache = process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+    const url = "https://example.com/seg-cancel.safetensors";
+    const id = "status-2356-seg-cancel";
+    const progressId = "progress-2356-seg-cancel";
+    process.env.COMFYUI_DOWNLOAD_CACHE_DIR = cache;
+    setProgressDir(dir);
+    try {
+      const partial = downloadCacheIdentity(url).partialPath;
+      await mkdir(dirname(partial), { recursive: true });
+      await writeFile(partial, Buffer.alloc(0));
+      await writeFile(segmentScratchPath(partial), Buffer.alloc(2048));
+      await writeFile(
+        join(dir, `control-job-${id}-session.json`),
+        JSON.stringify({
+          id,
+          trayId: "tray-2356-seg-cancel",
+          progressId,
+          partialPath: partial,
+          url,
+          target_subfolder: "checkpoints",
+          status: "cancelled",
+          via_manager: false,
+          partial_identity: { version: 1, cache_key: "seg-cancel-test", auth_mode: "none" },
+          started_at: Date.now() - 60_000,
+          updated: Date.now(),
+        }),
+      );
+
+      const { downloadStatus } = makeServer();
+      const text = (await downloadStatus({ id })).content[0].text;
+      expect(text).toContain("segmented staging is present");
+      expect(text).toContain("does not start from the beginning");
+      expect(text).not.toContain("starts from the beginning");
+    } finally {
+      setProgressDir("");
+      if (savedCache === undefined) delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+      else process.env.COMFYUI_DOWNLOAD_CACHE_DIR = savedCache;
       await rm(dir, { recursive: true, force: true });
       await rm(cache, { recursive: true, force: true });
     }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -30,6 +30,7 @@ import {
   planSegments,
   probeSegmentedRanges,
   runSegmentedDownload,
+  segmentScratchPath,
   segmentedDownloadPolicy,
   SegmentedRangeUnsupportedError,
   type SegmentedProbe,
@@ -3852,6 +3853,20 @@ export async function observeStagedPartial(
     return { state: "unavailable", path: "" };
   }
   return observeStagedPartialAtPath(partialPath);
+}
+
+/**
+ * Read the segmented `.seg` scratch next to the writer's exact staged partial.
+ * Path derivation is the writer's (`segmentScratchPath`); this is live-transfer
+ * evidence only. `.seg` is holey and is not a resume candidate (#2356 recurrence).
+ */
+export async function observeSegmentScratchAtPath(
+  partialPath: string | undefined,
+): Promise<StagedPartialObservation> {
+  if (typeof partialPath !== "string" || !partialPath) {
+    return { state: "unavailable", path: "" };
+  }
+  return observeStagedPartialAtPath(segmentScratchPath(partialPath));
 }
 
 /**

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -32,10 +32,10 @@ import {
   type DownloadJob,
 } from "../services/download-jobs.js";
 import {
+  observeSegmentScratchAtPath,
   observeStagedPartialAtPath,
   type StagedPartialObservation,
 } from "../services/download-cache.js";
-import { segmentScratchPath } from "../services/download-segments.js";
 import { downloadRetryPolicy } from "../services/download-retry.js";
 import { errorToToolResult, ModelError } from "../utils/errors.js";
 import {
@@ -262,13 +262,6 @@ function progressAgeMs(
   return lastEvidence > 0 ? Math.max(0, Date.now() - lastEvidence) : Number.POSITIVE_INFINITY;
 }
 
-async function observeSegmentScratch(partialPath: string | undefined): Promise<StagedPartialObservation> {
-  if (typeof partialPath !== "string" || !partialPath) {
-    return { state: "absent", path: "" };
-  }
-  return observeStagedPartialAtPath(segmentScratchPath(partialPath));
-}
-
 /**
  * Progress rows are arrival-based. Single-connection downloads stage a durable
  * `.partial`; segmented downloads (#1697) write a holey `.seg` until success or
@@ -372,7 +365,7 @@ async function progressViewForJob(
     return { bytes: formatProgressBytes(p), note: "" };
   }
   const partial = await observeStagedPartialAtPath(job.partialPath);
-  const scratch = await observeSegmentScratch(job.partialPath);
+  const scratch = await observeSegmentScratchAtPath(job.partialPath);
   return reconcileProgress(p, partial, scratch);
 }
 
@@ -403,23 +396,21 @@ async function exactPartialRecoveryAdvice(
       `determine whether bytes are resumable. Do not re-issue on an unreadable identity.`
     );
   }
+  const scratch = await observeSegmentScratchAtPath(job.partialPath);
   if (partial.state === "absent") {
-    const scratch = await observeSegmentScratch(job.partialPath);
-    if (scratch.state === "present") {
-      return (
-        `the exact staged .partial is absent or zero-byte (${job.partialPath}), but segmented ` +
-        `staging is present at ${scratch.path}. Cancel/failure publishes a contiguous hole-free ` +
-        `prefix to the durable .partial, so a re-issue does not start from the beginning. Wait ` +
-        `for that prefix to land, then re-issue to resume.`
-      );
+    if (scratch.state !== "present") {
+      return `the exact staged .partial is absent or zero-byte (${job.partialPath}); no resumable bytes were observed, so a re-issue starts from the beginning.`;
     }
-    return `the exact staged .partial is absent or zero-byte (${job.partialPath}); no resumable bytes were observed, so a re-issue starts from the beginning.`;
   }
+  const observedBytes = partial.state === "present" ? partial.bytes : scratch.state === "present" ? scratch.bytes : 0;
+  const observedPath = partial.state === "present" ? partial.path : scratch.path;
   let currentIdentity: ReturnType<typeof localDownloadCacheIdentity>;
   try {
     currentIdentity = localDownloadCacheIdentity(job.url);
   } catch {
-    return `the exact staged ${formatBytes(partial.bytes)} partial is observed at ${partial.path}, but the current local request identity could not be established; do not re-issue it.`;
+    return partial.state === "present"
+      ? `the exact staged ${formatBytes(partial.bytes)} partial is observed at ${partial.path}, but the current local request identity could not be established; do not re-issue it.`
+      : `segmented staging is present at ${scratch.path}, but the current local request identity could not be established; do not re-issue it.`;
   }
   if (
     currentIdentity.partialPath !== job.partialPath ||
@@ -427,9 +418,27 @@ async function exactPartialRecoveryAdvice(
     currentIdentity.partialIdentity.auth_mode !== job.partialIdentity.auth_mode
   ) {
     return (
-      `an exact ${formatBytes(partial.bytes)} partial is observed at ${partial.path}, but its ` +
+      (partial.state === "present"
+        ? `an exact ${formatBytes(observedBytes)} partial is observed at ${observedPath}, but its `
+        : `segmented staging is present at ${observedPath}, but its `) +
       `persisted route/identity proof does not match the current local request identity. ` +
       `Do not re-issue it or infer that those bytes are resumable.`
+    );
+  }
+  if (partial.state === "absent") {
+    if (job.partialIdentity.auth_mode === "explicit") {
+      return (
+        `the exact staged .partial is absent or zero-byte (${job.partialPath}), but segmented ` +
+        `staging is present at ${scratch.path}. A contiguous prefix may be published to the ` +
+        `durable .partial, but the persisted identity requires a per-request credential that ` +
+        `is not stored here. Do not re-issue without it and a matching identity check.`
+      );
+    }
+    return (
+      `the exact staged .partial is absent or zero-byte (${job.partialPath}), but segmented ` +
+      `staging is present at ${scratch.path}. Cancel/failure publishes a contiguous hole-free ` +
+      `prefix to the durable .partial, so a re-issue does not start from the beginning. Wait ` +
+      `for that prefix to land, then re-issue to resume.`
     );
   }
   const size = formatBytes(partial.bytes);

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -35,6 +35,7 @@ import {
   observeStagedPartialAtPath,
   type StagedPartialObservation,
 } from "../services/download-cache.js";
+import { segmentScratchPath } from "../services/download-segments.js";
 import { downloadRetryPolicy } from "../services/download-retry.js";
 import { errorToToolResult, ModelError } from "../utils/errors.js";
 import {
@@ -248,79 +249,116 @@ function formatBytes(bytes: number): string {
   return gb >= 1 ? `${gb.toFixed(2)} GB` : `${(bytes / 1024 ** 2).toFixed(1)} MB`;
 }
 
-function progressAgeMs(p: DownloadProgress | null, partial: StagedPartialObservation): number {
+function progressAgeMs(
+  p: DownloadProgress | null,
+  partial: StagedPartialObservation,
+  scratch?: StagedPartialObservation,
+): number {
   const lastEvidence = Math.max(
     p?.updated ?? 0,
     partial.state === "present" ? partial.modifiedMs : 0,
+    scratch?.state === "present" ? scratch.modifiedMs : 0,
   );
   return lastEvidence > 0 ? Math.max(0, Date.now() - lastEvidence) : Number.POSITIVE_INFINITY;
 }
 
+async function observeSegmentScratch(partialPath: string | undefined): Promise<StagedPartialObservation> {
+  if (typeof partialPath !== "string" || !partialPath) {
+    return { state: "absent", path: "" };
+  }
+  return observeStagedPartialAtPath(segmentScratchPath(partialPath));
+}
+
 /**
- * Progress rows are arrival-based and segmented downloads stage into `.seg`,
- * not the resumable `.partial`. The status surface therefore uses the partial
- * as its byte authority and withholds an in-memory count it cannot reconcile
- * (#2356). This is reporting only: it never cancels or otherwise changes the
- * downloader's existing stall/retry ownership.
+ * Progress rows are arrival-based. Single-connection downloads stage a durable
+ * `.partial`; segmented downloads (#1697) write a holey `.seg` until success or
+ * cancel publishes a contiguous prefix onto that `.partial`.
+ *
+ * Durable `.partial` bytes remain the resume authority (#2356). A present `.seg`
+ * is live-writer evidence, not a resume prefix — so status may show the live
+ * onBytes snapshot (those deltas are real writes) without treating `.seg` size
+ * as progress (out-of-order ranges make size lie). This is reporting only: it
+ * never cancels or otherwise changes the downloader's stall/retry ownership.
  */
 function reconcileProgress(
   p: DownloadProgress | null,
   partial: StagedPartialObservation,
+  scratch: StagedPartialObservation,
 ): ProgressView {
-  if (partial.state !== "present") {
-    const staleMs = progressAgeMs(p, partial);
+  if (partial.state === "present") {
+    const durableBytes = Math.max(0, partial.bytes);
+    const displayedBytes = p?.total && p.total > 0 ? Math.min(durableBytes, p.total) : durableBytes;
+    const bytes =
+      p?.total && p.total > 0
+        ? `  ${(displayedBytes / 1024 ** 3).toFixed(2)}/${(p.total / 1024 ** 3).toFixed(2)} GB (${Math.floor((displayedBytes / p.total) * 100)}%)`
+        : displayedBytes > 0
+          ? `  ${formatBytes(displayedBytes)} durable`
+          : "  0 bytes durable";
+    const ahead = p !== null && p.downloaded > durableBytes;
+    const ageMs = progressAgeMs(p, partial, scratch);
     const stallTimeoutMs = downloadRetryPolicy().stallTimeoutMs;
-    const stale = stallTimeoutMs > 0 && Number.isFinite(staleMs) && staleMs >= stallTimeoutMs;
-    const reason =
-      partial.state === "absent"
-        ? "no readable durable .partial is present yet"
-        : "the durable .partial could not be read";
-    if (stale) {
+    const notes = ahead
+      ? `\n    progress reconciled to the durable .partial (${formatBytes(durableBytes)} on disk); ` +
+        `the live snapshot was ahead and is not reported`
+      : "";
+    if (stallTimeoutMs > 0 && ageMs >= stallTimeoutMs) {
       return {
-        bytes: "",
+        bytes,
         note:
-          `\n    PROGRESS STALLED/UNAVAILABLE — ${reason}; the last byte snapshot is ` +
-          `${Math.round(staleMs / 1000)}s old. This status call does not cancel the download; ` +
+          notes +
+          `\n    PROGRESS STALLED — no new byte snapshot or durable partial growth for ` +
+          `${Math.round(ageMs / 1000)}s. The existing downloader stall watchdog may retry a ` +
+          `wedged HTTP attempt; this status call does not cancel it.`,
+      };
+    }
+    return { bytes, note: notes };
+  }
+
+  if (scratch.state === "present") {
+    const ageMs = progressAgeMs(p, partial, scratch);
+    const stallTimeoutMs = downloadRetryPolicy().stallTimeoutMs;
+    const liveNote =
+      `\n    live segmented staging at ${scratch.path}; ` +
+      `those bytes are not a hole-free durable prefix until success or cancel publishes ` +
+      `a contiguous prefix to the .partial. A re-issue after cancel does not start from the beginning.`;
+    if (stallTimeoutMs > 0 && Number.isFinite(ageMs) && ageMs >= stallTimeoutMs) {
+      return {
+        bytes: formatProgressBytes(p),
+        note:
+          liveNote +
+          `\n    PROGRESS STALLED — no new byte snapshot or .seg growth for ` +
+          `${Math.round(ageMs / 1000)}s. This status call does not cancel the download; ` +
           `confirm the writer before using action:"cancel".`,
       };
     }
+    return { bytes: formatProgressBytes(p), note: liveNote };
+  }
+
+  const staleMs = progressAgeMs(p, partial, scratch);
+  const stallTimeoutMs = downloadRetryPolicy().stallTimeoutMs;
+  const stale = stallTimeoutMs > 0 && Number.isFinite(staleMs) && staleMs >= stallTimeoutMs;
+  const reason =
+    partial.state === "absent"
+      ? "no readable durable .partial is present yet"
+      : "the durable .partial could not be read";
+  if (stale) {
     return {
       bytes: "",
       note:
-        `\n    PROGRESS UNAVAILABLE — ${reason}; live-stream byte counts are withheld until ` +
-        `they can be reconciled to durable disk bytes.` +
-        (stallTimeoutMs === 0
-          ? ` The stall watchdog is disabled, so age is not treated as a stall verdict.`
-          : ""),
+        `\n    PROGRESS STALLED/UNAVAILABLE — ${reason}; the last byte snapshot is ` +
+        `${Math.round(staleMs / 1000)}s old. This status call does not cancel the download; ` +
+        `confirm the writer before using action:"cancel".`,
     };
   }
-
-  const durableBytes = Math.max(0, partial.bytes);
-  const displayedBytes = p?.total && p.total > 0 ? Math.min(durableBytes, p.total) : durableBytes;
-  const bytes =
-    p?.total && p.total > 0
-      ? `  ${(displayedBytes / 1024 ** 3).toFixed(2)}/${(p.total / 1024 ** 3).toFixed(2)} GB (${Math.floor((displayedBytes / p.total) * 100)}%)`
-      : displayedBytes > 0
-        ? `  ${formatBytes(displayedBytes)} durable`
-        : "  0 bytes durable";
-  const ahead = p !== null && p.downloaded > durableBytes;
-  const ageMs = progressAgeMs(p, partial);
-  const stallTimeoutMs = downloadRetryPolicy().stallTimeoutMs;
-  const notes = ahead
-    ? `\n    progress reconciled to the durable .partial (${formatBytes(durableBytes)} on disk); ` +
-      `the live snapshot was ahead and is not reported`
-    : "";
-  if (stallTimeoutMs > 0 && ageMs >= stallTimeoutMs) {
-    return {
-      bytes,
-      note:
-        notes +
-        `\n    PROGRESS STALLED — no new byte snapshot or durable partial growth for ` +
-        `${Math.round(ageMs / 1000)}s. The existing downloader stall watchdog may retry a ` +
-        `wedged HTTP attempt; this status call does not cancel it.`,
-    };
-  }
-  return { bytes, note: notes };
+  return {
+    bytes: "",
+    note:
+      `\n    PROGRESS UNAVAILABLE — ${reason}; live-stream byte counts are withheld until ` +
+      `they can be reconciled to durable disk bytes.` +
+      (stallTimeoutMs === 0
+        ? ` The stall watchdog is disabled, so age is not treated as a stall verdict.`
+        : ""),
+  };
 }
 
 async function progressViewForJob(
@@ -333,10 +371,9 @@ async function progressViewForJob(
   if (job.status === "done" || job.viaManager === true) {
     return { bytes: formatProgressBytes(p), note: "" };
   }
-  return reconcileProgress(
-    p,
-    await observeStagedPartialAtPath(job.partialPath),
-  );
+  const partial = await observeStagedPartialAtPath(job.partialPath);
+  const scratch = await observeSegmentScratch(job.partialPath);
+  return reconcileProgress(p, partial, scratch);
 }
 
 /**
@@ -367,6 +404,15 @@ async function exactPartialRecoveryAdvice(
     );
   }
   if (partial.state === "absent") {
+    const scratch = await observeSegmentScratch(job.partialPath);
+    if (scratch.state === "present") {
+      return (
+        `the exact staged .partial is absent or zero-byte (${job.partialPath}), but segmented ` +
+        `staging is present at ${scratch.path}. Cancel/failure publishes a contiguous hole-free ` +
+        `prefix to the durable .partial, so a re-issue does not start from the beginning. Wait ` +
+        `for that prefix to land, then re-issue to resume.`
+      );
+    }
     return `the exact staged .partial is absent or zero-byte (${job.partialPath}); no resumable bytes were observed, so a re-issue starts from the beginning.`;
   }
   let currentIdentity: ReturnType<typeof localDownloadCacheIdentity>;


### PR DESCRIPTION
Closes #2356

## Recurrence

PR #2358 reconciled status to the durable `.partial`. Segmented downloads (#1697) stage into a holey `.seg` until success/cancel publishes a contiguous prefix. A healthy 19.53 GB transfer therefore reported `PROGRESS UNAVAILABLE — no readable durable .partial is present yet` for 32 minutes while `.seg` grew; cancel then produced a 4.23 GB `.partial` that resumed at 22%, and the cancel text incorrectly said a re-issue starts from the beginning.

## Change

- Treat a present `.seg` as live-writer evidence (not a resume prefix — size can lie because ranges write out of order).
- Show the live onBytes snapshot once that evidence exists, instead of withholding as "progress unavailable".
- Cancel/status recovery no longer claims a from-zero restart while segmented staging is still on disk.
- Observe `.seg` through `segmentScratchPath` (the writer's derivation) via `observeSegmentScratchAtPath`.
- Durable `.partial` remains the byte authority when both files exist (#2358).
- "Does not start from the beginning" is gated on matching cache/auth identity proof.

## Tests

```
npx vitest run src/__tests__/services/download-cache.test.ts src/__tests__/tools/download-cancel-partial.test.ts src/__tests__/tools/model-management.test.ts
```

133 passed (3 files), including:

- live `.seg` status reports 4.23/19.53 GB (21%) instead of PROGRESS UNAVAILABLE
- cancel during segmented staging does not claim a restart from zero
- leftover `.seg` does not override a durable `.partial`
- `.seg` is not treated as a resumable partial

Do not merge from this PR body; independent review/merge remains gated.
