### PR TITLE
chore(report-bug): raise the filing bar, drop the beta reporting bias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented here. This project adheres to
 - keep the causal line above a native fault and stop blaming a pass-through node (#2508)
 - direct-clone local git installs when Manager queue is unavailable (#2509)
 - make the Kimi Code backend usable (#2552)
+- only list history assets fetchable through /view (#2515)
 - reconcile release citations (#2519, #2520)
 
 

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-bug
-description: Self-heal and report bugs. Use when a defect in comfyui-mcp, the sidebar panel, a third-party custom node, or ComfyUI core actually cost the user something - it blocked them, produced a wrong result they would keep, lost or corrupted work, or crashed ComfyUI. For OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) diagnose and fix locally FIRST so the user is unblocked, then file with the diff so reports arrive as near-PRs, not tickets; attempt the fix ONCE, and if upstream-only say so with the precise change. Our intake Worker takes our repos; third-party goes to the node's own GitHub. Do NOT file a transient you recovered from at no cost, a missing capability (stabilisation freeze - parked on arrival), or behaviour that was merely surprising; say those in chat. A crash, lost work, or a wrong result the user might keep is STILL filed even if you recovered, and on a single occurrence. One report per root cause. An explicit "report this" bypasses this bar - route it and file.
+description: Self-heal and report bugs. Use when a defect in comfyui-mcp, the sidebar panel, a third-party custom node, or ComfyUI core actually cost the user something - it blocked them, produced a wrong result they would keep, lost or corrupted work, or crashed ComfyUI. For OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) diagnose and fix locally FIRST so the user is unblocked, then file with the diff so reports arrive as near-PRs, not tickets; attempt the fix ONCE, and if upstream-only say so with the precise change. Our intake Worker takes our repos; third-party goes to the node's own GitHub. Do NOT file a transient you recovered from at no cost, a missing capability (stabilisation freeze - parked on arrival), or behaviour that was merely surprising; say those in chat. A crash or lost/corrupted work is STILL filed even if you recovered, on a single occurrence. One report per root cause. An explicit "report this" bypasses this bar - route it and file.
 ---
 
 # Self-heal & report bugs (make the ecosystem better)
@@ -342,7 +342,9 @@ what the temporary workaround is, if any.
   without asking.
 - Do not claim a fix you did not verify (Step 4).
 - Do not file to be thorough. A report is a claim on a maintainer's
-  attention; if you cannot say what it cost the user, it is not one.
+  attention; if you cannot say what it cost the user, it is not one. Applies to
+  what you file on your own initiative — when the user asks, that is their call
+  to make and no justification is owed.
 
 ## Sources
 

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -67,9 +67,10 @@ Step 2 still decides:
   Their call, made with the facts.
 
 - A transient you recovered from at no cost to the user — a retry that worked.
-  This NEVER covers a crash, lost or corrupted work, or a wrong result the user
-  might keep: recovering afterwards does not undo any of those, and they are
-  filed under "File when both hold" above even when you carried on cleanly.
+  Recovering does NOT excuse a crash, lost or corrupted work, or a wrong result
+  the user might keep. Judge those on the bar above exactly as if you had not
+  recovered; recovering afterwards undoes none of them. (A crash or lost work
+  also needs only the one occurrence — see the exception in question 1.)
 - A missing capability or a feature you wish existed. We are in a stabilisation
   freeze, so these are parked on arrival — filing one adds a ticket nobody will
   action.

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -15,7 +15,8 @@ autonomously. Fix, then file, then inform the user with a short summary. Do not
 pepper them with permission prompts. For THIRD-PARTY and ComfyUI-core defects
 it is offer-and-ask (Step 6). You propose the workaround and/or the report and
 act only once the user agrees, because patching someone else's node or posting
-to someone else's tracker is their call. Even for our repos, pause and ask for
+to someone else's tracker is their call — so when THEY are the one asking, that
+call is already made and you file without asking again. Even for our repos, pause and ask for
 a fix that touches the user's own workflow or data, for anything large or
 risky, and for anything you cannot make safe.
 
@@ -88,7 +89,8 @@ fix.
 Still NOT bug reports (route elsewhere): ordinary generation and workflow
 failures such as OOM, a missing model or node, bad params, or user mistakes go
 to `troubleshooting`. Third-party and custom-node bugs go to their GitHub
-(Step 6), where you still offer and ask first rather than auto-file.
+(Step 6), where you offer and ask first rather than auto-file — unless the user
+asked for the report, which is already the go-ahead.
 
 The intake Worker dedupes server-side, so you need not research duplicates — but
 that is not a licence to file freely. Over-reporting is now the expensive
@@ -137,7 +139,7 @@ the user runs the patched version in the meantime. Capture the diff
 (`git diff`, or diff the file you touched) so Step 5 can attach it.
 
 THIRD-PARTY and ComfyUI-core defects are the exception. There you still offer
-and ask first before patching or filing (Step 6).
+and ask first before patching or filing, unless the user asked for it (Step 6).
 
 ## Step 4 — Verify the fix
 
@@ -299,7 +301,7 @@ touched and nothing is done as the user. That is the default and needs no ask.
 - **Fallback** (no `gh`, no Worker URL): use the `report_issue` tool for a
   prefilled GitHub issue link the user can submit in one click.
 
-## Step 6 — Third-party / ComfyUI-core bugs (offer + ASK first — not autonomous)
+## Step 6 — Third-party / ComfyUI-core bugs (offer + ASK first, unless they asked)
 
 Our Worker only files into OUR repos, so these go to their GitHub. Unlike
 our-repo defects (Steps 3 to 5, which you handle autonomously), third-party

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-bug
-description: Self-heal and report bugs. Use when a defect in comfyui-mcp, the sidebar panel, a third-party custom node, or ComfyUI core actually cost the user something - it blocked them, produced a wrong result they would keep, lost or corrupted work, or crashed ComfyUI. Diagnose it; for OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) fix it locally FIRST so the user is unblocked, then file a report including the diff, so reports arrive as near-PRs rather than tickets. Attempt the fix exactly ONCE; if it is upstream-only, say so with the precise change needed. Route it - our intake Worker for our repos, the node's own GitHub for third-party, which is offer-and-ask rather than autonomous. Do NOT file something you recovered from cleanly, a missing capability (we are in a stabilisation freeze, so those are parked on arrival), or behaviour that was merely surprising - say those in chat instead. One report per root cause, not one per symptom. Always file on "report this" or "fix this bug".
+description: Self-heal and report bugs. Use when a defect in comfyui-mcp, the sidebar panel, a third-party custom node, or ComfyUI core actually cost the user something - it blocked them, produced a wrong result they would keep, lost or corrupted work, or crashed ComfyUI. For OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) diagnose and fix locally FIRST so the user is unblocked, then file with the diff so reports arrive as near-PRs, not tickets; attempt the fix ONCE, and if it is upstream-only say so with the precise change. Our intake Worker takes our repos; third-party goes to the node's own GitHub and is offer-and-ask, not autonomous. Do NOT file a transient you recovered from at no cost, a missing capability (stabilisation freeze - parked on arrival), or behaviour that was merely surprising; say those in chat. A crash, lost work, or a wrong result the user might keep is STILL filed even if you recovered. One report per root cause, not per symptom. Always file on "report this" or "fix this bug".
 ---
 
 # Self-heal & report bugs (make the ecosystem better)
@@ -42,10 +42,13 @@ File when both hold:
   said so. (Silence is the expensive kind — the user cannot see it.)
 - You could not complete the task, and the reason is a defect in our software.
 
-**Do NOT file** — say it in chat and move on:
+**Do NOT file** — say it in chat and move on. None of these apply when the user
+asks: "report this" / "fix this bug" always files, whatever the bar says.
 
-- Anything you recovered from cleanly. A retry that worked is not a report; the
-  workaround is only a signal if the user is still paying for it.
+- A transient you recovered from at no cost to the user — a retry that worked.
+  This NEVER covers a crash, lost or corrupted work, or a wrong result the user
+  might keep: recovering afterwards does not undo any of those, and they are
+  filed under "File when both hold" above even when you carried on cleanly.
 - A missing capability or a feature you wish existed. We are in a stabilisation
   freeze, so these are parked on arrival — filing one adds a ticket nobody will
   action.

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -28,7 +28,10 @@ Two questions, both must be YES:
 
 1. **Is it ours, and does it still reproduce?** On the CURRENT version — check
    before filing, not after. A defect already fixed upstream of the user's
-   install is noise.
+   install is noise. **Exception —** a crash, lost or corrupted work, or a
+   destroyed workflow is filed on a SINGLE occurrence, with whatever evidence
+   exists (log tail, stack, minidump, the failing call). Those are rarely
+   reproducible on demand, and they are the ones most expensive to lose.
 2. **Did it cost the user something?** It blocked them, produced a wrong result
    they would have kept, lost or corrupted their work, or crashed ComfyUI.
 
@@ -43,7 +46,9 @@ File when both hold:
 - You could not complete the task, and the reason is a defect in our software.
 
 **Do NOT file** — say it in chat and move on. None of these apply when the user
-asks: "report this" / "fix this bug" always files, whatever the bar says.
+asks: "report this" / "fix this bug" always files, whatever the bar says. For a
+THIRD-PARTY defect their request IS the go-ahead Step 6 exists to obtain, so
+route it to that project's GitHub and file it — do not ask a second time.
 
 - A transient you recovered from at no cost to the user — a retry that worked.
   This NEVER covers a crash, lost or corrupted work, or a wrong result the user
@@ -54,8 +59,9 @@ asks: "report this" / "fix this bug" always files, whatever the bar says.
   action.
 - Behaviour that surprised you but was correct, or that you have not actually
   diagnosed. An unverified hunch costs a maintainer the whole investigation.
-- A one-off you cannot reproduce. Note it; if it happens again, that second
-  occurrence is the report.
+- A one-off you cannot reproduce — EXCEPT a crash or lost/corrupted work,
+  which is filed the first time it happens (see the exception above). For
+  anything lesser, note it; if it recurs, that second occurrence is the report.
 
 **One report per root cause.** If several symptoms trace to one component in one
 session, file ONE report covering them, not one per symptom. Three separate
@@ -281,7 +287,10 @@ touched and nothing is done as the user. That is the default and needs no ask.
 Our Worker only files into OUR repos, so these go to their GitHub. Unlike
 our-repo defects (Steps 3 to 5, which you handle autonomously), third-party
 bugs are offer-and-ask at every step. Patching someone else's node and posting
-to someone else's tracker are the user's calls, not yours.
+to someone else's tracker are the user's calls, not yours — which is why an
+explicit "report this" from the user already settles it. When they have asked,
+file it without a second confirmation; ask only when the offer originated with
+you.
 
 - **Ask before patching.** You may offer a local workaround (for example, patch
   the custom node so the user is not blocked), but apply it only once the user

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-bug
-description: Self-heal and report bugs. Use when a defect in comfyui-mcp, the sidebar panel, a third-party custom node, or ComfyUI core actually cost the user something - it blocked them, produced a wrong result they would keep, lost or corrupted work, or crashed ComfyUI. For OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) diagnose and fix locally FIRST so the user is unblocked, then file with the diff so reports arrive as near-PRs, not tickets; attempt the fix ONCE, and if it is upstream-only say so with the precise change. Our intake Worker takes our repos; third-party goes to the node's own GitHub and is offer-and-ask, not autonomous. Do NOT file a transient you recovered from at no cost, a missing capability (stabilisation freeze - parked on arrival), or behaviour that was merely surprising; say those in chat. A crash, lost work, or a wrong result the user might keep is STILL filed even if you recovered. One report per root cause, not per symptom. Always file on "report this" or "fix this bug".
+description: Self-heal and report bugs. Use when a defect in comfyui-mcp, the sidebar panel, a third-party custom node, or ComfyUI core actually cost the user something - it blocked them, produced a wrong result they would keep, lost or corrupted work, or crashed ComfyUI. For OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) diagnose and fix locally FIRST so the user is unblocked, then file with the diff so reports arrive as near-PRs, not tickets; attempt the fix ONCE, and if upstream-only say so with the precise change. Our intake Worker takes our repos; third-party goes to the node's own GitHub. Do NOT file a transient you recovered from at no cost, a missing capability (stabilisation freeze - parked on arrival), or behaviour that was merely surprising; say those in chat. A crash, lost work, or a wrong result the user might keep is STILL filed even if you recovered, and on a single occurrence. One report per root cause. An explicit "report this" bypasses this bar - route it and file.
 ---
 
 # Self-heal & report bugs (make the ecosystem better)
