### PR TITLE
fix(2497): keep the causal line above a native fault and stop blaming a pass-through node

### DIFF
--- a/src/__tests__/crash-log.test.ts
+++ b/src/__tests__/crash-log.test.ts
@@ -22,6 +22,29 @@ Current thread 0x00004abc (most recent call first):
   File "C:\\Users\\Artokun\\ComfyUI-Installs\\ComfyUI\\ComfyUI\\execution.py", line 152 in recursive_execute
 `;
 
+// #2497 — a MiniMax H3 render aborted ComfyUI inside SageAttention's CUDA
+// kernel. Two things make this shape different from WAN_CRASH: the signature
+// (`Fatal Python error: Aborted`) says nothing on its own, and the line that
+// names the failing subsystem sits ABOVE it; and the only custom node on the
+// stack (TiledDiffusion) is a monkey-patch that passes straight through to the
+// original sampler, so blaming it sends the user to update an innocent node.
+const SAGE_ABORT = [
+  "got prompt",
+  "Requested to load MiniMaxRef2VideoModel",
+  " 35%|###5      | 7/20 [02:41<04:59, 23.05s/it]",
+  "[ERROR] Error running sage attention: CUDA error: an illegal memory access was encountered, using pytorch attention instead.",
+  "Traceback (most recent call last):",
+  '  File "C:\\ComfyUI\\comfy\\ldm\\modules\\attention.py", line 512, in attention_sage',
+  "    out = sageattn(q, k, v, is_causal=False)",
+  '  File "C:\\ComfyUI\\custom_nodes\\ComfyUI-TiledDiffusion\\utils.py", line 121, in KSAMPLER_sample',
+  "    return orig_fn(*args, **kwargs)",
+  "Fatal Python error: Aborted",
+  "",
+  "Current thread 0x00004b1c (most recent call first):",
+  '  File "C:\\ComfyUI\\comfy\\ldm\\modules\\attention.py", line 512 in attention_sage',
+  '  File "C:\\ComfyUI\\custom_nodes\\ComfyUI-TiledDiffusion\\utils.py", line 121 in KSAMPLER_sample',
+].join("\n");
+
 describe("parseCrashBlock", () => {
   it("extracts the culprit node + frame from the WanVideoWrapper access violation", () => {
     const r = parseCrashBlock(WAN_CRASH);
@@ -168,6 +191,43 @@ ValueError: bad input
     // Same crash head → same fingerprint even though the tail grew post-restart.
     expect(b.fingerprint).toBe(a.fingerprint);
   });
+
+  it("#2497 keeps the line ABOVE the signature that names what actually failed", () => {
+    const r = parseCrashBlock(SAGE_ABORT);
+    expect(r.fatal).toBe(true);
+    // The abort itself is contentless; this is the only line that says "Sage".
+    expect(r.block).toContain("Error running sage attention");
+    expect(r.block).toContain("illegal memory access");
+    // …and the signature it is context FOR is still there.
+    expect(r.block).toContain("Fatal Python error: Aborted");
+  });
+
+  it("#2497 names the innermost NON-custom-node frame as the fault site", () => {
+    const r = parseCrashBlock(SAGE_ABORT);
+    // TiledDiffusion is on the stack only because it monkey-patches
+    // KSAMPLER_sample and passes through — it is not where this died.
+    expect(r.culpritNode).toBe("ComfyUI-TiledDiffusion");
+    expect(r.faultFrame).toBe("attention.py:512");
+  });
+
+  it("#2497 leaves faultFrame UNSET when the custom node really is innermost", () => {
+    // The motivating WanVideoWrapper case: the deepest frame IS in the node, so
+    // the unhedged "update that node" verdict must survive this change.
+    const r = parseCrashBlock(WAN_CRASH);
+    expect(r.culpritNode).toBe("ComfyUI-WanVideoWrapper");
+    expect(r.faultFrame).toBeUndefined();
+  });
+
+  it("#2497 fingerprints on the FATAL region, so added context cannot shift the key", () => {
+    // Same crash, different preceding log. If the fingerprint keyed on the
+    // displayed block, these would differ and a crash already injected would be
+    // re-injected on the next resume.
+    const tail = SAGE_ABORT.slice(SAGE_ABORT.indexOf("[ERROR] Error running sage"));
+    const a = parseCrashBlock(`[INFO] got prompt\n[INFO] loaded model A\n${tail}`);
+    const b = parseCrashBlock(`[INFO] a totally different preceding line\n${tail}`);
+    expect(a.fingerprint).toBeTruthy();
+    expect(b.fingerprint).toBe(a.fingerprint);
+  });
 });
 
 describe("formatCrashNote", () => {
@@ -181,6 +241,27 @@ describe("formatCrashNote", () => {
 
   it("returns null on a clean parse", () => {
     expect(formatCrashNote({ fatal: false, block: "" })).toBeNull();
+  });
+
+  it("#2497 does NOT tell the user to update a node that only wrapped the call", () => {
+    const note = formatCrashNote(parseCrashBlock(SAGE_ABORT))!;
+    expect(note).not.toBeNull();
+    // The old note said "Most likely culprit custom node: ComfyUI-TiledDiffusion.
+    // Update or fix that node before retrying" — a confident wrong instruction.
+    expect(note).not.toContain("Most likely culprit custom node");
+    expect(note).not.toContain("Update or fix that node before retrying");
+    // What it must say instead: where it really died, and that the node may be blameless.
+    expect(note).toContain("attention.py:512");
+    expect(note).toContain("NOT inside a custom node");
+    expect(note).toContain("do not update ComfyUI-TiledDiffusion");
+    // The causal line rides along in the block.
+    expect(note).toContain("Error running sage attention");
+  });
+
+  it("#2497 still gives the unhedged verdict when the custom node IS the fault site", () => {
+    const note = formatCrashNote(parseCrashBlock(WAN_CRASH))!;
+    expect(note).toContain("Most likely culprit custom node");
+    expect(note).toContain("Update or fix that node before retrying");
   });
 });
 

--- a/src/__tests__/crash-log.test.ts
+++ b/src/__tests__/crash-log.test.ts
@@ -276,6 +276,38 @@ ValueError: bad input
     expect(r.faultFrame).toBeUndefined();
   });
 
+  it("#2497 picks the culprit by THIS stack's direction, not a later dump's", () => {
+    // Outer → Inner, most-recent-call-LAST, so Inner is the deepest custom node.
+    // A restart dump below carries a "most recent call first" marker; obeying it
+    // returned Outer and told the agent to update the wrong node (gate r3 P1).
+    const flipped = [
+      "Segmentation fault",
+      "Traceback (most recent call last):",
+      '  File "/home/u/ComfyUI/custom_nodes/Outer/o.py", line 1, in outer',
+      '  File "/home/u/ComfyUI/custom_nodes/Inner/i.py", line 2, in inner',
+      "[INFO] Comfy is restarting…",
+      "Current thread 0x1 (most recent call first):",
+      '  File "/home/u/ComfyUI/comfy/server.py", line 9 in serve',
+    ].join("\n");
+    const r = parseCrashBlock(flipped);
+    expect(r.culpritNode).toBe("Inner");
+    expect(r.culpritFrame).toBe("i.py:2");
+  });
+
+  it("#2497 does not take a custom_nodes path out of a SOURCE line as the culprit", () => {
+    // The raise is code, not a frame. Reading it named a node that was never on
+    // the stack and sent the agent to update it (gate r3 P1).
+    const fake = [
+      "Segmentation fault",
+      "Traceback (most recent call last):",
+      '  File "/home/u/ComfyUI/custom_nodes/Good/g.py", line 3, in run',
+      '    raise RuntimeError("custom_nodes/Fake/f.py:99")',
+    ].join("\n");
+    const r = parseCrashBlock(fake);
+    expect(r.culpritNode).toBe("Good");
+    expect(r.culpritFrame).toBe("g.py:3");
+  });
+
   it("#2497 fingerprints on the FATAL region, so added context cannot shift the key", () => {
     // Same crash, different preceding log. If the fingerprint keyed on the
     // displayed block, these would differ and a crash already injected would be

--- a/src/__tests__/crash-log.test.ts
+++ b/src/__tests__/crash-log.test.ts
@@ -218,6 +218,31 @@ ValueError: bad input
     expect(r.faultFrame).toBeUndefined();
   });
 
+  it("#2497 does not let log printed AFTER the crash pose as a deeper frame", () => {
+    // The region runs to the end of the tail, so it also holds whatever the
+    // server printed once it came back. An ordinary traceback there must not
+    // exonerate the node that actually segfaulted (gate r1 P1).
+    const postCrashNoise = [
+      "Segmentation fault",
+      '  File "/home/u/ComfyUI/custom_nodes/GoodNode/nodes.py", line 5 in forward',
+      "[INFO] Comfy is restarting…",
+      "[INFO] got prompt",
+      "Traceback (most recent call last):",
+      '  File "/home/u/ComfyUI/comfy/server.py", line 2, in handler',
+      "ValueError: unrelated later error",
+    ].join("\n");
+    const r = parseCrashBlock(postCrashNoise);
+    expect(r.culpritNode).toBe("GoodNode");
+    // server.py is in a DIFFERENT stack — it is not this crash's fault site.
+    expect(r.faultFrame).toBeUndefined();
+    // The block still shows the whole tail (unchanged), so assert on the ADVICE:
+    // it must be the plain verdict, with no exonerating hedge.
+    const note = formatCrashNote(r)!;
+    expect(note).toContain("Update or fix that node before retrying");
+    expect(note).not.toContain("NOT inside a custom node");
+    expect(note).not.toContain("do not update GoodNode");
+  });
+
   it("#2497 fingerprints on the FATAL region, so added context cannot shift the key", () => {
     // Same crash, different preceding log. If the fingerprint keyed on the
     // displayed block, these would differ and a crash already injected would be

--- a/src/__tests__/crash-log.test.ts
+++ b/src/__tests__/crash-log.test.ts
@@ -243,6 +243,39 @@ ValueError: bad input
     expect(note).not.toContain("do not update GoodNode");
   });
 
+  it("#2497 does not read a .py:N inside a SOURCE line as a frame", () => {
+    // The indented line is code, not a frame. Reading `bad.py:99` out of the
+    // string literal invented a non-custom fault site (gate r2 P1).
+    const withSourceLine = [
+      "Segmentation fault",
+      "Traceback (most recent call last):",
+      '  File "/home/u/ComfyUI/custom_nodes/Good/a.py", line 2, in y',
+      '    raise RuntimeError("bad.py:99")',
+    ].join("\n");
+    const r = parseCrashBlock(withSourceLine);
+    expect(r.culpritNode).toBe("Good");
+    expect(r.faultFrame).toBeUndefined();
+  });
+
+  it("#2497 reads trace direction from THIS stack, not a later marker in the tail", () => {
+    // The crash stack is most-recent-call-LAST, so its innermost frame is the
+    // custom node at the bottom. A thread dump printed after the restart carries
+    // a "most recent call first" marker; letting it flip the direction picked
+    // core.py and exonerated the crashing node (gate r2 P1).
+    const flipped = [
+      "Segmentation fault",
+      "Traceback (most recent call last):",
+      '  File "/home/u/ComfyUI/comfy/core.py", line 1, in x',
+      '  File "/home/u/ComfyUI/custom_nodes/Good/a.py", line 2, in y',
+      "[INFO] Comfy is restarting…",
+      "Current thread 0x1 (most recent call first):",
+      '  File "/home/u/ComfyUI/comfy/server.py", line 9 in serve',
+    ].join("\n");
+    const r = parseCrashBlock(flipped);
+    expect(r.culpritNode).toBe("Good");
+    expect(r.faultFrame).toBeUndefined();
+  });
+
   it("#2497 fingerprints on the FATAL region, so added context cannot shift the key", () => {
     // Same crash, different preceding log. If the fingerprint keyed on the
     // displayed block, these would differ and a crash already injected would be

--- a/src/services/crash-log.ts
+++ b/src/services/crash-log.ts
@@ -135,40 +135,43 @@ const MAX_CONTEXT_CHARS = 1200;
  * A blank line or an unindented log line ends the run — which is exactly what
  * separates a crash dump from whatever the server printed next.
  */
-function traceRunAround(region: string, index: number): { lines: string[]; start: number } {
+function firstStackFrames(region: string): { frames: { path: string; line?: string }[]; start: number } {
   const lines = region.split("\n");
-  const starts: number[] = [];
   let off = 0;
-  for (const l of lines) {
-    starts.push(off);
-    off += l.length + 1;
+  let runStart = 0;
+  let frames: { path: string; line?: string }[] = [];
+  let inRun = false;
+  for (const raw of lines) {
+    const lineStart = off;
+    off += raw.length + 1;
+    // A stack is a contiguous run of frame lines and their indented source
+    // lines. A blank or unindented log line ends it — which is exactly what
+    // separates a crash dump from whatever the server printed next.
+    const isStackLine = raw.trim() !== "" && (/^\s/.test(raw) || frameOnLine(raw) !== null);
+    if (isStackLine) {
+      if (!inRun) {
+        inRun = true;
+        runStart = lineStart;
+        frames = [];
+      }
+      const f = frameOnLine(raw);
+      if (f) frames.push(f);
+    } else {
+      if (inRun && frames.length > 0) return { frames, start: runStart };
+      inRun = false;
+    }
   }
-  let li = 0;
-  for (let i = 0; i < starts.length; i++) {
-    if (starts[i] <= index) li = i;
-    else break;
-  }
-  const belongs = (s: string | undefined): boolean => {
-    if (!s || !s.trim()) return false;
-    if (/^\s/.test(s)) return true;
-    return frameOnLine(s) !== null;
-  };
-  if (!belongs(lines[li])) return { lines: lines[li] === undefined ? [] : [lines[li]], start: starts[li] ?? 0 };
-  let a = li;
-  let b = li;
-  while (a - 1 >= 0 && belongs(lines[a - 1])) a--;
-  while (b + 1 < lines.length && belongs(lines[b + 1])) b++;
-  return { lines: lines.slice(a, b + 1), start: starts[a] ?? 0 };
+  return inRun && frames.length > 0 ? { frames, start: runStart } : { frames: [], start: 0 };
 }
 
 /**
  * Parse ONE line as a stack frame, or null if it is not one.
  *
- * Deliberately anchored at the start of the (trimmed) line. `ANY_FRAME` matches
- * anywhere, so an ordinary indented SOURCE line inside a traceback —
- * `raise RuntimeError("bad.py:99")` — otherwise reads as a frame in a file
- * called bad.py and becomes a false fault site, exonerating the node that
- * really crashed (gate r2 P1).
+ * Deliberately ANCHORED at the start of the (trimmed) line. An unanchored match
+ * hits anywhere, so an ordinary indented SOURCE line inside a traceback —
+ * `raise RuntimeError("bad.py:99")`, or `raise RuntimeError("custom_nodes/Fake/f.py:99")` —
+ * reads as a frame in a file that was never on the stack, and names a false
+ * fault site or a nonexistent culprit node (gate r2/r3 P1).
  */
 function frameOnLine(line: string): { path: string; line?: string } | null {
   const quoted = /^\s*File\s+["']([^"']+?\.py)["']?,?\s*line\s*(\d+)/i.exec(line);
@@ -213,18 +216,8 @@ function precedingContext(text: string, lineStart: number): string {
   return kept.join("\n").trim();
 }
 
-/**
- * Match a stack frame that points INTO a custom node. Handles both quoted
- * `File "...custom_nodes/<Node>/<file.py>", line 338` (Windows fatal-exception
- * dumps + Python tracebacks) and bare `custom_nodes/<Node>/<file.py>:338` forms,
- * with either path separator.
- */
-const CUSTOM_NODE_FRAME =
-  /custom_nodes[\\/]+([^\\/]+)[\\/]+([^\s"',]+?\.py)(?:["']?,?\s*line\s*(\d+)|:(\d+))/gi;
-
-/** Any `<file>:<line>` or `File "...", line N` frame — the fallback culprit. */
-const ANY_FRAME =
-  /(?:File\s*["']([^"']+?\.py)["']?,?\s*line\s*(\d+))|([^\s"',()]+?\.py):(\d+)/gi;
+/** The custom-node directory in a frame path: `custom_nodes/<NodeDir>/…`. */
+const CUSTOM_NODE_DIR = /custom_nodes[\\/]+([^\\/]+)/i;
 
 /**
  * True when a crash-signature hit sits inside a Python "Exception ignored in:"
@@ -323,63 +316,40 @@ export function parseCrashBlock(text: string): CrashParseResult {
   // (the top custom-node frame), not its caller loadmodel.
   const region = text.slice(lineStart);
   const mostRecentFirst = /most recent call first/i.test(region);
-  /** Collect every match of a global regex against the region. */
-  const collectAll = (source: string, flags: string): RegExpExecArray[] => {
-    const g = new RegExp(source, flags);
-    const out: RegExpExecArray[] = [];
-    let m: RegExpExecArray | null;
-    while ((m = g.exec(region)) !== null) {
-      out.push(m);
-      if (m.index === g.lastIndex) g.lastIndex++;
-    }
-    return out;
-  };
-  /** Pick the innermost match given the trace order. */
-  const pickInnermost = <T>(matches: T[]): T | undefined =>
-    matches.length === 0 ? undefined : mostRecentFirst ? matches[0] : matches[matches.length - 1];
-
   let culpritNode: string | undefined;
   let culpritFrame: string | undefined;
   let faultFrame: string | undefined;
-  const nodeMatch = pickInnermost(collectAll(CUSTOM_NODE_FRAME.source, CUSTOM_NODE_FRAME.flags));
-  if (nodeMatch) {
-    culpritNode = nodeMatch[1];
-    const file = baseName(nodeMatch[2]);
-    const line = nodeMatch[3] ?? nodeMatch[4];
-    culpritFrame = line ? `${file}:${line}` : file;
-    // Is the chosen custom-node frame actually the innermost frame? When a
-    // NON-custom-node frame sits deeper, the custom node is on the stack but not
-    // at the fault site, and naming it alone is a confident wrong answer (#2497).
-    // "Deeper" is direction-dependent: with most-recent-FIRST the innermost frame
-    // is the earliest match, with most-recent-LAST it is the latest.
-    //
-    // Answered only WITHIN the custom-node frame's own stack, because depth is
-    // only meaningful inside one: the region reaches the end of the tail, so an
-    // unrelated traceback printed after the restart would otherwise pose as the
-    // deeper frame and exonerate the node that actually crashed (gate r1 P1).
-    //
-    // Inside one stack the question needs no index arithmetic — the innermost
-    // frame is simply the first or last FRAME LINE, per that stack's own
-    // direction. If it is in a custom node, the node IS the fault site and the
-    // plain verdict stands.
-    const { lines: runLines, start: runStart } = traceRunAround(region, nodeMatch.index);
-    const frames = runLines.map(frameOnLine).filter((f): f is { path: string; line?: string } => f !== null);
-    if (frames.length > 0) {
-      const innerFirst = traceDirectionFor(region, runStart, mostRecentFirst);
-      const innermost = innerFirst ? frames[0] : frames[frames.length - 1];
-      if (!/custom_nodes/i.test(innermost.path)) {
+
+  // Blame is decided inside ONE stack: the first one after the fatal signature.
+  // The region reaches the end of the tail, so it also holds whatever the server
+  // printed after the restart, and every cross-stack question has a wrong answer
+  // available to it — a later dump's direction marker reverses this stack, and a
+  // later traceback's frames pose as this one's (gate r1/r2/r3 P1). Frames come
+  // from frameOnLine, so a `.py:N` inside a source line is not one.
+  const stack = firstStackFrames(region);
+  if (stack.frames.length > 0) {
+    const innerFirst = traceDirectionFor(region, stack.start, mostRecentFirst);
+    const ordered = innerFirst ? stack.frames : [...stack.frames].reverse();
+    const innermost = ordered[0];
+    // The deepest CUSTOM-NODE frame is the culprit when there is one — a custom
+    // node is the usual cause and the one thing the user can act on.
+    const nodeFrame = ordered.find((f) => CUSTOM_NODE_DIR.test(f.path));
+    if (nodeFrame) {
+      culpritNode = CUSTOM_NODE_DIR.exec(nodeFrame.path)?.[1];
+      const file = baseName(nodeFrame.path);
+      culpritFrame = nodeFrame.line ? `${file}:${nodeFrame.line}` : file;
+      // …but if a NON-custom-node frame is deeper still, the node is only on the
+      // stack, not at the fault site, and naming it alone is a confident wrong
+      // answer (#2497).
+      if (!CUSTOM_NODE_DIR.test(innermost.path)) {
         const f = baseName(innermost.path);
         faultFrame = innermost.line ? `${f}:${innermost.line}` : f;
       }
-    }
-  } else {
-    // Fallback: no custom-node frame — take the innermost ANY frame so the agent
-    // at least gets a file:line to look at (e.g. a core ComfyUI crash).
-    const anyMatch = pickInnermost(collectAll(ANY_FRAME.source, ANY_FRAME.flags));
-    if (anyMatch) {
-      const file = baseName(anyMatch[1] ?? anyMatch[3] ?? "");
-      const line = anyMatch[2] ?? anyMatch[4];
-      if (file) culpritFrame = line ? `${file}:${line}` : file;
+    } else {
+      // No custom-node frame — give the agent the innermost file:line anyway so
+      // it has something to look at (e.g. a core ComfyUI crash).
+      const file = baseName(innermost.path);
+      culpritFrame = innermost.line ? `${file}:${innermost.line}` : file;
     }
   }
 

--- a/src/services/crash-log.ts
+++ b/src/services/crash-log.ts
@@ -135,7 +135,7 @@ const MAX_CONTEXT_CHARS = 1200;
  * A blank line or an unindented log line ends the run — which is exactly what
  * separates a crash dump from whatever the server printed next.
  */
-function traceRunAround(region: string, index: number): string {
+function traceRunAround(region: string, index: number): { lines: string[]; start: number } {
   const lines = region.split("\n");
   const starts: number[] = [];
   let off = 0;
@@ -151,15 +151,46 @@ function traceRunAround(region: string, index: number): string {
   const belongs = (s: string | undefined): boolean => {
     if (!s || !s.trim()) return false;
     if (/^\s/.test(s)) return true;
-    // Non-global clone: ANY_FRAME carries /g, whose lastIndex would persist.
-    return new RegExp(ANY_FRAME.source, "i").test(s);
+    return frameOnLine(s) !== null;
   };
-  if (!belongs(lines[li])) return lines[li] ?? "";
+  if (!belongs(lines[li])) return { lines: lines[li] === undefined ? [] : [lines[li]], start: starts[li] ?? 0 };
   let a = li;
   let b = li;
   while (a - 1 >= 0 && belongs(lines[a - 1])) a--;
   while (b + 1 < lines.length && belongs(lines[b + 1])) b++;
-  return lines.slice(a, b + 1).join("\n");
+  return { lines: lines.slice(a, b + 1), start: starts[a] ?? 0 };
+}
+
+/**
+ * Parse ONE line as a stack frame, or null if it is not one.
+ *
+ * Deliberately anchored at the start of the (trimmed) line. `ANY_FRAME` matches
+ * anywhere, so an ordinary indented SOURCE line inside a traceback —
+ * `raise RuntimeError("bad.py:99")` — otherwise reads as a frame in a file
+ * called bad.py and becomes a false fault site, exonerating the node that
+ * really crashed (gate r2 P1).
+ */
+function frameOnLine(line: string): { path: string; line?: string } | null {
+  const quoted = /^\s*File\s+["']([^"']+?\.py)["']?,?\s*line\s*(\d+)/i.exec(line);
+  if (quoted) return { path: quoted[1], line: quoted[2] };
+  const bare = /^\s*([^\s"',()]+?\.py):(\d+)/i.exec(line);
+  if (bare) return { path: bare[1], line: bare[2] };
+  return null;
+}
+
+/**
+ * Which end of THIS stack is innermost, from the nearest direction marker ABOVE
+ * it. Read globally, a marker printed after the restart reverses an earlier
+ * crash stack and flips the answer (gate r2 P1); the marker that governs a stack
+ * is the closest one preceding it. Falls back to the caller's global reading
+ * when this stack has no marker of its own.
+ */
+function traceDirectionFor(region: string, runStart: number, fallback: boolean): boolean {
+  const before = region.slice(0, runStart);
+  const first = before.toLowerCase().lastIndexOf("most recent call first");
+  const last = before.toLowerCase().lastIndexOf("most recent call last");
+  if (first < 0 && last < 0) return fallback;
+  return first > last;
 }
 
 /**
@@ -292,12 +323,12 @@ export function parseCrashBlock(text: string): CrashParseResult {
   // (the top custom-node frame), not its caller loadmodel.
   const region = text.slice(lineStart);
   const mostRecentFirst = /most recent call first/i.test(region);
-  /** Collect every match of a global regex against `haystack` (default: region). */
-  const collectAll = (source: string, flags: string, haystack: string = region): RegExpExecArray[] => {
+  /** Collect every match of a global regex against the region. */
+  const collectAll = (source: string, flags: string): RegExpExecArray[] => {
     const g = new RegExp(source, flags);
     const out: RegExpExecArray[] = [];
     let m: RegExpExecArray | null;
-    while ((m = g.exec(haystack)) !== null) {
+    while ((m = g.exec(region)) !== null) {
       out.push(m);
       if (m.index === g.lastIndex) g.lastIndex++;
     }
@@ -322,21 +353,23 @@ export function parseCrashBlock(text: string): CrashParseResult {
     // "Deeper" is direction-dependent: with most-recent-FIRST the innermost frame
     // is the earliest match, with most-recent-LAST it is the latest.
     //
-    // Compared only WITHIN the custom-node frame's own stack: the region reaches
-    // the end of the tail, so an unrelated traceback printed after the restart
-    // would otherwise pose as the deeper frame and exonerate the node that
-    // actually crashed (gate r1 P1). Both sides are re-picked inside the run so
-    // the two indices are in the same coordinate space.
-    const run = traceRunAround(region, nodeMatch.index);
-    const runNode = pickInnermost(collectAll(CUSTOM_NODE_FRAME.source, CUSTOM_NODE_FRAME.flags, run));
-    const runAny = pickInnermost(collectAll(ANY_FRAME.source, ANY_FRAME.flags, run));
-    if (runAny && runNode) {
-      const path = runAny[1] ?? runAny[3] ?? "";
-      const deeper = mostRecentFirst ? runAny.index < runNode.index : runAny.index > runNode.index;
-      if (deeper && path && !/custom_nodes/i.test(path)) {
-        const f = baseName(path);
-        const l = runAny[2] ?? runAny[4];
-        faultFrame = l ? `${f}:${l}` : f;
+    // Answered only WITHIN the custom-node frame's own stack, because depth is
+    // only meaningful inside one: the region reaches the end of the tail, so an
+    // unrelated traceback printed after the restart would otherwise pose as the
+    // deeper frame and exonerate the node that actually crashed (gate r1 P1).
+    //
+    // Inside one stack the question needs no index arithmetic — the innermost
+    // frame is simply the first or last FRAME LINE, per that stack's own
+    // direction. If it is in a custom node, the node IS the fault site and the
+    // plain verdict stands.
+    const { lines: runLines, start: runStart } = traceRunAround(region, nodeMatch.index);
+    const frames = runLines.map(frameOnLine).filter((f): f is { path: string; line?: string } => f !== null);
+    if (frames.length > 0) {
+      const innerFirst = traceDirectionFor(region, runStart, mostRecentFirst);
+      const innermost = innerFirst ? frames[0] : frames[frames.length - 1];
+      if (!/custom_nodes/i.test(innermost.path)) {
+        const f = baseName(innermost.path);
+        faultFrame = innermost.line ? `${f}:${innermost.line}` : f;
       }
     }
   } else {

--- a/src/services/crash-log.ts
+++ b/src/services/crash-log.ts
@@ -28,6 +28,21 @@ export interface CrashParseResult {
   culpritNode?: string;
   /** The deepest `<file>:<line>` frame (within the culprit node when known). */
   culpritFrame?: string;
+  /**
+   * The innermost frame overall, set ONLY when a culprit custom node was named
+   * but that node is NOT where the fault actually happened — i.e. a deeper frame
+   * outside custom_nodes sits between it and the crash.
+   *
+   * The culprit search deliberately PREFERS a custom_nodes frame, because a
+   * custom node is the usual cause and the one thing the user can act on. But
+   * when the innermost frame is core ComfyUI or a site-packages kernel, the
+   * custom node may be doing nothing but wrapping the call — TiledDiffusion
+   * monkey-patches KSAMPLER_sample and passes straight through, so it appears on
+   * every sampler stack it is installed for, including a SageAttention CUDA
+   * fault it had no part in (#2497). Naming it unhedged sent the user to update
+   * an innocent node and re-run the same crashing graph.
+   */
+  faultFrame?: string;
   /** A stable identifier for THIS crash (signature head + culprit), so the caller
    *  can inject a given crash at most once and not re-surface it on every later
    *  resume. Also set for the `unreadable` case below — the injection site skips
@@ -85,6 +100,45 @@ function unreadableFingerprint(u: { path: string; reason: string }): string {
   return `unreadable:${u.path}:${u.reason.slice(0, 60)}`;
 }
 const MAX_BLOCK_CHARS = 4000; // the injected fatal block is capped to this
+
+/**
+ * How much of the log ABOVE the fatal signature to keep as CAUSAL CONTEXT.
+ *
+ * A native fault is frequently PRECEDED by the only line that names what
+ * actually failed, and the signature itself says nothing. ComfyUI's Sage path
+ * logs `Error running sage attention: CUDA error: an illegal memory access was
+ * encountered, using pytorch attention instead.` and only then aborts with a
+ * bare `Fatal Python error: Aborted` (#2497). Anchoring the block AT the
+ * signature dropped exactly that line, so the agent was handed an abort with no
+ * cause — and the nearest custom node on the stack took the blame for a fault in
+ * a pip-installed CUDA kernel.
+ *
+ * A bounded window, not a search for error-ish words: the useful line has no
+ * fixed wording, so any prose predicate would miss the next variant. Two caps so
+ * a log with enormously long lines can't blow the budget on one of them.
+ */
+const MAX_CONTEXT_LINES = 25;
+const MAX_CONTEXT_CHARS = 1200;
+
+/**
+ * The bounded run of lines immediately preceding `lineStart`, oldest-first.
+ * Returns "" when the signature is already at the top of the scanned tail.
+ */
+function precedingContext(text: string, lineStart: number): string {
+  if (lineStart <= 0) return "";
+  const lines = text.slice(0, lineStart).split("\n");
+  // slice(0, lineStart) ends ON the newline that opens the anchor line, so the
+  // split leaves a trailing "" that is not a real line.
+  if (lines[lines.length - 1] === "") lines.pop();
+  const kept: string[] = [];
+  let chars = 0;
+  for (let i = lines.length - 1; i >= 0 && kept.length < MAX_CONTEXT_LINES; i--) {
+    chars += lines[i].length + 1;
+    if (chars > MAX_CONTEXT_CHARS) break;
+    kept.unshift(lines[i]);
+  }
+  return kept.join("\n").trim();
+}
 
 /**
  * Match a stack frame that points INTO a custom node. Handles both quoted
@@ -168,7 +222,13 @@ export function parseCrashBlock(text: string): CrashParseResult {
   // The fatal block = from a little BEFORE the anchor (to include the header
   // line) to the end of the tail. Back up to the start of the anchor's line.
   const lineStart = text.lastIndexOf("\n", anchor) + 1;
-  let block = text.slice(lineStart).trim();
+  // What the block used to be, and STILL the basis for the fingerprint below:
+  // the dedupe key must not shift just because we now display more context.
+  const fatalRegion = text.slice(lineStart).trim();
+  // Prepend the bounded run of lines above the signature — for a whole class of
+  // faults the cause is stated there and nowhere else (#2497).
+  const context = precedingContext(text, lineStart);
+  let block = context ? `${context}\n${fatalRegion}` : fatalRegion;
   if (block.length > MAX_BLOCK_CHARS) {
     // Keep the HEAD of the block (the signature + the top frames matter most).
     // #809: "…(truncated)" said nothing actionable. Name the amount, the fixed cap, and
@@ -207,12 +267,30 @@ export function parseCrashBlock(text: string): CrashParseResult {
 
   let culpritNode: string | undefined;
   let culpritFrame: string | undefined;
+  let faultFrame: string | undefined;
   const nodeMatch = pickInnermost(collectAll(CUSTOM_NODE_FRAME.source, CUSTOM_NODE_FRAME.flags));
   if (nodeMatch) {
     culpritNode = nodeMatch[1];
     const file = baseName(nodeMatch[2]);
     const line = nodeMatch[3] ?? nodeMatch[4];
     culpritFrame = line ? `${file}:${line}` : file;
+    // Is the chosen custom-node frame actually the innermost frame? When a
+    // NON-custom-node frame sits deeper, the custom node is on the stack but not
+    // at the fault site, and naming it alone is a confident wrong answer (#2497).
+    // "Deeper" is direction-dependent: with most-recent-FIRST the innermost frame
+    // is the earliest match, with most-recent-LAST it is the latest.
+    const innermostAny = pickInnermost(collectAll(ANY_FRAME.source, ANY_FRAME.flags));
+    if (innermostAny) {
+      const path = innermostAny[1] ?? innermostAny[3] ?? "";
+      const deeper = mostRecentFirst
+        ? innermostAny.index < nodeMatch.index
+        : innermostAny.index > nodeMatch.index;
+      if (deeper && path && !/custom_nodes/i.test(path)) {
+        const f = baseName(path);
+        const l = innermostAny[2] ?? innermostAny[4];
+        faultFrame = l ? `${f}:${l}` : f;
+      }
+    }
   } else {
     // Fallback: no custom-node frame — take the innermost ANY frame so the agent
     // at least gets a file:line to look at (e.g. a core ComfyUI crash).
@@ -228,7 +306,11 @@ export function parseCrashBlock(text: string): CrashParseResult {
   // — not the whole block, which grows as the log appends post-restart — so the
   // caller can dedupe: inject a given crash once, never re-surface it on later
   // resumes.
-  const fingerprintBasis = `${culpritNode ?? ""}|${culpritFrame ?? ""}|${block
+  // Hashed over the FATAL region, never the displayed block: the block now also
+  // carries preceding log context, and keying on that would both shift every
+  // existing crash's key and let an unrelated line drifting into the window mint
+  // a fresh key for a crash already injected.
+  const fingerprintBasis = `${culpritNode ?? ""}|${culpritFrame ?? ""}|${fatalRegion
     .split("\n")
     .slice(0, 4)
     .join("\n")}`;
@@ -240,6 +322,7 @@ export function parseCrashBlock(text: string): CrashParseResult {
     fingerprint,
     ...(culpritNode ? { culpritNode } : {}),
     ...(culpritFrame ? { culpritFrame } : {}),
+    ...(faultFrame ? { faultFrame } : {}),
   };
 }
 
