### PR TITLE
docs: record merged PR 2508 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - omit the unexpose reindex warning when the panel already reindexed (#2474)
+- keep the causal line above a native fault and stop blaming a pass-through node (#2508)
 
 
 ## [0.52.146] - 2026-08-27


### PR DESCRIPTION
Release-gate housekeeping only: records the already-merged PR #2508 in the v0.52.147 changelog so the existing changelog check can pass. No P0 implementation is changed.