@@ -24,6 +24,10 @@ missing model, bad params: use `troubleshooting`). First decide whose bug it is.
 
 ## When to file — a real defect that cost the user something
 
+This bar governs what YOU decide to file on your own initiative. An explicit
+request from the user is handled at the end of this section and is not subject
+to it.
+
 Two questions, both must be YES:
 
 1. **Is it ours, and does it still reproduce?** On the CURRENT version — check
@@ -46,9 +50,21 @@ File when both hold:
 - You could not complete the task, and the reason is a defect in our software.
 
 **Do NOT file** — say it in chat and move on. None of these apply when the user
-asks: "report this" / "fix this bug" always files, whatever the bar says. For a
-THIRD-PARTY defect their request IS the go-ahead Step 6 exists to obtain, so
-route it to that project's GitHub and file it — do not ask a second time.
+asks.
+
+**When the user asks explicitly** ("report this", "fix this bug"), the bar above
+does not apply — you never have to justify cost or reproducibility to them.
+Their request settles THAT it is reported; it does not change WHERE, which
+Step 2 still decides:
+
+- **Ours** — file it, no further questions.
+- **Third-party or ComfyUI core** — their request IS the go-ahead Step 6 exists
+  to obtain, so route it to that project's GitHub and file it without asking a
+  second time.
+- **Not a defect at all** (OOM, a missing model or node, bad params, a mistake) —
+  say plainly that it is not a bug in our software and fix it via
+  `troubleshooting`. If they still want it recorded after hearing that, file it.
+  Their call, made with the facts.
 
 - A transient you recovered from at no cost to the user — a retry that worked.
   This NEVER covers a crash, lost or corrupted work, or a wrong result the user