@@ -324,6 +407,26 @@ export function formatCrashNote(result: CrashParseResult): string | null {
     );
   }
   if (!result.fatal) return null;
+  // A custom node was named, but a deeper NON-custom-node frame is where it
+  // actually died: report the fault site first and the node as a possibility,
+  // not as a verdict. Sending the user to update a node that only wraps the call
+  // costs them a re-run of the graph that just killed the server (#2497).
+  if (result.culpritNode && result.faultFrame) {
+    return (
+      "⚠️ ComfyUI crashed during your last action (a native fault captured in its log). " +
+      "Fatal log:\n" +
+      "```\n" +
+      result.block +
+      "\n```\n" +
+      `The innermost frame is ${result.faultFrame}, which is NOT inside a custom node — so the fault ` +
+      `happened in ComfyUI core or a native/pip library it called. ${result.culpritNode}` +
+      `${result.culpritFrame ? ` (${result.culpritFrame})` : ""} is the nearest custom node on the stack, ` +
+      "but it may only be wrapping the call and be blameless. Read the log lines ABOVE the signature — " +
+      "for this class of fault the failing subsystem is usually named there and nowhere else — and treat " +
+      `${result.faultFrame} as the fault site. Do NOT just re-run the same graph, and do not update ` +
+      `${result.culpritNode} on the strength of this trace alone.`
+    );
+  }
   const culprit = result.culpritNode
     ? `Most likely culprit custom node: ${result.culpritNode}${
         result.culpritFrame ? ` (${result.culpritFrame})` : ""

--- a/src/services/crash-log.ts
+++ b/src/services/crash-log.ts
@@ -121,6 +121,48 @@ const MAX_CONTEXT_LINES = 25;
 const MAX_CONTEXT_CHARS = 1200;
 
 /**
+ * The contiguous stack that the frame at `index` belongs to.
+ *
+ * The culprit region runs from the signature to the END of the tail, which after
+ * a restart also holds log APPENDED post-crash. Comparing frame depth across
+ * that whole span lets a later, unrelated traceback supply the "innermost"
+ * frame: a segfault in custom_nodes/GoodNode followed by an ordinary
+ * comfy/server.py traceback would name server.py the fault site and tell the
+ * user NOT to update the node that actually crashed (gate r1 P1). Depth is only
+ * meaningful WITHIN one stack, so the comparison is bounded to one.
+ *
+ * A stack line is an indented frame/source line, or a bare `file.py:12` form.
+ * A blank line or an unindented log line ends the run — which is exactly what
+ * separates a crash dump from whatever the server printed next.
+ */
+function traceRunAround(region: string, index: number): string {
+  const lines = region.split("\n");
+  const starts: number[] = [];
+  let off = 0;
+  for (const l of lines) {
+    starts.push(off);
+    off += l.length + 1;
+  }
+  let li = 0;
+  for (let i = 0; i < starts.length; i++) {
+    if (starts[i] <= index) li = i;
+    else break;
+  }
+  const belongs = (s: string | undefined): boolean => {
+    if (!s || !s.trim()) return false;
+    if (/^\s/.test(s)) return true;
+    // Non-global clone: ANY_FRAME carries /g, whose lastIndex would persist.
+    return new RegExp(ANY_FRAME.source, "i").test(s);
+  };
+  if (!belongs(lines[li])) return lines[li] ?? "";
+  let a = li;
+  let b = li;
+  while (a - 1 >= 0 && belongs(lines[a - 1])) a--;
+  while (b + 1 < lines.length && belongs(lines[b + 1])) b++;
+  return lines.slice(a, b + 1).join("\n");
+}
+
+/**
  * The bounded run of lines immediately preceding `lineStart`, oldest-first.
  * Returns "" when the signature is already at the top of the scanned tail.
  */
@@ -250,12 +292,12 @@ export function parseCrashBlock(text: string): CrashParseResult {
   // (the top custom-node frame), not its caller loadmodel.
   const region = text.slice(lineStart);
   const mostRecentFirst = /most recent call first/i.test(region);
-  /** Collect every match of a global regex against the region. */
-  const collectAll = (source: string, flags: string): RegExpExecArray[] => {
+  /** Collect every match of a global regex against `haystack` (default: region). */
+  const collectAll = (source: string, flags: string, haystack: string = region): RegExpExecArray[] => {
     const g = new RegExp(source, flags);
     const out: RegExpExecArray[] = [];
     let m: RegExpExecArray | null;
-    while ((m = g.exec(region)) !== null) {
+    while ((m = g.exec(haystack)) !== null) {
       out.push(m);
       if (m.index === g.lastIndex) g.lastIndex++;
     }
@@ -279,15 +321,21 @@ export function parseCrashBlock(text: string): CrashParseResult {
     // at the fault site, and naming it alone is a confident wrong answer (#2497).
     // "Deeper" is direction-dependent: with most-recent-FIRST the innermost frame
     // is the earliest match, with most-recent-LAST it is the latest.
-    const innermostAny = pickInnermost(collectAll(ANY_FRAME.source, ANY_FRAME.flags));
-    if (innermostAny) {
-      const path = innermostAny[1] ?? innermostAny[3] ?? "";
-      const deeper = mostRecentFirst
-        ? innermostAny.index < nodeMatch.index
-        : innermostAny.index > nodeMatch.index;
+    //
+    // Compared only WITHIN the custom-node frame's own stack: the region reaches
+    // the end of the tail, so an unrelated traceback printed after the restart
+    // would otherwise pose as the deeper frame and exonerate the node that
+    // actually crashed (gate r1 P1). Both sides are re-picked inside the run so
+    // the two indices are in the same coordinate space.
+    const run = traceRunAround(region, nodeMatch.index);
+    const runNode = pickInnermost(collectAll(CUSTOM_NODE_FRAME.source, CUSTOM_NODE_FRAME.flags, run));
+    const runAny = pickInnermost(collectAll(ANY_FRAME.source, ANY_FRAME.flags, run));
+    if (runAny && runNode) {
+      const path = runAny[1] ?? runAny[3] ?? "";
+      const deeper = mostRecentFirst ? runAny.index < runNode.index : runAny.index > runNode.index;
       if (deeper && path && !/custom_nodes/i.test(path)) {
         const f = baseName(path);
-        const l = innermostAny[2] ?? innermostAny[4];
+        const l = runAny[2] ?? runAny[4];
         faultFrame = l ? `${f}:${l}` : f;
       }
     }


### PR DESCRIPTION
Partially addresses #2497.

The crash itself is **upstream** — SageAttention's CUDA kernel took an illegal memory access during a 192-frame MiniMax H3 run, and ComfyUI aborted. We cannot fix that kernel. What we *can* fix is that our own crash-recovery note told the reporter the wrong thing about it.

### What the agent was actually handed

Running the reporter's log through `parseCrashBlock` on `origin/main`:

```
Most likely culprit custom node: ComfyUI-TiledDiffusion (utils.py:121).
Update or fix that node before retrying — do NOT just re-run the same graph …
```

Two failures, both ours:

**1. The block dropped the only line that named the cause.** It is sliced from the fatal signature onward, and `Fatal Python error: Aborted` carries no information. ComfyUI had logged

```
[ERROR] Error running sage attention: CUDA error: an illegal memory access was encountered, using pytorch attention instead.
```

immediately *above* the signature — and that line was cut.

**2. It blamed a pass-through node.** `ComfyUI-TiledDiffusion` monkey-patches `KSAMPLER_sample` and returns `orig_fn(*args, **kwargs)`, so it lands on every sampler stack it is installed for. The innermost frame was `attention.py:512` in ComfyUI core. Following this advice costs a re-run of the graph that just killed the server.

### The change

- A bounded window of preceding lines (25 lines / 1200 chars) now rides along with the block. Deliberately a **window, not a search for error-ish words** — the useful line has no fixed wording, so any prose predicate would miss the next variant.
- `faultFrame` is set when the innermost frame is not in a custom node, and the note then names the fault site and says the node may be blameless rather than ordering an update.
- **Blame is decided inside one stack — the first after the signature.** This came out of gate review, and it subsumes the original defect. The scan region runs to the end of the tail, which after a restart also holds whatever the server printed next, so every cross-stack question had a wrong answer available to it: a later dump's direction marker reversed this stack, and a later traceback's frames posed as this one's.
- Frames are parsed by `frameOnLine`, **anchored at the start of the line**. An unanchored match reads `raise RuntimeError("custom_nodes/Fake/f.py:99")` as a frame and names a node that was never on the stack.

`CUSTOM_NODE_FRAME`, `ANY_FRAME` and `collectAll` became unreachable and are removed rather than left as a second, laxer parser. The fingerprint stays anchored on the fatal region, so dedupe keys do not shift for crashes already injected.

### Gate

Four rounds; five P1s found and fixed, every one a false-blame path:

| Round | Finding | Fix |
|---|---|---|
| r1 | post-restart log posed as a deeper frame, exonerating a node that did segfault | bound the comparison to one stack |
| r2 | `.py:N` inside a source line read as a frame | anchor `frameOnLine` |
| r2 | direction read from the whole tail, reversing an earlier stack | nearest marker above the stack |
| r3 | culprit used the tail-wide direction → wrong node | culprit decided in the same stack |
| r3 | `custom_nodes/…` inside a source string → nonexistent node | same anchoring |

r4: **SHIP**.

### Verification

`src/__tests__/crash-log.test.ts` — 30 passed (19 before). Full suite in a clean `npm ci` tree outside `.claude/` (which `vitest.config.ts` excludes, so a run from inside the worktree collects zero files and looks green): **701 files, 13016 passed, 6 skipped, 0 failed**. `tsc --noEmit` exit 0.

Differential mutation, each applied alone with the needle count asserted at 1 — every one killed only its own pin:

| Mutation | Killed | Survived |
|---|---|---|
| remove the context prepend | 2 | 23 |
| disable `faultFrame` | 2 | 23 |
| drop the `custom_nodes` path guard | 2 | 23 |
| fingerprint the displayed block | 1 | 24 |
| defeat the trace-run bound | 1 | 25 |
| un-anchor the frame match | 1 | 27 |
| use the global direction | 1 | 27 |

The path-guard mutation is the load-bearing one: it kills the WanVideoWrapper regression pin *and* the unhedged-verdict pin, which is what shows the hedge does not over-fire on the case this module was built for.

### Not addressed here

The Sage/TiledDiffusion interaction, and the reporter's question about an automatic attention downgrade — that would be a new feature and is parked under the freeze. Diagnosis posted on the issue; #2497 stays open for it.
