### PR TITLE
chore: release v0.52.147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.147] - 2026-08-28
+
+### MCP
+
+#### Fixed
+- omit the unexpose reindex warning when the panel already reindexed
+
+
 ## [0.52.146] - 2026-08-27
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
-- omit the unexpose reindex warning when the panel already reindexed
+- omit the unexpose reindex warning when the panel already reindexed (#2474)
 
 
 ## [0.52.146] - 2026-08-27

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.146",
+  "version": "0.52.147",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.146",
+      "version": "0.52.147",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.146",
+  "version": "0.52.147",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release MCP v0.52.147.

Includes merged PR #2474:
- suppress the unexpose reindex warning only when Panel provides authoritative host_links_reindexed=true.

Generated CHANGELOG.md and package metadata from the current origin/main after PR #2474 merged.