@@ -295,9 +311,10 @@ you.
 - **Ask before patching.** You may offer a local workaround (for example, patch
   the custom node so the user is not blocked), but apply it only once the user
   says yes. Same keep-the-patch logic once approved.
-- **Ask before filing.** Identify the node or project's GitHub repo (from its
-  metadata, `install_custom_node` (`action: "list"`), or its folder). Then, with
-  the user's go-ahead, use `report_issue` with that `owner/repo` (it returns a
+- **Ask before filing — unless they already asked.** Identify the node or
+  project's GitHub repo (from its metadata, `install_custom_node`
+  (`action: "list"`), or its folder). Then, with the user's go-ahead (which an
+  explicit "report this" already is), use `report_issue` with that `owner/repo` (it returns a
   prefilled link the user reviews and submits; it does not auto-file into
   third-party repos), OR `gh issue create -R owner/repo` if `gh` is authed and
   they agree.

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-bug
-description: Self-heal and report bugs to make the ecosystem better. Use when you hit ANY defect in comfyui-mcp or the sidebar panel, or in a third-party custom node or ComfyUI core. Diagnose it, and for OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) fix it locally FIRST so the user is unblocked, then file a report that includes the diff, so reports arrive as near-PRs rather than tickets. Attempt the fix exactly ONCE; if it is upstream-only, say so and include the precise change needed. Route it correctly. Our intake Worker takes our repos, the node's own GitHub takes third-party. For OUR repos act autonomously (fix-then-file, then inform the user, no per-step permission); for THIRD-PARTY or ComfyUI-core it is offer-and-ask. Bias HARD toward fix-then-file on our repos. Trigger on any error, crash, wrong or empty output, silent failure, confusing result, or limitation that forced an awkward workaround, EVEN IF you recovered. You do not need to be blocked. Also on "report this" and "fix this bug".
+description: Self-heal and report bugs. Use when a defect in comfyui-mcp, the sidebar panel, a third-party custom node, or ComfyUI core actually cost the user something - it blocked them, produced a wrong result they would keep, lost or corrupted work, or crashed ComfyUI. Diagnose it; for OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) fix it locally FIRST so the user is unblocked, then file a report including the diff, so reports arrive as near-PRs rather than tickets. Attempt the fix exactly ONCE; if it is upstream-only, say so with the precise change needed. Route it - our intake Worker for our repos, the node's own GitHub for third-party, which is offer-and-ask rather than autonomous. Do NOT file something you recovered from cleanly, a missing capability (we are in a stabilisation freeze, so those are parked on arrival), or behaviour that was merely surprising - say those in chat instead. One report per root cause, not one per symptom. Always file on "report this" or "fix this bug".
 ---
 
 # Self-heal & report bugs (make the ecosystem better)
