### PR TITLE
fix(panel): refresh transient promoted-subgraph reads (#2478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - omit the unexpose reindex warning when the panel already reindexed (#2474)
-- keep the causal line above a native fault and stop blaming a pass-through node (#2508) (#2519) (#2520)
+- keep the causal line above a native fault and stop blaming a pass-through node (#2508) (#2519) (#2520) (#2478) (#2509) (#2552)
 
 
 ## [0.52.146] - 2026-08-27

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -132,6 +132,9 @@ function bridge(opts: {
   /** #2314 P1: emulate a current receiver that publishes the recursive
    * renamed-promotion terminal witness. */
   promotedTerminalWitnesses?: boolean;
+  /** #2478: leave inner node identities absent so the current-capability path
+   * proves it refuses an incomplete identity-bearing envelope. */
+  omitInnerNodeIdentity?: boolean;
   /** #2314 final-rail race: relink the parent input after MCP's last
    * synchronous callback but before the receiver applies graph_set_widget. */
   parentRailRelinkAfterMcpFence?: boolean;
@@ -205,6 +208,28 @@ function bridge(opts: {
     let result = Object.prototype.hasOwnProperty.call(value, "viewing")
       ? value
       : { ...value, viewing: currentViewing() };
+    if (
+      !legacyBuild &&
+      opts.promotedTerminalWitnesses === true &&
+      opts.omitInnerNodeIdentity !== true &&
+      Array.isArray(result.nodes)
+    ) {
+      // Current panel projections publish an opaque per-object identity for every
+      // inner node. Keep explicit malformed/replacement identities untouched, but
+      // give older fixtures the same current-build shape so the harness exercises
+      // the paired identity-forwarding contract instead of capability skew.
+      result = {
+        ...result,
+        nodes: result.nodes.map((raw) => {
+          if (!raw || typeof raw !== "object" || Array.isArray(raw)) return raw;
+          const node = raw as Record<string, unknown>;
+          if (!Object.prototype.hasOwnProperty.call(node, "id") || Object.prototype.hasOwnProperty.call(node, "node_identity")) {
+            return raw;
+          }
+          return { ...node, node_identity: `node-incarnation:test:${String(node.id)}` };
+        }),
+      };
+    }
     const rawOwnerEnvelope = result.subgraph_of;
     if (rawOwnerEnvelope && typeof rawOwnerEnvelope === "object" && !Array.isArray(rawOwnerEnvelope)) {
       const owner = rawOwnerEnvelope as Record<string, unknown>;
@@ -3563,6 +3588,102 @@ describe("panel_set_widget transient promoted-subgraph read (#2478)", () => {
     expect(text).toMatch(/could not determine whether the addressed node is a promoted container/);
     expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(1);
     expect(bridgeRetryBudgets).toEqual([0]);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(mutations).toBe(0);
+  });
+});
+
+describe("panel_set_widget promoted inner identity forwarding (#2478)", () => {
+  const originalIdentity = "node-incarnation:inner-original";
+  const replacementIdentity = "node-incarnation:inner-replacement";
+  const currentEnvelope = (nodeIdentity: unknown) => ({
+    ...CURRENT_SAFE_PROMOTED_SUBGRAPH,
+    nodes: [
+      {
+        ...CURRENT_SAFE_PROMOTED_SUBGRAPH.nodes[0],
+        node_identity: nodeIdentity,
+      },
+    ],
+  });
+  const innerDetail = (nodeIdentity: unknown) => ({
+    nodes: [
+      {
+        id: 76,
+        type: "PrimitiveStringMultiline",
+        node_identity: nodeIdentity,
+      },
+    ],
+  });
+
+  it("forwards the immediate inner identity on the guarded write", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: currentEnvelope(originalIdentity),
+        postEnterGraphQueryById: { "76": innerDetail(originalIdentity) },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(text).toMatch(/applied|quality_prompt/);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({
+        node_id: 76,
+        widget: "quality_prompt",
+        expected_node_identity: originalIdentity,
+      }),
+    ]);
+  });
+
+  it("refuses a same-ID same-type inner replacement before dispatch", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: currentEnvelope(originalIdentity),
+        postEnterGraphQueryById: { "76": innerDetail(replacementIdentity) },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/identity|changed or became unverifiable|Nothing was applied/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(mutations).toBe(0);
+  });
+
+  it("refuses a current-capability envelope that omits the inner identity", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        omitInnerNodeIdentity: true,
+        subgraph: currentEnvelope(undefined),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/trustworthy immediate inner-node identity fence/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(mutations).toBe(0);
+  });
+
+  it("refuses a malformed inner identity rather than treating it as a legacy omission", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: currentEnvelope(42),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
     expect(mutations).toBe(0);
   });

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1038,7 +1038,11 @@ describe("panel_set_widget ordinary-node scope probe fence (#2401)", () => {
 
     expect(isError).toBe(true);
     expect(text).toMatch(/could not determine whether the addressed node is a promoted container/);
-    expect(calls.map((call) => call.cmd)).toEqual(["graph_query", "graph_get_subgraph"]);
+    expect(calls.map((call) => call.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_get_subgraph",
+    ]);
     expect(writesApplied).toBe(0);
     expect(mutations).toBe(0);
   });
@@ -1348,7 +1352,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(writes[0]).toMatchObject({ node_id: 76, widget });
   });
 
-  it("refuses an indeterminate graph_get_subgraph error before any container write", async () => {
+  it("refuses after one indeterminate graph_get_subgraph refresh before any container write", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
@@ -1362,6 +1366,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.map((c) => c.cmd)).toEqual([
       "graph_query",
       "graph_query",
+      "graph_get_subgraph",
       "graph_get_subgraph",
     ]);
   });
@@ -1430,7 +1435,7 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(text).not.toContain("This usually follows a ComfyUI backend restart");
   });
 
-  it("leaves every NON-diagnosed indeterminate read on its original wording", async () => {
+  it("leaves every NON-diagnosed indeterminate read on its original wording after one refresh", async () => {
     const { text, isError, calls, mutations } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
@@ -1441,9 +1446,14 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
 
     expect(isError).toBe(true);
     expect(mutations).toBe(0);
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_query", "graph_get_subgraph"]);
-    // Unchanged from before panel#1869: a transport failure IS transient, so
-    // "retry once stable" is honest advice there and must survive.
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_query",
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_get_subgraph",
+    ]);
+    // The refusal wording remains unchanged: a transport failure IS transient,
+    // so "retry once stable" is honest advice after the bounded refresh fails.
     expect(text).toContain("could not determine whether the addressed node is a promoted container");
     expect(text).toContain("retry only after the panel binding and subgraph mapping are stable");
     expect(text).not.toContain("[canvas-root-divergence]");
@@ -3329,6 +3339,47 @@ describe("#2393 promoted-terminal witness is judged on the requested alias", () 
     expect(isError).toBe(true);
     expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+});
+
+describe("panel_set_widget transient promoted-subgraph read (#2478)", () => {
+  const transientRead = new Error("graph_get_subgraph temporarily unavailable during panel binding");
+
+  it("refreshes one indeterminate read before applying the validated promoted write", async () => {
+    const { isError, calls, writesApplied, mutations } = await setWidget(
+      { node_id: 78, widget: "steps", value: 8 },
+      {
+        firstWrite: "ok",
+        subgraphSequence: [transientRead, SUBGRAPH],
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(writesApplied).toBe(1);
+    expect(mutations).toBe(1);
+    // The shipped handler performs the initial read, exactly one transient
+    // refresh, and the pre-entry mapping confirmation before the inner write.
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(3);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 75, widget: "steps", value: 8 }),
+    ]);
+  });
+
+  it("still refuses when the one refresh remains indeterminate", async () => {
+    const { isError, text, calls, writesApplied, mutations } = await setWidget(
+      { node_id: 78, widget: "steps", value: 8 },
+      {
+        firstWrite: "ok",
+        subgraphSequence: [transientRead, transientRead],
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/could not determine whether the addressed node is a promoted container/);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(2);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(writesApplied).toBe(0);
+    expect(mutations).toBe(0);
   });
 });
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -3605,12 +3605,23 @@ describe("panel_set_widget promoted inner identity forwarding (#2478)", () => {
       },
     ],
   });
