### PR TITLE
fix(ui-bridge): rewrite bare unknown <cmd> when panel_version is missing (#619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - omit the unexpose reindex warning when the panel already reindexed (#2474)
 - keep the causal line above a native fault and stop blaming a pass-through node (#2508) (#2519) (#2520) (#2478) (#2509) (#2552)
+- rewrite a panel's bare `unknown <cmd>` (and a missing `panel_version`) into the same actionable version-skew error as `Unknown command "…"` (#619)
 
 
 ## [0.52.146] - 2026-08-27

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -6,6 +6,7 @@ import {
   makeUnknownCommandError,
   panelVersionProvesUnsupported,
   isPanelCmdUnsupportedError,
+  isUnknownCommandReply,
   MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
   minPanelVersionForCmd,
   markDispatched,
@@ -4614,6 +4615,9 @@ describe("makeUnknownCommandError (old-panel version gate)", () => {
     expect(e?.message.toLowerCase()).toContain("update");
     expect(e?.message.toLowerCase()).toContain("latest release");
     expect(e?.message.toLowerCase()).toContain("reconnect");
+    // Missing hello version is still a connected version: name it "unknown"
+    // rather than omitting the parenthetical (#619 recurrence).
+    expect(e?.message).toContain("detected panel unknown");
     // The 0.11.4 fallback baseline is a floor, not this command's minimum — quoting
     // it would fabricate a requirement (#619).
     expect(e?.message).not.toContain(MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS);
@@ -4820,6 +4824,76 @@ describe("makeUnknownCommandError (old-panel version gate)", () => {
     expect(makeUnknownCommandError('Unknown command "graph_resize_node"', "0.11.32")).toBeNull();
   });
 
+  // #619 recurrence (2026-08-29): a legacy/cached sidebar with NO panel_version
+  // replied `unknown graph_outline` (no "command" word, no quotes). The mapper
+  // only recognized `Unknown command "…"`, so the raw error leaked and skipped
+  // the upgrade remedy. Both spellings, with the version absent, must rewrite.
+  it("rewrites a bare unknown <cmd> with no panel_version into actionable skew guidance (#619 recurrence)", () => {
+    for (const raw of [
+      "unknown graph_outline",
+      "Unknown graph_outline",
+      'unknown "graph_outline"',
+      "Error: unknown graph_outline",
+    ]) {
+      const e = makeUnknownCommandError(raw);
+      expect(e, raw).not.toBeNull();
+      expect(e?.message, raw).toContain("graph_outline");
+      expect(e?.message, raw).toContain("detected panel unknown");
+      expect(e?.message, raw).toContain("0.4.6");
+      expect(e?.message.toLowerCase(), raw).toContain("does not implement");
+      expect(e?.message.toLowerCase(), raw).toContain("update");
+      expect(e?.message, raw).not.toBe(raw);
+      expect(e?.message.toLowerCase(), raw).not.toMatch(/^unknown /);
+    }
+  });
+
+  it("rewrites a bare unknown refresh_nodes with no panel_version, quoting ≥0.11.28 (#619 recurrence)", () => {
+    const e = makeUnknownCommandError("unknown refresh_nodes");
+    expect(e).not.toBeNull();
+    expect(e?.message).toContain("refresh_nodes");
+    expect(e?.message).toContain("detected panel unknown");
+    expect(e?.message).toContain("0.11.28");
+    expect(e?.message.toLowerCase()).toContain("update");
+    expect(e?.message).not.toBe("unknown refresh_nodes");
+  });
+
+  it("still names panel unknown for Unknown-command spelling when the hello omitted the version (#619 recurrence)", () => {
+    const e = makeUnknownCommandError('Unknown command "refresh_nodes"');
+    expect(e).not.toBeNull();
+    expect(e?.message).toContain("refresh_nodes");
+    expect(e?.message).toContain("detected panel unknown");
+    expect(e?.message).toContain("0.11.28");
+    expect(e?.message).toMatch(/, mcp \d+\.\d+\.\d+/);
+  });
+
+  it("does NOT rewrite a bare unknown <cmd> from a panel that advertises a new-enough version (#352)", () => {
+    expect(makeUnknownCommandError("unknown graph_outline", "0.11.21")).toBeNull();
+    expect(makeUnknownCommandError("unknown graph_outline", "0.4.6")).toBeNull();
+    expect(makeUnknownCommandError("Error: unknown graph_outline", "0.11.21")).toBeNull();
+  });
+
+  it("does NOT rewrite English 'unknown <word>' that is not a bridge command", () => {
+    expect(makeUnknownCommandError("unknown node")).toBeNull();
+    expect(makeUnknownCommandError("unknown backend")).toBeNull();
+    expect(makeUnknownCommandError("unknown prompt")).toBeNull();
+  });
+
+  it("does NOT rewrite a bare unknown <cmd> that continues with an explanation (smoke-mock shape)", () => {
+    expect(
+      makeUnknownCommandError(
+        "unknown graph_outline — this tab is the knowledge-parity SMOKE MOCK, not a real panel",
+      ),
+    ).toBeNull();
+  });
+
+  it("isUnknownCommandReply accepts both dispatcher spellings (#619 recurrence)", () => {
+    expect(isUnknownCommandReply('Unknown command "refresh_nodes"')).toBe(true);
+    expect(isUnknownCommandReply("unknown graph_outline")).toBe(true);
+    expect(isUnknownCommandReply("Error: unknown graph_outline")).toBe(true);
+    expect(isUnknownCommandReply("unknown node")).toBe(false);
+    expect(isUnknownCommandReply("node 5 not found")).toBe(false);
+  });
+
 });
 
 describe("panelVersionProvesUnsupported (#392 proactive version gate)", () => {
@@ -4906,6 +4980,19 @@ describe("isPanelCmdUnsupportedError (#413 structured unsupported-command detect
     ).toBe(false);
   });
 
+  it("matches the bare unknown <cmd> spelling (#619 recurrence)", () => {
+    expect(isPanelCmdUnsupportedError(new Error("unknown graph_outline"))).toBe(true);
+    expect(isPanelCmdUnsupportedError(new Error("unknown graph_outline"), "graph_outline")).toBe(
+      true,
+    );
+    expect(isPanelCmdUnsupportedError(new Error("unknown graph_outline"), "refresh_nodes")).toBe(
+      false,
+    );
+    expect(isPanelCmdUnsupportedError(new Error("Error: unknown refresh_nodes"), "refresh_nodes")).toBe(
+      true,
+    );
+  });
+
   it("matches the rewritten 'too old for' text even without the tag", () => {
     const raw = new Error('This ComfyUI-MCP panel is too old for "graph_serialize" — update…');
     expect(isPanelCmdUnsupportedError(raw)).toBe(true);
@@ -4949,6 +5036,49 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
     await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab" })).rejects.toThrow(
       /too old for "graph_query".*0\.6\.8.*update/is,
     );
+  });
+
+  // #619 recurrence: a cached sidebar hello omits panel_version and the
+  // dispatcher answers `unknown graph_outline` (not `Unknown command "…"`).
+  // The send path must still rewrite to the upgrade remedy, naming the command,
+  // connected panel "unknown", and the command's minimum.
+  it("rewrites a bare unknown <cmd> from a no-version tab into actionable skew guidance (#619 recurrence)", async () => {
+    const sock = await connectPanel("legacy-cached");
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        sock.send(JSON.stringify({ rid: msg.rid, ok: false, error: `unknown ${msg.cmd}` }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const outline = await bridge
+      .send({ cmd: "graph_outline" }, { tabId: "legacy-cached" })
+      .then(
+        () => {
+          throw new Error("graph_outline should have been rejected");
+        },
+        (e: Error) => e,
+      );
+    expect(outline.message).toMatch(/does not implement "graph_outline"/i);
+    expect(outline.message).toContain("detected panel unknown");
+    expect(outline.message).toContain("0.4.6");
+    expect(outline.message.toLowerCase()).toContain("update");
+    expect(outline.message).not.toBe("unknown graph_outline");
+
+    const refresh = await bridge
+      .send({ cmd: "refresh_nodes" }, { tabId: "legacy-cached" })
+      .then(
+        () => {
+          throw new Error("refresh_nodes should have been rejected");
+        },
+        (e: Error) => e,
+      );
+    expect(refresh.message).toMatch(/does not implement "refresh_nodes"/i);
+    expect(refresh.message).toContain("detected panel unknown");
+    expect(refresh.message).toContain("0.11.28");
+    expect(refresh.message.toLowerCase()).toContain("update");
+    expect(refresh.message).not.toBe("unknown refresh_nodes");
   });
 
   // #236 — for a command with NO changelog-verified per-command minimum (so the

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1006,9 +1006,11 @@ function buildPanelTooOldError(
           // would be a claim nothing here supports.
           ` (this connection advertised no panel version; an earlier connection for this tab ` +
           `reported ${reading.inherited}, which may be out of date${mcpTail})`
-        : mcpVersion
-          ? ` (detected mcp ${mcpVersion})`
-          : "";
+        // No advertised version at all (legacy/cached sidebar that predates
+        // `panel_version` in hello — #619 recurrence). Still name the connected
+        // panel as unknown so the skew message is complete; do not omit the
+        // parenthetical and skip the upgrade remedy.
+        : ` (detected panel unknown${mcpTail})`;
   const min = BRIDGE_CMD_MIN_PANEL_VERSION[cmd];
   // "TOO OLD" IS AN AGE VERDICT, and it may only be reached from an age
   // OBSERVATION: a version that parsed AND compares below the command's known
@@ -1058,9 +1060,10 @@ export function isPanelCmdUnsupportedError(err: unknown, cmd?: string): boolean 
     ?.panelCmdUnsupported;
   if (typeof tag === "string") return cmd == null || tag === cmd;
   const msg = err instanceof Error ? err.message : String(err ?? "");
+  const parsed = parseUnknownCommandReply(msg);
+  if (parsed) return cmd == null || parsed === cmd;
   const cmdPat = cmd ? cmd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : "[\\w.-]+";
   return (
-    new RegExp(`unknown command\\s*["“']?${cmdPat}`, "i").test(msg) ||
     new RegExp(`too old for\\s*["“']?${cmdPat}`, "i").test(msg) ||
     new RegExp(`does not implement\\s*["“']?${cmdPat}`, "i").test(msg)
   );
@@ -1076,18 +1079,43 @@ export function isPanelCmdUnsupportedError(err: unknown, cmd?: string): boolean 
  * into an actionable "update your panel" message instead of surfacing the opaque
  * internal command name to the agent/user. Returns null when `error` is anything
  * else (a genuine command failure), so the happy/normal-error path is untouched.
+ *
+ * Also matches the legacy/cached spelling `unknown <cmd>` (no "command" word,
+ * no quotes) that a sidebar tab predating the current dispatcher used — the
+ * #619 recurrence on 0.52.147 leaked `Error: unknown graph_outline` because
+ * only the `Unknown command "…"` shape was recognized.
  */
-/** The panel dispatcher's raw "Unknown command" reply shape (anchored, quote- and
- *  case-tolerant). Shared by makeUnknownCommandError and isUnknownCommandReply so the
- *  reactive rewrite and the #422 veto-revocation agree on exactly one definition. */
+/** Current dispatcher: `Unknown command "graph_query"` (quotes optional). */
 const UNKNOWN_COMMAND_RE = /^unknown command\s*["“']?([\w.-]+)["”']?/i;
+/** Legacy/cached dispatcher: the entire message is `unknown graph_outline`. */
+const UNKNOWN_BARE_CMD_RE = /^unknown\s+["“']?([\w.-]+)["”']?\s*$/i;
+
+/** True when `token` is a bridge command name, not English (`unknown node`). */
+function looksLikeBridgeCommand(cmd: string): boolean {
+  if (BRIDGE_CMD_MIN_PANEL_VERSION[cmd]) return true;
+  return /^(?:graph|ui|workflow|refresh|nodes)_[\w.-]+$/.test(cmd);
+}
+
+/** Extract the command from either dispatcher spelling. Shared so the rewrite,
+ *  the #422 veto-revocation, and the tagless unsupported detector agree. */
+function parseUnknownCommandReply(error: string): string | null {
+  const text = String(error ?? "")
+    .trim()
+    .replace(/^error:\s+/i, "")
+    .trim();
+  const withCommand = UNKNOWN_COMMAND_RE.exec(text);
+  if (withCommand) return withCommand[1];
+  const bare = UNKNOWN_BARE_CMD_RE.exec(text);
+  if (!bare) return null;
+  return looksLikeBridgeCommand(bare[1]) ? bare[1] : null;
+}
 
 /** True when `error` is the panel's own "Unknown command" dispatch reply — proof this
  *  build does NOT implement the command, INDEPENDENT of any advertised-version guard
  *  (#422). Used to revoke a stale proven-supported veto even when the version is new
  *  enough to suppress the "too old" rewrite, so a genuine downgrade always re-gates. */
 export function isUnknownCommandReply(error: string): boolean {
-  return UNKNOWN_COMMAND_RE.test(String(error ?? "").trim());
+  return parseUnknownCommandReply(error) != null;
 }
 
 export function makeUnknownCommandError(
@@ -1097,14 +1125,11 @@ export function makeUnknownCommandError(
   panelVersion?: string | PanelVersionReading,
   mcpVersion?: string,
 ): Error | null {
-  // Match the panel's exact shape: `Unknown command "graph_query"` (quotes
-  // optional/variable). ANCHORED at the start of the (trimmed) message so an
-  // unrelated error that merely QUOTES an unknown-command phrase somewhere in its
-  // text is never rewritten — only the panel dispatcher's own reply, which is
-  // exactly this string. Case-insensitive, tolerant of straight or smart quotes.
-  const m = UNKNOWN_COMMAND_RE.exec(error.trim());
-  if (!m) return null;
-  const cmd = m[1];
+  // Current shape: `Unknown command "graph_query"`. Recurrence shape: `unknown
+  // graph_outline` (and the MCP-prefixed `Error: unknown graph_outline`). Start-
+  // anchored so an error that merely quotes the phrase mid-message is not rewritten.
+  const cmd = parseUnknownCommandReply(error);
+  if (!cmd) return null;
   // #352 FALSE-NEGATIVE GUARD: if the panel advertised a version that already
   // meets this command's real minimum, the panel is NOT too old — an "Unknown
   // command" reply here means something else (a genuinely retired/renamed command,


### PR DESCRIPTION
Closes #619

## Problem

Recurrence on comfyui-mcp 0.52.147: a legacy/cached sidebar tab with **no `panel_version`** returned `Error: unknown graph_outline`. That spelling bypassed the version-skew rewrite that only recognized `Unknown command "…"`, so the agent saw an opaque dispatcher miss instead of an upgrade remedy.

Previous merges (#622, #675) already handled tabled minimums and untabled `Unknown command` replies. They still skipped:

1. a hello that omits `panel_version` (connected version was dropped from the parenthetical)
2. the bare `unknown <cmd>` / `Error: unknown <cmd>` dispatcher shape (`graph_outline`, `refresh_nodes`)

## Fix

In `src/services/ui-bridge.ts`:

- Parse both `Unknown command "cmd"` and the entire-message `unknown cmd` spelling (plus an optional `Error:` prefix).
- Bare `unknown <word>` only rewrites when the token looks like a bridge command, so `unknown node` / smoke-mock explanations still pass through.
- When the hello carried no version, the rewrite now says `detected panel unknown` and still quotes the command-specific minimum (or latest-release for untabled cmds).
- `#352` is unchanged: a parseable advertised version at/above the tabled minimum still suppresses the rewrite.

Tools stay advertised; the error names the command, connected panel version (or unknown), and the upgrade remedy.

## Tests

`npx vitest run src/__tests__/services/ui-bridge.test.ts` — 248 passed.

Regression coverage:

- `unknown graph_outline` / `Error: unknown graph_outline` with no version → `does not implement "graph_outline" (detected panel unknown) … ≥0.4.6`
- `unknown refresh_nodes` with no version → quotes `≥0.11.28`
- send() e2e: no-version tab replies `unknown <cmd>` → same actionable message
- `#352` still returns null for a new-enough advertised version
- English `unknown node` and the smoke-mock explained form are not rewritten