@@ -22,33 +22,53 @@ risky, and for anything you cannot make safe.
 This is for bugs in software, not ordinary workflow or generation errors (OOM,
 missing model, bad params: use `troubleshooting`). First decide whose bug it is.
 
-## When to file — bias HARD toward reporting (we're in beta)
+## When to file — a real defect that cost the user something
 
-While comfyui-mcp is in beta, the default is to file. You do NOT need to be
-blocked, and it does NOT need to be fatal. If you notice a defect in our
-software, report it, even after you have already recovered. File when any of
-these happen:
+Two questions, both must be YES:
 
-- A tool, panel, or orchestrator call errors, throws, or crashes ComfyUI.
-- A tool returns wrong, misleading, empty, or malformed output, or succeeds but
-  did the wrong thing.
-- A silent failure, where something that should have happened did not and no
-  error appeared.
-- You had to retry, work around, or take an awkward path because a tool or the
-  panel misbehaved or lacked an obvious capability. Report it even though you
-  recovered; the workaround is the signal.
-- Behavior that is confusing, inconsistent, or surprising in our own tools or
-  panel (a flag that did not take, a stale or duplicate state, a race, a
-  reconnect glitch).
+1. **Is it ours, and does it still reproduce?** On the CURRENT version — check
+   before filing, not after. A defect already fixed upstream of the user's
+   install is noise.
+2. **Did it cost the user something?** It blocked them, produced a wrong result
+   they would have kept, lost or corrupted their work, or crashed ComfyUI.
+
+File when both hold:
+
+- A tool, panel, or orchestrator call crashes ComfyUI, loses work, or corrupts a
+  workflow.
+- A tool returns wrong or misleading output the user would act on, or succeeds
+  while doing something different from what it reported.
+- A silent failure: something that should have happened did not, and nothing
+  said so. (Silence is the expensive kind — the user cannot see it.)
+- You could not complete the task, and the reason is a defect in our software.
+
+**Do NOT file** — say it in chat and move on:
+
+- Anything you recovered from cleanly. A retry that worked is not a report; the
+  workaround is only a signal if the user is still paying for it.
+- A missing capability or a feature you wish existed. We are in a stabilisation
+  freeze, so these are parked on arrival — filing one adds a ticket nobody will
+  action.
+- Behaviour that surprised you but was correct, or that you have not actually
+  diagnosed. An unverified hunch costs a maintainer the whole investigation.
+- A one-off you cannot reproduce. Note it; if it happens again, that second
+  occurrence is the report.
+
+**One report per root cause.** If several symptoms trace to one component in one
+session, file ONE report covering them, not one per symptom. Three separate
+reports for three faults in the same backend are three triage passes for one
+fix.
 
 Still NOT bug reports (route elsewhere): ordinary generation and workflow
 failures such as OOM, a missing model or node, bad params, or user mistakes go
 to `troubleshooting`. Third-party and custom-node bugs go to their GitHub
 (Step 6), where you still offer and ask first rather than auto-file.
 
