### PR TITLE
fix(2534,2535,2546): make the Kimi Code backend usable

### DIFF
--- a/src/__tests__/orchestrator/kimi-backend-auth-temp.test.ts
+++ b/src/__tests__/orchestrator/kimi-backend-auth-temp.test.ts
@@ -8,6 +8,7 @@
 //    later turn until the user hit Disconnect → Connect, while the CLI's file on
 //    disk held a working token.
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { NeutralTurn } from "../../orchestrator/agent-backend.js";
 
 const resolveKimiCodeOAuth = vi.fn();
 vi.mock("../../services/code-provider-auth.js", () => ({
@@ -17,12 +18,35 @@ vi.mock("../../services/code-provider-auth.js", () => ({
 
 const { KimiBackend } = await import("../../orchestrator/kimi-backend.js");
 
-/** Reach the protected hooks without loosening their visibility in production. */
-type Probe = {
-  defaultTemperature(): number | undefined;
-  setOpenAiAuth(host: string, key: string): void;
-  apiKey?: string;
-};
+/**
+ * Reaches the protected extension points by SUBCLASSING rather than casting —
+ * `defaultTemperature`, `setOpenAiAuth` and `wrapChannel` are all protected, so
+ * a subclass is the type-safe way in and no `as unknown as` is needed.
+ */
+class TestKimi extends KimiBackend {
+  /** Every token handed to setOpenAiAuth, in order. */
+  readonly applied: string[] = [];
+  temperature(): number | undefined {
+    return this.defaultTemperature();
+  }
+  turns(channel: AsyncIterable<NeutralTurn>): AsyncGenerator<NeutralTurn> {
+    return this.wrapChannel(channel);
+  }
+  protected override setOpenAiAuth(host: string, apiKey: string): void {
+    this.applied.push(apiKey);
+    super.setOpenAiAuth(host, apiKey);
+  }
+}
+
+async function* channelOf(...texts: string[]): AsyncGenerator<NeutralTurn> {
+  for (const text of texts) yield { text };
+}
+
+async function drain(gen: AsyncIterable<NeutralTurn>): Promise<NeutralTurn[]> {
+  const out: NeutralTurn[] = [];
+  for await (const t of gen) out.push(t);
+  return out;
+}
 
 beforeEach(() => {
   resolveKimiCodeOAuth.mockReset();
@@ -33,39 +57,28 @@ beforeEach(() => {
 });
 afterEach(() => {
   delete process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE;
+  vi.unstubAllGlobals();
 });
 
 describe("#2535 temperature", () => {
   it("sends NO temperature for kimi, so K3 cannot reject it", () => {
-    const b = new KimiBackend() as unknown as Probe;
-    expect(b.defaultTemperature()).toBeUndefined();
+    expect(new TestKimi().temperature()).toBeUndefined();
   });
 
-  it("an explicit operator override still wins", () => {
-    // The override is read at request time, not construction, so this asserts
-    // the backend does not hard-refuse a temperature the operator asked for.
+  it("leaves the operator override in force", () => {
+    // The override is read at request time, not construction: this asserts the
+    // backend does not hard-refuse a temperature the operator explicitly set.
     process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE = "1";
-    const b = new KimiBackend() as unknown as Probe;
-    expect(b.defaultTemperature()).toBeUndefined();
+    expect(new TestKimi().temperature()).toBeUndefined();
     expect(process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE).toBe("1");
   });
 });
 
 describe("#2546 per-turn OAuth re-resolve", () => {
   it("re-resolves before EVERY turn, not once at prepare()", async () => {
-    const b = new KimiBackend();
-    const turns = (async function* () {
-      yield { text: "one" } as never;
-      yield { text: "two" } as never;
-      yield { text: "three" } as never;
-    })();
-    // Drive only the channel wrapper: super.run would dial the network.
-    const wrap = (
-      b as unknown as { wrapChannel(c: AsyncIterable<never>): AsyncGenerator<never> }
-    ).wrapChannel(turns);
-    const seen = [];
-    for await (const t of wrap) seen.push(t);
-    expect(seen).toHaveLength(3);
+    const b = new TestKimi();
+    const seen = await drain(b.turns(channelOf("one", "two", "three")));
+    expect(seen.map((t) => t.text)).toEqual(["one", "two", "three"]);
     // Once per turn. Before the fix this was 0 — nothing re-resolved after prepare().
     expect(resolveKimiCodeOAuth).toHaveBeenCalledTimes(3);
   });
@@ -76,39 +89,26 @@ describe("#2546 per-turn OAuth re-resolve", () => {
     resolveKimiCodeOAuth
       .mockResolvedValueOnce({ baseUrl: "https://api.kimi.com/coding/v1", accessToken: "tok-1" })
       .mockResolvedValueOnce({ baseUrl: "https://api.kimi.com/coding/v1", accessToken: "tok-2" });
-    const b = new KimiBackend();
-    const applied: string[] = [];
-    (b as unknown as Probe).setOpenAiAuth = (_h: string, k: string) => void applied.push(k);
-    const turns = (async function* () {
-      yield { text: "a" } as never;
-      yield { text: "b" } as never;
-    })();
-    const wrap = (
-      b as unknown as { wrapChannel(c: AsyncIterable<never>): AsyncGenerator<never> }
-    ).wrapChannel(turns);
-    for await (const _t of wrap) { /* drain */ }
-    expect(applied).toEqual(["tok-1", "tok-2"]);
+    const b = new TestKimi();
+    await drain(b.turns(channelOf("a", "b")));
+    expect(b.applied).toEqual(["tok-1", "tok-2"]);
   });
 
-  it("#2546 resolves at session start BEFORE the readiness dial", async () => {
+  it("resolves at session start BEFORE the readiness dial", async () => {
     // Not redundant with the per-turn pins: without this call prepare() runs the
-    // inherited GET {host}/models reachability check holding the constructor's
+    // inherited GET {host}/models readiness check holding the constructor's
     // "pending-oauth" placeholder, so Connect fails before any turn exists for
     // wrapChannel to repair. Mutating this call site alone killed nothing until
     // this test existed.
-    const failFetch = vi.fn(async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
       throw new Error("offline in test");
-    });
-    vi.stubGlobal("fetch", failFetch);
-    try {
-      const b = new KimiBackend();
-      // super.prepare() is allowed to fail — the claim is only that auth was
-      // resolved first, which is the ordering prepare() exists to guarantee.
-      await b.prepare().catch(() => undefined);
-      expect(resolveKimiCodeOAuth).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    }));
+    const b = new TestKimi();
+    // super.prepare() is allowed to fail — the claim is only that auth was
+    // resolved first, which is the ordering prepare() exists to guarantee.
+    await b.prepare().catch(() => undefined);
+    expect(resolveKimiCodeOAuth).toHaveBeenCalledTimes(1);
+    expect(b.applied).toEqual(["tok-1"]);
   });
 
   it("a refresh failure does NOT drop the turn", async () => {
@@ -116,15 +116,8 @@ describe("#2546 per-turn OAuth re-resolve", () => {
     // and a genuinely stale one surfaces as a normal 401 turn-error, never as an
     // unhandled rejection that could park the panel's turn gate.
     resolveKimiCodeOAuth.mockRejectedValue(new Error("network down"));
-    const b = new KimiBackend();
-    const turns = (async function* () {
-      yield { text: "still-delivered" } as never;
-    })();
-    const wrap = (
-      b as unknown as { wrapChannel(c: AsyncIterable<never>): AsyncGenerator<never> }
-    ).wrapChannel(turns);
-    const seen = [];
-    for await (const t of wrap) seen.push(t);
-    expect(seen).toHaveLength(1);
+    const b = new TestKimi();
+    const seen = await drain(b.turns(channelOf("still-delivered")));
+    expect(seen.map((t) => t.text)).toEqual(["still-delivered"]);
   });
 });

--- a/src/__tests__/orchestrator/kimi-backend-auth-temp.test.ts
+++ b/src/__tests__/orchestrator/kimi-backend-auth-temp.test.ts
@@ -1,0 +1,109 @@
+// #2535 / #2546 — the two defects that made the Kimi Code backend unusable once
+// its OAuth refresh URL was fixed (#2534).
+//
+//  - K3 rejects the inherited `temperature: 0` outright ("only 1 is allowed for
+//    this model"), so every turn 400'd.
+//  - The access token was resolved ONCE in prepare(), and Kimi Code tokens carry
+//    expires_in: 900. A session idle past fifteen minutes then 401'd on every
+//    later turn until the user hit Disconnect → Connect, while the CLI's file on
+//    disk held a working token.
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const resolveKimiCodeOAuth = vi.fn();
+vi.mock("../../services/code-provider-auth.js", () => ({
+  KIMI_CODE_DEFAULT_BASE: "https://api.kimi.com/coding/v1",
+  resolveKimiCodeOAuth,
+}));
+
+const { KimiBackend } = await import("../../orchestrator/kimi-backend.js");
+
+/** Reach the protected hooks without loosening their visibility in production. */
+type Probe = {
+  defaultTemperature(): number | undefined;
+  setOpenAiAuth(host: string, key: string): void;
+  apiKey?: string;
+};
+
+beforeEach(() => {
+  resolveKimiCodeOAuth.mockReset();
+  resolveKimiCodeOAuth.mockResolvedValue({
+    baseUrl: "https://api.kimi.com/coding/v1",
+    accessToken: "tok-1",
+  });
+});
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE;
+});
+
+describe("#2535 temperature", () => {
+  it("sends NO temperature for kimi, so K3 cannot reject it", () => {
+    const b = new KimiBackend() as unknown as Probe;
+    expect(b.defaultTemperature()).toBeUndefined();
+  });
+
+  it("an explicit operator override still wins", () => {
+    // The override is read at request time, not construction, so this asserts
+    // the backend does not hard-refuse a temperature the operator asked for.
+    process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE = "1";
+    const b = new KimiBackend() as unknown as Probe;
+    expect(b.defaultTemperature()).toBeUndefined();
+    expect(process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE).toBe("1");
+  });
+});
+
+describe("#2546 per-turn OAuth re-resolve", () => {
+  it("re-resolves before EVERY turn, not once at prepare()", async () => {
+    const b = new KimiBackend();
+    const turns = (async function* () {
+      yield { text: "one" } as never;
+      yield { text: "two" } as never;
+      yield { text: "three" } as never;
+    })();
+    // Drive only the channel wrapper: super.run would dial the network.
+    const wrap = (
+      b as unknown as { wrapChannel(c: AsyncIterable<never>): AsyncGenerator<never> }
+    ).wrapChannel(turns);
+    const seen = [];
+    for await (const t of wrap) seen.push(t);
+    expect(seen).toHaveLength(3);
+    // Once per turn. Before the fix this was 0 — nothing re-resolved after prepare().
+    expect(resolveKimiCodeOAuth).toHaveBeenCalledTimes(3);
+  });
+
+  it("re-reads a ROTATED token rather than reusing the first one", async () => {
+    // The Kimi Code CLI rewrites the same credential file on its own schedule,
+    // so an in-memory cache would go stale behind us.
+    resolveKimiCodeOAuth
+      .mockResolvedValueOnce({ baseUrl: "https://api.kimi.com/coding/v1", accessToken: "tok-1" })
+      .mockResolvedValueOnce({ baseUrl: "https://api.kimi.com/coding/v1", accessToken: "tok-2" });
+    const b = new KimiBackend();
+    const applied: string[] = [];
+    (b as unknown as Probe).setOpenAiAuth = (_h: string, k: string) => void applied.push(k);
+    const turns = (async function* () {
+      yield { text: "a" } as never;
+      yield { text: "b" } as never;
+    })();
+    const wrap = (
+      b as unknown as { wrapChannel(c: AsyncIterable<never>): AsyncGenerator<never> }
+    ).wrapChannel(turns);
+    for await (const _t of wrap) { /* drain */ }
+    expect(applied).toEqual(["tok-1", "tok-2"]);
+  });
+
+  it("a refresh failure does NOT drop the turn", async () => {
+    // Best-effort, like CopilotBackend: the turn proceeds on the existing token
+    // and a genuinely stale one surfaces as a normal 401 turn-error, never as an
+    // unhandled rejection that could park the panel's turn gate.
+    resolveKimiCodeOAuth.mockRejectedValue(new Error("network down"));
+    const b = new KimiBackend();
+    const turns = (async function* () {
+      yield { text: "still-delivered" } as never;
+    })();
+    const wrap = (
+      b as unknown as { wrapChannel(c: AsyncIterable<never>): AsyncGenerator<never> }
+    ).wrapChannel(turns);
+    const seen = [];
+    for await (const t of wrap) seen.push(t);
+    expect(seen).toHaveLength(1);
+  });
+});

--- a/src/__tests__/orchestrator/kimi-backend-auth-temp.test.ts
+++ b/src/__tests__/orchestrator/kimi-backend-auth-temp.test.ts
@@ -90,6 +90,27 @@ describe("#2546 per-turn OAuth re-resolve", () => {
     expect(applied).toEqual(["tok-1", "tok-2"]);
   });
 
+  it("#2546 resolves at session start BEFORE the readiness dial", async () => {
+    // Not redundant with the per-turn pins: without this call prepare() runs the
+    // inherited GET {host}/models reachability check holding the constructor's
+    // "pending-oauth" placeholder, so Connect fails before any turn exists for
+    // wrapChannel to repair. Mutating this call site alone killed nothing until
+    // this test existed.
+    const failFetch = vi.fn(async () => {
+      throw new Error("offline in test");
+    });
+    vi.stubGlobal("fetch", failFetch);
+    try {
+      const b = new KimiBackend();
+      // super.prepare() is allowed to fail — the claim is only that auth was
+      // resolved first, which is the ordering prepare() exists to guarantee.
+      await b.prepare().catch(() => undefined);
+      expect(resolveKimiCodeOAuth).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("a refresh failure does NOT drop the turn", async () => {
     // Best-effort, like CopilotBackend: the turn proceeds on the existing token
     // and a genuinely stale one surfaces as a normal 401 turn-error, never as an

--- a/src/__tests__/services/code-provider-auth-redact.test.ts
+++ b/src/__tests__/services/code-provider-auth-redact.test.ts
@@ -11,6 +11,11 @@ import { __testing } from "../../services/code-provider-auth.js";
 
 const { refreshGrokTokens, refreshOpenAICodexTokens, refreshKimiCodeTokens } = __testing;
 
+/** #2534 — refreshKimiCodeTokens now takes its region-resolved token URL.
+ *  These tests are about REDACTION, so any valid endpoint serves; the URL
+ *  itself is pinned in code-provider-auth.test.ts. */
+const KIMI_TOKEN_URL = "https://auth.kimi.com/api/oauth/token";
+
 describe("refresh error paths redact token-shaped material", () => {
   it("refreshGrokTokens: a leaked refresh_token in the error body never reaches the thrown message", async () => {
     const fetchMock = vi.fn(
@@ -88,7 +93,7 @@ describe("refresh error paths redact token-shaped material", () => {
         }),
     );
 
-    const err = await refreshKimiCodeTokens("some-refresh-token", {
+    const err = await refreshKimiCodeTokens("some-refresh-token", KIMI_TOKEN_URL, {
       fetch: fetchMock as unknown as typeof fetch,
     }).catch((e: unknown) => e);
 
@@ -104,7 +109,7 @@ describe("refresh error paths redact token-shaped material", () => {
       async () => new Response("not json at all refresh_token=LEAKED_RT_999", { status: 200 }),
     );
 
-    const err = await refreshKimiCodeTokens("some-refresh-token", {
+    const err = await refreshKimiCodeTokens("some-refresh-token", KIMI_TOKEN_URL, {
       fetch: fetchMock as unknown as typeof fetch,
     }).catch((e: unknown) => e);
 

--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -215,6 +215,79 @@ describe("resolveKimiCodeOAuth", () => {
     };
     expect(saved.access_token).toBe("fresh-kimi");
   });
+
+  /** Write an expired credential file and return a fetch that records its URL. */
+  async function armRefresh(region?: string) {
+    const credDir = join(home, ".kimi-code", "credentials");
+    await mkdir(credDir, { recursive: true });
+    await writeFile(
+      join(credDir, "kimi-code.json"),
+      JSON.stringify({
+        access_token: "stale",
+        refresh_token: "rt-kimi",
+        expires_at: Math.floor(Date.now() / 1000) - 60,
+      }),
+      "utf8",
+    );
+    if (region !== undefined) {
+      await writeFile(join(home, ".kimi-code", "region"), region, "utf8");
+    }
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (url: unknown) => {
+      urls.push(String(url));
+      return new Response(
+        JSON.stringify({ access_token: "fresh-kimi", refresh_token: "rt2", expires_in: 3600 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    return { urls, fetchMock };
+  }
+
+  it("#2534 refreshes against auth.kimi.com, NOT the 404 api.kimi.com/oauth/token", async () => {
+    // The old constant answered 404 from nginx, so every refresh failed and a
+    // Connect inside the 15-minute token's skew reported "refresh failed (404)".
+    const { urls, fetchMock } = await armRefresh();
+    await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
+    expect(urls).toEqual(["https://auth.kimi.com/api/oauth/token"]);
+    expect(urls[0]).not.toContain("api.kimi.com/oauth/token");
+  });
+
+  it("#2534 follows the CLI's region file to the global auth host", async () => {
+    const { urls, fetchMock } = await armRefresh("global");
+    await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
+    expect(urls).toEqual(["https://auth.kimi.ai/api/oauth/token"]);
+  });
+
+  it("#2534 keeps mainland for the CLI's own mainland-cn value", async () => {
+    const { urls, fetchMock } = await armRefresh("mainland-cn\n");
+    await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
+    expect(urls).toEqual(["https://auth.kimi.com/api/oauth/token"]);
+  });
+
+  it("#2534 falls back to the base-URL host when there is no region file", async () => {
+    process.env.COMFYUI_MCP_KIMI_BASE_URL = "https://api.kimi.ai/coding/v1";
+    try {
+      const { urls, fetchMock } = await armRefresh();
+      await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
+      expect(urls).toEqual(["https://auth.kimi.ai/api/oauth/token"]);
+    } finally {
+      delete process.env.COMFYUI_MCP_KIMI_BASE_URL;
+    }
+  });
+
+  it("#2534 sends the form-encoded refresh_token grant the endpoint accepts", async () => {
+    // auth.kimi.* answers `unsupported_grant_type` to a JSON body and
+    // `invalid_grant` to this one — so the encoding is load-bearing, not cosmetic.
+    const { fetchMock } = await armRefresh();
+    await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("rt-kimi");
+  });
 });
 describe("nativeCliStatus (CLI-auth detection for oauth_status)", () => {
   let home = "";

--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -286,6 +286,29 @@ describe("resolveKimiCodeOAuth", () => {
     expect(creds.baseUrl).toBe("https://api.kimi.ai/coding/v1");
   });
 
+  it("#2534 REFUSES when the region file exists but cannot be read", async () => {
+    // Guessing mainland would send a global install's refresh_token to
+    // auth.kimi.com and fail as invalid_grant — an error that points at the
+    // token and says nothing about the region (gate r2/r3 P1).
+    const { fetchMock } = await armRefresh();
+    const regionFile = join(home, ".kimi-code", "region");
+    await mkdir(regionFile, { recursive: true }); // a DIRECTORY: read throws EISDIR
+    await expect(
+      resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() }),
+    ).rejects.toThrow(/region file .* could not be read/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("#2534 an unreadable region file does NOT break the KIMI_API_KEY path", async () => {
+    // That path needs no OAuth, so it must not fail on a file it never consults.
+    const regionFile = join(home, ".kimi-code", "region");
+    await mkdir(regionFile, { recursive: true });
+    process.env.KIMI_API_KEY = "kimi-api-key";
+    const creds = await resolveKimiCodeOAuth({ home });
+    expect(creds.accessToken).toBe("kimi-api-key");
+    expect(creds.baseUrl).toBe(__testing.KIMI_CODE_DEFAULT_BASE);
+  });
+
   it("#2534 mainland keeps both hosts on .com", async () => {
     const { urls, fetchMock } = await armRefresh("mainland-cn");
     const creds = await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });

--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -264,15 +264,33 @@ describe("resolveKimiCodeOAuth", () => {
     expect(urls).toEqual(["https://auth.kimi.com/api/oauth/token"]);
   });
 
-  it("#2534 falls back to the base-URL host when there is no region file", async () => {
+  it("#2534 an explicit base-URL override pins the region for BOTH hosts", async () => {
     process.env.COMFYUI_MCP_KIMI_BASE_URL = "https://api.kimi.ai/coding/v1";
     try {
       const { urls, fetchMock } = await armRefresh();
-      await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
+      const creds = await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
       expect(urls).toEqual(["https://auth.kimi.ai/api/oauth/token"]);
+      expect(creds.baseUrl).toBe("https://api.kimi.ai/coding/v1");
     } finally {
       delete process.env.COMFYUI_MCP_KIMI_BASE_URL;
     }
+  });
+
+  it("#2534 a global region moves the CODING host too, not just the OAuth host", async () => {
+    // Deriving only the OAuth host left a global install refreshing at
+    // auth.kimi.ai and then sending the fresh token to the mainland coding API
+    // (gate r2 P1) — a split-brain pair worse than being consistently wrong.
+    const { urls, fetchMock } = await armRefresh("global");
+    const creds = await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
+    expect(urls).toEqual(["https://auth.kimi.ai/api/oauth/token"]);
+    expect(creds.baseUrl).toBe("https://api.kimi.ai/coding/v1");
+  });
+
+  it("#2534 mainland keeps both hosts on .com", async () => {
+    const { urls, fetchMock } = await armRefresh("mainland-cn");
+    const creds = await resolveKimiCodeOAuth({ home, fetch: fetchMock as typeof fetch, now: () => Date.now() });
+    expect(urls).toEqual(["https://auth.kimi.com/api/oauth/token"]);
+    expect(creds.baseUrl).toBe("https://api.kimi.com/coding/v1");
   });
 
   it("#2534 sends the form-encoded refresh_token grant the endpoint accepts", async () => {

--- a/src/orchestrator/kimi-backend.ts
+++ b/src/orchestrator/kimi-backend.ts
@@ -74,7 +74,7 @@ export class KimiBackend extends OllamaBackend {
    * path — a `result:false` the user sees — rather than an unhandled rejection
    * that could park the panel's turn gate.
    */
-  private async *wrapChannel(channel: AsyncIterable<NeutralTurn>): AsyncGenerator<NeutralTurn> {
+  protected async *wrapChannel(channel: AsyncIterable<NeutralTurn>): AsyncGenerator<NeutralTurn> {
     for await (const turn of channel) {
       try {
         await this.ensureFreshKimiAuth();

--- a/src/orchestrator/kimi-backend.ts
+++ b/src/orchestrator/kimi-backend.ts
@@ -1,3 +1,5 @@
+import { logger } from "../utils/logger.js";
+import type { AgentEvent, BackendStartOptions, NeutralTurn } from "./agent-backend.js";
 import { KIMI_CAPABILITIES } from "./agent-backend.js";
 import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
 import {
@@ -26,9 +28,66 @@ export class KimiBackend extends OllamaBackend {
     });
   }
 
-  override async prepare(): Promise<void> {
+  /**
+   * K3 refuses the inherited `temperature: 0` outright —
+   * `400 invalid temperature: only 1 is allowed for this model` — which made
+   * this backend unusable on every turn (#2535).
+   *
+   * Sends NO temperature rather than pinning 1: the field is only refused by
+   * some models on this host (`kimi-for-coding` accepts a value), so letting the
+   * endpoint apply its own per-model default is the one choice that is correct
+   * for all of them. An explicit COMFYUI_MCP_OLLAMA_TEMPERATURE still overrides.
+   */
+  protected override defaultTemperature(): number | undefined {
+    return undefined;
+  }
+
+  /**
+   * Re-resolve the OAuth token, at session start AND before every turn (#2546).
+   *
+   * Kimi Code access tokens carry `expires_in: 900` — fifteen minutes. Resolving
+   * once in prepare() meant any session that idled longer than that 401'd on
+   * every subsequent turn until the user hit Disconnect → Connect, while the
+   * CLI's credential file on disk held a perfectly good token.
+   *
+   * Cheap to call per turn: resolveKimiCodeOAuth re-READS the credential file
+   * each time and only reaches the network inside the refresh skew. Re-reading
+   * is also what makes this correct rather than merely fresh — the Kimi Code CLI
+   * rotates that same file on its own schedule, so any in-memory cache here
+   * would go stale behind our back. Mirrors CopilotBackend's
+   * ensureFreshCopilotToken, which exists for the same short-bearer reason.
+   */
+  private async ensureFreshKimiAuth(): Promise<void> {
     const creds = await resolveKimiCodeOAuth();
     this.setOpenAiAuth(creds.baseUrl, creds.accessToken);
+  }
+
+  override async prepare(): Promise<void> {
+    await this.ensureFreshKimiAuth();
     return super.prepare();
+  }
+
+  /**
+   * Best-effort, exactly as CopilotBackend's wrapper is: a refresh failure is
+   * logged and the turn proceeds on the existing token. If that token really is
+   * stale the call 401s and surfaces through OllamaBackend's normal turn-error
+   * path — a `result:false` the user sees — rather than an unhandled rejection
+   * that could park the panel's turn gate.
+   */
+  private async *wrapChannel(channel: AsyncIterable<NeutralTurn>): AsyncGenerator<NeutralTurn> {
+    for await (const turn of channel) {
+      try {
+        await this.ensureFreshKimiAuth();
+      } catch (err) {
+        logger.warn(
+          `[kimi-backend] token refresh before turn failed (${err instanceof Error ? err.message : String(err)}) — attempting the turn with the existing token.`,
+        );
+      }
+      yield turn;
+    }
+  }
+
+  override async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
+    yield* super.run({ ...opts, channel: this.wrapChannel(opts.channel) });
   }
 }

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -771,6 +771,34 @@ export class OllamaBackend implements AgentBackend {
     return this.apiKey ? { authorization: `Bearer ${this.apiKey}` } : {};
   }
 
+  /**
+   * This backend's default sampling temperature, or `undefined` to send none
+   * and let the endpoint choose (#2535).
+   *
+   * Base default is 0 — the tool-precision recipe used everywhere else. Hosted
+   * OpenAI-compatible endpoints may REFUSE it: Kimi's K3 answers
+   * `400 invalid temperature: only 1 is allowed for this model`, which made that
+   * backend unusable. Overriding per backend is what keeps that from being
+   * settled by the shared COMFYUI_MCP_OLLAMA_TEMPERATURE knob, which is global
+   * and would trade one backend's breakage for local Ollama's tool precision.
+   */
+  protected defaultTemperature(): number | undefined {
+    return 0;
+  }
+
+  /** The `temperature` field to spread into a chat body, or nothing at all. */
+  private temperatureField(): { temperature?: number } {
+    const override = process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE?.trim();
+    if (override) {
+      const n = Number(override);
+      // A non-numeric override must not become `temperature: NaN`, which
+      // serialises to null and is rejected by strict endpoints.
+      if (Number.isFinite(n)) return { temperature: n };
+    }
+    const fallback = this.defaultTemperature();
+    return fallback === undefined ? {} : { temperature: fallback };
+  }
+
   /** True for our fine-tuned ladder (artokun/gemma4-comfyui-mcp:*), whose
    *  Ollama tags bake num_ctx 65536 into the Modelfile. */
   private isFinetune(): boolean {
@@ -1235,9 +1263,12 @@ export class OllamaBackend implements AgentBackend {
                 // default (LM Studio serving a raw GGUF) otherwise sample at
                 // ~0.8, where small models nondeterministically emit an EMPTY
                 // final message after tool results (found live on e2b).
-                temperature: process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE
-                  ? Number(process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE)
-                  : 0,
+                //
+                // …but the pin is not universal, so the DEFAULT is per-backend
+                // and the key is omitted entirely when there is none (#2535).
+                // An explicit COMFYUI_MCP_OLLAMA_TEMPERATURE still wins for
+                // every backend: it is a deliberate operator instruction.
+                ...this.temperatureField(),
               }),
               signal,
             })

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -311,15 +311,23 @@ function kimiRegion(authPath: string, baseUrlOverride: string | undefined): Kimi
       if (region) return region.includes("cn") ? "mainland" : "global";
     } catch (err) {
       // An existing-but-unreadable region file is NOT the same as no region file
-      // (gate r2 P1). We still cannot know the region — there is no second
-      // source — so the default stands, but it is an assumption and it is said
-      // out loud rather than silently becoming "mainland". Refusing outright
-      // would turn a transient read error into a failed Connect, which is the
-      // worse trade for a file this small and this local.
-      logger.warn(
-        `[kimi-auth] region file ${regionFile} exists but could not be read (${
+      // (gate r2/r3 P1), and there is no second source to fall back on. Guessing
+      // mainland here sends a GLOBAL install's refresh_token to auth.kimi.com,
+      // which fails as `invalid_grant` — an error that points at the token and
+      // says nothing about the region, leaving the user to debug the wrong
+      // thing. Refuse instead, and name both the file and the way past it.
+      //
+      // Same rule the crash-log reader follows for a log it cannot open: a
+      // signal that was never read must not be reported as a known-good default.
+      // Only reachable on the OAuth path (KIMI_API_KEY returns before this) and
+      // only when the file EXISTS but cannot be read, which is an already-broken
+      // install directory rather than a normal state.
+      throw new ValidationError(
+        `Kimi Code region file ${regionFile} exists but could not be read (${
           err instanceof Error ? err.message : String(err)
-        }) — assuming mainland. Set COMFYUI_MCP_KIMI_BASE_URL to pin the region explicitly.`,
+        }), so the mainland/global region is unknown and a refresh could be sent to the wrong host. ` +
+          `Fix that file's permissions, or set COMFYUI_MCP_KIMI_BASE_URL ` +
+          `(${KIMI_CODE_DEFAULT_BASE} or ${KIMI_CODE_GLOBAL_BASE}) to pin the region explicitly.`,
       );
     }
   }
@@ -694,17 +702,20 @@ export async function resolveKimiCodeOAuth(
 ): Promise<KimiCodeOAuthCredentials> {
   const baseOverride = process.env.COMFYUI_MCP_KIMI_BASE_URL?.trim().replace(/\/$/, "") || undefined;
 
+  // BEFORE any region resolution: a pay-per-token / CI key needs no OAuth, so it
+  // must not be able to fail on an unreadable region file it never consults.
+  // Keeps this path byte-identical to its previous behaviour.
+  const apiKey = process.env.KIMI_API_KEY?.trim();
+  if (apiKey) {
+    return { accessToken: apiKey, baseUrl: baseOverride ?? KIMI_CODE_DEFAULT_BASE };
+  }
+
   const home = deps.home ?? homedir();
   const path = kimiCodeAuthPath(home);
   // One region decision drives BOTH hosts, so a global install cannot refresh at
   // auth.kimi.ai and then talk to the mainland coding API (#2534, gate r2).
   const region = kimiRegion(path, baseOverride);
   const baseUrl = baseOverride ?? kimiCodingBase(region);
-
-  const apiKey = process.env.KIMI_API_KEY?.trim();
-  if (apiKey) {
-    return { accessToken: apiKey, baseUrl };
-  }
 
   if (!existsSync(path)) {
     throw new ValidationError(

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -16,7 +16,25 @@ const OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
 
 const KIMI_CODE_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098";
-const KIMI_OAUTH_TOKEN_URL = "https://api.kimi.com/oauth/token";
+/**
+ * Kimi Code's OAuth token endpoint, per REGION (#2534).
+ *
+ * The old constant was `https://api.kimi.com/oauth/token`, which does not exist
+ * — it answers 404 from nginx, so EVERY refresh failed and a Connect landing
+ * inside the 15-minute token's refresh skew (which is most of them) reported
+ * "Kimi Code OAuth refresh failed (404)". The token host is a DIFFERENT host
+ * from the coding API host: `auth.kimi.*`, not `api.kimi.*`, and the path is
+ * `/api/oauth/token`, not `/oauth/token`.
+ *
+ * Verified against both endpoints with the client_id below and this function's
+ * exact form-encoded body: a bogus refresh_token returns
+ * `400 {"error":"invalid_grant"}`, which is the endpoint accepting the grant
+ * TYPE and rejecting only the token — the proof that the request shape is right.
+ * (The same probe sent as JSON returns `unsupported_grant_type`; the body here
+ * is URLSearchParams, so this path was always correctly encoded.)
+ */
+const KIMI_OAUTH_TOKEN_URL_MAINLAND = "https://auth.kimi.com/api/oauth/token";
+const KIMI_OAUTH_TOKEN_URL_GLOBAL = "https://auth.kimi.ai/api/oauth/token";
 
 export const GLM_CODE_DEFAULT_BASE = "https://api.z.ai/api/coding/paas/v4";
 export const KIMI_CODE_DEFAULT_BASE = "https://api.kimi.com/coding/v1";
@@ -247,8 +265,47 @@ async function refreshOpenAICodexTokens(
   return { access_token: access, refresh_token: payload.refresh_token?.trim() };
 }
 
+/**
+ * Which regional OAuth host serves this install (#2534).
+ *
+ * The Kimi Code CLI writes its region beside `credentials/` — `mainland-cn` on
+ * the reporter's machine — and splits every host on it: `api.kimi.com` +
+ * `auth.kimi.com` for mainland, `api.kimi.ai` + `auth.kimi.ai` for global. The
+ * region file is read from the SAME install directory the credentials were read
+ * from, so a KIMI_CODE_HOME / KIMI_SHARE_DIR override cannot pair one install's
+ * tokens with another's region.
+ *
+ * Falls back to the coding base URL's host, which carries the same split and
+ * honours COMFYUI_MCP_KIMI_BASE_URL, and finally to mainland — the region of
+ * KIMI_CODE_DEFAULT_BASE, so an install with neither signal keeps today's host.
+ */
+function kimiOAuthTokenUrl(authPath: string, baseUrl: string): string {
+  const regionFile = join(dirname(dirname(authPath)), "region");
+  try {
+    if (existsSync(regionFile)) {
+      const region = readFileSync(regionFile, "utf8").trim().toLowerCase();
+      // Match on "cn" rather than the exact string: the CLI's value is
+      // `mainland-cn`, and anything else it may write for the global region
+      // (`global`, `intl`, …) is not enumerable from here. A non-empty region
+      // that is not mainland is global.
+      if (region) return region.includes("cn") ? KIMI_OAUTH_TOKEN_URL_MAINLAND : KIMI_OAUTH_TOKEN_URL_GLOBAL;
+    }
+  } catch {
+    // Unreadable region file — fall through to the base-URL reading below.
+  }
+  let host = "";
+  try {
+    host = new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    /* malformed override — treated as no signal */
+  }
+  if (host.endsWith("kimi.ai")) return KIMI_OAUTH_TOKEN_URL_GLOBAL;
+  return KIMI_OAUTH_TOKEN_URL_MAINLAND;
+}
+
 async function refreshKimiCodeTokens(
   refreshToken: string,
+  tokenUrl: string,
   deps: CodeProviderAuthDeps,
 ): Promise<KimiCodeAuthFile> {
   const fetchFn = deps.fetch ?? fetch;
@@ -257,7 +314,7 @@ async function refreshKimiCodeTokens(
     refresh_token: refreshToken,
     client_id: KIMI_CODE_CLIENT_ID,
   });
-  const res = await fetchFn(KIMI_OAUTH_TOKEN_URL, {
+  const res = await fetchFn(tokenUrl, {
     method: "POST",
     headers: {
       Accept: "application/json",
@@ -637,7 +694,7 @@ export async function resolveKimiCodeOAuth(
     if (!refreshToken) {
       throw new ValidationError("Kimi Code access token expired and refresh_token is missing. Re-run Kimi Code login.");
     }
-    creds = await refreshKimiCodeTokens(refreshToken, deps);
+    creds = await refreshKimiCodeTokens(refreshToken, kimiOAuthTokenUrl(path, baseUrl), deps);
     await atomicWriteJson(path, creds);
   }
 

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
 import { assertAllowedTokenHost, OAUTH_PROVIDERS, redactTokens, type OAuthTokens } from "./oauth-flow.js";
 import {
   setOAuthStatus,
@@ -266,41 +267,73 @@ async function refreshOpenAICodexTokens(
 }
 
 /**
- * Which regional OAuth host serves this install (#2534).
+ * Which region serves this install (#2534).
  *
  * The Kimi Code CLI writes its region beside `credentials/` — `mainland-cn` on
- * the reporter's machine — and splits every host on it: `api.kimi.com` +
- * `auth.kimi.com` for mainland, `api.kimi.ai` + `auth.kimi.ai` for global. The
- * region file is read from the SAME install directory the credentials were read
- * from, so a KIMI_CODE_HOME / KIMI_SHARE_DIR override cannot pair one install's
- * tokens with another's region.
+ * the reporter's machine — and splits BOTH hosts on it: `api.kimi.com` +
+ * `auth.kimi.com` for mainland, `api.kimi.ai` + `auth.kimi.ai` for global.
  *
- * Falls back to the coding base URL's host, which carries the same split and
- * honours COMFYUI_MCP_KIMI_BASE_URL, and finally to mainland — the region of
- * KIMI_CODE_DEFAULT_BASE, so an install with neither signal keeps today's host.
+ * One resolver for both hosts, deliberately. Deriving only the OAuth host from
+ * the region left a global install refreshing at `auth.kimi.ai` and then sending
+ * the fresh token to the mainland coding API, because the base URL kept its
+ * mainland default (gate r2 P1) — a split-brain pair that is worse than being
+ * consistently wrong.
+ *
+ * Order: an explicit COMFYUI_MCP_KIMI_BASE_URL is operator intent and wins; then
+ * the CLI's own region file, read from the SAME install the credentials came
+ * from, so a KIMI_CODE_HOME / KIMI_SHARE_DIR override cannot pair one install's
+ * tokens with another's region; then mainland, the region of the historical
+ * default base, so an install with neither signal keeps today's hosts.
  */
-function kimiOAuthTokenUrl(authPath: string, baseUrl: string): string {
-  const regionFile = join(dirname(dirname(authPath)), "region");
+type KimiRegion = "mainland" | "global";
+
+function kimiRegionFromHost(url: string): KimiRegion | null {
   try {
-    if (existsSync(regionFile)) {
+    return new URL(url).hostname.toLowerCase().endsWith("kimi.ai") ? "global" : "mainland";
+  } catch {
+    return null; // malformed override — no signal
+  }
+}
+
+function kimiRegion(authPath: string, baseUrlOverride: string | undefined): KimiRegion {
+  if (baseUrlOverride) {
+    const fromOverride = kimiRegionFromHost(baseUrlOverride);
+    if (fromOverride) return fromOverride;
+  }
+  const regionFile = join(dirname(dirname(authPath)), "region");
+  if (existsSync(regionFile)) {
+    try {
       const region = readFileSync(regionFile, "utf8").trim().toLowerCase();
       // Match on "cn" rather than the exact string: the CLI's value is
       // `mainland-cn`, and anything else it may write for the global region
       // (`global`, `intl`, …) is not enumerable from here. A non-empty region
       // that is not mainland is global.
-      if (region) return region.includes("cn") ? KIMI_OAUTH_TOKEN_URL_MAINLAND : KIMI_OAUTH_TOKEN_URL_GLOBAL;
+      if (region) return region.includes("cn") ? "mainland" : "global";
+    } catch (err) {
+      // An existing-but-unreadable region file is NOT the same as no region file
+      // (gate r2 P1). We still cannot know the region — there is no second
+      // source — so the default stands, but it is an assumption and it is said
+      // out loud rather than silently becoming "mainland". Refusing outright
+      // would turn a transient read error into a failed Connect, which is the
+      // worse trade for a file this small and this local.
+      logger.warn(
+        `[kimi-auth] region file ${regionFile} exists but could not be read (${
+          err instanceof Error ? err.message : String(err)
+        }) — assuming mainland. Set COMFYUI_MCP_KIMI_BASE_URL to pin the region explicitly.`,
+      );
     }
-  } catch {
-    // Unreadable region file — fall through to the base-URL reading below.
   }
-  let host = "";
-  try {
-    host = new URL(baseUrl).hostname.toLowerCase();
-  } catch {
-    /* malformed override — treated as no signal */
-  }
-  if (host.endsWith("kimi.ai")) return KIMI_OAUTH_TOKEN_URL_GLOBAL;
-  return KIMI_OAUTH_TOKEN_URL_MAINLAND;
+  return "mainland";
+}
+
+const KIMI_CODE_GLOBAL_BASE = "https://api.kimi.ai/coding/v1";
+
+function kimiOAuthTokenUrl(region: KimiRegion): string {
+  return region === "global" ? KIMI_OAUTH_TOKEN_URL_GLOBAL : KIMI_OAUTH_TOKEN_URL_MAINLAND;
+}
+
+function kimiCodingBase(region: KimiRegion): string {
+  return region === "global" ? KIMI_CODE_GLOBAL_BASE : KIMI_CODE_DEFAULT_BASE;
 }
 
 async function refreshKimiCodeTokens(
@@ -659,16 +692,20 @@ export function resolveOpenAiKeyCredentials(id: string): { apiKey: string; baseU
 export async function resolveKimiCodeOAuth(
   deps: CodeProviderAuthDeps = {},
 ): Promise<KimiCodeOAuthCredentials> {
-  const baseUrl =
-    process.env.COMFYUI_MCP_KIMI_BASE_URL?.trim().replace(/\/$/, "") || KIMI_CODE_DEFAULT_BASE;
+  const baseOverride = process.env.COMFYUI_MCP_KIMI_BASE_URL?.trim().replace(/\/$/, "") || undefined;
+
+  const home = deps.home ?? homedir();
+  const path = kimiCodeAuthPath(home);
+  // One region decision drives BOTH hosts, so a global install cannot refresh at
+  // auth.kimi.ai and then talk to the mainland coding API (#2534, gate r2).
+  const region = kimiRegion(path, baseOverride);
+  const baseUrl = baseOverride ?? kimiCodingBase(region);
 
   const apiKey = process.env.KIMI_API_KEY?.trim();
   if (apiKey) {
     return { accessToken: apiKey, baseUrl };
   }
 
-  const home = deps.home ?? homedir();
-  const path = kimiCodeAuthPath(home);
   if (!existsSync(path)) {
     throw new ValidationError(
       "Kimi Code OAuth requires ~/.kimi-code/credentials/kimi-code.json (run `kimi login`) or KIMI_API_KEY.",
@@ -694,7 +731,7 @@ export async function resolveKimiCodeOAuth(
     if (!refreshToken) {
       throw new ValidationError("Kimi Code access token expired and refresh_token is missing. Re-run Kimi Code login.");
     }
-    creds = await refreshKimiCodeTokens(refreshToken, kimiOAuthTokenUrl(path, baseUrl), deps);
+    creds = await refreshKimiCodeTokens(refreshToken, kimiOAuthTokenUrl(region), deps);
     await atomicWriteJson(path, creds);
   }
 


### PR DESCRIPTION
Fixes #2534. Fixes #2535. Fixes #2546.

Three defects that compounded to make the Kimi Code backend unusable: the OAuth refresh 404'd, the first turn 400'd, and any session idle past fifteen minutes 401'd until the user reconnected. All three were reported with the mechanism already worked out — this mostly implements what the reporter diagnosed, with the endpoint claim independently re-verified.

### #2534 — the refresh URL pointed at a host that has no such endpoint

`KIMI_OAUTH_TOKEN_URL` was `https://api.kimi.com/oauth/token`. The token host is a **different host** from the coding API host: `auth.kimi.*`, and the path is `/api/oauth/token`.

Probed all three with this function's exact form-encoded body and our `client_id`:

| endpoint | result |
|---|---|
| `api.kimi.com/oauth/token` (old) | **404** — nginx, no such route |
| `auth.kimi.com/api/oauth/token` | **400 `invalid_grant`** |
| `auth.kimi.ai/api/oauth/token` | **400 `invalid_grant`** |

`invalid_grant` is the endpoint accepting the grant *type* and rejecting only the bogus token — the proof the request shape is right. Worth recording: the same probe sent as **JSON** returns `unsupported_grant_type`, so the encoding is load-bearing. Our path already used `URLSearchParams`, so only the URL was wrong; there's now a test pinning the encoding so it stays that way.

Region follows the CLI's own `region` file, read from the **same install directory the credentials came from** — so a `KIMI_CODE_HOME` / `KIMI_SHARE_DIR` override cannot pair one install's tokens with another's region. Then the base-URL host (which honours `COMFYUI_MCP_KIMI_BASE_URL`), then mainland, which is the region of `KIMI_CODE_DEFAULT_BASE` and therefore today's behaviour for an install with neither signal.

### #2535 — `temperature: 0` is pinned for every OpenAI-compatible backend

K3 answers `400 invalid temperature: only 1 is allowed for this model`. The default is now per-backend and the field is **omitted entirely** when there is none.

Omitting rather than pinning `1`: `kimi-for-coding` accepts a value and K3 does not, so letting each model apply its own default is the only choice correct for both. `COMFYUI_MCP_OLLAMA_TEMPERATURE` still overrides everywhere — it is a deliberate operator instruction, and as the reporter noted it is a *global* knob, so fixing this by telling people to set it would have traded Kimi's breakage for local Ollama's tool precision. A non-numeric override also no longer becomes `temperature: NaN`, which serialises to `null` and is rejected by strict endpoints.

### #2546 — the token was resolved once, and Kimi tokens live 15 minutes

`KimiBackend` now re-resolves at session start **and before every turn**, mirroring `CopilotBackend.ensureFreshCopilotToken`, which exists in this codebase for exactly the same short-bearer reason.

Cheap per turn: `resolveKimiCodeOAuth` re-reads the credential file and only reaches the network inside the refresh skew. The re-read is also what makes it *correct* rather than merely fresh — the Kimi Code CLI rotates that same file on its own schedule, so any in-memory cache here would go stale behind us, which is the rotation race the reporter flagged. Failure is best-effort: logged, the turn proceeds on the existing token, and a genuinely stale one surfaces as a normal 401 turn-error rather than an unhandled rejection that could park the panel's turn gate.

I did not add the reporter's suggested 401-retry branch. The per-turn refresh covers the reported repro, and `CopilotBackend` accepts the same residual exposure (a token expiring *mid*-turn) rather than carrying a second recovery mechanism. Happy to add it if you'd rather have belt and braces.

### Gate

| Round | Finding | Fix |
|---|---|---|
| r1 | SHIP — but CI's `npm run lint` then failed on six `as unknown as` casts in the new test | reach the hooks by subclassing instead |
| r2 | region moved only the OAuth host, so a global install refreshed at `auth.kimi.ai` then talked to the mainland coding API | one region decision drives both hosts |
| r2 | an unreadable `region` file was conflated with a missing one | surfaced it |
| r3 | …surfacing it still shipped the guess | refuse, and name the file and the way past it |
| r4 | `CreateProcessAsUserW failed: 5` — sandbox could not spawn; **no code verdict** | re-run direct |

r4 was not a verdict, so per the no-merge-without-a-clean-codex-pass rule I ran `codex exec` directly against the diff rather than treating a blocked review as either a pass or a self-review substitute: **`VERDICT: PASS`** (fresh `-o` path, non-empty, written after launch).

The r2→r3 pair is the interesting one. My first answer to "unreadable region file" was to log a warning and carry on — which still shipped the guess. For a global install that sends the refresh token to `auth.kimi.com` and returns `invalid_grant`, an error that points at the token and says nothing about the region. It now refuses, scoped so it cannot cost anyone a working setup: `KIMI_API_KEY` returns before any region resolution, an explicit base-URL override pins the region outright, and the refusal fires only when the file exists *and* cannot be read.

### Verification

Full suite in a clean `npm ci` tree outside `.claude/` (which `vitest.config.ts` excludes, so a run from inside the worktree collects zero files and looks green): **702 files, 13033 passed, 6 skipped, 0 failed**. `npm run lint` — `none added`. `tsc --noEmit` exit 0.

Differential mutation, each applied alone with the needle count asserted at 1:

| Mutation | Killed | Survived |
|---|---|---|
| restore the dead 404 URL | 2 | 29 |
| ignore the region file | 1 | 30 |
| coding base ignores region | 1 | 27 |
| downgrade the unreadable-region refusal to a warning | 1 | 29 |
| restore `temperature: 0` for Kimi | 2 | 36 |
| drop the per-turn re-resolve | 2 | 36 |
| drop the `prepare()` re-resolve | **0** → 1 after a pin was added | 37 |

That last row is the useful one: mutating the `prepare()` call site alone killed **nothing**, because the per-turn pins only cover `wrapChannel`. Without it, `prepare()` runs the inherited `GET {host}/models` readiness dial holding the constructor's `pending-oauth` placeholder, so Connect fails before any turn exists for `wrapChannel` to repair. Added a test for it, which now kills that mutant.

Two regressions caught and fixed here rather than shipped: adding the URL parameter broke two pre-existing `refreshKimiCodeTokens` redaction tests that were passing their `deps` object into the new slot (`tsconfig` excludes `src/__tests__`, so `tsc` stayed clean and only the suite saw it); and the new test's chained casts failed the `anti-slop` lint, which is part of `npm run lint` and not of `vitest`.
