### PR TITLE
fix: direct-clone local git installs when Manager queue is unavailable

### DIFF
--- a/src/__tests__/services/apply-manifest-partial-queue-status.test.ts
+++ b/src/__tests__/services/apply-manifest-partial-queue-status.test.ts
@@ -31,6 +31,7 @@ import {
   clearManifestPartialLeftover,
   describeManifestSource,
   getManifestPartialLeftover,
+  recordManifestPartial,
 } from "../../services/manifest-partial.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import {
@@ -178,5 +179,41 @@ describe("apply_manifest leftover + panel_node_queue_status (#1699)", () => {
     const { parsed } = await queueStatus();
     expect(parsed?.queue_complete_for_apply_manifest).toBeUndefined();
     expect(parsed?.apply_manifest_partial).toBeUndefined();
+  });
+
+  it("retains submitted UNKNOWN entries when no custom_node was left unsubmitted (#1129)", async () => {
+    const id = "https://github.com/example/ambiguous-pack";
+    const partial = buildManifestPartial({
+      source: "this inline manifest",
+      notStarted: [],
+      stillInstalling: [id],
+      outcomeUnknown: [id],
+    });
+
+    expect(partial).not.toBeNull();
+    expect(partial).toMatchObject({
+      not_started: [],
+      still_installing: [id],
+      outcome_unknown: [id],
+    });
+    expect(partial?.message).toMatch(/outcome is UNKNOWN/i);
+    expect(partial?.message).toMatch(/no local direct-install fallback is authorized/i);
+
+    recordManifestPartial(partial);
+    expect(getManifestPartialLeftover()).toMatchObject({
+      not_started: [],
+      still_installing: [id],
+      outcome_unknown: [id],
+    });
+
+    const { text, parsed } = await queueStatus();
+    expect(parsed?.queue_complete_for_apply_manifest).toBe(false);
+    expect(parsed?.apply_manifest_partial).toMatchObject({
+      not_started: [],
+      still_installing: [id],
+      outcome_unknown: [id],
+    });
+    expect(text).toMatch(/UNKNOWN/i);
+    expect(text).toMatch(/no local direct-install fallback is authorized/i);
   });
 });

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -107,7 +107,11 @@ vi.mock("../../comfyui/client.js", () => ({
 // They reach `cloneCustomNodeFallback` from two different call sites, and a
 // guard on only one of them is a guard that is not there. ────────────────────
 const http = vi.hoisted(() => ({
-  mode: "refuse-enqueue" as "refuse-enqueue" | "accept-enqueue" | "manager-absent",
+  mode: "refuse-enqueue" as
+    | "refuse-enqueue"
+    | "accept-enqueue"
+    | "manager-absent"
+    | "manager-unavailable",
   calls: [] as string[],
 }));
 vi.mock("../../comfyui/fetch.js", () => {
@@ -129,6 +133,15 @@ vi.mock("../../comfyui/fetch.js", () => {
         return new Response("missing", { status: 404, statusText: "Not Found" });
       }
       const { pathname } = new URL(url);
+      if (
+        http.mode === "manager-unavailable" &&
+        (pathname === "/v2/manager/queue/status" || pathname === "/manager/queue/status")
+      ) {
+        // H3/Desktop can answer these routes without a usable Manager queue
+        // payload. This is the #1129 path, not the already-shipped both-404
+        // Manager-absent path.
+        return new Response("", { status: 200 });
+      }
       if (pathname === "/manager/queue/install") return json({ ui_id: "queued" });
       if (pathname === "/manager/queue/start") return json({});
       if (pathname === "/manager/queue/status") {
@@ -301,6 +314,39 @@ describe("#1765 — install_custom_node must not write into an install this sess
   it("asks the running server which install it is — the shipped path never did", async () => {
     await install({ id: REPO, source: "git" });
     expect(live.statsCalls).toBeGreaterThan(0);
+  });
+
+  it("#1129 clones to the verified live root when Manager queue status is unavailable", async () => {
+    http.mode = "manager-unavailable";
+    resetManagerApiCache("#1129 manager-unavailable regression");
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
+    expect(existsSync(join(SAVED_DEFAULT, PACK_DIR))).toBe(false);
+    expect(http.calls.some((url) => url.endsWith("/manager/queue/install"))).toBe(false);
+    expect(ok).toMatchObject({
+      details: { managerStatus: { manager_unavailable: true } },
+    });
+  });
+
+  it("#1129 serializes concurrent unavailable-Manager git installs", async () => {
+    http.mode = "manager-unavailable";
+    resetManagerApiCache("#1129 concurrent manager-unavailable regression");
+
+    const [first, second] = await Promise.all([
+      install({ id: REPO, source: "git" }),
+      install({ id: REPO, source: "git" }),
+    ]);
+
+    expect(first.error).toBeUndefined();
+    expect(second.error).toBeUndefined();
+    expect(first.ok).toMatchObject({ mechanism: "git-clone" });
+    expect(second.ok).toMatchObject({ mechanism: "git-clone" });
+    expect(git.calls.filter((call) => call[0] === "git" && call[1] === "clone")).toHaveLength(1);
+    expect(existsSync(join(CONNECTED, PACK_DIR))).toBe(true);
   });
 
   it("clones normally when the configured root IS the connected install", async () => {

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -186,7 +186,7 @@ function stubServer(opts: {
     } else {
       if (path === "/v2/manager/queue/task") {
         const status = opts.taskStatus?.(url) ?? 200;
-        return new Response(status === 200 ? "" : String(status), { status });
+        return status === 200 ? jsonResponse({ accepted: true }) : new Response(String(status), { status });
       }
       // v4 registers install_model but validates a ModelMetadata envelope — the
       // 3.x-shaped body the v2-batch dialect sends is rejected 400 (#646).

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -1642,7 +1642,7 @@ describe("applyManifest", () => {
     }
   });
 
-  it("trims git manifest identity before late local-fallback classification", async () => {
+  it("trims git manifest identity before late-ambiguity classification", async () => {
     const prevBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
     process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";
     const paddedId = "  https://github.com/example/local-fallback-pack  ";
@@ -1654,12 +1654,14 @@ describe("applyManifest", () => {
       });
 
       expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 2 });
-      expect(result.results[0].message).toMatch(/local direct-install fallback/i);
+      expect(result.results[0].message).toMatch(/outcome is UNKNOWN/i);
+      expect(result.results[0].message).toMatch(/no local direct-install fallback is authorized/i);
       expect(result.partial).toMatchObject({
         not_started: ["next-pack"],
         still_installing: [paddedId],
-        local_fallback_pending: [paddedId],
+        outcome_unknown: [paddedId],
       });
+      expect(result.partial).not.toHaveProperty("local_fallback_pending");
       expect(installCustomNodeMock).toHaveBeenCalledWith(
         expect.objectContaining({
           id: "https://github.com/example/local-fallback-pack",

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -971,12 +971,15 @@ describe("applyManifest", () => {
       ["pip", "install", "--python", `${codeRoot}/python`, "numpy"],
       expect.objectContaining({ cwd: codeRoot }),
     );
-    expect(installCustomNodeMock).toHaveBeenCalledWith({
+    expect(installCustomNodeMock).toHaveBeenCalledWith(expect.objectContaining({
       id: "split-root-pack",
       comfyuiPath: dataRoot,
       managerBase: "http://127.0.0.1:8188",
       targetGeneration: 0,
-    });
+    }));
+    expect(installCustomNodeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ onLocalFallback: expect.any(Function) }),
+    );
     expect(installInterpreterMock).not.toHaveBeenCalledWith(dataRoot);
   });
 
@@ -1601,6 +1604,44 @@ describe("applyManifest", () => {
     }
   });
 
+  it("does not call a local fallback queued server-side when the node budget wins", async () => {
+    const prevBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+    process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";
+    installCustomNodeMock.mockImplementationOnce(
+      (opts: { onLocalFallback?: () => void }) => {
+        opts.onLocalFallback?.();
+        return new Promise(() => {});
+      },
+    );
+
+    try {
+      const result = await applyManifest({
+        manifest: {
+          custom_nodes: [
+            "https://github.com/example/local-fallback-pack",
+            "next-pack",
+          ],
+        },
+      });
+
+      expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 2 });
+      expect(result.results[0].message).toMatch(/local direct-install fallback/i);
+      expect(result.results[0].message).toMatch(/NOT queued server-side/i);
+      expect(result.results[0].message).toMatch(/NOT on the ComfyUI-Manager queue/i);
+      expect(result.results[0].message).not.toMatch(/poll panel_node_queue_status/i);
+      expect(result.partial).toMatchObject({
+        not_started: ["next-pack"],
+        still_installing: [],
+      });
+      expect(installCustomNodeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ onLocalFallback: expect.any(Function) }),
+      );
+    } finally {
+      if (prevBudget === undefined) delete process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+      else process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = prevBudget;
+    }
+  });
+
   it("clears leftover not-started names when a later apply submits everything (#1699)", async () => {
     const prevBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
     process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";
@@ -1914,11 +1955,11 @@ describe("applyManifest", () => {
       expect(byAction.pip.status).toBe("skipped");
       expect(execFileSyncMock).not.toHaveBeenCalled();
       // custom_nodes still go through the Manager HTTP install (remote-ok).
-      expect(installCustomNodeMock).toHaveBeenCalledWith({
+      expect(installCustomNodeMock).toHaveBeenCalledWith(expect.objectContaining({
         id: "x",
         managerBase: "http://127.0.0.1:8188",
         targetGeneration: 0,
-      });
+      }));
       // models route through installModelViaManager, NOT the local downloadModel.
       expect(downloadModelMock).not.toHaveBeenCalled();
       expect(installModelViaManagerMock).toHaveBeenCalledWith({

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -1642,6 +1642,36 @@ describe("applyManifest", () => {
     }
   });
 
+  it("trims git manifest identity before late local-fallback classification", async () => {
+    const prevBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+    process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";
+    const paddedId = "  https://github.com/example/local-fallback-pack  ";
+    installCustomNodeMock.mockReturnValueOnce(new Promise(() => {}));
+
+    try {
+      const result = await applyManifest({
+        manifest: { custom_nodes: [paddedId, "next-pack"] },
+      });
+
+      expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 2 });
+      expect(result.results[0].message).toMatch(/local direct-install fallback/i);
+      expect(result.partial).toMatchObject({
+        not_started: ["next-pack"],
+        still_installing: [paddedId],
+        local_fallback_pending: [paddedId],
+      });
+      expect(installCustomNodeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "https://github.com/example/local-fallback-pack",
+          localCloneFallback: "verified-only",
+        }),
+      );
+    } finally {
+      if (prevBudget === undefined) delete process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+      else process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = prevBudget;
+    }
+  });
+
   it("clears leftover not-started names when a later apply submits everything (#1699)", async () => {
     const prevBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
     process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -245,6 +245,8 @@ function stubFetch(opts: {
   queueOpStatus?: number;
   /** Exact body returned by the Manager queue operation when queueOpStatus is set. */
   queueOpBody?: string;
+  /** Return an empty successful body for a custom-node install enqueue. */
+  queueOpEmpty?: boolean;
   /** Body for `https://api.comfy.org/nodes/:id` (registry-zip empty-pack fallback). */
   registryDetails?: unknown;
   /** Body for v4 per-task queue history lookups. */
@@ -332,6 +334,16 @@ function stubFetch(opts: {
               "A security error has occurred. Please check the terminal logs",
             { status: opts.queueOpStatus },
           );
+        }
+        if (opts.queueOpEmpty && isInstallOp) {
+          opts.onQueue?.();
+          return new Response("", { status: 200 });
+        }
+        // A successful install enqueue normally has an acknowledgement body;
+        // keep that distinct from the adversarial empty-2xx race fixture.
+        if (isInstallOp) {
+          opts.onQueue?.();
+          return jsonResponse({ accepted: true });
         }
         opts.onQueue?.();
       }
@@ -794,7 +806,28 @@ describe("node-management service", () => {
       ).toBeDefined();
     });
 
-    it("invalidates a warm dialect cache when enqueue/status routes become empty", async () => {
+    it("fails closed when Manager accepts a git enqueue with an empty success body", async () => {
+      const { calls } = stubFetch({ installedBody: {}, queueOpEmpty: true });
+
+      await expect(
+        installCustomNode({
+          id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+          source: "git",
+        }),
+      ).rejects.toMatchObject({
+        details: { kind: "manager-enqueue-empty-success" },
+      });
+
+      // The successful empty enqueue is ambiguous: do not start/poll it and
+      // never race a possible Manager task with a local clone.
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(false);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeUndefined();
+    });
+
+    it("fails closed when a warm dialect cache later returns an empty queue status", async () => {
       const fetchOptions = {
         managerQueueStatus: undefined as "manager-unavailable" | undefined,
       };
@@ -825,16 +858,21 @@ describe("node-management service", () => {
       const res = await installCustomNode({
         id: "https://github.com/teskor-hub/comfyui-teskors-utils",
         source: "git",
-      });
+      }).catch((err) => err);
 
-      expect(res.mechanism).toBe("git-clone");
-      expect(res.message).toMatch(/queue\/status surface was unavailable/);
-      expect(res.message).toMatch(/before any install task was submitted/);
+      expect(res).toMatchObject({
+        details: { kind: "manager-queue-empty-status" },
+      });
+      expect(res.message).toMatch(/outcome is UNKNOWN/);
+      expect(res.message).toMatch(/no local fallback is authorized/);
       expect(
         mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
-      ).toBeDefined();
-      // The first empty status must invalidate the warm v2 classification and
-      // probe the alternate dialect before authorizing the local fallback.
+      ).toBeUndefined();
+      // The task was accepted with a non-empty acknowledgement, then status
+      // went empty. Reclassification is still attempted, but cannot authorize
+      // a clone after the enqueue has happened.
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
       expect(calls.some((c) => c.url.endsWith("/manager/queue/status"))).toBe(true);
     });
 
@@ -3655,6 +3693,9 @@ describe("node-management service", () => {
           }
           if (path === "/customnode/installed") {
             return jsonResponse(opts.installedBody ?? {});
+          }
+          if (path === "/manager/queue/install") {
+            return jsonResponse({ accepted: true });
           }
           return new Response("", { status: 200 });
         },

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -253,6 +253,7 @@ function stubFetch(opts: {
   managerQueueStatus?:
     | "absent"
     | "manager-unavailable"
+    | "manager-unavailable-explicit"
     | "malformed"
     | "timeout"
     | "server-error"
@@ -288,8 +289,11 @@ function stubFetch(opts: {
           // payload exists. It is not a frontend HTML catchall.
           return new Response("", { status: 200 });
         }
+        if (opts.managerQueueStatus === "manager-unavailable-explicit") {
+          return jsonResponse({ error: "ComfyUI-Manager not reachable" });
+        }
         if (opts.managerQueueStatus === "malformed") {
-          return new Response("<!doctype html>", { status: 200 });
+          return new Response("<!doctype html><title>ComfyUI-Manager unavailable</title>", { status: 200 });
         }
         if (opts.managerQueueStatus === "timeout") {
           throw new Error("request timed out");
@@ -813,6 +817,33 @@ describe("node-management service", () => {
       expect(res.mechanism).toBe("git-clone");
       expect(res.message).toMatch(/queue\/status surface was unavailable/);
       expect(res.message).toMatch(/before any install task was submitted/);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeDefined();
+    });
+
+    it("#1129 accepts repeated explicit Manager-unavailable responses", async () => {
+      stubFetch({ managerQueueStatus: "manager-unavailable-explicit" });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        source: "git",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/queue\/status surface was unavailable/);
       expect(
         mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
       ).toBeDefined();

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -258,6 +258,8 @@ function stubFetch(opts: {
   queueOpEmpty?: boolean;
   /** Return JSON null for a custom-node install enqueue. */
   queueOpNull?: boolean;
+  /** Delay a custom-node install enqueue response to exercise apply_manifest's late race. */
+  queueOpDelayMs?: number;
   /** Body for `https://api.comfy.org/nodes/:id` (registry-zip empty-pack fallback). */
   registryDetails?: unknown;
   /** Body for v4 per-task queue history lookups. */
@@ -347,6 +349,9 @@ function stubFetch(opts: {
               "A security error has occurred. Please check the terminal logs",
             { status: opts.queueOpStatus },
           );
+        }
+        if (opts.queueOpDelayMs && isInstallOp) {
+          await new Promise<void>((resolve) => setTimeout(resolve, opts.queueOpDelayMs));
         }
         if (opts.queueOpNull && isInstallOp) {
           opts.onQueue?.();
@@ -1014,15 +1019,18 @@ describe("node-management service", () => {
           item: "https://github.com/teskor-hub/comfyui-teskors-utils",
           status: "pending",
         });
-        expect(first.message).toMatch(/still resolving/i);
-        expect(first.message).toMatch(/Manager queue or.*local direct-install fallback/i);
+        expect(first.message).toMatch(/outcome is UNKNOWN/i);
+        expect(first.message).toMatch(/no local direct-install fallback is authorized/i);
+        expect(first.message).not.toMatch(/may transition.*local direct-install fallback/i);
         expect(first.message).not.toMatch(/poll panel_node_queue_status/i);
         expect(result.partial).toMatchObject({
           not_started: ["next-pack"],
           still_installing: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
-          local_fallback_pending: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
+          outcome_unknown: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
         });
-        expect(result.partial?.message).toMatch(/route may remain on the Manager queue/i);
+        expect(result.partial).not.toHaveProperty("local_fallback_pending");
+        expect(result.partial?.message).toMatch(/outcome is UNKNOWN/i);
+        expect(result.partial?.message).toMatch(/no local direct-install fallback is authorized/i);
         expect(result.partial?.message).not.toMatch(/ON the queue, pollable/i);
 
         // This is the production late transition: the queue drains after the
@@ -1038,6 +1046,58 @@ describe("node-management service", () => {
         expect(
           mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
         ).toBeDefined();
+      } finally {
+        if (previousBudget === undefined) delete process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+        else process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = previousBudget;
+      }
+    });
+
+    it("does not authorize a late local clone when Manager enqueue eventually returns null (#1129)", async () => {
+      const previousBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+      process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";
+      const { calls } = stubFetch({
+        installedBody: {},
+        queueOpNull: true,
+        queueOpDelayMs: 100,
+      });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      try {
+        const result = await applyManifest({
+          manifest: {
+            custom_nodes: [
+              "https://github.com/teskor-hub/comfyui-teskors-utils",
+              "next-pack",
+            ],
+          },
+        });
+
+        expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 2 });
+        expect(result.results[0].message).toMatch(/outcome is UNKNOWN/i);
+        expect(result.results[0].message).toMatch(/no local direct-install fallback is authorized/i);
+        expect(result.partial).toMatchObject({
+          not_started: ["next-pack"],
+          still_installing: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
+          outcome_unknown: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
+        });
+        expect(result.partial).not.toHaveProperty("local_fallback_pending");
+        expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+
+        await new Promise<void>((resolve) => setTimeout(resolve, 130));
+        expect(cloned).toBe(false);
+        expect(
+          mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+        ).toBeUndefined();
       } finally {
         if (previousBudget === undefined) delete process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
         else process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = previousBudget;

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -794,6 +794,50 @@ describe("node-management service", () => {
       ).toBeDefined();
     });
 
+    it("invalidates a warm dialect cache when enqueue/status routes become empty", async () => {
+      const fetchOptions = {
+        managerQueueStatus: undefined as "manager-unavailable" | undefined,
+      };
+      const { calls } = stubFetch(fetchOptions);
+
+      // Warm the production dialect cache through a real Manager operation.
+      await installModelViaManager({
+        name: "warmup.safetensors",
+        url: "https://example.com/warmup.safetensors",
+        filename: "warmup.safetensors",
+        type: "checkpoints",
+      });
+      fetchOptions.managerQueueStatus = "manager-unavailable";
+
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        source: "git",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/queue\/status surface was unavailable/);
+      expect(res.message).toMatch(/before any install task was submitted/);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeDefined();
+      // The first empty status must invalidate the warm v2 classification and
+      // probe the alternate dialect before authorizing the local fallback.
+      expect(calls.some((c) => c.url.endsWith("/manager/queue/status"))).toBe(true);
+    });
+
     it("#1129 falls back when both queue-status dialects repeatedly answer empty", async () => {
       stubFetch({ managerQueueStatus: "manager-unavailable" });
       let cloned = false;

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -227,6 +227,7 @@ function stubFetch(opts: {
   /** Shape of both Manager queue/status dialect probes for fallback tests. */
   managerQueueStatus?:
     | "absent"
+    | "manager-unavailable"
     | "malformed"
     | "timeout"
     | "server-error"
@@ -256,6 +257,11 @@ function stubFetch(opts: {
       if (path === "/v2/manager/queue/status" || path === "/manager/queue/status") {
         if (opts.managerQueueStatus === "absent") {
           return new Response("missing", { status: 404 });
+        }
+        if (opts.managerQueueStatus === "manager-unavailable") {
+          // H3/Desktop shape: the route answers, but no Manager queue/status
+          // payload exists. It is not a frontend HTML catchall.
+          return new Response("", { status: 200 });
         }
         if (opts.managerQueueStatus === "malformed") {
           return new Response("<!doctype html>", { status: 200 });
@@ -754,6 +760,34 @@ describe("node-management service", () => {
       expect(res.mechanism).toBe("git-clone");
       expect(res.message).toMatch(/confirmed absent/);
       expect(res.message).toMatch(/both queue\/status dialects returned HTTP 404/);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeDefined();
+    });
+
+    it("#1129 falls back when both queue-status dialects repeatedly answer empty", async () => {
+      stubFetch({ managerQueueStatus: "manager-unavailable" });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        source: "git",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/queue\/status surface was unavailable/);
+      expect(res.message).toMatch(/before any install task was submitted/);
       expect(
         mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
       ).toBeDefined();

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -179,10 +179,35 @@ import {
   NodeManagementError,
 } from "../../services/node-management.js";
 import { ProcessControlError, ValidationError } from "../../utils/errors.js";
+import { withPanelMutationLock } from "../../services/panel-pin-guard.js";
 
 const mockedExec = vi.mocked(execFileSync);
 const mockedExists = vi.mocked(existsSync);
 let priorComfyuiPathEnv: string | undefined;
+
+/** Hold the shared writer lock so a production install call can prove which
+ * work is actually inside its critical section. */
+function holdPanelMutationLock() {
+  let releaseLock!: () => void;
+  let markReady!: () => void;
+  const ready = new Promise<void>((resolve) => {
+    markReady = resolve;
+  });
+  const done = withPanelMutationLock(async () => {
+    await new Promise<void>((resolve) => {
+      releaseLock = resolve;
+      markReady();
+    });
+  });
+  return { ready, done, release: () => releaseLock() };
+}
+
+async function settlesBefore<T>(promise: Promise<T>, timeoutMs = 500): Promise<boolean> {
+  return Promise.race([
+    promise.then(() => true, () => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+  ]);
+}
 
 // The product builds these paths with node:path (join), so they use the
 // platform separator (backslashes on Windows). Build the expected values the
@@ -2166,6 +2191,34 @@ describe("node-management service", () => {
       expect(taskOf(calls, "install").params).toMatchObject({ id: "my-pack" });
     });
 
+    it("does not wait on the local writer lock while unavailable comfy-cli falls back to Manager", async () => {
+      mockedExists.mockReturnValue(false);
+      let markManagerReached!: () => void;
+      const managerReached = new Promise<void>((resolve) => {
+        markManagerReached = resolve;
+      });
+      const { calls } = stubFetch({
+        installedBody: {
+          "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true },
+        },
+        onQueue: markManagerReached,
+      });
+      const held = holdPanelMutationLock();
+      await held.ready;
+      const install = installCustomNode({ id: "my-pack", useCmCli: true });
+      try {
+        // This is the Manager-only branch: it must reach the queue while a
+        // separate local writer is still holding the shared lock.
+        expect(await settlesBefore(managerReached)).toBe(true);
+        expect(await settlesBefore(install)).toBe(true);
+      } finally {
+        held.release();
+        await held.done;
+      }
+      await expect(install).resolves.toMatchObject({ mechanism: "manager-http" });
+      expect(taskOf(calls, "install").params).toMatchObject({ id: "my-pack" });
+    });
+
     it("useCmCli still uses comfy-cli when it IS available", async () => {
       mockedExec.mockReturnValue(cliEnvelope({ message: "ok" }) as never);
       const res = await installCustomNode({ id: "my-pack", useCmCli: true });
@@ -2278,6 +2331,34 @@ describe("node-management service", () => {
       expect(gitCalls.some((args) => args[2] === "checkout")).toBe(false);
     });
 
+  });
+
+  describe("local install writer lock boundary (#2509)", () => {
+    it("does not wait on the local writer lock before refusing an accepted remote git fallback", async () => {
+      remoteFlags.remoteMode = true;
+      let markManagerReached!: () => void;
+      const managerReached = new Promise<void>((resolve) => {
+        markManagerReached = resolve;
+      });
+      stubFetch({ installedBody: {}, onQueue: markManagerReached });
+      const held = holdPanelMutationLock();
+      await held.ready;
+      const install = installCustomNode({
+        id: "https://github.com/foo/unregistered-pack",
+        source: "git",
+      });
+      try {
+        // Manager may be contacted while the local writer lock is occupied.
+        // The eventual clone helper refusal is also a non-write path and must
+        // not wait for that lock.
+        expect(await settlesBefore(managerReached)).toBe(true);
+        expect(await settlesBefore(install)).toBe(true);
+      } finally {
+        held.release();
+        await held.done;
+      }
+      await expect(install).rejects.toThrow(/REMOTE ComfyUI/);
+    });
   });
 
   // ---- disable / enable / uninstall (#775) ----------------------------------

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -180,6 +180,7 @@ import {
 } from "../../services/node-management.js";
 import { ProcessControlError, ValidationError } from "../../utils/errors.js";
 import { withPanelMutationLock } from "../../services/panel-pin-guard.js";
+import { applyManifest } from "../../services/manifest.js";
 
 const mockedExec = vi.mocked(execFileSync);
 const mockedExists = vi.mocked(existsSync);
@@ -232,9 +233,17 @@ interface Call {
  * Install a fetch stub that records every call and returns canned responses.
  * The queue status returns "done" on the first poll so runManagerQueue resolves.
  */
+type QueueStatusFixture = {
+  total_count: number;
+  done_count: number;
+  in_progress_count: number;
+  is_processing: boolean;
+  pending_count?: number;
+};
+
 function stubFetch(opts: {
   installedBody?: unknown;
-  statusSequence?: unknown[];
+  statusSequence?: QueueStatusFixture[] | (() => QueueStatusFixture);
   /** Fires when a queue op is submitted — lets a test make the install REAL. */
   onQueue?: () => void;
   /**
@@ -308,7 +317,9 @@ function stubFetch(opts: {
         }
       }
       if (path === "/v2/manager/queue/status") {
-        const s = statusSeq[Math.min(statusIdx, statusSeq.length - 1)];
+        const s = typeof statusSeq === "function"
+          ? statusSeq()
+          : statusSeq[Math.min(statusIdx, statusSeq.length - 1)];
         statusIdx++;
         return jsonResponse(s);
       }
@@ -902,6 +913,101 @@ describe("node-management service", () => {
       expect(
         mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
       ).toBeDefined();
+    });
+
+    it("keeps apply_manifest truthful when a late Manager drain selects local fallback (#1129)", async () => {
+      const previousBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+      process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "80";
+      const pending = {
+        total_count: 1,
+        done_count: 0,
+        in_progress_count: 1,
+        is_processing: true,
+      };
+      const drainedStatus = {
+        total_count: 1,
+        done_count: 1,
+        in_progress_count: 0,
+        is_processing: false,
+      };
+      let statusCalls = 0;
+      let drained = false;
+      const { calls } = stubFetch({
+        installedBody: {},
+        // The first status response is the dialect probe. Hold the real queue
+        // open until apply_manifest has returned, then let installCustomNode's
+        // actual post-drain verification select its local clone fallback.
+        statusSequence: () =>
+          statusCalls++ === 0 || drained ? drainedStatus : pending,
+      });
+      let cloned = false;
+      let markCloneStarted!: () => void;
+      const cloneStarted = new Promise<void>((resolve) => {
+        markCloneStarted = resolve;
+      });
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      fsCtl.readdirSync = (p) => {
+        const norm = p.replace(/\\/g, "/");
+        return norm.endsWith("/comfyui-teskors-utils") ? ["__init__.py"] : [];
+      };
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") {
+          cloned = true;
+          markCloneStarted();
+        }
+        return "";
+      }) as never);
+
+      try {
+        const result = await applyManifest({
+          manifest: {
+            custom_nodes: [
+              "https://github.com/teskor-hub/comfyui-teskors-utils",
+              "next-pack",
+            ],
+          },
+        });
+
+        const first = result.results[0];
+        expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 2 });
+        expect(first).toMatchObject({
+          action: "custom_node",
+          item: "https://github.com/teskor-hub/comfyui-teskors-utils",
+          status: "pending",
+        });
+        expect(first.message).toMatch(/still resolving/i);
+        expect(first.message).toMatch(/Manager queue or.*local direct-install fallback/i);
+        expect(first.message).not.toMatch(/poll panel_node_queue_status/i);
+        expect(result.partial).toMatchObject({
+          not_started: ["next-pack"],
+          still_installing: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
+          local_fallback_pending: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
+        });
+        expect(result.partial?.message).toMatch(/route may remain on the Manager queue/i);
+        expect(result.partial?.message).not.toMatch(/ON the queue, pollable/i);
+
+        // This is the production late transition: the queue drains after the
+        // response, then the real installCustomNode path verifies Manager's
+        // empty installed list and runs git clone.
+        drained = true;
+        const late = await Promise.race([
+          cloneStarted.then(() => "cloned" as const),
+          new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 500)),
+        ]);
+        expect(late).toBe("cloned");
+        expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+        expect(
+          mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+        ).toBeDefined();
+      } finally {
+        if (previousBudget === undefined) delete process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+        else process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = previousBudget;
+      }
     });
 
     it("#1129 accepts repeated explicit Manager-unavailable responses", async () => {

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -256,6 +256,8 @@ function stubFetch(opts: {
   queueOpBody?: string;
   /** Return an empty successful body for a custom-node install enqueue. */
   queueOpEmpty?: boolean;
+  /** Return JSON null for a custom-node install enqueue. */
+  queueOpNull?: boolean;
   /** Body for `https://api.comfy.org/nodes/:id` (registry-zip empty-pack fallback). */
   registryDetails?: unknown;
   /** Body for v4 per-task queue history lookups. */
@@ -346,9 +348,20 @@ function stubFetch(opts: {
             { status: opts.queueOpStatus },
           );
         }
+        if (opts.queueOpNull && isInstallOp) {
+          opts.onQueue?.();
+          return jsonResponse(null);
+        }
         if (opts.queueOpEmpty && isInstallOp) {
           opts.onQueue?.();
           return new Response("", { status: 200 });
+        }
+        // A 405 on the unified task route is retried through v2-batch; model
+        // that downgrade as an acknowledged enqueue for the existing race
+        // coverage below.
+        if (opts.queueOpStatus === 405 && path.endsWith("/queue/batch")) {
+          opts.onQueue?.();
+          return jsonResponse({ accepted: true });
         }
         // A successful install enqueue normally has an acknowledgement body;
         // keep that distinct from the adversarial empty-2xx race fixture.
@@ -731,7 +744,7 @@ describe("node-management service", () => {
       });
     });
 
-    it("falls back to a direct git clone when the Manager can't resolve the repo", async () => {
+    it("falls back to a direct git clone after a non-empty accepted Manager enqueue", async () => {
       // Manager drains "done" but the pack never appears → unregistered repo.
       const { calls } = stubFetch({ installedBody: {} });
       // Simulate clone landing the dir on disk, with no requirements/install.py.
@@ -765,6 +778,8 @@ describe("node-management service", () => {
       expect(taskOf(calls, "install").params).toMatchObject({
         id: "comfyui-teskors-utils",
       });
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
       // git clone was invoked with the URL + the target node dir (shallow, no ref).
       const cloneCall = mockedExec.mock.calls.find(
         (c) => c[0] === "git" && (c[1] as string[])[0] === "clone",
@@ -831,6 +846,25 @@ describe("node-management service", () => {
 
       // The successful empty enqueue is ambiguous: do not start/poll it and
       // never race a possible Manager task with a local clone.
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(false);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeUndefined();
+    });
+
+    it("fails closed when Manager accepts a git enqueue with JSON null", async () => {
+      const { calls } = stubFetch({ installedBody: {}, queueOpNull: true });
+
+      await expect(
+        installCustomNode({
+          id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+          source: "git",
+        }),
+      ).rejects.toMatchObject({
+        details: { kind: "manager-enqueue-empty-success" },
+      });
+
       expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
       expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(false);
       expect(
@@ -4275,7 +4309,11 @@ describe("node-management service", () => {
   describe("v2 task 405 → v2-batch negotiation (issue #464)", () => {
     /** Stub a build whose /v2 queue surface answers status but 405s the unified
      *  task route, with `is_legacy_manager_ui` absent (catchall HTML). */
-    function stub464Fetch(opts: { failed?: unknown[]; installedBody?: unknown } = {}) {
+    function stub464Fetch(opts: {
+      failed?: unknown[];
+      installedBody?: unknown;
+      batchResponse?: "accepted" | "empty" | "null";
+    } = {}) {
       const calls: Call[] = [];
       const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
         const method = init?.method ?? "GET";
@@ -4299,6 +4337,8 @@ describe("node-management service", () => {
           return new Response("405: Method Not Allowed", { status: 405 });
         }
         if (path === "/v2/manager/queue/batch" && method === "POST") {
+          if (opts.batchResponse === "empty") return new Response("", { status: 200 });
+          if (opts.batchResponse === "null") return jsonResponse(null);
           return jsonResponse({ failed: opts.failed ?? [] });
         }
         if (path === "/v2/manager/queue/start" && method === "POST") {
@@ -4308,6 +4348,59 @@ describe("node-management service", () => {
       });
       vi.stubGlobal("fetch", fetchMock);
       return { calls };
+    }
+
+    function armGitCloneFixture(): () => boolean {
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        return s.includes("comfyui-teskors-utils") ? cloned : false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+      return () => cloned;
+    }
+
+    it("uses the verified local fallback after an accepted v2-to-v2-batch downgrade", async () => {
+      const { calls } = stub464Fetch({ installedBody: {} });
+      const wasCloned = armGitCloneFixture();
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/task")).toBe(true);
+      expect(calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/batch")).toBe(true);
+      expect(calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/start")).toBe(true);
+      expect(wasCloned()).toBe(true);
+    });
+
+    for (const [label, batchResponse] of [
+      ["an empty success body", "empty"],
+      ["JSON null", "null"],
+    ] as const) {
+      it(`fails closed when a v2-to-v2-batch downgrade returns ${label}`, async () => {
+        const { calls } = stub464Fetch({ installedBody: {}, batchResponse });
+        const wasCloned = armGitCloneFixture();
+
+        await expect(
+          installCustomNode({
+            id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+          }),
+        ).rejects.toMatchObject({
+          details: { kind: "manager-enqueue-empty-success" },
+        });
+
+        expect(calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/task")).toBe(true);
+        expect(calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/batch")).toBe(true);
+        expect(calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/start")).toBe(false);
+        expect(wasCloned()).toBe(false);
+      });
     }
 
     it("panel_update_node succeeds via batch when /v2 task 405s (no raw 405 surfaced)", async () => {

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -268,6 +268,7 @@ function stubFetch(opts: {
   managerQueueStatus?:
     | "absent"
     | "manager-unavailable"
+    | "manager-unavailable-null"
     | "manager-unavailable-explicit"
     | "malformed"
     | "timeout"
@@ -360,6 +361,11 @@ function stubFetch(opts: {
         if (opts.queueOpEmpty && isInstallOp) {
           opts.onQueue?.();
           return new Response("", { status: 200 });
+        }
+        if (opts.managerQueueStatus === "manager-unavailable-null") {
+          // A JSON null is a successful response with no queue evidence. It
+          // must take the same fail-closed path as the empty 200 body.
+          return jsonResponse(null);
         }
         // A 405 on the unified task route is retried through v2-batch; model
         // that downgrade as an acknowledged enqueue for the existing race
@@ -879,7 +885,10 @@ describe("node-management service", () => {
 
     it("fails closed when a warm dialect cache later returns an empty queue status", async () => {
       const fetchOptions = {
-        managerQueueStatus: undefined as "manager-unavailable" | undefined,
+        managerQueueStatus: undefined as
+          | "manager-unavailable"
+          | "manager-unavailable-null"
+          | undefined,
       };
       const { calls } = stubFetch(fetchOptions);
 
@@ -924,6 +933,51 @@ describe("node-management service", () => {
       expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
       expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
       expect(calls.some((c) => c.url.endsWith("/manager/queue/status"))).toBe(true);
+    });
+
+    it("preserves UNKNOWN in production apply_manifest after a warm cached enqueue sees JSON null status (#1129)", async () => {
+      const fetchOptions = {
+        managerQueueStatus: undefined as "manager-unavailable-null" | undefined,
+      };
+      const { calls } = stubFetch(fetchOptions);
+
+      // Warm the real Manager dialect cache, then make both queue/status
+      // dialects answer JSON null. The custom-node enqueue still returns an
+      // acknowledgement, so apply_manifest must report UNKNOWN/pending rather
+      // than converting the tagged error into failed or authorizing a clone.
+      await installModelViaManager({
+        name: "warmup.safetensors",
+        url: "https://example.com/warmup.safetensors",
+        filename: "warmup.safetensors",
+        type: "checkpoints",
+      });
+      fetchOptions.managerQueueStatus = "manager-unavailable-null";
+
+      const started = Date.now();
+      const result = await applyManifest({
+        manifest: {
+          custom_nodes: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
+        },
+      });
+
+      expect(Date.now() - started).toBeLessThan(1000);
+      expect(result.success).toBe(false);
+      expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 1 });
+      expect(result.results[0]).toMatchObject({
+        action: "custom_node",
+        status: "pending",
+      });
+      expect(result.results[0].message).toMatch(/outcome is UNKNOWN/i);
+      expect(result.results[0].message).toMatch(/no local fallback is authorized/i);
+      expect(result.partial).toMatchObject({
+        not_started: [],
+        still_installing: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
+        outcome_unknown: ["https://github.com/teskor-hub/comfyui-teskors-utils"],
+      });
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeUndefined();
     });
 
     it("#1129 falls back when both queue-status dialects repeatedly answer empty", async () => {

--- a/src/__tests__/services/panel-mutation-lock-cross-process.test.ts
+++ b/src/__tests__/services/panel-mutation-lock-cross-process.test.ts
@@ -1,0 +1,114 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+interface ChildRun {
+  child: ChildProcessWithoutNullStreams;
+  done: Promise<{ code: number | null; stdout: string; stderr: string }>;
+  get stdout(): string;
+}
+
+function spawnLockChild(source: string, lockPath: string): ChildRun {
+  const child = spawn(process.execPath, ["--import", "tsx", "--eval", source], {
+    cwd: process.cwd(),
+    env: { ...process.env, COMFYUI_MCP_PANEL_LOCK: lockPath },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const done = new Promise<{ code: number | null; stdout: string; stderr: string }>(
+    (resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code) => resolve({ code, stdout, stderr }));
+    },
+  );
+  return { child, done, get stdout() { return stdout; } };
+}
+
+async function waitForMarker(run: ChildRun, marker: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (run.stdout.includes(marker)) return;
+    const finished = await Promise.race([
+      run.done.then(() => true, () => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 20)),
+    ]);
+    if (finished) {
+      const result = await run.done.catch((error: unknown) => ({
+        code: null,
+        stdout: run.stdout,
+        stderr: String(error),
+      }));
+      throw new Error(
+        `child exited before ${marker}: code=${result.code}\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+      );
+    }
+  }
+  throw new Error(`timed out waiting for child marker ${marker}; stdout=${run.stdout}`);
+}
+
+function stopChild(run: ChildRun): void {
+  if (run.child.exitCode === null) run.child.kill();
+}
+
+describe("panel mutation lock across processes", () => {
+  it("waits for a slow holder beyond the old 60s default", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cmcp-lock-cross-process-"));
+    const lockPath = join(dir, "panel-op.lock");
+    const moduleUrl = JSON.stringify(
+      pathToFileURL(resolve(process.cwd(), "src/services/panel-pin-guard.ts")).href,
+    );
+    // Scale only the waiter's Date.now clock. A 1.5s real holder represents
+    // 150s of the production budget, so the old 60s default fails in ~600ms;
+    // the corrected 630s default still waits for the live holder to release.
+    const clockRate = 100;
+    const holder = spawnLockChild(
+      `import { withPanelMutationLock } from ${moduleUrl};
+       await withPanelMutationLock(async () => {
+         console.log("holder-acquired");
+         await new Promise((resolve) => setTimeout(resolve, 1500));
+         console.log("holder-releasing");
+       });`,
+      lockPath,
+    );
+
+    try {
+      await waitForMarker(holder, "holder-acquired");
+      const waiter = spawnLockChild(
+        `const realNow = Date.now;
+         const startedAt = realNow();
+         Date.now = () => startedAt + (realNow() - startedAt) * ${clockRate};
+         const { withPanelMutationLock } = await import(${moduleUrl});
+         try {
+           await withPanelMutationLock(async () => console.log("waiter-acquired"));
+           console.log("waiter-complete");
+         } catch (error) {
+           console.error(String(error instanceof Error ? error.message : error));
+           process.exitCode = 1;
+         }`,
+        lockPath,
+      );
+      const [holderResult, waiterResult] = await Promise.all([holder.done, waiter.done]);
+
+      expect(holderResult.code).toBe(0);
+      expect(waiterResult.code).toBe(0);
+      expect(waiterResult.stdout).toContain("waiter-acquired");
+      expect(waiterResult.stdout).toContain("waiter-complete");
+      expect(waiterResult.stderr).not.toMatch(/Timed out .* panel operation lock/);
+    } finally {
+      stopChild(holder);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/src/__tests__/services/panel-mutation-lock-cross-process.test.ts
+++ b/src/__tests__/services/panel-mutation-lock-cross-process.test.ts
@@ -69,13 +69,11 @@ describe("panel mutation lock across processes", () => {
     const moduleUrl = JSON.stringify(
       pathToFileURL(resolve(process.cwd(), "src/services/panel-pin-guard.ts")).href,
     );
-    // Scale only the waiter's Date.now clock. A 4s real holder represents
-    // 2,400s of production budget: close to the 2,460s worst-case writer
-    // contract (clone/ref git ceilings plus requirements.txt and install.py).
-    // The old 630s budget fails after ~1.05s; the corrected 2,520s budget still
-    // waits for the live holder to release.
+    // Scale only the waiter's Date.now clock. A 4.25s real holder represents
+    // 2,550s of production budget: beyond the previous 2,520s ceiling, but
+    // inside the corrected 2,640s budget, which includes in-lock /system_stats.
     const clockRate = 600;
-    const holderDurationMs = 4_000;
+    const holderDurationMs = 4_250;
     const holder = spawnLockChild(
       `import { withPanelMutationLock } from ${moduleUrl};
        await withPanelMutationLock(async () => {

--- a/src/__tests__/services/panel-mutation-lock-cross-process.test.ts
+++ b/src/__tests__/services/panel-mutation-lock-cross-process.test.ts
@@ -63,21 +63,24 @@ function stopChild(run: ChildRun): void {
 }
 
 describe("panel mutation lock across processes", () => {
-  it("waits for a slow holder beyond the old 60s default", async () => {
+  it("waits for a holder near the full local install ceiling", async () => {
     const dir = mkdtempSync(join(tmpdir(), "cmcp-lock-cross-process-"));
     const lockPath = join(dir, "panel-op.lock");
     const moduleUrl = JSON.stringify(
       pathToFileURL(resolve(process.cwd(), "src/services/panel-pin-guard.ts")).href,
     );
-    // Scale only the waiter's Date.now clock. A 1.5s real holder represents
-    // 150s of the production budget, so the old 60s default fails in ~600ms;
-    // the corrected 630s default still waits for the live holder to release.
-    const clockRate = 100;
+    // Scale only the waiter's Date.now clock. A 4s real holder represents
+    // 2,400s of production budget: close to the 2,460s worst-case writer
+    // contract (clone/ref git ceilings plus requirements.txt and install.py).
+    // The old 630s budget fails after ~1.05s; the corrected 2,520s budget still
+    // waits for the live holder to release.
+    const clockRate = 600;
+    const holderDurationMs = 4_000;
     const holder = spawnLockChild(
       `import { withPanelMutationLock } from ${moduleUrl};
        await withPanelMutationLock(async () => {
          console.log("holder-acquired");
-         await new Promise((resolve) => setTimeout(resolve, 1500));
+         await new Promise((resolve) => setTimeout(resolve, ${holderDurationMs}));
          console.log("holder-releasing");
        });`,
       lockPath,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4709,13 +4709,21 @@ async function settleDroppedEnqueue(
 }
 
 /**
- * #1699 — a drained Manager queue is not apply_manifest completion when
- * custom_nodes were never submitted. Keep the panel payload parseable (do not
- * append prose after the JSON) and name the leftover entries on the object.
+ * #1699/#1129 — a drained Manager queue is not apply_manifest completion when
+ * custom_nodes were never submitted or a submitted operation is unresolved.
+ * Keep the panel payload parseable (do not append prose after the JSON) and
+ * name the outstanding entries on the object.
  */
 function annotateQueueStatusWithManifestPartial(res: ToolResult): ToolResult {
   const leftover = getManifestPartialLeftover();
-  if (!leftover || leftover.not_started.length === 0) return res;
+  if (
+    !leftover ||
+    (leftover.not_started.length === 0 &&
+      leftover.still_installing.length === 0 &&
+      (leftover.outcome_unknown?.length ?? 0) === 0)
+  ) {
+    return res;
+  }
   if (res.isError) return res;
   const parsed = parseToolResultJson(res);
   if (!parsed) return appendNote(res, formatQueueStatusPartialNote(leftover));
@@ -22779,9 +22787,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       "Check the built-in Manager's install/update queue status (to see if a queued install finished). Read-only. " +
         "A drained queue (total_count: 0, is_processing: false) only means THIS queue is idle — " +
         "it does not include apply_manifest custom_nodes that were never submitted (#1699). " +
-        "When apply_manifest returned a PARTIAL INSTALL, this tool names the leftover entries and " +
-        "sets queue_complete_for_apply_manifest:false; do not restart ComfyUI until those are " +
-        "submitted (re-run apply_manifest).",
+        "When apply_manifest returned a PARTIAL INSTALL, this tool names the outstanding entries and " +
+        "sets queue_complete_for_apply_manifest:false; do not treat queue idle as completion until " +
+        "those entries are verified (re-run apply_manifest only when the result authorizes it).",
       {},
       async (_args, ctx) => {
         const res = await ctx.call({ cmd: "nodes_queue_status" }, 20000);

--- a/src/services/manifest-partial.ts
+++ b/src/services/manifest-partial.ts
@@ -76,6 +76,16 @@ export function formatStillInstallingMessage(): string {
   );
 }
 
+export function formatLocalFallbackMessage(): string {
+  return (
+    "A local direct-install fallback is still in progress in this MCP process when the " +
+    "apply_manifest time budget elapsed. This is NOT queued server-side work and is NOT " +
+    "on the ComfyUI-Manager queue. Do not use Manager queue status to track this local " +
+    "work or re-issue this node while the fallback is running; verify the custom_nodes " +
+    "directory after it finishes."
+  );
+}
+
 export function buildManifestPartial(opts: {
   source: string;
   notStarted: string[];

--- a/src/services/manifest-partial.ts
+++ b/src/services/manifest-partial.ts
@@ -20,11 +20,12 @@ export interface ManifestPartialInstall {
   /** custom_node ids submitted but unresolved when the budget elapsed. */
   still_installing: string[];
   /**
-   * A subset of still_installing whose local git fallback can be selected after
-   * Manager drains. Their route is unresolved, so queue status alone cannot
-   * account for them.
+   * A subset of still_installing whose install promise did not settle before
+   * apply_manifest returned. No Manager or local-fallback outcome is known for
+   * these entries, so neither queue state nor local cloning is authorized by
+   * this result.
    */
-  local_fallback_pending?: string[];
+  outcome_unknown?: string[];
   message: string;
 }
 
@@ -37,8 +38,8 @@ export function recordManifestPartial(partial: ManifestPartialInstall | null): v
           ...partial,
           not_started: [...partial.not_started],
           still_installing: [...partial.still_installing],
-          ...(partial.local_fallback_pending
-            ? { local_fallback_pending: [...partial.local_fallback_pending] }
+          ...(partial.outcome_unknown
+            ? { outcome_unknown: [...partial.outcome_unknown] }
             : {}),
         }
       : null;
@@ -76,15 +77,17 @@ export function formatNotStartedMessage(item: string): string {
 }
 
 export function formatStillInstallingMessage(
-  opts: { localFallbackPossible?: boolean } = {},
+  opts: { outcomeUnknown?: boolean } = {},
 ): string {
-  if (opts.localFallbackPossible) {
+  if (opts.outcomeUnknown) {
     return (
-      "Install is still resolving when the apply_manifest time budget elapsed. It may " +
-      "still be running on the ComfyUI-Manager queue or may transition to a verified " +
-      "local direct-install fallback after Manager finishes. This is NOT a failure and " +
-      "must not be re-issued. Do not use Manager queue status alone to decide completion; " +
-      "verify the custom_nodes directory after the operation settles."
+      "Install outcome is UNKNOWN because the apply_manifest time budget elapsed before " +
+      "the Manager operation settled. It may still be running on the ComfyUI-Manager " +
+      "queue, or it may later settle to a result that does not authorize cloning. No " +
+      "local direct-install fallback is authorized from this unresolved result. This " +
+      "is NOT a failure and must not be re-issued. Do not use Manager queue status alone " +
+      "to decide completion; verify the custom_nodes directory after the operation " +
+      "settles."
     );
   }
   return (
@@ -110,18 +113,18 @@ export function buildManifestPartial(opts: {
   source: string;
   notStarted: string[];
   stillInstalling: string[];
-  localFallbackPending?: string[];
+  outcomeUnknown?: string[];
 }): ManifestPartialInstall | null {
   if (opts.notStarted.length === 0) return null;
   const names = opts.notStarted.join(", ");
-  const localFallbackPending = (opts.localFallbackPending ?? []).filter((id) =>
+  const outcomeUnknown = (opts.outcomeUnknown ?? []).filter((id) =>
     opts.stillInstalling.includes(id),
   );
   const still = opts.stillInstalling.length
-    ? localFallbackPending.length
-      ? ` Still unresolved: ${opts.stillInstalling.join(", ")}. For ${localFallbackPending.join(", ")}, ` +
-        `the route may remain on the Manager queue or transition to a verified local ` +
-        `fallback; do not use queue status alone to decide completion.`
+    ? outcomeUnknown.length
+      ? ` Still unresolved: ${opts.stillInstalling.join(", ")}. For ${outcomeUnknown.join(", ")}, ` +
+        `the install outcome is UNKNOWN and no local direct-install fallback is ` +
+        `authorized from this result; do not use queue status alone to decide completion.`
       : ` Still installing (ON the queue, pollable): ${opts.stillInstalling.join(", ")}.`
     : "";
   const n = opts.notStarted.length;
@@ -130,9 +133,7 @@ export function buildManifestPartial(opts: {
     source: opts.source,
     not_started: [...opts.notStarted],
     still_installing: [...opts.stillInstalling],
-    ...(localFallbackPending.length
-      ? { local_fallback_pending: [...localFallbackPending] }
-      : {}),
+    ...(outcomeUnknown.length ? { outcome_unknown: [...outcomeUnknown] } : {}),
     message:
       `PARTIAL INSTALL of ${opts.source}: ${n} custom_node ` +
       `${n === 1 ? "entry was" : "entries were"} NEVER submitted to ` +

--- a/src/services/manifest-partial.ts
+++ b/src/services/manifest-partial.ts
@@ -3,12 +3,13 @@
  *
  * The ComfyUI-Manager queue only knows about tasks it was given. When
  * apply_manifest's time budget expires, later custom_nodes are reported
- * "pending" / "not started" and are NEVER enqueued. panel_node_queue_status
- * then reports a drained queue (total_count: 0, is_processing: false) which
- * agents read as "all installs finished". This module is the process-local
- * record of those unsubmitted names so apply_manifest (which names the
- * PARTIAL INSTALL) and panel_node_queue_status (which refuses to look
- * complete while they remain) share one source of truth.
+ * "pending" / "not started" and are NEVER enqueued; an accepted-but-ambiguous
+ * operation can also remain unresolved. panel_node_queue_status then reports a
+ * drained queue (total_count: 0, is_processing: false) which agents read as
+ * "all installs finished". This module is the process-local record of both
+ * unsubmitted and unresolved names so apply_manifest (which names the PARTIAL
+ * INSTALL) and panel_node_queue_status (which refuses to look complete while
+ * they remain) share one source of truth.
  */
 
 export interface ManifestPartialInstall {
@@ -33,7 +34,10 @@ let leftover: ManifestPartialInstall | null = null;
 
 export function recordManifestPartial(partial: ManifestPartialInstall | null): void {
   leftover =
-    partial && partial.not_started.length > 0
+    partial &&
+    (partial.not_started.length > 0 ||
+      partial.still_installing.length > 0 ||
+      (partial.outcome_unknown?.length ?? 0) > 0)
       ? {
           ...partial,
           not_started: [...partial.not_started],
@@ -115,11 +119,11 @@ export function buildManifestPartial(opts: {
   stillInstalling: string[];
   outcomeUnknown?: string[];
 }): ManifestPartialInstall | null {
-  if (opts.notStarted.length === 0) return null;
-  const names = opts.notStarted.join(", ");
   const outcomeUnknown = (opts.outcomeUnknown ?? []).filter((id) =>
     opts.stillInstalling.includes(id),
   );
+  if (opts.notStarted.length === 0 && opts.stillInstalling.length === 0) return null;
+  const names = opts.notStarted.join(", ");
   const still = opts.stillInstalling.length
     ? outcomeUnknown.length
       ? ` Still unresolved: ${opts.stillInstalling.join(", ")}. For ${outcomeUnknown.join(", ")}, ` +
@@ -128,6 +132,16 @@ export function buildManifestPartial(opts: {
       : ` Still installing (ON the queue, pollable): ${opts.stillInstalling.join(", ")}.`
     : "";
   const n = opts.notStarted.length;
+  const unsubmitted =
+    n > 0
+      ? `${n} custom_node ${n === 1 ? "entry was" : "entries were"} NEVER submitted to ` +
+        `ComfyUI-Manager (${names}). panel_node_queue_status going idle does NOT ` +
+        `mean they installed — they are not on that queue. Do not restart ComfyUI ` +
+        `yet. Re-run apply_manifest with the same pack/path/manifest to submit the ` +
+        `remaining entries.`
+      : `No custom_node entries were left unsubmitted, but the submitted entries ` +
+        `below remain unresolved; panel_node_queue_status going idle does NOT prove ` +
+        `this apply_manifest completed.`;
   return {
     kind: "custom_nodes_not_started",
     source: opts.source,
@@ -135,23 +149,24 @@ export function buildManifestPartial(opts: {
     still_installing: [...opts.stillInstalling],
     ...(outcomeUnknown.length ? { outcome_unknown: [...outcomeUnknown] } : {}),
     message:
-      `PARTIAL INSTALL of ${opts.source}: ${n} custom_node ` +
-      `${n === 1 ? "entry was" : "entries were"} NEVER submitted to ` +
-      `ComfyUI-Manager (${names}). panel_node_queue_status going idle does NOT ` +
-      `mean they installed — they are not on that queue. Do not restart ComfyUI ` +
-      `yet. Re-run apply_manifest with the same pack/path/manifest to submit the ` +
-      `remaining entries.` +
+      `PARTIAL INSTALL of ${opts.source}: ${unsubmitted}` +
       still,
   };
 }
 
 export function formatQueueStatusPartialNote(partial: ManifestPartialInstall): string {
-  return (
-    `WARNING — PARTIAL INSTALL, QUEUE DRAIN IS NOT COMPLETION. apply_manifest of ` +
-    `${partial.source} never submitted: ${partial.not_started.join(", ")}. ` +
-    `Those entries are NOT on the ComfyUI-Manager queue, so this status (even ` +
-    `total_count: 0 / is_processing: false) cannot account for them. Re-run ` +
-    `apply_manifest to submit the remaining custom_nodes. Do not restart ComfyUI ` +
-    `until those entries report applied or skipped.`
-  );
+  const unsubmitted = partial.not_started.length
+    ? `apply_manifest of ${partial.source} never submitted: ${partial.not_started.join(", ")}. ` +
+      `Those entries are NOT on the ComfyUI-Manager queue, so this status cannot ` +
+      `account for them. Re-run apply_manifest to submit the remaining custom_nodes.`
+    : "No entries were left unsubmitted, but submitted entries remain unresolved.";
+  const unresolved = partial.still_installing.length
+    ? ` Unresolved submitted entries: ${partial.still_installing.join(", ")}.` +
+      (partial.outcome_unknown?.length
+        ? ` For ${partial.outcome_unknown.join(", ")}, the install outcome is UNKNOWN; ` +
+          `no local direct-install fallback is authorized and queue idle is not proof ` +
+          `of completion. Verify the custom_nodes directory before reissuing.`
+        : " Do not treat queue idle as proof that this apply_manifest completed.")
+    : "";
+  return `WARNING — PARTIAL INSTALL, QUEUE DRAIN IS NOT COMPLETION. ${unsubmitted}${unresolved}`;
 }

--- a/src/services/manifest-partial.ts
+++ b/src/services/manifest-partial.ts
@@ -17,8 +17,14 @@ export interface ManifestPartialInstall {
   source: string;
   /** custom_node ids that were never submitted to ComfyUI-Manager. */
   not_started: string[];
-  /** custom_node ids submitted but still running when the budget elapsed. */
+  /** custom_node ids submitted but unresolved when the budget elapsed. */
   still_installing: string[];
+  /**
+   * A subset of still_installing whose local git fallback can be selected after
+   * Manager drains. Their route is unresolved, so queue status alone cannot
+   * account for them.
+   */
+  local_fallback_pending?: string[];
   message: string;
 }
 
@@ -31,6 +37,9 @@ export function recordManifestPartial(partial: ManifestPartialInstall | null): v
           ...partial,
           not_started: [...partial.not_started],
           still_installing: [...partial.still_installing],
+          ...(partial.local_fallback_pending
+            ? { local_fallback_pending: [...partial.local_fallback_pending] }
+            : {}),
         }
       : null;
 }
@@ -66,7 +75,18 @@ export function formatNotStartedMessage(item: string): string {
   );
 }
 
-export function formatStillInstallingMessage(): string {
+export function formatStillInstallingMessage(
+  opts: { localFallbackPossible?: boolean } = {},
+): string {
+  if (opts.localFallbackPossible) {
+    return (
+      "Install is still resolving when the apply_manifest time budget elapsed. It may " +
+      "still be running on the ComfyUI-Manager queue or may transition to a verified " +
+      "local direct-install fallback after Manager finishes. This is NOT a failure and " +
+      "must not be re-issued. Do not use Manager queue status alone to decide completion; " +
+      "verify the custom_nodes directory after the operation settles."
+    );
+  }
   return (
     "Still installing on the ComfyUI-Manager queue when the apply_manifest time " +
     "budget elapsed. This is NOT a failure — the install continues server-side. " +
@@ -90,11 +110,19 @@ export function buildManifestPartial(opts: {
   source: string;
   notStarted: string[];
   stillInstalling: string[];
+  localFallbackPending?: string[];
 }): ManifestPartialInstall | null {
   if (opts.notStarted.length === 0) return null;
   const names = opts.notStarted.join(", ");
+  const localFallbackPending = (opts.localFallbackPending ?? []).filter((id) =>
+    opts.stillInstalling.includes(id),
+  );
   const still = opts.stillInstalling.length
-    ? ` Still installing (ON the queue, pollable): ${opts.stillInstalling.join(", ")}.`
+    ? localFallbackPending.length
+      ? ` Still unresolved: ${opts.stillInstalling.join(", ")}. For ${localFallbackPending.join(", ")}, ` +
+        `the route may remain on the Manager queue or transition to a verified local ` +
+        `fallback; do not use queue status alone to decide completion.`
+      : ` Still installing (ON the queue, pollable): ${opts.stillInstalling.join(", ")}.`
     : "";
   const n = opts.notStarted.length;
   return {
@@ -102,6 +130,9 @@ export function buildManifestPartial(opts: {
     source: opts.source,
     not_started: [...opts.notStarted],
     still_installing: [...opts.stillInstalling],
+    ...(localFallbackPending.length
+      ? { local_fallback_pending: [...localFallbackPending] }
+      : {}),
     message:
       `PARTIAL INSTALL of ${opts.source}: ${n} custom_node ` +
       `${n === 1 ? "entry was" : "entries were"} NEVER submitted to ` +

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -1121,9 +1121,10 @@ async function applyManifestSections(
   // tools/call timeout (300s) and the caller sees a FALSE failure while the
   // Manager keeps installing. So we mirror the model-download grace pattern:
   // install sequentially, but RACE each install against the remaining budget. If
-  // the budget wins, the install keeps running either SERVER-SIDE or as a local
-  // fallback (we stop awaiting it, swallowing its late result) and is reported
-  // "pending" — never failed — and
+  // the budget wins, the install keeps running and its late result is swallowed;
+  // before that result settles, only the already-fired local-fallback callback can
+  // establish a local route. Otherwise the outcome is explicitly UNKNOWN and is
+  // reported "pending" — never failed — and
   // every not-yet-started node is reported "pending" too.
   //
   // #1699: a "not started" pending is NOT on the Manager queue. Telling the
@@ -1135,7 +1136,7 @@ async function applyManifestSections(
   const nodeDeadline = Date.now() + manifestNodeBudgetMs();
   const notStarted: string[] = [];
   const stillInstalling: string[] = [];
-  const localFallbackPending: string[] = [];
+  const outcomeUnknown: string[] = [];
   let nodeBudgetSpent = false;
   // Even the INITIAL installed-list probe is budget-bounded — a hung Manager here
   // must not blow the tools/call timeout before we can report anything.
@@ -1212,23 +1213,24 @@ async function applyManifestSections(
 
     if (outcome === BUDGET_TIMEOUT) {
       // Budget spent mid-install: leave it running, but distinguish a local
-      // direct fallback from a Manager task. Both promises already have a
-      // .catch, so their eventual settle is safely ignored; only the Manager
-      // case belongs in stillInstalling and the queue-polling message.
+      // direct fallback only after its callback has actually fired. If a Git
+      // install is still unresolved, its eventual Manager response may be
+      // empty/null or otherwise fail closed; local mode/root/Git syntax alone
+      // cannot authorize cloning. Both promises already have a .catch, so
+      // their eventual settle is safely ignored.
       nodeBudgetSpent = true;
       if (localFallbackSelected) {
         results.push(report("custom_node", id, "pending", formatLocalFallbackMessage()));
       } else {
         stillInstalling.push(id);
-        const localFallbackPossible =
-          localMode && Boolean(customNodesBase) && isGitManifestSource;
-        if (localFallbackPossible) localFallbackPending.push(id);
+        const outcomeIsUnknown = isGitManifestSource;
+        if (outcomeIsUnknown) outcomeUnknown.push(id);
         results.push(
           report(
             "custom_node",
             id,
             "pending",
-            formatStillInstallingMessage({ localFallbackPossible }),
+            formatStillInstallingMessage({ outcomeUnknown: outcomeIsUnknown }),
           ),
         );
       }
@@ -1634,7 +1636,7 @@ async function applyManifestSections(
     source,
     notStarted,
     stillInstalling,
-    localFallbackPending,
+    outcomeUnknown,
   });
   recordManifestPartial(partial);
 

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -992,7 +992,8 @@ async function resolveLocalManifestBase(): Promise<string | undefined> {
 }
 
 function looksLikeGitManifestSource(id: string): boolean {
-  return /^(?:https?:\/\/|git@|git\+)/i.test(id) || /\.git(?:[?#]|$)/i.test(id);
+  const candidate = id.trim();
+  return /^(?:https?:\/\/|git@|git\+)/i.test(candidate) || /\.git(?:[?#]|$)/i.test(candidate);
 }
 
 async function resolveLocalManifestCustomNodesBase(): Promise<string | undefined> {
@@ -1142,6 +1143,9 @@ async function applyManifestSections(
   const installedNodes = initialList === BUDGET_TIMEOUT ? [] : initialList;
   if (initialList === BUDGET_TIMEOUT) nodeBudgetSpent = true;
   for (const id of manifest.custom_nodes) {
+    const normalizedId = id.trim();
+    const isGitManifestSource = looksLikeGitManifestSource(normalizedId);
+
     if (getComfyuiTargetGeneration() !== targetGeneration) {
       results.push(
         report(
@@ -1154,7 +1158,7 @@ async function applyManifestSections(
       );
       continue;
     }
-    const isPanelTarget = targetsPanelPackExactly(id);
+    const isPanelTarget = targetsPanelPackExactly(normalizedId);
     if (isPanelTarget) {
       // `apply_manifest` has a Manager target but no authoritative association
       // between that target and a local served-panel root. In particular,
@@ -1173,7 +1177,7 @@ async function applyManifestSections(
       );
       continue;
     }
-    if (nodeAlreadyInstalled(id, installedNodes)) {
+    if (nodeAlreadyInstalled(normalizedId, installedNodes)) {
       results.push(report("custom_node", id, "skipped", "Custom node is already installed."));
       continue;
     }
@@ -1191,9 +1195,9 @@ async function applyManifestSections(
     // (#1715/#1770). Pip uses codeBase independently above.
     let localFallbackSelected = false;
     const installOutcome = installCustomNode({
-      id,
+      id: normalizedId,
       ...(customNodesBase ? { comfyuiPath: customNodesBase } : {}),
-      ...(looksLikeGitManifestSource(id)
+      ...(isGitManifestSource
         ? { localCloneFallback: "verified-only" as const }
         : {}),
       managerBase,
@@ -1217,7 +1221,7 @@ async function applyManifestSections(
       } else {
         stillInstalling.push(id);
         const localFallbackPossible =
-          localMode && Boolean(customNodesBase) && looksLikeGitManifestSource(id);
+          localMode && Boolean(customNodesBase) && isGitManifestSource;
         if (localFallbackPossible) localFallbackPending.push(id);
         results.push(
           report(

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -55,6 +55,7 @@ import { logger } from "../utils/logger.js";
 import {
   buildManifestPartial,
   describeManifestSource,
+  formatLocalFallbackMessage,
   formatNotStartedMessage,
   formatStillInstallingMessage,
   recordManifestPartial,
@@ -74,7 +75,8 @@ function manifestDownloadGraceMs(): number {
  *  big pack. Blocking apply_manifest until it drains blows past the MCP tools/call
  *  timeout (300s) and the caller sees a FALSE failure while the Manager keeps
  *  installing (#489). Bounding the phase well under that cap lets us hand back a
- *  "pending" result (poll the Manager queue) instead. Env-tunable; default 240s. */
+ *  "pending" result (poll the Manager queue when the operation really is
+ *  server-side). Env-tunable; default 240s. */
 function manifestNodeBudgetMs(): number {
   const raw = Number(process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS);
   return Number.isFinite(raw) && raw > 0 ? raw : 240_000;
@@ -1118,8 +1120,9 @@ async function applyManifestSections(
   // tools/call timeout (300s) and the caller sees a FALSE failure while the
   // Manager keeps installing. So we mirror the model-download grace pattern:
   // install sequentially, but RACE each install against the remaining budget. If
-  // the budget wins, the install keeps running SERVER-SIDE (we stop awaiting it,
-  // swallowing its late result) and is reported "pending" — never failed — and
+  // the budget wins, the install keeps running either SERVER-SIDE or as a local
+  // fallback (we stop awaiting it, swallowing its late result) and is reported
+  // "pending" — never failed — and
   // every not-yet-started node is reported "pending" too.
   //
   // #1699: a "not started" pending is NOT on the Manager queue. Telling the
@@ -1185,6 +1188,7 @@ async function applyManifestSections(
     // Thread the call-scoped DATA/base (no global config mutation) so the
     // git-clone / ref-checkout fallback writes into the tree the runtime scans
     // (#1715/#1770). Pip uses codeBase independently above.
+    let localFallbackSelected = false;
     const installOutcome = installCustomNode({
       id,
       ...(customNodesBase ? { comfyuiPath: customNodesBase } : {}),
@@ -1193,18 +1197,26 @@ async function applyManifestSections(
         : {}),
       managerBase,
       targetGeneration,
+      onLocalFallback: () => {
+        localFallbackSelected = true;
+      },
     })
       .then((res) => ({ kind: "settled" as const, res }))
       .catch((err) => ({ kind: "error" as const, err }));
     const outcome = await raceDeadline(installOutcome, nodeDeadline);
 
     if (outcome === BUDGET_TIMEOUT) {
-      // Budget spent mid-install: leave it running server-side (installOutcome
-      // already has a .catch, so its eventual settle is safely ignored) and stop
-      // blocking on the remaining nodes.
+      // Budget spent mid-install: leave it running, but distinguish a local
+      // direct fallback from a Manager task. Both promises already have a
+      // .catch, so their eventual settle is safely ignored; only the Manager
+      // case belongs in stillInstalling and the queue-polling message.
       nodeBudgetSpent = true;
-      stillInstalling.push(id);
-      results.push(report("custom_node", id, "pending", formatStillInstallingMessage()));
+      if (localFallbackSelected) {
+        results.push(report("custom_node", id, "pending", formatLocalFallbackMessage()));
+      } else {
+        stillInstalling.push(id);
+        results.push(report("custom_node", id, "pending", formatStillInstallingMessage()));
+      }
       continue;
     }
     if (outcome.kind === "error") {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -1134,6 +1134,7 @@ async function applyManifestSections(
   const nodeDeadline = Date.now() + manifestNodeBudgetMs();
   const notStarted: string[] = [];
   const stillInstalling: string[] = [];
+  const localFallbackPending: string[] = [];
   let nodeBudgetSpent = false;
   // Even the INITIAL installed-list probe is budget-bounded — a hung Manager here
   // must not blow the tools/call timeout before we can report anything.
@@ -1215,7 +1216,17 @@ async function applyManifestSections(
         results.push(report("custom_node", id, "pending", formatLocalFallbackMessage()));
       } else {
         stillInstalling.push(id);
-        results.push(report("custom_node", id, "pending", formatStillInstallingMessage()));
+        const localFallbackPossible =
+          localMode && Boolean(customNodesBase) && looksLikeGitManifestSource(id);
+        if (localFallbackPossible) localFallbackPending.push(id);
+        results.push(
+          report(
+            "custom_node",
+            id,
+            "pending",
+            formatStillInstallingMessage({ localFallbackPossible }),
+          ),
+        );
       }
       continue;
     }
@@ -1615,7 +1626,12 @@ async function applyManifestSections(
   // #1699 — name the PARTIAL INSTALL (unsubmitted custom_nodes) so a drained
   // Manager queue cannot be read as completion. Replacing the leftover record
   // on every apply keeps queue-status honest about THIS call only.
-  const partial = buildManifestPartial({ source, notStarted, stillInstalling });
+  const partial = buildManifestPartial({
+    source,
+    notStarted,
+    stillInstalling,
+    localFallbackPending,
+  });
   recordManifestPartial(partial);
 
   return {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -260,9 +260,9 @@ export interface ApplyManifestResult {
   summary: Record<ManifestItemStatus, number>;
   results: ManifestItemReport[];
   /**
-   * Present only when some custom_nodes were never submitted to ComfyUI-Manager
-   * (#1699). Names the PARTIAL INSTALL. A drained Manager queue does not include
-   * these entries — re-run apply_manifest to submit them.
+   * Present when custom_nodes were never submitted or a submitted operation
+   * remains unresolved (#1699/#1129). Names the PARTIAL INSTALL. A drained
+   * Manager queue does not by itself account for these entries.
    */
   partial?: ManifestPartialInstall;
 }
@@ -1012,6 +1012,21 @@ async function resolveLocalManifestCustomNodesBase(): Promise<string | undefined
   }
 }
 
+/**
+ * Manager can report a successful-but-empty enqueue or an empty queue/status
+ * response after a warm dialect cache. Both are deliberately tagged UNKNOWN
+ * by node-management: the request may already have reached the host, so no
+ * caller may reissue it or authorize a local clone. Keep that meaning intact
+ * when apply_manifest assembles its structured per-item result.
+ */
+function isUnknownManagerInstallOutcome(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const details = (err as { details?: unknown }).details;
+  if (!details || typeof details !== "object") return false;
+  const kind = (details as { kind?: unknown }).kind;
+  return kind === "manager-enqueue-empty-success" || kind === "manager-queue-empty-status";
+}
+
 async function applyManifestSections(
   manifest: ComfyManifest,
   localRoots: {
@@ -1237,12 +1252,23 @@ async function applyManifestSections(
       continue;
     }
     if (outcome.kind === "error") {
+      const message =
+        outcome.err instanceof Error ? outcome.err.message : String(outcome.err);
+      if (isUnknownManagerInstallOutcome(outcome.err)) {
+        // UNKNOWN is an unsettled, fail-closed result, not a hard failure. The
+        // Manager may have accepted the task; preserve the no-reissue/no-clone
+        // disclosure and keep it visible to panel_node_queue_status.
+        stillInstalling.push(id);
+        outcomeUnknown.push(id);
+        results.push(report("custom_node", id, "pending", message));
+        continue;
+      }
       results.push(
         report(
           "custom_node",
           id,
           "failed",
-          outcome.err instanceof Error ? outcome.err.message : String(outcome.err),
+          message,
         ),
       );
       continue;

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -40,7 +40,7 @@ import {
   resolveComfyCliExecutable,
   runComfyCliSync,
 } from "./comfy-cli.js";
-import { withPanelPinGuard } from "./panel-pin-guard.js";
+import { withPanelMutationLock, withPanelPinGuard } from "./panel-pin-guard.js";
 import {
   ambiguousBareNameRefusal,
   ambiguousBareNameWarning,
@@ -221,6 +221,10 @@ interface ManagerFetchOptions {
   soft?: boolean;
   /** Preserve the status class that a soft capability probe observed. */
   onSoftFailure?: (status: number | undefined) => void;
+  /** Preserve a transport failure separately from an empty/malformed 2xx body. */
+  onSoftTransportFailure?: () => void;
+  /** Observe the parsed body of a successful soft probe, including an empty body. */
+  onSoftResponse?: (body: unknown) => void;
 }
 
 /**
@@ -320,6 +324,8 @@ async function managerFetch<T>(
     base = managerBaseUrl(),
     soft = false,
     onSoftFailure,
+    onSoftTransportFailure,
+    onSoftResponse,
   } = options;
   const url = `${base}${path}`;
   logger.debug("Manager API request", { url, method });
@@ -337,6 +343,7 @@ async function managerFetch<T>(
   } catch (err) {
     if (soft) {
       onSoftFailure?.(undefined);
+      onSoftTransportFailure?.();
       return undefined;
     }
     throw new NodeManagementError(
@@ -382,13 +389,17 @@ async function managerFetch<T>(
 
   // Some endpoints return empty bodies (e.g. queue ops). Parse defensively.
   const raw = await res.text();
-  if (!raw) return undefined;
+  if (!raw.trim()) {
+    if (soft) onSoftResponse?.(undefined);
+    return undefined;
+  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
     parsed = raw;
   }
+  if (soft) onSoftResponse?.(parsed);
   return parsed as T;
 }
 
@@ -519,6 +530,42 @@ function looksLikeQueueStatus(s: unknown): boolean {
   );
 }
 
+function managerQueueStatusKind(status: number): ManagerQueueStatusKind {
+  if (status === 404) return "not-found";
+  if (status === 405) return "method-not-allowed";
+  if (status >= 500) return "server-error";
+  return "http-error";
+}
+
+/**
+ * Some local ComfyUI Desktop builds leave the Manager queue/status endpoints
+ * registered as successful routes but return no body (or an explicit Manager
+ * unavailable error). That is different from the frontend HTML catchall: the
+ * former is a stable, positive answer that no queue/status surface is
+ * available, while the latter is merely an unrecognized route response.
+ */
+function looksLikeManagerUnavailableResponse(body: unknown): boolean {
+  if (looksLikeHtml(body)) return false;
+  const text =
+    typeof body === "string"
+      ? body
+      : body && typeof body === "object"
+        ? Object.values(body as Record<string, unknown>)
+            .filter((value): value is string => typeof value === "string")
+            .join(" ")
+        : "";
+  return /(?:comfyui[-\s]?manager|manager).{0,80}(?:not\s+reachable|unavailable|not\s+enabled|not\s+installed)/i.test(
+    text,
+  );
+}
+
+function managerQueueResponseKind(body: unknown): ManagerQueueStatusKind {
+  if (looksLikeQueueStatus(body)) return "queue";
+  if (body === undefined) return "empty";
+  if (looksLikeManagerUnavailableResponse(body)) return "unavailable";
+  return "malformed";
+}
+
 /**
  * What the two Manager queue/status routes established for ONE connected
  * ComfyUI. A 404 on only one route is not enough: the other route may be the
@@ -526,6 +573,22 @@ function looksLikeQueueStatus(s: unknown): boolean {
  * that Manager is absent.
  */
 export type ManagerQueueAvailability = "available" | "absent" | "unreadable";
+
+/** The evidence captured for each queue/status dialect during generation
+ * detection. Only `empty` / `unavailable` (and an already-shipped 404) can
+ * authorize the local git fallback; a timeout, HTML catchall, 405, 5xx, or
+ * authentication response is deliberately not absence evidence. */
+type ManagerQueueStatusKind =
+  | "queue"
+  | "not-found"
+  | "empty"
+  | "unavailable"
+  | "malformed"
+  | "method-not-allowed"
+  | "server-error"
+  | "http-error"
+  | "transport"
+  | "hard-error";
 
 /** Internal marker carried by the all-soft queue-generation probe. */
 const MANAGER_QUEUE_DETECTION_FAILURE = "manager-queue-detection";
@@ -571,6 +634,55 @@ export async function probeManagerQueueAvailability(
   return statuses.length === 2 && statuses.every((status) => status === 404)
     ? "absent"
     : "unreadable";
+}
+
+/**
+ * Repeat the queue/status probe with the response class preserved. The public
+ * availability helper intentionally exposes only its conservative three-state
+ * result; the install fallback needs the extra distinction between a stable
+ * empty/unavailable response and a timeout or malformed catchall.
+ */
+async function probeManagerQueueStatusKinds(
+  base: string,
+): Promise<ManagerQueueStatusKind[]> {
+  const kinds: ManagerQueueStatusKind[] = [];
+  for (const path of ["/v2/manager/queue/status", "/manager/queue/status"]) {
+    let kind: ManagerQueueStatusKind = "hard-error";
+    try {
+      await managerFetch<unknown>(path, {
+        base,
+        soft: true,
+        onSoftFailure: (status) => {
+          kind = status === undefined ? "transport" : managerQueueStatusKind(status);
+        },
+        onSoftTransportFailure: () => {
+          kind = "transport";
+        },
+        onSoftResponse: (body) => {
+          kind = managerQueueResponseKind(body);
+        },
+      });
+    } catch {
+      // Authentication and other hard probe failures must not become local
+      // clone authorization, even though managerFetch had already observed a
+      // status before throwing.
+      kind = "hard-error";
+    }
+    kinds.push(kind);
+  }
+  return kinds;
+}
+
+function isManagerUnavailableQueueKinds(kinds: unknown): kinds is ManagerQueueStatusKind[] {
+  if (!Array.isArray(kinds) || kinds.length !== 2) return false;
+  const allowed = new Set<ManagerQueueStatusKind>(["not-found", "empty", "unavailable"]);
+  if (!kinds.every((kind): kind is ManagerQueueStatusKind => allowed.has(kind as ManagerQueueStatusKind))) {
+    return false;
+  }
+  // Both 404s have their own already-shipped, stronger absence contract. This
+  // branch is for the new unavailable surface and therefore needs at least one
+  // positive empty/unavailable response rather than re-labelling 404 absence.
+  return kinds.some((kind) => kind === "empty" || kind === "unavailable");
 }
 
 async function probeManagerMajor(base: string): Promise<number | undefined> {
@@ -672,11 +784,20 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
   // the newer state (#646).
   const stamp = managerApiCacheStamp();
   const queueStatusCodes: Array<number | undefined> = [undefined, undefined];
+  const queueStatusKinds: ManagerQueueStatusKind[] = ["hard-error", "hard-error"];
   const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", {
     base,
     soft: true,
     onSoftFailure: (status) => {
       queueStatusCodes[0] = status;
+      queueStatusKinds[0] =
+        status === undefined ? "transport" : managerQueueStatusKind(status);
+    },
+    onSoftTransportFailure: () => {
+      queueStatusKinds[0] = "transport";
+    },
+    onSoftResponse: (body) => {
+      queueStatusKinds[0] = managerQueueResponseKind(body);
     },
   });
   if (looksLikeQueueStatus(v2)) {
@@ -689,6 +810,14 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
     soft: true,
     onSoftFailure: (status) => {
       queueStatusCodes[1] = status;
+      queueStatusKinds[1] =
+        status === undefined ? "transport" : managerQueueStatusKind(status);
+    },
+    onSoftTransportFailure: () => {
+      queueStatusKinds[1] = "transport";
+    },
+    onSoftResponse: (body) => {
+      queueStatusKinds[1] = managerQueueResponseKind(body);
     },
   });
   if (looksLikeQueueStatus(legacy)) {
@@ -729,6 +858,7 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
       kind: MANAGER_QUEUE_DETECTION_FAILURE,
       base,
       queueStatusCodes,
+      queueStatusKinds,
     },
   );
 }
@@ -3086,11 +3216,15 @@ function initialManagerQueueAbsenceWasProven(err: unknown): boolean {
 
 /**
  * A direct clone is safe after either a Manager-native policy refusal whose body
- * explicitly proves no task was queued, a direct enqueue route-level 404, or a
+ * explicitly proves no task was queued, a direct enqueue route-level 404, a
  * detection failure followed by a fresh probe proving BOTH queue dialects are
- * 404 on the same captured ComfyUI base.
- * A bare 401/403/407, timeout, 5xx, malformed response, or unrelated reachability
- * error remains fail-closed.
+ * 404 on the same captured ComfyUI base, or the new local Manager-unavailable
+ * surface: both dialects repeatedly answer with an empty/explicitly-unavailable
+ * response before any enqueue route is attempted.
+ *
+ * A bare 401/403/407, timeout, 5xx, 405, malformed/HTML response, or unrelated
+ * reachability error remains fail-closed. This keeps a response that could be a
+ * live Manager or an accepted background task from being raced by the clone.
  */
 async function managerAbsenceAllowsGitFallback(
   err: unknown,
@@ -3106,12 +3240,36 @@ async function managerAbsenceAllowsGitFallback(
   if (status !== undefined) return false;
   if (
     status === undefined &&
-    (!isManagerQueueDetectionFailure(err) || !initialManagerQueueAbsenceWasProven(err))
+    !isManagerQueueDetectionFailure(err)
   ) {
     return false;
   }
+
+  if (initialManagerQueueAbsenceWasProven(err)) {
+    try {
+      return (await probeManagerQueueAvailability(base)) === "absent";
+    } catch {
+      return false;
+    }
+  }
+
+  const details = err instanceof NodeManagementError && err.details && typeof err.details === "object"
+    ? (err.details as { queueStatusKinds?: unknown })
+    : undefined;
+  const initialKinds = details?.queueStatusKinds;
+  if (!isManagerUnavailableQueueKinds(initialKinds)) return false;
+
+  // Re-read the same two endpoints. A single empty response can be a transient
+  // proxy/server failure; two identical no-queue observations are the minimum
+  // evidence this pre-enqueue fallback can safely act on. The direct probe keeps
+  // 405/5xx/auth/transport/malformed responses distinct instead of collapsing
+  // them into the public "unreadable" state.
   try {
-    return (await probeManagerQueueAvailability(base)) === "absent";
+    const freshKinds = await probeManagerQueueStatusKinds(base);
+    return (
+      isManagerUnavailableQueueKinds(freshKinds) &&
+      freshKinds.every((kind, index) => kind === initialKinds[index])
+    );
   } catch {
     return false;
   }
@@ -3450,6 +3608,21 @@ async function withObjectInfoInvalidation<T>(op: () => Promise<T>): Promise<T> {
   return result;
 }
 
+/**
+ * A git URL can end in a local filesystem write when Manager is unavailable or
+ * accepts an unregistered pack without installing it. Serialize that whole
+ * decision and write, not just the final `git clone`, so two orchestrators
+ * cannot both observe a missing destination and race into the same
+ * custom_nodes directory. `useCmCli` is included because comfy-cli is also a
+ * local writer and must share the same critical section.
+ */
+function needsLocalInstallMutationLock(opts: InstallOptions): boolean {
+  if (opts.useCmCli === true) return true;
+  if (opts.source === "git") return true;
+  if (opts.source === "registry") return false;
+  return looksLikeGitUrl(parseGitUrl(opts.id).baseUrl);
+}
+
 // NOTE on `async`: these wrappers are declared async purely so the PIN GUARD's
 // throw surfaces as a REJECTED PROMISE rather than a synchronous exception.
 // Callers rely on that — apply_manifest does `installCustomNode(...).then().catch()`
@@ -3461,9 +3634,10 @@ export async function installCustomNode(opts: InstallOptions): Promise<NodeOpRes
   // operation that install_comfyui(action:'panel') drives. Guarding here — where the TARGET is
   // known — covers every caller, including a bulk "all". The check and the
   // mutation are atomic under the panel mutation lock (withPanelPinGuard).
-  return withPanelPinGuard("install", opts.id, () =>
+  const op = () => withPanelPinGuard("install", opts.id, () =>
     withObjectInfoInvalidation(() => installCustomNodeImpl(opts)),
   );
+  return needsLocalInstallMutationLock(opts) ? withPanelMutationLock(op) : op();
 }
 
 /**
@@ -3742,7 +3916,11 @@ async function installCustomNodeImpl(
           wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
         );
       }
-      logger.info("Manager refused or was proven absent — cloning directly", {
+      const managerUnavailable =
+        refusedBy === undefined &&
+        isManagerQueueDetectionFailure(err) &&
+        !initialManagerQueueAbsenceWasProven(err);
+      logger.info("Manager refused, was unavailable, or was proven absent — cloning directly", {
         status: refusedBy,
         gitId,
       });
@@ -3752,7 +3930,9 @@ async function installCustomNodeImpl(
         gitRef,
         refusedBy === 403 || refusedBy === 404
           ? { manager_refused: refusedBy }
-          : { manager_absent: true },
+          : managerUnavailable
+            ? { manager_unavailable: true }
+            : { manager_absent: true },
         cliWorkspace,
         {
           refFromVersion,
@@ -3764,6 +3944,10 @@ async function installCustomNodeImpl(
               : refusedBy === 404
                 ? `ComfyUI-Manager's git-install route returned HTTP 404 before queueing. ` +
                   `Nothing was queued there.`
+                : managerUnavailable
+                  ? `ComfyUI-Manager's queue/status surface was unavailable: both dialect ` +
+                    `probes repeatedly returned no queue status before any install task was ` +
+                    `submitted. Nothing was queued there.`
                 : `ComfyUI-Manager is confirmed absent: both queue/status dialects returned HTTP 404 ` +
                   `on the connected ComfyUI. Nothing was queued there.`,
         },

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1486,7 +1486,7 @@ interface ManagerEnqueueOptions {
   rejectEmptyEnqueue?: boolean;
 }
 
-type ManagerEnqueueResponse = Record<string, unknown> | string | undefined;
+type ManagerEnqueueResponse = Record<string, unknown> | string | null | undefined;
 
 function assertManagerEnqueueResponse(
   response: unknown,
@@ -1496,7 +1496,7 @@ function assertManagerEnqueueResponse(
   path: string,
   base: string,
 ): void {
-  if (!options.rejectEmptyEnqueue || response !== undefined) return;
+  if (!options.rejectEmptyEnqueue || (response !== undefined && response !== null)) return;
   throw new NodeManagementError(
     `ComfyUI-Manager returned a successful but empty response for the ${kind} enqueue ` +
       `on the "${api}" dialect. The task may have been submitted, so its outcome is ` +
@@ -1879,7 +1879,15 @@ async function enqueueManagerTask(
       // Rebuild the body for the dialect we are downgrading TO: this build runs
       // the 3.x handlers under /v2, so a dialect-specific body (a git install)
       // must be its 3.x shape, not the v2 one we just tried.
-      await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId, base);
+      const response = await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId, base);
+      assertManagerEnqueueResponse(
+        response,
+        options,
+        kind,
+        "v2-batch",
+        kind === "install-model" ? "/v2/manager/queue/install_model" : "/v2/manager/queue/batch",
+        base,
+      );
       // Pin the corrected dialect ONLY after the batch enqueue actually
       // succeeded, so a transient/proxy 405 on a genuine v4 host (task 405 but
       // batch also unavailable) never poisons the cache: enqueueV2BatchTask

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -561,7 +561,10 @@ function looksLikeManagerUnavailableResponse(body: unknown): boolean {
 
 function managerQueueResponseKind(body: unknown): ManagerQueueStatusKind {
   if (looksLikeQueueStatus(body)) return "queue";
-  if (body === undefined) return "empty";
+  // A successful JSON `null` is the same absence of queue evidence as a 200
+  // with no body. Treat both as empty so a warm cached dialect cannot poll
+  // until timeout and then invite a re-issue (#1129).
+  if (body === undefined || body === null) return "empty";
   if (looksLikeManagerUnavailableResponse(body)) return "unavailable";
   return "malformed";
 }
@@ -1389,7 +1392,11 @@ async function runManagerQueue(
       base,
       soft: true,
       onSoftResponse: (body) => {
-        emptyStatusResponse = body === undefined;
+        // managerFetch preserves JSON null, so it must be fail-closed exactly
+        // like an empty successful body. Otherwise a stale warm-cache install
+        // waits for the full queue budget instead of being classified as an
+        // ambiguous outcome immediately.
+        emptyStatusResponse = body === undefined || body === null;
       },
     });
     if (emptyStatusResponse) {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1460,13 +1460,55 @@ async function reclassifyAfterEmptyQueueStatus(
       `Manager queue/status returned an empty successful response on the cached "${used}" dialect`,
     );
   }
-  const fresh = await detectManagerApi(base);
+  let fresh: ManagerApi | undefined;
+  try {
+    fresh = await detectManagerApi(base);
+  } catch {
+    // Re-detection can itself conclude that both queue surfaces are empty or
+    // unavailable. That is useful classification evidence, but it is NOT proof
+    // that the enqueue already observed by this operation did not submit a task.
+    // Keep the post-enqueue ambiguity distinct so the local git fallback cannot
+    // race an accepted Manager task.
+  }
   throw new NodeManagementError(
     `ComfyUI-Manager queue/status returned an empty successful response while the cached ` +
-      `"${used}" dialect was in use. The live server reclassified as "${fresh}", but the ` +
-      `${kind ?? "Manager"} enqueue outcome is UNKNOWN and was NOT retried automatically. ` +
-      `Verify whether it took effect before reissuing it.`,
+      `"${used}" dialect was in use. The live server ` +
+      (fresh ? `reclassified as "${fresh}"` : `could not be reclassified`) +
+      `, but the ${kind ?? "Manager"} enqueue may already have submitted a task. Its ` +
+      `outcome is UNKNOWN; it was NOT retried automatically and no local fallback is ` +
+      `authorized. Verify whether it took effect before reissuing it.`,
     { kind: "manager-queue-empty-status", base, used, fresh },
+  );
+}
+
+interface ManagerEnqueueOptions {
+  /** A git install may fall back to a local clone, so an empty 2xx is unsafe. */
+  rejectEmptyEnqueue?: boolean;
+}
+
+type ManagerEnqueueResponse = Record<string, unknown> | string | undefined;
+
+function assertManagerEnqueueResponse(
+  response: unknown,
+  options: ManagerEnqueueOptions,
+  kind: ManagerTaskKind,
+  api: ManagerApi,
+  path: string,
+  base: string,
+): void {
+  if (!options.rejectEmptyEnqueue || response !== undefined) return;
+  throw new NodeManagementError(
+    `ComfyUI-Manager returned a successful but empty response for the ${kind} enqueue ` +
+      `on the "${api}" dialect. The task may have been submitted, so its outcome is ` +
+      `UNKNOWN; the queue was not started and no local fallback is authorized. ` +
+      `Verify whether it took effect before reissuing it.`,
+    {
+      kind: "manager-enqueue-empty-success",
+      operation: kind,
+      api,
+      path,
+      base,
+    },
   );
 }
 
@@ -1481,8 +1523,9 @@ async function queueManagerTask(
   kind: ManagerTaskKind,
   params: ManagerTaskParams,
   base = managerBaseUrl(),
+  options: ManagerEnqueueOptions = {},
 ): Promise<QueueStatus> {
-  return (await queueManagerTaskTracked(kind, params, base)).status;
+  return (await queueManagerTaskTracked(kind, params, base, options)).status;
 }
 
 /**
@@ -1500,6 +1543,7 @@ async function queueManagerTaskTracked(
   kind: ManagerTaskKind,
   params: ManagerTaskParams,
   base = managerBaseUrl(),
+  options: ManagerEnqueueOptions = {},
 ): Promise<{ status: QueueStatus; uiId: string }> {
   // Normalize to a resolver so every attempt builds its body for the dialect it
   // is about to speak — a few operations (git installs) have dialect-specific
@@ -1517,7 +1561,7 @@ async function queueManagerTaskTracked(
   // retry, queue start, or verification of a request the user already made.
   const used = await enqueueWithDialectSelfHeal(kind, (api, epoch) => {
     uiId = randomUUID();
-    return enqueueManagerTask(api, kind, resolve, uiId, base, epoch);
+    return enqueueManagerTask(api, kind, resolve, uiId, base, epoch, options);
   }, base);
   // Thread the kind so a model download gets the model budget, not the node one (#817).
   const status = await runManagerQueue(used, base, kind);
@@ -1791,18 +1835,21 @@ async function enqueueManagerTask(
   uiId: string,
   base: string,
   startEpoch: number,
+  options: ManagerEnqueueOptions = {},
 ): Promise<ManagerApi> {
   if (api === "legacy") {
-    await enqueueLegacyTask(kind, resolveParams("legacy"), uiId, base);
+    const response = await enqueueLegacyTask(kind, resolveParams("legacy"), uiId, base);
+    assertManagerEnqueueResponse(response, options, kind, api, "/manager/queue/install", base);
     return "legacy";
   }
   if (api === "v2-batch") {
-    await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId, base);
+    const response = await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId, base);
+    assertManagerEnqueueResponse(response, options, kind, api, "/v2/manager/queue/batch", base);
     return "v2-batch";
   }
   // v2 unified task envelope (normal-mode pip Manager v4).
   try {
-    await managerFetch("/v2/manager/queue/task", {
+    const response = await managerFetch("/v2/manager/queue/task", {
       method: "POST",
       base,
       body: {
@@ -1812,6 +1859,7 @@ async function enqueueManagerTask(
         params: { ...resolveParams("v2"), ui_id: uiId },
       },
     });
+    assertManagerEnqueueResponse(response, options, kind, api, "/v2/manager/queue/task", base);
   } catch (err) {
     if (errorStatus(err) === 405) {
       // Detection chose the unified /v2 task dialect (the /v2 queue surface
@@ -1854,10 +1902,10 @@ async function enqueueLegacyTask(
   params: Record<string, unknown>,
   uiId: string,
   base: string,
-): Promise<void> {
+): Promise<ManagerEnqueueResponse> {
   const { path, body } = legacyTaskRequest(kind, params, uiId);
   try {
-    await managerFetch(path, { method: "POST", body, base });
+    return await managerFetch<Record<string, unknown> | string>(path, { method: "POST", body, base });
   } catch (err) {
     throw annotateLegacyError(err, kind);
   }
@@ -1877,11 +1925,11 @@ async function enqueueV2BatchTask(
   params: Record<string, unknown>,
   uiId: string,
   base: string,
-): Promise<void> {
+): Promise<ManagerEnqueueResponse> {
   const { path, body } = legacyTaskRequest(kind, params, uiId);
   try {
     if (kind === "install-model") {
-      await managerFetch("/v2/manager/queue/install_model", { method: "POST", body, base });
+      return await managerFetch<Record<string, unknown> | string>("/v2/manager/queue/install_model", { method: "POST", body, base });
     } else {
       // legacyTaskRequest's path is "/manager/queue/<op>"; the batch key is
       // that trailing op ("enable" maps to an install body → key "install").
@@ -1899,6 +1947,7 @@ async function enqueueV2BatchTask(
             "gating is a common cause).",
         );
       }
+      return res;
     }
   } catch (err) {
     throw annotateLegacyError(err, kind, MANAGER_LEGACY_UI_HINT);
@@ -3974,6 +4023,10 @@ async function installCustomNodeImpl(
             mode: opts.mode ?? "cache",
           },
       managerBase,
+      // This branch can authorize a local clone after Manager returns. An
+      // empty successful enqueue is ambiguous, so fail before start/status
+      // rather than treating it as a safe pre-queue refusal.
+      { rejectEmptyEnqueue: true },
     );
 
     let status: unknown;

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1384,10 +1384,17 @@ async function runManagerQueue(
   let lastStatus: QueueStatus | undefined;
   while (Date.now() - start < timeoutMs) {
     await sleep(queueTiming.pollIntervalMs);
+    let emptyStatusResponse = false;
     const status = await managerFetch<QueueStatus>(`${prefix}/status`, {
       base,
       soft: true,
+      onSoftResponse: (body) => {
+        emptyStatusResponse = body === undefined;
+      },
     });
+    if (emptyStatusResponse) {
+      await reclassifyAfterEmptyQueueStatus(api, kind, base);
+    }
     if (status) {
       lastStatus = status;
       // Manager defines total_count = done + in_progress + queued. The queue
@@ -1422,6 +1429,44 @@ async function runManagerQueue(
           `automatically, and size-verified before anything is reported as landed.`
         : `The Manager worker may still be running the task on the host; check its state before retrying.`),
     lastStatus,
+  );
+}
+
+/**
+ * A warm dialect cache can send an enqueue and queue-start request to a local
+ * ComfyUI whose Manager surface has since disappeared. Those routes may answer
+ * 2xx with empty bodies, so there is no enqueue HTTP error for the existing
+ * dialect self-heal to see. An empty queue/status response is the first
+ * production-path signal that the cached classification may be stale: clear it
+ * and classify the live server before waiting for the queue timeout.
+ *
+ * If a different usable dialect is found, the earlier empty enqueue is
+ * ambiguous and must not be re-sent. If both dialects remain empty/unavailable,
+ * detectManagerApi() preserves the queue-status evidence that the git-install
+ * fallback is allowed to re-check. Every other probe failure remains fail-closed.
+ */
+async function reclassifyAfterEmptyQueueStatus(
+  used: ManagerApi,
+  kind: ManagerTaskKind | undefined,
+  base: string,
+): Promise<never> {
+  // Do not discard a newer classification another operation may have committed
+  // after this operation captured `used`. If the cache is already absent, the
+  // detector below will perform the needed fresh probe without another epoch
+  // bump; if it names another dialect, it is already the reclassification we
+  // need to observe.
+  if (getCachedManagerApi(base) === used) {
+    resetManagerApiCache(
+      `Manager queue/status returned an empty successful response on the cached "${used}" dialect`,
+    );
+  }
+  const fresh = await detectManagerApi(base);
+  throw new NodeManagementError(
+    `ComfyUI-Manager queue/status returned an empty successful response while the cached ` +
+      `"${used}" dialect was in use. The live server reclassified as "${fresh}", but the ` +
+      `${kind ?? "Manager"} enqueue outcome is UNKNOWN and was NOT retried automatically. ` +
+      `Verify whether it took effect before reissuing it.`,
+    { kind: "manager-queue-empty-status", base, used, fresh },
   );
 }
 
@@ -3588,6 +3633,24 @@ export interface InstallOptions {
   managerBase?: string;
   /** Monotonic ComfyUI target generation captured with managerBase. */
   targetGeneration?: number;
+  /**
+   * Internal apply_manifest phase hook. Called once when this operation has
+   * selected its local git fallback, before it waits for the local writer lock.
+   * It is observational only and does not change the install decision.
+   */
+  onLocalFallback?: () => void;
+}
+
+function notifyLocalFallbackSelected(opts: InstallOptions): void {
+  try {
+    opts.onLocalFallback?.();
+  } catch (err) {
+    // This is an observational hook used by apply_manifest; a reporting
+    // callback must never prevent the selected local fallback from running.
+    logger.debug("Ignoring local fallback phase-hook failure", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 /**
@@ -3934,6 +3997,7 @@ async function installCustomNodeImpl(
           wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
         );
       }
+      if (!isRemoteMode()) notifyLocalFallbackSelected(opts);
       const managerUnavailable =
         refusedBy === undefined &&
         isManagerQueueDetectionFailure(err) &&
@@ -4001,6 +4065,7 @@ async function installCustomNodeImpl(
         wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
       );
     }
+    if (!isRemoteMode()) notifyLocalFallbackSelected(opts);
     const clone = () => cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
       refFromVersion,
       allowSharedWorkspaceFallback: cliWorkspace !== undefined,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3608,21 +3608,6 @@ async function withObjectInfoInvalidation<T>(op: () => Promise<T>): Promise<T> {
   return result;
 }
 
-/**
- * A git URL can end in a local filesystem write when Manager is unavailable or
- * accepts an unregistered pack without installing it. Serialize that whole
- * decision and write, not just the final `git clone`, so two orchestrators
- * cannot both observe a missing destination and race into the same
- * custom_nodes directory. `useCmCli` is included because comfy-cli is also a
- * local writer and must share the same critical section.
- */
-function needsLocalInstallMutationLock(opts: InstallOptions): boolean {
-  if (opts.useCmCli === true) return true;
-  if (opts.source === "git") return true;
-  if (opts.source === "registry") return false;
-  return looksLikeGitUrl(parseGitUrl(opts.id).baseUrl);
-}
-
 // NOTE on `async`: these wrappers are declared async purely so the PIN GUARD's
 // throw surfaces as a REJECTED PROMISE rather than a synchronous exception.
 // Callers rely on that — apply_manifest does `installCustomNode(...).then().catch()`
@@ -3637,7 +3622,7 @@ export async function installCustomNode(opts: InstallOptions): Promise<NodeOpRes
   const op = () => withPanelPinGuard("install", opts.id, () =>
     withObjectInfoInvalidation(() => installCustomNodeImpl(opts)),
   );
-  return needsLocalInstallMutationLock(opts) ? withPanelMutationLock(op) : op();
+  return op();
 }
 
 /**
@@ -3719,6 +3704,25 @@ function assertInstallTargetStable(
       actualGeneration,
     },
   );
+}
+
+/**
+ * Serialize only a local install writer. The callback must be the complete
+ * filesystem transaction, including any existence check that decides whether
+ * it will create the destination. Manager probing, enqueueing, draining, and
+ * Manager-only fallback decisions stay outside this boundary.
+ */
+function withLocalInstallMutationLock<T>(
+  expectedGeneration: number,
+  managerBase: string,
+  op: () => Promise<T>,
+): Promise<T> {
+  return withPanelMutationLock(async () => {
+    // Another local writer may have held the lock while the target changed.
+    // Refuse before touching the captured filesystem target in that case.
+    assertInstallTargetStable(expectedGeneration, managerBase);
+    return op();
+  });
 }
 
 async function installCustomNodeImpl(
@@ -3814,11 +3818,25 @@ async function installCustomNodeImpl(
       }
       // cm-cli install accepts registry ids and git urls alike.
       const installId = source === "git" ? gitId : id;
-      const out = runCmCli(["install", installId, "--mode", mode, "--channel", channel], cliWorkspace);
-      let checkoutWarning: string | undefined;
-      if (source === "git" && gitRef) {
-        checkoutWarning = runGitCheckout(gitId, gitRef, cliWorkspace, { refFromVersion });
-      }
+      const { out, checkoutWarning } = await withLocalInstallMutationLock(
+        targetGeneration,
+        managerBase,
+        async () => {
+          // The lock is intentionally acquired only after the CLI availability
+          // probe and Manager-only fallback decision. The helper re-checks the
+          // target after waiting, so a retarget while another local writer held
+          // the lock cannot send this mutation to an obsolete install.
+          const out = runCmCli(
+            ["install", installId, "--mode", mode, "--channel", channel],
+            cliWorkspace,
+          );
+          let checkoutWarning: string | undefined;
+          if (source === "git" && gitRef) {
+            checkoutWarning = runGitCheckout(gitId, gitRef, cliWorkspace, { refFromVersion });
+          }
+          return { out, checkoutWarning };
+        },
+      );
       return {
         mechanism: "comfy-cli",
         message: `Installed "${id}" via official comfy-cli.${checkoutWarning ? ` ${checkoutWarning}` : ""}`,
@@ -3924,7 +3942,7 @@ async function installCustomNodeImpl(
         status: refusedBy,
         gitId,
       });
-      const cloned = await cloneCustomNodeFallback(
+      const clone = () => cloneCustomNodeFallback(
         gitId,
         repoName,
         gitRef,
@@ -3952,6 +3970,13 @@ async function installCustomNodeImpl(
                   `on the connected ComfyUI. Nothing was queued there.`,
         },
       );
+      // A remote target never writes locally. In particular, an accepted
+      // Manager task that resolves no pack reaches cloneCustomNodeFallback only
+      // to receive its authoritative remote-target refusal; do not make that
+      // refusal wait behind an unrelated local writer.
+      const cloned = isRemoteMode()
+        ? await clone()
+        : await withLocalInstallMutationLock(targetGeneration, managerBase, clone);
       assertInstallTargetStable(targetGeneration, managerBase);
       return withCliNote(cloned);
     }
@@ -3976,10 +4001,16 @@ async function installCustomNodeImpl(
         wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
       );
     }
-    const cloned = await cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
+    const clone = () => cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
       refFromVersion,
       allowSharedWorkspaceFallback: cliWorkspace !== undefined,
     });
+    // An accepted remote Manager task that resolves no pack still reaches this
+    // helper only for its authoritative remote-target refusal; it is not a
+    // local write and must not wait on the local writer lock.
+    const cloned = isRemoteMode()
+      ? await clone()
+      : await withLocalInstallMutationLock(targetGeneration, managerBase, clone);
     assertInstallTargetStable(targetGeneration, managerBase);
     return withCliNote(cloned);
   }

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -286,14 +286,18 @@ export function panelLockPath(): string {
 }
 
 /**
- * Default acquisition budget for a guarded mutation. It must cover the
- * longest operation that can validly hold this cross-process lock: Manager and
- * comfy-cli node operations are bounded at 10 minutes, while direct git work
- * is bounded at 3 minutes. Keep a small margin for the final filesystem work
- * and the 100 ms polling cadence. Callers that must not block (the
- * fire-and-forget on-load ensure) pass something much shorter.
+ * Default acquisition budget for a guarded mutation. This lock has NO expiry:
+ * the owner holds it until its callback returns, and only a proven dead owner
+ * can take the abandoned-lock recovery path. The budget is for a WAITER.
+ *
+ * The longest current local custom-node writer can spend 1,260s in git command
+ * ceilings (clone plus the version/ref probes and checkout) and another 1,200s
+ * in the sequential requirements.txt and install.py ceilings: 2,460s total.
+ * Give a valid concurrent writer 60s for final filesystem work and polling.
+ * Callers that must not block (the fire-and-forget on-load ensure) pass a much
+ * shorter explicit budget.
  */
-const DEFAULT_ACQUIRE_MS = 10 * 60_000 + 30_000;
+const DEFAULT_ACQUIRE_MS = 42 * 60_000;
 
 const POLL_MS = 100;
 

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -291,13 +291,15 @@ export function panelLockPath(): string {
  * can take the abandoned-lock recovery path. The budget is for a WAITER.
  *
  * The longest current local custom-node writer can spend 1,260s in git command
- * ceilings (clone plus the version/ref probes and checkout) and another 1,200s
- * in the sequential requirements.txt and install.py ceilings: 2,460s total.
- * Give a valid concurrent writer 60s for final filesystem work and polling.
+ * ceilings (clone plus the version/ref probes and checkout), another 1,200s
+ * in the sequential requirements.txt and install.py ceilings, and 120s in the
+ * in-lock /system_stats request used while resolving the install interpreter:
+ * 2,580s total. Give a valid concurrent writer 60s for final filesystem work
+ * and polling.
  * Callers that must not block (the fire-and-forget on-load ensure) pass a much
  * shorter explicit budget.
  */
-const DEFAULT_ACQUIRE_MS = 42 * 60_000;
+const DEFAULT_ACQUIRE_MS = 44 * 60_000;
 
 const POLL_MS = 100;
 

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -285,9 +285,15 @@ export function panelLockPath(): string {
   );
 }
 
-/** Default acquisition budget. Callers that must not block (the fire-and-forget
- *  on-load ensure) pass something much shorter. */
-const DEFAULT_ACQUIRE_MS = 60_000;
+/**
+ * Default acquisition budget for a guarded mutation. It must cover the
+ * longest operation that can validly hold this cross-process lock: Manager and
+ * comfy-cli node operations are bounded at 10 minutes, while direct git work
+ * is bounded at 3 minutes. Keep a small margin for the final filesystem work
+ * and the 100 ms polling cadence. Callers that must not block (the
+ * fire-and-forget on-load ensure) pass something much shorter.
+ */
+const DEFAULT_ACQUIRE_MS = 10 * 60_000 + 30_000;
 
 const POLL_MS = 100;
 


### PR DESCRIPTION
## Summary\n\nFixes #1129. Local install_custom_node git URLs now use the verified direct-clone fallback when both Manager queue-status dialects repeatedly return an empty or explicit unavailable response before any install task is submitted. The existing 403/404 pre-queue, accepted-but-never-enqueued, remote-target, 405, 5xx, auth, malformed-response, and comfy-cli behaviors remain distinct.\n\nThe full local filesystem mutation is serialized with the existing cross-process mutation lock, and live-root/target-generation ownership checks remain in force.\n\n## Tests\n\n- npm.cmd exec vitest -- run src/__tests__/services/node-management.test.ts src/__tests__/services/install-node-target-1765.test.ts --passWithNoTests\n- npm.cmd run build\n- npm.cmd run lint\n- npm.cmd test: all auxiliary gates passed; one unrelated load-sensitive late-mutation-e2e test failed in the full run and passed when rerun alone\n\nNo init.py or apps_routes.py files were changed. This PR is intentionally not merged.