-Do not over-think dedup or whether it is worth it. The intake Worker dedupes
-server-side, so a duplicate is a no-op. Under-reporting is the expensive
-failure mode. When in doubt during beta, file it and move on.
+The intake Worker dedupes server-side, so you need not research duplicates — but
+that is not a licence to file freely. Over-reporting is now the expensive
+failure mode: every low-value report costs a maintainer a read, a triage, and a
+close, and it buries the reports that matter. When genuinely in doubt, tell the
+user what you saw and let them decide.
 
 ## Step 1 — Diagnose (root cause, not symptom)
 
@@ -292,6 +312,8 @@ what the temporary workaround is, if any.
 - Patches stay minimal and reversible; never touch the user's workflow data
   without asking.
 - Do not claim a fix you did not verify (Step 4).
+- Do not file to be thorough. A report is a claim on a maintainer's
+  attention; if you cannot say what it cost the user, it is not one.
 
 ## Sources
 


### PR DESCRIPTION
Raises the bar for filing a bug report from the panel. The board is taking more reports than it can action, and the low-value ones bury the ones that matter.

### What was driving the volume

The skill told agents, in the section heading itself, to **"bias HARD toward reporting (we're in beta)"**:

> the default is to file. You do NOT need to be blocked, and it does NOT need to be fatal. If you notice a defect in our software, report it, even after you have already recovered.
>
> — You had to retry, work around, or take an awkward path … **Report it even though you recovered; the workaround is the signal.**
> — Behavior that is confusing, inconsistent, or **surprising** …
>
> **Under-reporting is the expensive failure mode. When in doubt during beta, file it and move on.**