-  const innerDetail = (nodeIdentity: unknown) => ({
+  // This is the actual one-ID compact graph_query envelope emitted by the
+  // Panel: the human-readable compact line is accompanied by the bounded,
+  // identity-bearing structured witness. Keep the response shape here in sync
+  // with browser_tests/unit/graph-query-detail-budget.test.mjs so this test
+  // exercises the producer/consumer contract rather than a bare nodes array.
+  const innerCompactResponse = (nodeIdentity: unknown) => ({
+    truncated: false,
+    truncated_by: null,
+    text:
+      "1 match(es) of 1 in scope (viewing: 2 nodes)\n" +
+      "#76 PrimitiveStringMultiline · quality_prompt=new",
     nodes: [
       {
         id: 76,
         type: "PrimitiveStringMultiline",
         node_identity: nodeIdentity,
+        is_subgraph: false,
       },
     ],
   });
@@ -3622,13 +3633,20 @@ describe("panel_set_widget promoted inner identity forwarding (#2478)", () => {
         firstWrite: "ok",
         promotedTerminalWitnesses: true,
         subgraph: currentEnvelope(originalIdentity),
-        postEnterGraphQueryById: { "76": innerDetail(originalIdentity) },
+        postEnterGraphQueryById: { "76": innerCompactResponse(originalIdentity) },
       },
     );
 
     expect(isError).toBe(false);
     expect(text).toMatch(/applied|quality_prompt/);
     expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_query" && call.ids?.[0] === 76)).toContainEqual(
+      expect.objectContaining({
+        fields: "compact",
+        limit: 1,
+        max_chars: 2048,
+      }),
+    );
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
       expect.objectContaining({
         node_id: 76,
@@ -3638,6 +3656,27 @@ describe("panel_set_widget promoted inner identity forwarding (#2478)", () => {
     ]);
   });
 
+  it("refuses a legacy compact text row that omits the current node identity", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "new" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: currentEnvelope(originalIdentity),
+        postEnterGraphQueryById: {
+          "76": {
+            text: "1 match(es) of 1 in scope (viewing: 1 nodes)\n#76 PrimitiveStringMultiline",
+          },
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/identity|changed or became unverifiable/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(mutations).toBe(0);
+  });
+
   it("refuses a same-ID same-type inner replacement before dispatch", async () => {
     const { text, isError, calls, mutations } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "new" },
@@ -3645,7 +3684,7 @@ describe("panel_set_widget promoted inner identity forwarding (#2478)", () => {
         firstWrite: "ok",
         promotedTerminalWitnesses: true,
         subgraph: currentEnvelope(originalIdentity),
-        postEnterGraphQueryById: { "76": innerDetail(replacementIdentity) },
+        postEnterGraphQueryById: { "76": innerCompactResponse(replacementIdentity) },
       },
     );
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -75,6 +75,9 @@ function bridge(opts: {
   /** #2393: successive graph_get_subgraph replies, used to model a witness
    * that is incomplete immediately after an official template load. */
   subgraphSequence?: Array<Record<string, unknown> | Error>;
+  /** #2478: replace the ordinary node after the definitive refresh, so a raw
+   * write would falsely succeed unless the handler carries the type fence. */
+  ordinaryNodeTypeAfterRefresh?: string;
   /** #2401: change the routing or panel connection identity after the async
    * ordinary-node scope probe has produced its result, before the caller can
    * take the fast path. */
@@ -156,9 +159,11 @@ function bridge(opts: {
   receiverUnresolvable?: boolean;
 }) {
   const calls: Array<Record<string, unknown>> = [];
+  const bridgeRetryBudgets: Array<number | undefined> = [];
   let writes = 0;
   let mutations = 0;
   let subgraphReads = 0;
+  let ordinaryNodeType = "OrdinaryNode";
   let postEnterGraphQueries = 0;
   let authoritativeScopeReads = 0;
   let inSubgraph = opts.startInSubgraph === true;
@@ -250,8 +255,11 @@ function bridge(opts: {
   const b = {
     send: async (
       cmd: Record<string, unknown>,
-      sendOpts?: { beforeDispatch?: () => void },
+      sendOpts?: { beforeDispatch?: () => void; maxReconnectRetries?: number },
     ) => {
+      if (cmd.cmd === "graph_get_subgraph") {
+        bridgeRetryBudgets.push(sendOpts?.maxReconnectRetries);
+      }
       if (cmd.cmd === "graph_set_widget" && sendOpts?.beforeDispatch) {
         const mutation = beforeWrite.mutate;
         beforeWrite.mutate = undefined;
@@ -309,6 +317,14 @@ function bridge(opts: {
             throw new Error("graph_set_widget promoted parent rail changed before dispatch: Nothing was applied.");
           }
         }
+        if (
+          opts.ordinaryNodeTypeAfterRefresh !== undefined &&
+          cmd.expected_node_type !== undefined &&
+          String(cmd.node_id) === "78" &&
+          cmd.expected_node_type !== ordinaryNodeType
+        ) {
+          throw new Error("graph_set_widget expected node type changed before dispatch: Nothing was applied.");
+        }
         writes += 1;
         if (writes === 1 && opts.ambiguous) throw new Error(AMBIGUOUS);
         if (writes === 1 && opts.scopeLost) throw new Error(SCOPE_REFUSAL);
@@ -361,7 +377,12 @@ function bridge(opts: {
         }
         if (opts.subgraphSequence && opts.subgraphSequence.length > 0) {
           const selected = opts.subgraphSequence[Math.min(subgraphReads - 1, opts.subgraphSequence.length - 1)];
-          if (selected instanceof Error) throw selected;
+          if (selected instanceof Error) {
+            if (subgraphReads === 2 && opts.ordinaryNodeTypeAfterRefresh !== undefined) {
+              ordinaryNodeType = opts.ordinaryNodeTypeAfterRefresh;
+            }
+            throw selected;
+          }
           return withCurrentViewing(selected);
         }
         if (inSubgraph) {
@@ -534,6 +555,9 @@ function bridge(opts: {
     get mutations() {
       return mutations;
     },
+    get bridgeRetryBudgets() {
+      return bridgeRetryBudgets;
+    },
   };
 }
 
@@ -565,6 +589,7 @@ async function setWidget(
     postEnterGraphQueries: harness.postEnterGraphQueries,
     writesApplied: harness.writesApplied,
     mutations: harness.mutations,
+    bridgeRetryBudgets: harness.bridgeRetryBudgets,
   };
 }
 
@@ -3379,6 +3404,70 @@ describe("panel_set_widget transient promoted-subgraph read (#2478)", () => {
     expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(2);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
     expect(writesApplied).toBe(0);
+    expect(mutations).toBe(0);
+  });
+
+  it("fences a definitive ordinary refresh before the raw write", async () => {
+    const { isError, calls, mutations, bridgeRetryBudgets } = await setWidget(
+      { node_id: 78, widget: "steps", value: 8 },
+      {
+        firstWrite: "ok",
+        subgraphSequence: [
+          transientRead,
+          new Error("Node 78 (OrdinaryNode) is not a subgraph"),
+        ],
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(bridgeRetryBudgets).toEqual([0, 0]);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(2);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({
+        node_id: 78,
+        widget: "steps",
+        expected_node_type: "OrdinaryNode",
+      }),
+    ]);
+  });
+
+  it("refuses instead of falsely succeeding when the ordinary node is replaced", async () => {
+    const { isError, text, calls, writesApplied, mutations, bridgeRetryBudgets } = await setWidget(
+      { node_id: 78, widget: "steps", value: 8 },
+      {
+        firstWrite: "ok",
+        ordinaryNodeTypeAfterRefresh: "ReplacementNode",
+        subgraphSequence: [
+          transientRead,
+          new Error("Node 78 (OrdinaryNode) is not a subgraph"),
+        ],
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/expected node type changed before dispatch/);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(2);
+    expect(bridgeRetryBudgets).toEqual([0, 0]);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(writesApplied).toBe(0);
+    expect(mutations).toBe(0);
+  });
+
+  it("does not spend the refresh on a permanent application error", async () => {
+    const { isError, text, calls, mutations, bridgeRetryBudgets } = await setWidget(
+      { node_id: 78, widget: "steps", value: 8 },
+      {
+        firstWrite: "ok",
+        subgraph: new Error("graph_get_subgraph rejected a malformed response"),
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/could not determine whether the addressed node is a promoted container/);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(1);
+    expect(bridgeRetryBudgets).toEqual([0]);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
     expect(mutations).toBe(0);
   });
 });

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -78,6 +78,14 @@ function bridge(opts: {
   /** #2478: replace the ordinary node after the definitive refresh, so a raw
    * write would falsely succeed unless the handler carries the type fence. */
   ordinaryNodeTypeAfterRefresh?: string;
+  /** #2478: replace the ordinary node object after the definitive refresh
+   * without changing its id or type. The receiver must fence this incarnation
+   * change with the opaque identity witness. */
+  ordinaryNodeIdentityAfterRefresh?: string;
+  /** #2478: publish the preflight node row used by the ordinary recovery path. */
+  preflightNodeIdentity?: string;
+  preflightNodeType?: string;
+  preflightNodeIsSubgraph?: boolean;
   /** #2401: change the routing or panel connection identity after the async
    * ordinary-node scope probe has produced its result, before the caller can
    * take the fast path. */
@@ -164,6 +172,7 @@ function bridge(opts: {
   let mutations = 0;
   let subgraphReads = 0;
   let ordinaryNodeType = "OrdinaryNode";
+  let ordinaryNodeIdentity = opts.preflightNodeIdentity ?? "node:78:original";
   let postEnterGraphQueries = 0;
   let authoritativeScopeReads = 0;
   let inSubgraph = opts.startInSubgraph === true;
@@ -325,6 +334,13 @@ function bridge(opts: {
         ) {
           throw new Error("graph_set_widget expected node type changed before dispatch: Nothing was applied.");
         }
+        if (
+          cmd.expected_node_identity !== undefined &&
+          String(cmd.node_id) === "78" &&
+          cmd.expected_node_identity !== ordinaryNodeIdentity
+        ) {
+          throw new Error("graph_set_widget expected node identity changed before dispatch: Nothing was applied.");
+        }
         writes += 1;
         if (writes === 1 && opts.ambiguous) throw new Error(AMBIGUOUS);
         if (writes === 1 && opts.scopeLost) throw new Error(SCOPE_REFUSAL);
@@ -381,6 +397,9 @@ function bridge(opts: {
             if (subgraphReads === 2 && opts.ordinaryNodeTypeAfterRefresh !== undefined) {
               ordinaryNodeType = opts.ordinaryNodeTypeAfterRefresh;
             }
+            if (subgraphReads === 2 && opts.ordinaryNodeIdentityAfterRefresh !== undefined) {
+              ordinaryNodeIdentity = opts.ordinaryNodeIdentityAfterRefresh;
+            }
             throw selected;
           }
           return withCurrentViewing(selected);
@@ -431,6 +450,21 @@ function bridge(opts: {
         }
         if (opts.detailById && wantId && opts.detailById[wantId] !== undefined) {
           return returnGraphQuery(opts.detailById[wantId], wantId);
+        }
+        if (opts.preflightNodeIdentity !== undefined && wantId === "78") {
+          return returnGraphQuery(
+            {
+              nodes: [
+                {
+                  id: 78,
+                  type: opts.preflightNodeType ?? "PromotedContainer",
+                  is_subgraph: opts.preflightNodeIsSubgraph ?? true,
+                  node_identity: opts.preflightNodeIdentity,
+                },
+              ],
+            },
+            wantId,
+          );
         }
         if (opts.stackDataIdentity && !inSubgraph) return returnGraphQuery(opts.stackDataIdentity, wantId);
         if (opts.stackDataIdentity && inSubgraph) {
@@ -502,6 +536,7 @@ function bridge(opts: {
     // v0.15.85's hello DOES advertise this one, which is why a legacy build
     // reaches the scope checks at all instead of stopping at the node-type fence.
     tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedNodeIdentityFenceCapability: () => true,
     tabExpectedScopeGraphIdentityFenceCapability: () =>
       opts.scopeGraphIdentityFence === true || (!legacyBuild && opts.scopeGraphIdentityFence !== false),
     tabPromotedTerminalWitnessCapability: () =>
@@ -3412,6 +3447,9 @@ describe("panel_set_widget transient promoted-subgraph read (#2478)", () => {
       { node_id: 78, widget: "steps", value: 8 },
       {
         firstWrite: "ok",
+        preflightNodeIdentity: "node:78:original",
+        preflightNodeType: "PromotedContainer",
+        preflightNodeIsSubgraph: true,
         subgraphSequence: [
           transientRead,
           new Error("Node 78 (OrdinaryNode) is not a subgraph"),
@@ -3421,13 +3459,14 @@ describe("panel_set_widget transient promoted-subgraph read (#2478)", () => {
 
     expect(isError).toBe(false);
     expect(mutations).toBe(1);
-    expect(bridgeRetryBudgets).toEqual([0, 0]);
+    expect(bridgeRetryBudgets.slice(0, 2)).toEqual([0, 0]);
     expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(2);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
       expect.objectContaining({
         node_id: 78,
         widget: "steps",
         expected_node_type: "OrdinaryNode",
+        expected_node_identity: "node:78:original",
       }),
     ]);
   });
@@ -3438,6 +3477,9 @@ describe("panel_set_widget transient promoted-subgraph read (#2478)", () => {
       {
         firstWrite: "ok",
         ordinaryNodeTypeAfterRefresh: "ReplacementNode",
+        preflightNodeIdentity: "node:78:original",
+        preflightNodeType: "PromotedContainer",
+        preflightNodeIsSubgraph: true,
         subgraphSequence: [
           transientRead,
           new Error("Node 78 (OrdinaryNode) is not a subgraph"),
@@ -3452,6 +3494,60 @@ describe("panel_set_widget transient promoted-subgraph read (#2478)", () => {
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(1);
     expect(writesApplied).toBe(0);
     expect(mutations).toBe(0);
+  });
+
+  it("refuses a same-type same-id replacement using the node identity fence", async () => {
+    const { isError, text, calls, writesApplied, mutations, bridgeRetryBudgets } = await setWidget(
+      { node_id: 78, widget: "steps", value: 8 },
+      {
+        firstWrite: "ok",
+        preflightNodeIdentity: "node:78:original",
+        preflightNodeType: "PromotedContainer",
+        preflightNodeIsSubgraph: true,
+        ordinaryNodeIdentityAfterRefresh: "node:78:replacement",
+        subgraphSequence: [
+          transientRead,
+          new Error("Node 78 (OrdinaryNode) is not a subgraph"),
+        ],
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/expected node identity changed before dispatch/);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(2);
+    expect(bridgeRetryBudgets).toEqual([0, 0]);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(writesApplied).toBe(0);
+    expect(mutations).toBe(0);
+  });
+
+  it.each([
+    "Panel tab tmp:panel is not open",
+    "socket hang up",
+    "WebSocket connection closed",
+    "no connected tab for the requested panel",
+    "genuinely gone",
+    "Failed to fetch",
+    "Panel not reachable",
+    "ECONNRESET",
+    "premature close",
+    "other side closed",
+    "ECONNABORTED",
+    "EPIPE",
+    'the panel is switching/refreshing "workflow-a" right now, so "graph_get_subgraph" was NOT applied — nothing changed',
+  ])("refreshes known transient refusal %s", async (message) => {
+    const { isError, calls, mutations, bridgeRetryBudgets } = await setWidget(
+      { node_id: 78, widget: "steps", value: 8 },
+      {
+        firstWrite: "ok",
+        subgraphSequence: [new Error(message), SUBGRAPH],
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(3);
+    expect(bridgeRetryBudgets.slice(0, 2)).toEqual([0, 0]);
   });
 
   it("does not spend the refresh on a permanent application error", async () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -162,7 +162,7 @@ async function startBridgeOnFreePort(
 function connectPanel(
   tabId?: string,
   title = "workflow-a",
-  opts: { tabSessionId?: string } = {},
+  opts: { tabSessionId?: string; expectedNodeIdentityFence?: boolean } = {},
 ): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const sock = new WebSocket(`ws://127.0.0.1:${port}`);
@@ -179,6 +179,7 @@ function connectPanel(
             enforces_workflow_stamp: true,
             enforces_workflow_stamp_at_write: true,
             enforces_expected_node_type_at_write: true,
+            enforces_expected_node_identity_at_write: opts.expectedNodeIdentityFence ?? true,
             enforces_expected_scope_at_write: true,
             enforces_expected_scope_graph_identity_at_write: true,
             enforces_promoted_parent_rail_at_write: true,
@@ -3474,6 +3475,73 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(isCapabilityRefusal(caught)).toBe(true);
     expect(dispatchOutcomeOf(caught)).toBe(false);
     modern.close();
+  });
+
+  it("forwards expected_node_identity to a panel advertising the write fence", async () => {
+    const modern = await connectPanel("tmp:node-identity", "identity");
+    const frames: Array<Record<string, unknown>> = [];
+    modern.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (msg.rid && msg.cmd) frames.push(msg);
+    });
+    autoReply(modern, "identity");
+    await waitFor(() =>
+      expect(bridge.tabExpectedNodeIdentityFenceCapability("tmp:node-identity")).toBe(true),
+    );
+
+    await expect(
+      bridge.send(
+        {
+          cmd: "graph_set_widget",
+          node_id: 7,
+          widget: "steps",
+          value: 30,
+          expected_node_identity: "node:7:original",
+        },
+        { tabId: "tmp:node-identity" },
+      ),
+    ).resolves.toMatchObject({ from: "identity" });
+    expect(frames).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cmd: "graph_set_widget",
+          expected_node_identity: "node:7:original",
+        }),
+      ]),
+    );
+    modern.close();
+  });
+
+  it("FAILS CLOSED when expected_node_identity reaches a panel without its write fence", async () => {
+    const old = await connectPanel("tmp:old-node-identity", "old identity", {
+      expectedNodeIdentityFence: false,
+    });
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:old-node-identity")).toBe(true),
+    );
+    expect(bridge.tabExpectedNodeIdentityFenceCapability("tmp:old-node-identity")).toBe(false);
+    const caught = await bridge
+      .send(
+        {
+          cmd: "graph_set_widget",
+          node_id: 7,
+          widget: "steps",
+          value: 30,
+          expected_node_identity: "node:7:original",
+        },
+        { tabId: "tmp:old-node-identity" },
+      )
+      .then(
+        () => null,
+        (err) => err,
+      );
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(
+      /atomic expected-node-identity write fence/,
+    );
+    expect(isCapabilityRefusal(caught)).toBe(true);
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+    old.close();
   });
 
   it("FAILS CLOSED when expected_scope reaches a panel without #2314's receiver fence", async () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1153,6 +1153,30 @@ describe("UiBridge (multi-tab)", () => {
     a2.close();
   });
 
+  it("does not bridge-resume an identity-sensitive read when its budget is zero", async () => {
+    const a1 = await connectPanel("tab-2478-one-shot");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    const firstFrames: Array<Record<string, unknown>> = [];
+    a1.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (msg.cmd === "graph_get_subgraph") firstFrames.push(msg);
+    });
+    const promise = bridge.send(
+      { cmd: "graph_get_subgraph", node_id: 78 },
+      { tabId: "tab-2478-one-shot", timeoutMs: 1000, maxReconnectRetries: 0 },
+    );
+    await waitFor(() => expect(firstFrames).toHaveLength(1));
+    a1.close();
+
+    const a2 = await connectPanel("tab-2478-one-shot");
+    const replacementFrames: Array<Record<string, unknown>> = [];
+    a2.on("message", (buf) => replacementFrames.push(JSON.parse(buf.toString())));
+    await expect(promise).rejects.toThrow(/disconnected mid-command|genuinely gone/);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(replacementFrames.some((msg) => msg.cmd === "graph_get_subgraph")).toBe(false);
+    a2.close();
+  });
+
   it("dropQueuedDeliveries CANCELS a parked read so it is NOT re-dispatched onto a replacement (#570 P0)", async () => {
     const a1 = await connectPanel("wf:foo.json");
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6006,7 +6006,7 @@ function parseQueriedNodeType(payload: Record<string, unknown> | null): string |
   return null;
 }
 
-type QueriedNodeIdentity = { id: string; type: string };
+type QueriedNodeIdentity = { id: string; type: string; nodeIdentity?: string };
 
 function canonicalQueriedNodeId(value: unknown): string | null {
   if (typeof value === "number") {
@@ -6033,12 +6033,23 @@ function parseQueriedNodeIdentityRow(row: unknown): QueriedNodeIdentity | null {
     return null;
   }
   const resolvedType = typeof type === "string" ? type : classType;
-  return resolvedType ? { id, type: resolvedType } : null;
+  const nodeIdentity = record.node_identity;
+  if (
+    nodeIdentity !== undefined &&
+    (typeof nodeIdentity !== "string" || nodeIdentity.length === 0 || nodeIdentity.length > 256)
+  ) {
+    return null;
+  }
+  return resolvedType
+    ? { id, type: resolvedType, ...(nodeIdentity !== undefined ? { nodeIdentity } : {}) }
+    : null;
 }
 
 type QueriedNodeScope = {
   activeView: "root" | "subgraph";
   node: "ordinary" | "container";
+  nodeType: string;
+  nodeIdentity?: string;
 };
 
 /** Read the active viewing scope and node's explicit container bit before
@@ -6091,6 +6102,8 @@ function parseVerifiedQueriedNodeScope(
   return {
     activeView,
     node: isSubgraph ? "container" : "ordinary",
+    nodeType: identity.type,
+    ...(identity.nodeIdentity !== undefined ? { nodeIdentity: identity.nodeIdentity } : {}),
   };
 }
 
@@ -6519,6 +6532,7 @@ type PromotedWritePlan = {
 type OrdinaryWritePlan = {
   kind: "ordinary-write";
   expectedNodeType: string;
+  expectedNodeIdentity: string;
 };
 
 type PromotedExpectedScope = PromotedScopeWitness & {
@@ -6602,10 +6616,18 @@ function classifyPromotedSubgraphReadError(res: ToolResult): PromotedSubgraphRea
   if (!res.isError) return "permanent";
   if (isDefinitiveNonPromotedSubgraphRead(res)) return "definitive-ordinary";
   const text = textOfToolResult(res);
+  // Keep this list aligned with the bridge's established reconnect classifier.
+  // The promoted preflight opts out of the ordinary retry wrapper, so this is
+  // the one place that decides whether its explicit refresh is allowed. The
+  // panel's workflow-switch guard is a separate, known-safe pre-executor
+  // refusal: it explicitly says nothing was applied and asks for a retry.
   if (
-    /(?:websocket|socket).*(?:disconnected|closed|reset)|(?:disconnected|closed|reset).*(?:websocket|socket)|\b(?:no connected tab|genuinely gone|unavailable|panel not reachable|failed to fetch|ECONNRESET|ECONNABORTED|EPIPE|premature close|other side closed)\b/i.test(
+    isTransientReconnectError(new Error(text)) ||
+    /(?:websocket|socket).*(?:disconnected|closed|reset)|(?:disconnected|closed|reset).*(?:websocket|socket)/i.test(
       text,
-    )
+    ) ||
+    /\bunavailable\b/i.test(text) ||
+    isWorkflowSwitchGuardRefusal(new Error(text))
   ) {
     return "transient";
   }
@@ -7214,6 +7236,13 @@ async function preparePromotedWidgetWrite(
             "the definitive ordinary refresh did not publish a node type fence",
           );
         }
+        const expectedNodeIdentity = targetScope?.nodeIdentity;
+        if (!expectedNodeIdentity) {
+          return promotedWriteRefusal(
+            widget,
+            "the preflight ordinary-node read did not publish a trustworthy node identity fence",
+          );
+        }
         if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
           return promotedPanelBuildRefusal(
             ctx,
@@ -7223,7 +7252,16 @@ async function preparePromotedWidgetWrite(
             "enforces_expected_node_type_at_write",
           );
         }
-        return { kind: "ordinary-write", expectedNodeType };
+        if (ctx.tabExpectedNodeIdentityFenceCapability?.() !== true) {
+          return promotedPanelBuildRefusal(
+            ctx,
+            nodeId,
+            widget,
+            "does not advertise the atomic ordinary-node identity write fence",
+            "enforces_expected_node_identity_at_write",
+          );
+        }
+        return { kind: "ordinary-write", expectedNodeType, expectedNodeIdentity };
       }
       return promotedSubgraphReadRefusal(
         widget,
@@ -13691,6 +13729,7 @@ interface BridgeProbe {
   readPromotedScope?: (tabId: string, innerNodeId: number | string) => Promise<TabPromotedScopeRead>;
   tabPromotedTerminalWitnessCapability?: (tabId: string) => boolean;
   tabPromotedParentRailFenceCapability?: (tabId: string) => boolean;
+  tabExpectedNodeIdentityFenceCapability?: (tabId: string) => boolean;
   lastFenceRefusal?: (tabId: string) => string | undefined;
   isHeadless?: (tabId: string) => boolean;
   canReach?: (tabId: string) => boolean;
@@ -13847,6 +13886,11 @@ export interface PanelToolCtx {
    * expected_node_type at the synchronous mutation boundary. Real contexts
    * provide this; omitted/false is a fail-closed answer for #2107. */
   tabExpectedNodeTypeFenceCapability?: () => boolean;
+  /** Whether the currently bound panel enforces the opaque node-incarnation
+   * expected_node_identity at the synchronous mutation boundary. Real contexts
+   * provide this; omitted/false is a fail-closed answer for the transient
+   * ordinary-node recovery path. */
+  tabExpectedNodeIdentityFenceCapability?: () => boolean;
   /** Whether the currently bound panel enforces the stable graph identity in
    * expected_scope at the synchronous mutation boundary. Real contexts provide
    * this; omitted/false is a fail-closed answer for promoted writes (#2314 P1). */
@@ -15363,6 +15407,9 @@ export function makePanelToolCtx(
   ctx.tabCanMutateGraph = () => bridge.tabCanMutateGraph(ctx.tabId);
   ctx.tabExpectedNodeTypeFenceCapability = () =>
     bridge.tabExpectedNodeTypeFenceCapability(ctx.tabId);
+  ctx.tabExpectedNodeIdentityFenceCapability = () =>
+    typeof bridge.tabExpectedNodeIdentityFenceCapability === "function" &&
+    bridge.tabExpectedNodeIdentityFenceCapability(ctx.tabId);
   ctx.tabExpectedScopeGraphIdentityFenceCapability = () =>
     bridge.tabExpectedScopeGraphIdentityFenceCapability(ctx.tabId);
   ctx.tabPromotedTerminalWitnessCapability = () =>
@@ -18489,6 +18536,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           : null;
 
         let expectedNodeType: string | undefined = ordinaryPlan?.expectedNodeType;
+        let expectedNodeIdentity: string | undefined = ordinaryPlan?.expectedNodeIdentity;
         if (!promotedPlan && !ordinaryPlan && args.widget === DASIWA_STACK_WIDGET) {
           const daSiWaFence = await verifyDaSiWaStackWriteFence(ctx, args.node_id);
           if (daSiWaFence && "content" in daSiWaFence) return daSiWaFence;
@@ -18512,6 +18560,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           targetExpectedNodeType: string | undefined = expectedNodeType,
           beforeDispatch?: () => void,
           targetExpectedScope?: PromotedExpectedScope,
+          targetExpectedNodeIdentity: string | undefined = expectedNodeIdentity,
         ): Promise<ToolResult> =>
           stripVerifiedLastObservedSchemaNote(
             summarizeSetWidgetEcho(
@@ -18527,6 +18576,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   // and supplies that node's own type.
                   ...(targetExpectedNodeType
                     ? { expected_node_type: targetExpectedNodeType }
+                    : {}),
+                  ...(targetExpectedNodeIdentity
+                    ? { expected_node_identity: targetExpectedNodeIdentity }
                     : {}),
                   ...(targetExpectedScope
                     ? {
@@ -18588,7 +18640,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           const blocked = await refuseKnownBadWriteBeforeDispatch(ctx, nodeId, widget);
           if (blocked) return blocked;
           if (promotedRetry && promotedRetry.kind === "ordinary-write") {
-            return write(nodeId, widget, promotedRetry.expectedNodeType);
+            return write(
+              nodeId,
+              widget,
+              promotedRetry.expectedNodeType,
+              undefined,
+              undefined,
+              promotedRetry.expectedNodeIdentity,
+            );
           }
           return write(nodeId, widget, targetExpectedNodeType);
         };

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6516,13 +6516,18 @@ type PromotedWritePlan = {
   binding: PromotedWriteBinding;
 };
 
+type OrdinaryWritePlan = {
+  kind: "ordinary-write";
+  expectedNodeType: string;
+};
+
 type PromotedExpectedScope = PromotedScopeWitness & {
   terminal?: PromotedTerminalWitness;
   promotedWidget?: string;
   parentRail?: PromotedParentRailWitness;
 };
 
-type PromotedWritePreflight = PromotedWritePlan | ToolResult | null;
+type PromotedWritePreflight = PromotedWritePlan | OrdinaryWritePlan | ToolResult | null;
 
 function promotedEnvelopeCarriesEvidence(payload: Record<string, unknown> | null): boolean {
   if (!payload) return false;
@@ -6570,6 +6575,41 @@ function isDefinitiveNonPromotedSubgraphRead(res: ToolResult): boolean {
   return /^Error:\s*Node\s+\S+(?:\s+\((?:(?:[^()]|\([^()]*\))*|[^)]*)\))?\s+is not a subgraph\b/i.test(
     textOfToolResult(res),
   );
+}
+
+/** Extract the receiver-published type from the definitive ordinary-node
+ * refusal. A definitive classification without a type is still enough to
+ * avoid treating the node as promoted, but not enough to fence a write after
+ * an indeterminate read: an id can have been reused while the read was away. */
+function definitiveNonPromotedNodeType(res: ToolResult): string | null {
+  if (!isDefinitiveNonPromotedSubgraphRead(res)) return null;
+  const match = /^Error:\s*Node\s+\S+\s+([\s\S]*?)\s+is not a subgraph\b/i.exec(
+    textOfToolResult(res),
+  );
+  if (!match) return null;
+  const type = match[1].trim();
+  if (!type.startsWith("(") || !type.endsWith(")")) return null;
+  const unwrapped = type.slice(1, -1).trim();
+  return unwrapped || null;
+}
+
+type PromotedSubgraphReadErrorKind = "definitive-ordinary" | "transient" | "permanent";
+
+/** The promoted-write refresh is deliberately narrower than the broad panel
+ * call retry classifier. Only known transport/reconnect shapes may consume the
+ * one explicit refresh; application refusals must not be replayed. */
+function classifyPromotedSubgraphReadError(res: ToolResult): PromotedSubgraphReadErrorKind {
+  if (!res.isError) return "permanent";
+  if (isDefinitiveNonPromotedSubgraphRead(res)) return "definitive-ordinary";
+  const text = textOfToolResult(res);
+  if (
+    /(?:websocket|socket).*(?:disconnected|closed|reset)|(?:disconnected|closed|reset).*(?:websocket|socket)|\b(?:no connected tab|genuinely gone|unavailable|panel not reachable|failed to fetch|ECONNRESET|ECONNABORTED|EPIPE|premature close|other side closed)\b/i.test(
+      text,
+    )
+  ) {
+    return "transient";
+  }
+  return "permanent";
 }
 
 /**
@@ -6779,16 +6819,22 @@ function resolvePromotedWriteTarget(
   return resolveLegacyInnerPromotedTarget(payload, widget, nodeId);
 }
 
+const PROMOTED_PREFLIGHT_READ_OPTIONS: PanelToolCallOptions = {
+  retry: false,
+  maxBridgeReconnectRetries: 0,
+};
+
 async function readPromotedTargetScope(
   ctx: PanelToolCtx,
   nodeId: unknown,
+  options: PanelToolCallOptions = PROMOTED_PREFLIGHT_READ_OPTIONS,
 ): Promise<QueriedNodeScope | null> {
   const probe = await ctx.call({
     cmd: "graph_query",
     ids: [nodeId],
     fields: "detail",
     limit: 1,
-  });
+  }, undefined, undefined, undefined, options);
   if (probe.isError) return null;
   return parseVerifiedQueriedNodeScope(parseToolResultJson(probe), nodeId);
 }
@@ -7094,7 +7140,11 @@ async function preparePromotedWidgetWrite(
   // promoted-container classifier to resolve a target that is intentionally
   // absent. An unreadable scope probe is not permission for an outer write;
   // it falls through to the existing conservative graph_get_subgraph path.
-  const targetScope = await readPromotedTargetScope(ctx, nodeId);
+  const targetScope = await readPromotedTargetScope(
+    ctx,
+    nodeId,
+    PROMOTED_PREFLIGHT_READ_OPTIONS,
+  );
   if (targetScope?.activeView === "root" && targetScope.node === "ordinary") {
     // The scope probe crossed an await. Re-read the binding before taking the
     // ordinary fast path; otherwise a tab/connection rebind can make this
@@ -7104,9 +7154,16 @@ async function preparePromotedWidgetWrite(
     return null;
   }
 
-  let sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
+  let sub = await ctx.call(
+    { cmd: "graph_get_subgraph", node_id: nodeId },
+    undefined,
+    undefined,
+    undefined,
+    PROMOTED_PREFLIGHT_READ_OPTIONS,
+  );
   if (sub.isError) {
-    if (isDefinitiveNonPromotedSubgraphRead(sub)) {
+    const firstReadKind = classifyPromotedSubgraphReadError(sub);
+    if (firstReadKind === "definitive-ordinary") {
       const drift2 = panelBindingDriftReason(ctx, "after the subgraph read", hasIdentityApi, identityBefore, tabBefore);
       if (drift2) return promotedWriteRefusal(widget, drift2);
       return null;
@@ -7121,13 +7178,27 @@ async function preparePromotedWidgetWrite(
         "graph_get_subgraph could not determine whether the addressed node is a promoted container",
       );
     }
+    if (firstReadKind === "permanent") {
+      return promotedSubgraphReadRefusal(
+        widget,
+        sub,
+        "graph_get_subgraph could not determine whether the addressed node is a promoted container",
+      );
+    }
     // A binding/subgraph registration transition can make the first read
     // indeterminate even though the same live container is readable immediately
     // afterward. Refresh once, then keep the existing fail-closed classification
     // and identity checks for the fresh reply.
-    const refreshedSub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
+    const refreshedSub = await ctx.call(
+      { cmd: "graph_get_subgraph", node_id: nodeId },
+      undefined,
+      undefined,
+      undefined,
+      PROMOTED_PREFLIGHT_READ_OPTIONS,
+    );
     if (refreshedSub.isError) {
-      if (isDefinitiveNonPromotedSubgraphRead(refreshedSub)) {
+      const refreshedReadKind = classifyPromotedSubgraphReadError(refreshedSub);
+      if (refreshedReadKind === "definitive-ordinary") {
         const driftAfterRefresh = panelBindingDriftReason(
           ctx,
           "after the subgraph refresh",
@@ -7136,7 +7207,23 @@ async function preparePromotedWidgetWrite(
           tabBefore,
         );
         if (driftAfterRefresh) return promotedWriteRefusal(widget, driftAfterRefresh);
-        return null;
+        const expectedNodeType = definitiveNonPromotedNodeType(refreshedSub);
+        if (!expectedNodeType) {
+          return promotedWriteRefusal(
+            widget,
+            "the definitive ordinary refresh did not publish a node type fence",
+          );
+        }
+        if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
+          return promotedPanelBuildRefusal(
+            ctx,
+            nodeId,
+            widget,
+            "does not advertise the atomic ordinary-node write fence",
+            "enforces_expected_node_type_at_write",
+          );
+        }
+        return { kind: "ordinary-write", expectedNodeType };
       }
       return promotedSubgraphReadRefusal(
         widget,
@@ -13622,6 +13709,13 @@ export interface ExplicitCurrentRebindProof {
   savedIdentity: string;
 }
 
+export interface PanelToolCallOptions {
+  /** Disable the orchestrator's post-transport retry for a one-shot probe. */
+  retry?: boolean;
+  /** Limit UiBridge reconnect resumption for this call. */
+  maxBridgeReconnectRetries?: number;
+}
+
 export interface PanelToolCtx {
   /** Forward a command to the panel and wrap the reply as a tool result. An
    *  optional observer receives the bridge request id after the frame is written,
@@ -13634,6 +13728,7 @@ export interface PanelToolCtx {
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
     beforeDispatch?: () => void,
+    options?: PanelToolCallOptions,
   ) => Promise<ToolResult>;
   /** Human-in-the-loop yes/no confirm card. Tri-state (#360): "yes" on an explicit
    *  affirmative, "no" on a decline / no-panel / transport error, "timeout" when the
@@ -14075,6 +14170,7 @@ export function makePanelToolCtx(
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
     beforeDispatch?: () => void,
+    options?: PanelToolCallOptions,
   ): Promise<unknown> => {
     const target = workflowTargets?.get(ctx.tabId);
     const routed = target ? withWorkflowTarget(cmd, target) : cmd;
@@ -14083,6 +14179,7 @@ export function makePanelToolCtx(
       timeoutMs,
       onDispatchedRid,
       beforeDispatch,
+      maxReconnectRetries: options?.maxBridgeReconnectRetries,
     });
   };
 
@@ -14098,6 +14195,7 @@ export function makePanelToolCtx(
     // fourteenth is added, and the fact being carried belongs to the ERROR rather
     // than to any one of those wordings.
     onFailure?: (err: unknown) => void,
+    options?: PanelToolCallOptions,
   ): Promise<ToolResult> => {
     // #694: capture the rid of THIS call's dispatched attempt so an OUTCOME-UNKNOWN
     // mutating failure can name it as the caller's explicit retry token (see the
@@ -14135,7 +14233,7 @@ export function makePanelToolCtx(
       // The bridge owns the graph lane and re-resolves the live connection after
       // waiting. Pass the fence through so it runs at the actual socket dispatch,
       // not before that retarget window.
-      const firstTry = ok(await sendRouted(cmd, timeoutMs, observeRid, beforeDispatch));
+      const firstTry = ok(await sendRouted(cmd, timeoutMs, observeRid, beforeDispatch, options));
       // panel#1097 — a guard-domain command that SUCCEEDS is the evidence that the
       // switch is over, whichever attempt lands it. Without this an ordinary
       // first-attempt success left the old run in place, and a later unrelated
@@ -14171,11 +14269,12 @@ export function makePanelToolCtx(
       const workerTransportRetry =
         isWorkerTransportSendError(err) && isWorkerTransportRetrySafeCmd(cmd);
       if (
-        preExecutorRefusal ||
+        options?.retry !== false &&
+        (preExecutorRefusal ||
         (isRetrySafeCmd(cmd) &&
           (isTransientReconnectError(err) ||
             isWorkflowSwitchGuardRefusal(err) ||
-            workerTransportRetry))
+            workerTransportRetry)))
       ) {
         // panel#1097 — declared out here so the refusal branch below can see it,
         // and REASSIGNED after ensureReachable so it names the tab the command is
@@ -14219,7 +14318,9 @@ export function makePanelToolCtx(
           await awaitReachable();
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
           holdTab = ctx.tabId;
-          const retried = ok(await sendRouted(cmd, timeoutMs, observeRid, beforeDispatch));
+          const retried = ok(
+            await sendRouted(cmd, timeoutMs, observeRid, beforeDispatch, options),
+          );
           // Cleared HERE and nowhere else, and only when the failure this retried
           // was a SWITCH refusal. Clearing on every routed success let an unguarded
           // status read wipe the evidence while graph commands stayed refused
@@ -15052,11 +15153,19 @@ export function makePanelToolCtx(
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
     beforeDispatch?: () => void,
+    options?: PanelToolCallOptions,
   ): Promise<ToolResult> => {
     let failure: unknown;
-    const res = await callOnce(cmd, timeoutMs, onDispatchedRid, beforeDispatch, (err) => {
-      failure = err;
-    });
+    const res = await callOnce(
+      cmd,
+      timeoutMs,
+      onDispatchedRid,
+      beforeDispatch,
+      (err) => {
+        failure = err;
+      },
+      options,
+    );
     return carryWorkflowListReadinessMark(
       failure,
       carryMidCommandDisconnectMark(failure, carryPanelAnsweredMark(failure, res)),
@@ -18375,9 +18484,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const promotedPlan = promotedPreflight && promotedPreflight.kind === "promoted-write"
           ? promotedPreflight
           : null;
+        const ordinaryPlan = promotedPreflight && promotedPreflight.kind === "ordinary-write"
+          ? promotedPreflight
+          : null;
 
-        let expectedNodeType: string | undefined;
-        if (!promotedPlan && args.widget === DASIWA_STACK_WIDGET) {
+        let expectedNodeType: string | undefined = ordinaryPlan?.expectedNodeType;
+        if (!promotedPlan && !ordinaryPlan && args.widget === DASIWA_STACK_WIDGET) {
           const daSiWaFence = await verifyDaSiWaStackWriteFence(ctx, args.node_id);
           if (daSiWaFence && "content" in daSiWaFence) return daSiWaFence;
           expectedNodeType = daSiWaFence?.expectedNodeType;
@@ -18475,6 +18587,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
           const blocked = await refuseKnownBadWriteBeforeDispatch(ctx, nodeId, widget);
           if (blocked) return blocked;
+          if (promotedRetry && promotedRetry.kind === "ordinary-write") {
+            return write(nodeId, widget, promotedRetry.expectedNodeType);
+          }
           return write(nodeId, widget, targetExpectedNodeType);
         };
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6521,6 +6521,7 @@ type PromotedWritePlan = {
   inner: {
     innerNodeId: number | string;
     widget: string;
+    nodeIdentity?: string;
     parentRail?: PromotedParentRailWitness;
   };
   innerNodeType: string;
@@ -7442,6 +7443,28 @@ async function preparePromotedWidgetWrite(
     const terminalBlocked = refuseKnownBadPromotedTerminal(inner.terminal);
     if (terminalBlocked) return terminalBlocked;
   }
+  // A current receiver that publishes the complete promoted-terminal witness also
+  // publishes the immediate inner node's opaque incarnation identity. Carry it
+  // through the enter/recheck/write sequence so same-id, same-type replacement
+  // cannot satisfy the inner write fence. Older receivers retain the legacy
+  // omission when this capability is not advertised.
+  if (ctx.tabPromotedTerminalWitnessCapability?.() === true) {
+    if (ctx.tabExpectedNodeIdentityFenceCapability?.() !== true) {
+      return promotedPanelBuildRefusal(
+        ctx,
+        nodeId,
+        widget,
+        "does not advertise the atomic inner-node identity write fence",
+        "enforces_expected_node_identity_at_write",
+      );
+    }
+    if (!inner.nodeIdentity) {
+      return promotedWriteRefusal(
+        widget,
+        "the current receiver did not publish a trustworthy immediate inner-node identity fence",
+      );
+    }
+  }
   // panel#1859 — these three are capability skew, exactly like the missing
   // graph identity above: the hello either advertises the fence or it does not,
   // and a caller cannot change that by trying again.
@@ -7485,6 +7508,7 @@ type PromotedMappingProof = {
   inner: {
     innerNodeId: number | string;
     widget: string;
+    nodeIdentity?: string;
     parentRail?: PromotedParentRailWitness;
   };
   innerNodeType: string;
@@ -7502,6 +7526,7 @@ async function recheckPromotedOuterMapping(
   expectedInner: {
     innerNodeId: number | string;
     widget: string;
+    nodeIdentity?: string;
     parentRail?: PromotedParentRailWitness;
   },
   expectedScope: PromotedScopeWitness,
@@ -7546,6 +7571,7 @@ async function recheckPromotedOuterMapping(
     !inner ||
     canonicalQueriedNodeId(inner.innerNodeId) !== canonicalQueriedNodeId(expectedInner.innerNodeId) ||
     inner.widget !== expectedInner.widget ||
+    (expectedInner.nodeIdentity !== undefined && inner.nodeIdentity !== expectedInner.nodeIdentity) ||
     !samePromotedParentRail(inner.parentRail, expectedInner.parentRail) ||
     !samePromotedTerminal(inner.terminal, expectedTerminal)
   ) {
@@ -7585,6 +7611,7 @@ async function recheckPromotedInnerTarget(
   expectedInner: {
     innerNodeId: number | string;
     widget: string;
+    nodeIdentity?: string;
     parentRail?: PromotedParentRailWitness;
   },
   expectedNodeType: string,
@@ -7617,7 +7644,8 @@ async function recheckPromotedInnerTarget(
     !identity ||
     !expectedId ||
     identity.id !== expectedId ||
-    identity.type !== expectedNodeType
+    identity.type !== expectedNodeType ||
+    (expectedInner.nodeIdentity !== undefined && identity.nodeIdentity !== expectedInner.nodeIdentity)
   ) {
     return promotedWriteRefusal(
       widget,
@@ -7659,9 +7687,23 @@ async function recheckPromotedInnerTarget(
         "the nested promoted terminal mapping changed or became unverifiable after entering",
       );
     }
-    return { inner: expectedInner, innerNodeType: identity.type, terminal: expectedTerminal };
+    return {
+      inner: {
+        ...expectedInner,
+        ...(identity.nodeIdentity !== undefined ? { nodeIdentity: identity.nodeIdentity } : {}),
+      },
+      innerNodeType: identity.type,
+      terminal: expectedTerminal,
+    };
   }
-  return { inner: expectedInner, innerNodeType: identity.type, ...(expectedTerminal ? { terminal: expectedTerminal } : {}) };
+  return {
+    inner: {
+      ...expectedInner,
+      ...(identity.nodeIdentity !== undefined ? { nodeIdentity: identity.nodeIdentity } : {}),
+    },
+    innerNodeType: identity.type,
+    ...(expectedTerminal ? { terminal: expectedTerminal } : {}),
+  };
 }
 
 function daSiWaStackRefusal(type: string): ToolResult {
@@ -18846,6 +18888,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 parentRail: plan.inner.parentRail,
                 ...(plan.terminal ? { terminal: plan.terminal } : {}),
               },
+              ctx.tabExpectedNodeIdentityFenceCapability?.() === true
+                ? afterEnterMapping.inner.nodeIdentity ?? plan.inner.nodeIdentity
+                : undefined,
             );
             const exited = await leave();
             if (written.isError) {
@@ -19493,6 +19538,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           recoveryBeforeDispatch,
           recoveryScope
             ? { ...recoveryScope, ...(inner.terminal ? { terminal: inner.terminal } : {}) }
+            : undefined,
+          ctx.tabExpectedNodeIdentityFenceCapability?.() === true
+            ? legacyFinalMapping.inner.nodeIdentity ?? inner.nodeIdentity
             : undefined,
         );
         const exited = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6285,6 +6285,11 @@ const DYNAMIC_COMBO_REFUSED_CHILD_TYPE = "STRING";
  *  The node most likely to overflow that budget is the node already holding a long
  *  prompt, i.e. exactly the #2299 report ("<any long prompt>"). */
 const DYNAMIC_COMBO_PROBE_MAX_CHARS = 60000;
+// #2478 — the Panel's one-ID compact projection carries a minimal structured
+// node witness, including its opaque incarnation identity. Keep every strict
+// identity probe below the graph_query floor's bounded budget; broad/detail
+// reads retain their existing budgets and semantics.
+const PROMOTED_IDENTITY_PROBE_MAX_CHARS = 2048;
 
 function dynamicComboSubWidgetRefusal(
   nodeType: string,
@@ -7624,6 +7629,7 @@ async function recheckPromotedInnerTarget(
     ids: [expectedInner.innerNodeId],
     fields: "compact",
     limit: 1,
+    max_chars: PROMOTED_IDENTITY_PROBE_MAX_CHARS,
   });
   if (probe.isError) {
     return promotedWriteRefusal(
@@ -7781,6 +7787,7 @@ async function refuseDaSiWaStackWrite(
       ids: [nodeId],
       fields: "compact",
       limit: 1,
+      max_chars: PROMOTED_IDENTITY_PROBE_MAX_CHARS,
     });
   } catch {
     return daSiWaIdentityRefusal("the graph_query probe failed before identity could be verified");
@@ -7854,6 +7861,7 @@ async function verifyDaSiWaStackWriteFence(
       ids: [nodeId],
       fields: "compact",
       limit: 1,
+      max_chars: PROMOTED_IDENTITY_PROBE_MAX_CHARS,
     });
   } catch {
     return daSiWaIdentityRefusal("the final graph_query fence failed before dispatch");
@@ -19334,7 +19342,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // reject a valid inner node, while omitting a fence would let a same-
           // type replacement mutate a detached object and report false success.
           const innerProbe = await ctx.call(
-            { cmd: "graph_query", ids: [inner.innerNodeId], fields: "compact", limit: 1 },
+            {
+              cmd: "graph_query",
+              ids: [inner.innerNodeId],
+              fields: "compact",
+              limit: 1,
+              max_chars: PROMOTED_IDENTITY_PROBE_MAX_CHARS,
+            },
             OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
           );
           const innerIdentity = innerProbe.isError

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7104,18 +7104,47 @@ async function preparePromotedWidgetWrite(
     return null;
   }
 
-  const sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
+  let sub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
   if (sub.isError) {
     if (isDefinitiveNonPromotedSubgraphRead(sub)) {
       const drift2 = panelBindingDriftReason(ctx, "after the subgraph read", hasIdentityApi, identityBefore, tabBefore);
       if (drift2) return promotedWriteRefusal(widget, drift2);
       return null;
     }
-    return promotedSubgraphReadRefusal(
-      widget,
-      sub,
-      "graph_get_subgraph could not determine whether the addressed node is a promoted container",
-    );
+    // A canvas/root divergence is a panel diagnosis with its own remedy, not a
+    // transient ownership read. Preserve that diagnosis instead of replacing it
+    // with a generic retry result (panel#1869).
+    if (textOfToolResult(sub).includes(CANVAS_ROOT_DIVERGENCE_MARKER)) {
+      return promotedSubgraphReadRefusal(
+        widget,
+        sub,
+        "graph_get_subgraph could not determine whether the addressed node is a promoted container",
+      );
+    }
+    // A binding/subgraph registration transition can make the first read
+    // indeterminate even though the same live container is readable immediately
+    // afterward. Refresh once, then keep the existing fail-closed classification
+    // and identity checks for the fresh reply.
+    const refreshedSub = await ctx.call({ cmd: "graph_get_subgraph", node_id: nodeId });
+    if (refreshedSub.isError) {
+      if (isDefinitiveNonPromotedSubgraphRead(refreshedSub)) {
+        const driftAfterRefresh = panelBindingDriftReason(
+          ctx,
+          "after the subgraph refresh",
+          hasIdentityApi,
+          identityBefore,
+          tabBefore,
+        );
+        if (driftAfterRefresh) return promotedWriteRefusal(widget, driftAfterRefresh);
+        return null;
+      }
+      return promotedSubgraphReadRefusal(
+        widget,
+        refreshedSub,
+        "graph_get_subgraph could not determine whether the addressed node is a promoted container",
+      );
+    }
+    sub = refreshedSub;
   }
   let payload = parseToolResultJson(sub);
   if (!payload || !promotedEnvelopeCarriesEvidence(payload)) {

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -28,6 +28,8 @@ export type ContradictoryPromotedWidgetRefusal = {
 export type InnerPromotedTarget = {
   innerNodeId: number | string;
   widget: string;
+  /** Opaque panel-owned identity of the immediate inner node, when published. */
+  nodeIdentity?: string;
   /** Current-panel witnesses must prove the exact local parent rail that
    * serializes this promoted value. Legacy envelopes omit this proof. */
   parentRail?: PromotedParentRailWitness;
@@ -321,6 +323,13 @@ export function validatePromotedSubgraphEnvelope(
   const normalized: Array<Record<string, unknown>> = [];
   for (const raw of nodes) {
     if (!isRecord(raw) || innerNodeId(raw) == null) return null;
+    const nodeIdentity = raw.node_identity;
+    if (
+      nodeIdentity !== undefined &&
+      (typeof nodeIdentity !== "string" || nodeIdentity.length === 0 || nodeIdentity.length > 256)
+    ) {
+      return null;
+    }
     normalized.push(raw);
   }
   const promotedTerminals = Object.prototype.hasOwnProperty.call(subgraph, "promoted_terminals")
@@ -504,6 +513,9 @@ export function resolveInnerPromotedTarget(
     return {
       innerNodeId: entry.immediateNodeId,
       widget: entry.immediateWidget,
+      ...(typeof immediateNode.node_identity === "string"
+        ? { nodeIdentity: immediateNode.node_identity }
+        : {}),
       parentRail: entry.parentRail,
       terminal: entry.terminal,
     };
@@ -514,7 +526,13 @@ export function resolveInnerPromotedTarget(
     const id = innerNodeId(node);
     if (id == null) continue;
     const matched = matchListedName(displayedWidget, widgetNamesOnInner(node));
-    if (matched) hits.push({ innerNodeId: id, widget: matched });
+    if (matched) {
+      hits.push({
+        innerNodeId: id,
+        widget: matched,
+        ...(typeof node.node_identity === "string" ? { nodeIdentity: node.node_identity } : {}),
+      });
+    }
   }
   if (hits.length !== 1) return null;
   return hits[0];

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -224,6 +224,11 @@ interface Conn {
    * ignore the field and leave the node-replacement fence unenforced. */
   enforcesExpectedNodeTypeAtWrite: boolean;
   /** True only when THIS hello advertises that the panel validates an optional
+   * opaque expected_node_identity at the synchronous graph_set_widget write
+   * boundary. A same-type, same-id replacement must not satisfy a stale
+   * promoted-write preflight. */
+  enforcesExpectedNodeIdentityAtWrite: boolean;
+  /** True only when THIS hello advertises that the panel validates an optional
    * expected_scope (promoted owner/workflow witness) at the synchronous
    * graph_set_widget write boundary. Re-read per hello and fail closed when
    * absent: an older panel would silently ignore receiver identity and could
@@ -1625,6 +1630,10 @@ function fenceRefusal(tabId: string, fence: string, capability: string): Error {
 
 function expectedNodeTypeFenceRefusal(tabId: string): Error {
   return fenceRefusal(tabId, "expected-node-type", "enforces_expected_node_type_at_write");
+}
+
+function expectedNodeIdentityFenceRefusal(tabId: string): Error {
+  return fenceRefusal(tabId, "expected-node-identity", "enforces_expected_node_identity_at_write");
 }
 
 function expectedScopeFenceRefusal(tabId: string): Error {
@@ -3122,6 +3131,9 @@ export class UiBridge {
             (msg as { enforces_workflow_stamp_at_write?: unknown }).enforces_workflow_stamp_at_write === true,
           enforcesExpectedNodeTypeAtWrite:
             (msg as { enforces_expected_node_type_at_write?: unknown }).enforces_expected_node_type_at_write === true,
+          enforcesExpectedNodeIdentityAtWrite:
+            (msg as { enforces_expected_node_identity_at_write?: unknown })
+              .enforces_expected_node_identity_at_write === true,
           enforcesExpectedScopeAtWrite:
             (msg as { enforces_expected_scope_at_write?: unknown }).enforces_expected_scope_at_write === true,
           enforcesExpectedScopeGraphIdentityAtWrite:
@@ -3777,6 +3789,16 @@ export class UiBridge {
   tabExpectedNodeTypeFenceCapability(tabId: string): boolean {
     try {
       return this.resolveTarget(tabId).enforcesExpectedNodeTypeAtWrite === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Whether THIS connected panel enforces graph_set_widget's optional opaque
+   * expected-node-identity fence at the actual mutation boundary. */
+  tabExpectedNodeIdentityFenceCapability(tabId: string): boolean {
+    try {
+      return this.resolveTarget(tabId).enforcesExpectedNodeIdentityAtWrite === true;
     } catch {
       return false;
     }
@@ -5549,6 +5571,17 @@ export class UiBridge {
       );
       return Promise.reject(markCapabilityRefusal(refusal));
     }
+    if (
+      cmd.cmd === "graph_set_widget" &&
+      Object.prototype.hasOwnProperty.call(cmd, "expected_node_identity") &&
+      !conn.enforcesExpectedNodeIdentityAtWrite
+    ) {
+      const refusal = markDispatched(
+        expectedNodeIdentityFenceRefusal(conn.tabId),
+        false,
+      );
+      return Promise.reject(markCapabilityRefusal(refusal));
+    }
     // #2314 — an expected_scope is meaningful only when the receiving panel
     // compares it against its LIVE current graph at the synchronous mutation
     // boundary. An older panel silently ignoring this optional field could
@@ -5984,6 +6017,15 @@ export class UiBridge {
       ) {
         return Promise.reject(
           markCapabilityRefusal(markDispatched(expectedNodeTypeFenceRefusal(live.tabId), false)),
+        );
+      }
+      if (
+        cmd.cmd === "graph_set_widget" &&
+        Object.prototype.hasOwnProperty.call(cmd, "expected_node_identity") &&
+        !live.enforcesExpectedNodeIdentityAtWrite
+      ) {
+        return Promise.reject(
+          markCapabilityRefusal(markDispatched(expectedNodeIdentityFenceRefusal(live.tabId), false)),
         );
       }
       if (

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -91,8 +91,8 @@ export interface PanelTab {
 
 /** Shared per-send context that survives a re-dispatch (idempotent read retried
  *  onto a fresh socket after a mid-command reconnect). Carries the caller's
- *  resolve/reject, the original command, and an absolute deadline so retries are
- *  always bounded. */
+ *  resolve/reject, the original command, an absolute deadline, and a finite
+ *  reconnect retry budget. */
 type SendCtx = {
   resolve: (v: unknown) => void;
   reject: (e: Error) => void;
@@ -106,6 +106,8 @@ type SendCtx = {
   mutating: boolean;
   /** Absolute ms after which even an idempotent read stops waiting for reconnect. */
   deadline: number;
+  /** Remaining bridge-owned reconnect re-dispatches for this send. */
+  reconnectRetriesRemaining: number;
   /** #570 — the trusted per-instance workflow uuid this command was ISSUED FOR (the
    *  caller's intended tab), stamped onto the outgoing frame so the panel can refuse to
    *  EXECUTE it against a DIFFERENT workflow it has since switched to. Undefined for a tab
@@ -2351,6 +2353,9 @@ export class UiBridge {
   /** How long a dropped idempotent read waits for its tab to re-hello before we
    *  declare the panel genuinely gone. Bounded so a caller never hangs. */
   private static readonly RECONNECT_GRACE_MS = 4000;
+  /** No single bridge send may be re-dispatched more than once by reconnect
+   *  handling. Callers can lower this to zero for identity-sensitive probes. */
+  private static readonly MAX_RECONNECT_RETRIES = 1;
   /** Bridge commands with no side effect — safe to re-dispatch after a reconnect.
    *  Everything else is treated as mutating (no auto-retry) so a render/edit is
    *  never silently double-applied. Single source of truth at module scope
@@ -5453,6 +5458,9 @@ export class UiBridge {
       onDispatchedRid?: (rid: string) => void;
       /** Synchronous fence at the final live-connection dispatch boundary. */
       beforeDispatch?: () => void;
+      /** Maximum bridge-owned reconnect re-dispatches for this send. The bridge
+       * clamps this to its finite global bound; zero makes a read one-shot. */
+      maxReconnectRetries?: number;
     } = {},
   ): Promise<unknown> {
     // #357: read (idempotent) ops get a more tolerant default so a busy-but-alive
@@ -6031,6 +6039,19 @@ export class UiBridge {
         );
       }
       return new Promise((resolve, reject) => {
+        const requestedReconnectRetries = opts.maxReconnectRetries;
+        const reconnectRetriesRemaining =
+          requestedReconnectRetries === undefined
+            ? UiBridge.MAX_RECONNECT_RETRIES
+            : Number.isFinite(requestedReconnectRetries)
+              ? Math.max(
+                  0,
+                  Math.min(
+                    UiBridge.MAX_RECONNECT_RETRIES,
+                    Math.floor(requestedReconnectRetries),
+                  ),
+                )
+              : 0;
         const ctx: SendCtx = {
           resolve,
           reject,
@@ -6044,6 +6065,7 @@ export class UiBridge {
           // Timeout starts at DISPATCH, not enqueue: waiting for a sibling graph
           // read cannot itself produce the reporter's 30 s false timeout (#2069).
           deadline: Date.now() + timeoutMs,
+          reconnectRetriesRemaining,
           // #570 — graph ops resolve from the CALLER'S intended tab (opts.tabId), NOT
           // the canonical conn.tabId: after a same-socket switch the two differ, and
           // we must stamp the workflow the command was ISSUED FOR (so the panel, now
@@ -6358,19 +6380,25 @@ export class UiBridge {
     // Idempotent read, still within its deadline → park it for a bounded grace and
     // re-dispatch if the same tab re-hellos. Safe: re-running a read has no side
     // effect, and it was in `pending` (un-acked), so no reply was lost.
-    if (!ctx.mutating && Date.now() < ctx.deadline) {
+    if (
+      !ctx.mutating &&
+      ctx.reconnectRetriesRemaining > 0 &&
+      Date.now() < ctx.deadline
+    ) {
       // A replacement socket for this tab is ALREADY live (a reload/supersede whose
       // hello landed before this dead socket's close handler ran — so resume already
       // fired and won't fire again). Re-dispatch straight onto it instead of parking
       // and expiring as "gone". Safe: idempotent read, un-acked.
       const live = this.conns.get(ctx.tabId);
       if (live && live.sock !== pend.sock && live.sock.readyState === WebSocket.OPEN) {
+        ctx.reconnectRetriesRemaining -= 1;
         logger.info(
           `[ui-bridge] tab ${short} already reconnected — resuming "${cmd}" on the live socket`,
         );
         this.dispatch(live, ctx);
         return;
       }
+      ctx.reconnectRetriesRemaining -= 1;
       const list = this.awaitingReconnect.get(ctx.tabId) ?? [];
       const graceMs = Math.max(0, Math.min(UiBridge.RECONNECT_GRACE_MS, ctx.deadline - Date.now()));
       const entry = {


### PR DESCRIPTION
Fixes #2478\n\n## Summary\n- Retry graph_get_subgraph exactly once when the initial promoted-container ownership read is indeterminate.\n- Preserve canvas-root-divergence diagnostics, binding-identity fences, definitive non-promoted handling, and fail-closed behavior when the refresh is also indeterminate.\n- Add regression coverage through the production panel_set_widget handler and bridge mock, verifying the validated promoted write reaches graph_set_widget only after the fresh mapping read.\n\n## Validation\n- 
pm.cmd run test:vitest -- src/__tests__/orchestrator/promoted-widget.test.ts — 142 passed\n- 
pm.cmd test — 701 test files, 13,020 passed, 6 skipped; all repository checks passed\n- 
pm.cmd run build — passed\n- 
pm.cmd run lint — passed\n- 
ode scripts/check-changelog.mjs — passed\n- git diff --check — passed\n\nBrowser/e2e coverage was not run: this worktree has no live panel/browser harness. The regression uses the production MCP handler and bridge test path. The PR also restores the pre-existing #2508 changelog entry required by the repository guard.\n\nDo not merge until independent review and the release gate are complete.