The frontmatter — which is what decides whether the skill fires at all, and is pre-loaded into every system prompt — said the same: *"Use when you hit ANY defect … Trigger on any error, crash, wrong or empty output, silent failure, confusing result, or limitation that forced an awkward workaround, EVEN IF you recovered. You do not need to be blocked."*

That was the right setting while the intake was cold. It is the wrong one now.

### The new bar

Two questions, both must be yes:

1. **Is it ours, and does it still reproduce on the current version?** Checked before filing, not after.
2. **Did it cost the user something?** Blocked them, produced a wrong result they would have kept, lost or corrupted their work, or crashed ComfyUI.

And an explicit **do-not-file** list aimed at exactly what was generating the noise — anything recovered from cleanly, a missing capability, behaviour that was merely surprising or undiagnosed, and a one-off that cannot be reproduced (if it recurs, *that* is the report).

The missing-capability line matters most under the current freeze: those are parked on arrival, so filing one is pure cost. The skill now says so and tells the agent to raise it in chat instead.

**One report per root cause, not per symptom.** Straight from this week's board: #2534, #2535 and #2546 were three separate P1s for three faults in one backend, filed serially. They were three triage passes for what turned out to be one PR.

### Deliberately unchanged

Report **quality** was never the problem — the reports arriving are genuinely good, several with minidumps and root-cause analysis. So the fix-then-file default, the report body format, routing, and the third-party offer-and-ask rule are all untouched. An explicit "report this" from the user still always files.

### Review — seven rounds, and every one found a real contradiction

I wrote the first draft as one bar plus one do-not-file list, and that shape kept refusing things we must still capture. Codex found, in order:

1. A cleanly-recovered **crash** was excluded from filing, while the file-when list demanded crashes.
2. The do-not-file list could refuse an explicit "report this".
3. The reproducibility gate and the one-off rule rejected a **single, unreproducible crash** — which is what crashes usually are.
4. Third-party offer-and-ask contradicted "report this always files".
5. The frontmatter promised single-occurrence filing for a wrong result, which the body did not grant; and the absolute rule I added ("if you cannot say what it cost the user, it is not a report") contradicted the user override.
6. "Recovered from" and "reproducible" were collapsed into one unconditional "are filed".
7. The **same** offer-and-ask contradiction at a fourth site.

Two of those are worth calling out. Findings 1 and 3 were the dangerous ones: both would have suppressed exactly the reports we most want — #2497 was a single abort, and panel#2023 happens ~7×/day and still is not reproducible on demand. Finding 7 is my process error: I had been patching offer-and-ask one site per round as each was reported, so a fourth survived. I grepped for all of them and fixed them together.

The resulting design separates things that were tangled:

- The bar governs what the agent files **on its own initiative**.
- An explicit user request bypasses the **bar**, never the **routing**.
- "Recovered from" and "reproducible" are **independent** tests. Recovering excuses nothing; needing only one occurrence is a narrower exemption covering a crash and lost or corrupted work.

Round 8: **`VERDICT: PASS`**.

The merge gate itself could not issue a verdict on this branch — `CreateProcessAsUserW failed: 5 (Access is denied.)`, twice — so these are direct `codex exec` runs, each with a fresh output path checked non-empty and newer than launch.

### Verification

Two files — the skill, and the changelog entries below.

- Full suite — **703 files, 13052 passed, 6 skipped, 0 failed**.
- `npm run lint` — `none added`. `check:changelog` — passes.
- `skill-authoring-limits` + both `report-issue` suites — **309 passed**.

Frontmatter description is **975 chars** against the documented 1024 max. Drafts hit 1149 and 1028 first; the length assertion now runs **before** the write rather than after, so an over-cap draft is never written to disk.

### Also in here: the changelog was red repo-wide

`check:changelog` was failing on **every** open PR, not just this one — #2509 and #2552 both merged after the 0.52.147 section was written and neither was added. #2552 is mine. Fixed both, since one blocker blocks everyone.

Entries name PR numbers only: the check resolves each reference to a commit in `v0.52.146..HEAD`, so citing the issue numbers (#1129, #2534/#2535/#2546) fails — they are real issues, but no commit carries them.
