### PR TITLE
fix: reconcile manifest outcomes across processes (#1129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ All notable changes to this project are documented here. This project adheres to
 - retry graph reads after enter or panel_run (#2395, #2567)
 - harden #619 command probe lookup (#2564)
 - do not refuse promoted writes when the connection fingerprint is missing (#2475)
-- keep apply_manifest's scoped outcome handoff truthful through queue-status polling (#1129)
 
 ## [0.52.149] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented here. This project adheres to
 - retry graph reads after enter or panel_run (#2395, #2567)
 - harden #619 command probe lookup (#2564)
 - do not refuse promoted writes when the connection fingerprint is missing (#2475)
+- keep apply_manifest's scoped outcome handoff truthful through queue-status polling (#1129)
 
 ## [0.52.149] - 2026-08-30
 

--- a/src/__tests__/orchestrator/inherited-mcp-not-in-session.test.ts
+++ b/src/__tests__/orchestrator/inherited-mcp-not-in-session.test.ts
@@ -121,9 +121,18 @@ afterEach(async () => {
   writeConfig(SERVER);
 });
 
-async function callListMcpOverHttp(): Promise<ListMcpReply> {
+async function callListMcpOverHttp(
+  manifestOutcomeScopeForTab?: (tabId: string) => string | undefined,
+): Promise<ListMcpReply> {
   // Ephemeral port so a developer's live orchestrator on 9181 is never disturbed.
-  httpServer = await startPanelMcpHttpServer(bridge, 0);
+  httpServer = await startPanelMcpHttpServer(
+    bridge,
+    0,
+    "127.0.0.1",
+    undefined,
+    undefined,
+    manifestOutcomeScopeForTab,
+  );
   const url = httpServer.urlFor(TAB);
   const init = await fetch(url, {
     method: "POST",
@@ -210,6 +219,18 @@ describe("a CLI-lane session is not told it has the user's Claude-config MCP ser
   it("still reports the servers this lane genuinely was handed", async () => {
     const reply = await callListMcpOverHttp();
     expect(reply.builtin).toEqual(["comfyui", "panel"]);
+  });
+
+  it("preserves the backend-qualified agent key at the HTTP outcome-scope boundary", async () => {
+    let receivedTabId: string | undefined;
+    await callListMcpOverHttp((tabId) => {
+      receivedTabId = tabId;
+      return tabId;
+    });
+    // The production Codex/Gemini URL is addressed by the composite agent key,
+    // not by a real panel tab. The callback must receive that exact key so the
+    // queue-status reader can find the child outcome under the same scope.
+    expect(receivedTabId).toBe(TAB);
   });
 });
 

--- a/src/__tests__/orchestrator/inherited-mcp-not-in-session.test.ts
+++ b/src/__tests__/orchestrator/inherited-mcp-not-in-session.test.ts
@@ -548,7 +548,7 @@ describe("the wiring that makes the above reachable in production", () => {
   it("the loopback HTTP lane declares itself non-inheriting when it builds its ctx", () => {
     const src = read("../../orchestrator/panel-mcp-http.ts");
     expect(src).toMatch(
-      /registerPanelTools\(\s*server,\s*makePanelToolCtx\(bridge, tabId, workflowTargets, onRunTicketOpened, \{\s*inheritsUserMcpServers: false,\s*\}\),\s*\)/,
+      /registerPanelTools\(\s*server,\s*makePanelToolCtx\(bridge, tabId, workflowTargets, onRunTicketOpened, \{\s*inheritsUserMcpServers: false,[\s\S]*?\}\),\s*\)/,
     );
   });
 

--- a/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
+++ b/src/__tests__/orchestrator/install-accepted-never-enqueued.test.ts
@@ -53,10 +53,15 @@ function bridge(opts: {
   queueErrors?: boolean;
   /** Model a bridge that cannot say which panel holds the route key. */
   noIncarnation?: boolean;
+  tabId?: string;
+  resolveSharedTabId?: (scopeId?: string) => string | undefined;
+  incarnationArgs?: string[];
+  dispatchedTabIds?: string[];
 }) {
   return {
-    send: async (cmd: Record<string, unknown>) => {
+    send: async (cmd: Record<string, unknown>, sendOpts?: { tabId?: string }) => {
       sent.push(String(cmd.cmd));
+      if (sendOpts?.tabId) opts.dispatchedTabIds?.push(sendOpts.tabId);
       if (cmd.cmd === "nodes_install") {
         // The reporter's exact reply.
         return opts.install ?? { queued: true, pending: true, dialect: "legacy" };
@@ -71,7 +76,14 @@ function bridge(opts: {
     // The REAL UiBridge always reports this; a fixture without it models a
     // bridge that cannot identify which panel answered, which is a separate case
     // asserted below.
-    tabIncarnation: () => (opts.noIncarnation ? undefined : "inc-A"),
+    resolveSharedTabId: opts.resolveSharedTabId,
+    tabIncarnation: (id: string) => {
+      opts.incarnationArgs?.push(id);
+      if (opts.tabId?.startsWith("orchestrator::") && id !== TAB) {
+        throw new Error(`scope address leaked to tabIncarnation: ${id}`);
+      }
+      return opts.noIncarnation ? undefined : "inc-A";
+    },
     push: () => 1,
     canReach: (id: string) => id === TAB,
     isHeadless: () => false,
@@ -87,7 +99,7 @@ function bridge(opts: {
 async function install(
   opts: Parameters<typeof bridge>[0],
 ): Promise<{ text: string; isError: boolean }> {
-  const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
+  const ctx = makePanelToolCtx(bridge(opts), opts.tabId ?? TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_install_node");
   if (!def) throw new Error("panel_install_node is not registered");
   const res: ToolResult = await def.handler({ repository: REPO } as never, ctx);
@@ -324,6 +336,24 @@ describe("an install the Manager accepted and dropped says so (#1129)", () => {
     const res: ToolResult = await def!.handler({ repository: REPO } as never, ctx);
 
     expect(textOf(res)).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+  });
+
+  it("resolves the Claude scope address before reading the panel incarnation", async () => {
+    const SCOPE = "orchestrator::claude";
+    const incarnationArgs: string[] = [];
+    const dispatchedTabIds: string[] = [];
+    const out = await install({
+      tabId: SCOPE,
+      resolveSharedTabId: (scopeId) => (scopeId === SCOPE ? TAB : undefined),
+      incarnationArgs,
+      dispatchedTabIds,
+    });
+
+    // A production-shaped Claude context carries the scope address into the
+    // tool server, while the bridge routes it to the real panel connection.
+    expect(out.text).toMatch(/THE QUEUE DOES NOT HAVE THIS TASK/);
+    expect(dispatchedTabIds).toEqual([SCOPE, SCOPE]);
+    expect(incarnationArgs).toEqual([TAB, TAB]);
   });
 
   it("claims nothing when the bridge cannot identify the panel (codex final)", async () => {

--- a/src/__tests__/orchestrator/shared-session-invariant.test.ts
+++ b/src/__tests__/orchestrator/shared-session-invariant.test.ts
@@ -212,10 +212,10 @@ describe("sessions are orchestrator-scoped, never workflow-scoped (#884)", () =>
     // and the callback is the join that promotes a fast completion arm when
     // panel_run opens its journal ticket (#2021).
     expect(src).toMatch(
-      /createPanelMcpServer\(\s*bridge,\s*key,\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\)/s,
+      /createPanelMcpServer\(\s*bridge,\s*key,\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\(\)\s*=>\s*manifestOutcomeTarget,\s*\)/s,
     );
     expect(src).toMatch(
-      /startPanelMcpHttpServer\(\s*bridge,\s*panelMcpPort,\s*"127\.0\.0\.1",\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\)/s,
+      /startPanelMcpHttpServer\(\s*bridge,\s*panelMcpPort,\s*"127\.0\.0\.1",\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\(panelTabId\)\s*=>\s*agentKeyFor\(panelTabId\),\s*\(\)\s*=>\s*manifestOutcomeTarget,\s*\)/s,
     );
     expect(src.match(/runCompletionWatchdog\?\.markTicketed\(promptIds\)/g) ?? []).toHaveLength(2);
 

--- a/src/__tests__/orchestrator/shared-session-invariant.test.ts
+++ b/src/__tests__/orchestrator/shared-session-invariant.test.ts
@@ -215,7 +215,7 @@ describe("sessions are orchestrator-scoped, never workflow-scoped (#884)", () =>
       /createPanelMcpServer\(\s*bridge,\s*key,\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\(\)\s*=>\s*manifestOutcomeTarget,\s*\)/s,
     );
     expect(src).toMatch(
-      /startPanelMcpHttpServer\(\s*bridge,\s*panelMcpPort,\s*"127\.0\.0\.1",\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\(agentKey\)\s*=>\s*agentKey,\s*\(\)\s*=>\s*manifestOutcomeTarget,\s*\)/s,
+      /startPanelMcpHttpServer\(\s*bridge,\s*panelMcpPort,\s*"127\.0\.0\.1",\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),[\s\S]*?\(agentKey\)\s*=>\s*agentKey,\s*\(\)\s*=>\s*manifestOutcomeTarget,\s*\)/s,
     );
     expect(src.match(/runCompletionWatchdog\?\.markTicketed\(promptIds\)/g) ?? []).toHaveLength(2);
 

--- a/src/__tests__/orchestrator/shared-session-invariant.test.ts
+++ b/src/__tests__/orchestrator/shared-session-invariant.test.ts
@@ -215,7 +215,7 @@ describe("sessions are orchestrator-scoped, never workflow-scoped (#884)", () =>
       /createPanelMcpServer\(\s*bridge,\s*key,\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\(\)\s*=>\s*manifestOutcomeTarget,\s*\)/s,
     );
     expect(src).toMatch(
-      /startPanelMcpHttpServer\(\s*bridge,\s*panelMcpPort,\s*"127\.0\.0\.1",\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\(panelTabId\)\s*=>\s*agentKeyFor\(panelTabId\),\s*\(\)\s*=>\s*manifestOutcomeTarget,\s*\)/s,
+      /startPanelMcpHttpServer\(\s*bridge,\s*panelMcpPort,\s*"127\.0\.0\.1",\s*workflowTargets,\s*\(promptIds\)\s*=>\s*runCompletionWatchdog\?\.markTicketed\(promptIds\),\s*\(agentKey\)\s*=>\s*agentKey,\s*\(\)\s*=>\s*manifestOutcomeTarget,\s*\)/s,
     );
     expect(src.match(/runCompletionWatchdog\?\.markTicketed\(promptIds\)/g) ?? []).toHaveLength(2);
 

--- a/src/__tests__/services/apply-manifest-partial-queue-status.test.ts
+++ b/src/__tests__/services/apply-manifest-partial-queue-status.test.ts
@@ -4,7 +4,7 @@
 //
 // This file drives the SHIPPED applyManifest + panel_node_queue_status path
 // (I/O is mocked; the result assembly and queue-status annotation are real).
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -32,8 +32,10 @@ import { applyManifest } from "../../services/manifest.js";
 import {
   buildManifestPartial,
   clearManifestPartialLeftover,
+  createManifestPartialOperation,
   describeManifestSource,
   getManifestPartialLeftover,
+  readManifestPartials,
   recordManifestPartial,
 } from "../../services/manifest-partial.js";
 import {
@@ -50,6 +52,9 @@ import {
 } from "../../orchestrator/panel-tools.js";
 
 const TAB = "11111111-2222-3333-4444-555555555555";
+const TARGET = "http://127.0.0.1:8188";
+const SCOPE = "orchestrator::test";
+let previousOutcomeScope: string | undefined;
 
 const textOf = (r: ToolResult): string =>
   r.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
@@ -85,8 +90,14 @@ function drainedBridge(): PanelToolCtx["bridge"] {
   } as unknown as PanelToolCtx["bridge"];
 }
 
-async function queueStatus(): Promise<{ text: string; parsed: Record<string, unknown> | null }> {
-  const ctx = makePanelToolCtx(drainedBridge(), TAB, new WorkflowTargetStore());
+async function queueStatus(opts: {
+  bridge?: PanelToolCtx["bridge"];
+  target?: () => { url: string; generation: number } | undefined;
+} = {}): Promise<{ text: string; parsed: Record<string, unknown> | null }> {
+  const ctx = makePanelToolCtx(opts.bridge ?? drainedBridge(), TAB, new WorkflowTargetStore(), undefined, {
+    manifestOutcomeScope: SCOPE,
+    manifestOutcomeTarget: opts.target ?? (() => ({ url: TARGET, generation: 0 })),
+  });
   const def = buildPanelToolDefs().find((d) => d.name === "panel_node_queue_status");
   if (!def) throw new Error("panel_node_queue_status is not registered");
   const res: ToolResult = await def.handler({} as never, ctx);
@@ -102,8 +113,16 @@ async function queueStatus(): Promise<{ text: string; parsed: Record<string, unk
 
 beforeEach(() => {
   clearManifestPartialLeftover();
+  previousOutcomeScope = process.env.COMFYUI_MCP_TAB;
+  process.env.COMFYUI_MCP_TAB = SCOPE;
   listInstalledNodesMock.mockReset().mockResolvedValue([]);
   installCustomNodeMock.mockReset();
+});
+
+afterEach(() => {
+  clearManifestPartialLeftover();
+  if (previousOutcomeScope === undefined) delete process.env.COMFYUI_MCP_TAB;
+  else process.env.COMFYUI_MCP_TAB = previousOutcomeScope;
 });
 
 describe("apply_manifest leftover + panel_node_queue_status (#1699)", () => {
@@ -207,7 +226,7 @@ describe("apply_manifest leftover + panel_node_queue_status (#1699)", () => {
     expect(partial?.message).toMatch(/outcome is UNKNOWN/i);
     expect(partial?.message).toMatch(/no local direct-install fallback is authorized/i);
 
-    recordManifestPartial(partial);
+    recordManifestPartial(partial, { target: TARGET, scope: SCOPE });
     expect(getManifestPartialLeftover()).toMatchObject({
       not_started: [],
       still_installing: [id],
@@ -242,11 +261,13 @@ describe("apply_manifest leftover + panel_node_queue_status (#1699)", () => {
         publishManifestOutcome(partial, {
           dir,
           secret: "orchestrator-issued-child-secret",
-          scope: "orchestrator::codex",
-          target: "http://127.0.0.1:8188",
+          scope: SCOPE,
+          target: TARGET,
         }),
       ).toBe(true);
-      configureManifestOutcomeReader(dir, () => ["orchestrator-issued-child-secret"]);
+      configureManifestOutcomeReader(dir, () => [
+        { secret: "orchestrator-issued-child-secret", scope: SCOPE },
+      ]);
 
       clearManifestPartialLeftover();
       const { parsed, text } = await queueStatus();
@@ -260,5 +281,88 @@ describe("apply_manifest leftover + panel_node_queue_status (#1699)", () => {
       resetManifestOutcomeReader();
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("refuses to annotate a status poll that crosses a ComfyUI retarget", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cmcp-manifest-retarget-"));
+    const id = "https://github.com/example/old-target-pack";
+    const partial = buildManifestPartial({
+      source: "this inline manifest",
+      notStarted: [],
+      stillInstalling: [id],
+      outcomeUnknown: [id],
+    });
+    if (!partial) throw new Error("expected partial fixture");
+    let current = { url: TARGET, generation: 1 };
+    const bridge = drainedBridge();
+    const send = bridge.send;
+    bridge.send = async (cmd: Record<string, unknown>) => {
+      const result = await send(cmd);
+      if (cmd.cmd === "nodes_queue_status") current = { url: "http://127.0.0.1:8189", generation: 2 };
+      return result;
+    };
+    try {
+      expect(
+        publishManifestOutcome(partial, {
+          dir,
+          secret: "retarget-child-secret",
+          scope: SCOPE,
+          target: TARGET,
+          operationId: "retarget-operation",
+        }),
+      ).toBe(true);
+      configureManifestOutcomeReader(dir, () => [
+        { secret: "retarget-child-secret", scope: SCOPE },
+      ]);
+      const { parsed } = await queueStatus({ bridge, target: () => current });
+      expect(parsed?.apply_manifest_partial).toBeUndefined();
+      expect(parsed?.queue_complete_for_apply_manifest).toBeUndefined();
+    } finally {
+      resetManifestOutcomeReader();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a late callback from an older operation after a newer record supersedes it", () => {
+    const id = "https://github.com/example/old-operation-pack";
+    const oldOperation = createManifestPartialOperation({
+      operationId: "old-operation",
+      source: "this inline manifest",
+      scope: SCOPE,
+      target: TARGET,
+      targetGeneration: 1,
+    });
+    const oldBinding = oldOperation.bindItem(id);
+    const oldPartial = buildManifestPartial({
+      source: "this inline manifest",
+      notStarted: [],
+      stillInstalling: [id],
+      outcomeUnknown: [id],
+    });
+    if (!oldPartial) throw new Error("expected old partial fixture");
+    expect(
+      oldOperation.reconcile({ ...oldBinding }, "selected"),
+    ).toBe(false);
+    expect(oldOperation.reconcile(oldBinding, "selected")).toBe(true);
+    oldOperation.record(oldPartial);
+
+    const newId = "https://github.com/example/new-operation-pack";
+    const newOperation = createManifestPartialOperation({
+      operationId: "new-operation",
+      source: "this inline manifest",
+      scope: SCOPE,
+      target: TARGET,
+      targetGeneration: 1,
+    });
+    const newPartial = buildManifestPartial({
+      source: "this inline manifest",
+      notStarted: [newId],
+      stillInstalling: [],
+    });
+    if (!newPartial) throw new Error("expected new partial fixture");
+    newOperation.record(newPartial);
+
+    expect(oldOperation.reconcile(oldBinding, "failed")).toBe(false);
+    expect(readManifestPartials(TARGET, SCOPE, 1)).toEqual([newPartial]);
   });
 });

--- a/src/__tests__/services/apply-manifest-partial-queue-status.test.ts
+++ b/src/__tests__/services/apply-manifest-partial-queue-status.test.ts
@@ -5,6 +5,9 @@
 // This file drives the SHIPPED applyManifest + panel_node_queue_status path
 // (I/O is mocked; the result assembly and queue-status annotation are real).
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const installCustomNodeMock = vi.hoisted(() => vi.fn());
 const listInstalledNodesMock = vi.hoisted(() => vi.fn());
@@ -33,6 +36,11 @@ import {
   getManifestPartialLeftover,
   recordManifestPartial,
 } from "../../services/manifest-partial.js";
+import {
+  configureManifestOutcomeReader,
+  publishManifestOutcome,
+  resetManifestOutcomeReader,
+} from "../../services/manifest-outcome-channel.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import {
   buildPanelToolDefs,
@@ -215,5 +223,42 @@ describe("apply_manifest leftover + panel_node_queue_status (#1699)", () => {
     });
     expect(text).toMatch(/UNKNOWN/i);
     expect(text).toMatch(/no local direct-install fallback is authorized/i);
+  });
+
+  it("annotates a signed child partial through the production channel", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cmcp-manifest-panel-"));
+    const id = "https://github.com/example/child-only-pack";
+    const partial = buildManifestPartial({
+      source: "this inline manifest",
+      notStarted: [],
+      stillInstalling: [id],
+      outcomeUnknown: [id],
+    });
+    if (!partial) throw new Error("expected partial fixture");
+    try {
+      // This is the child-side write; the panel tool reads through a separately
+      // configured orchestrator-side verifier, with no process-local record.
+      expect(
+        publishManifestOutcome(partial, {
+          dir,
+          secret: "orchestrator-issued-child-secret",
+          scope: "orchestrator::codex",
+          target: "http://127.0.0.1:8188",
+        }),
+      ).toBe(true);
+      configureManifestOutcomeReader(dir, () => ["orchestrator-issued-child-secret"]);
+
+      clearManifestPartialLeftover();
+      const { parsed, text } = await queueStatus();
+      expect(parsed?.queue_complete_for_apply_manifest).toBe(false);
+      expect(parsed?.apply_manifest_partial).toMatchObject({
+        still_installing: [id],
+        outcome_unknown: [id],
+      });
+      expect(text).toMatch(/UNKNOWN/i);
+    } finally {
+      resetManifestOutcomeReader();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/__tests__/services/manifest-outcome-channel.test.ts
+++ b/src/__tests__/services/manifest-outcome-channel.test.ts
@@ -14,6 +14,7 @@ import { buildManifestPartial } from "../../services/manifest-partial.js";
 
 const TARGET = "http://127.0.0.1:8188";
 const SECRET = "child-secret-for-1129";
+const SCOPE = "orchestrator::codex";
 
 function partial(id = "https://github.com/example/slow-pack") {
   const value = buildManifestPartial({
@@ -43,9 +44,10 @@ describe("manifest outcome cross-process channel (#1129)", () => {
         target: TARGET,
       }),
     ).toBe(true);
-    configureManifestOutcomeReader(dir, () => [SECRET]);
+    configureManifestOutcomeReader(dir, () => [{ secret: SECRET, scope: SCOPE }]);
 
-    expect(readPublishedManifestOutcomes(TARGET)).toEqual([partial()]);
+    expect(readPublishedManifestOutcomes(TARGET, SCOPE, 0)).toEqual([partial()]);
+    expect(readPublishedManifestOutcomes(TARGET, SCOPE, 1)).toEqual([]);
   });
 
   it("publishes through the real stdio-child environment boundary", () => {
@@ -64,6 +66,8 @@ describe("manifest outcome cross-process channel (#1129)", () => {
           ...process.env,
           COMFYUI_MCP_PROGRESS_DIR: dir,
           COMFYUI_MCP_MANIFEST_OUTCOME_SECRET: SECRET,
+          COMFYUI_MCP_MANIFEST_OPERATION: "child-operation",
+          COMFYUI_MCP_TARGET_GENERATION: "0",
           COMFYUI_MCP_TAB: "orchestrator::codex",
           COMFYUI_URL: TARGET,
         },
@@ -73,8 +77,8 @@ describe("manifest outcome cross-process channel (#1129)", () => {
     );
     expect(child.status, child.stderr).toBe(0);
 
-    configureManifestOutcomeReader(dir, () => [SECRET]);
-    expect(readPublishedManifestOutcomes(TARGET)).toEqual([value]);
+    configureManifestOutcomeReader(dir, () => [{ secret: SECRET, scope: SCOPE }]);
+    expect(readPublishedManifestOutcomes(TARGET, SCOPE, 0)).toEqual([value]);
   });
 
   it("rejects forged, stale-target, and malformed records before annotation", () => {
@@ -98,26 +102,60 @@ describe("manifest outcome cross-process channel (#1129)", () => {
         signature: "0".repeat(64),
       }),
     );
-    configureManifestOutcomeReader(dir, () => [SECRET]);
+    configureManifestOutcomeReader(dir, () => [{ secret: SECRET, scope: SCOPE }]);
 
-    expect(readPublishedManifestOutcomes("http://127.0.0.1:8189")).toEqual([]);
-    expect(readPublishedManifestOutcomes(TARGET)).toHaveLength(1);
+    expect(readPublishedManifestOutcomes("http://127.0.0.1:8189", SCOPE, 0)).toEqual([]);
+    expect(readPublishedManifestOutcomes(TARGET, SCOPE, 0)).toHaveLength(1);
     expect(readFileSync(file, "utf8")).toContain("attacker");
   });
 
   it("removes the child record when the outcome settles", () => {
-    publishManifestOutcome(partial(), { dir, secret: SECRET, target: TARGET });
-    configureManifestOutcomeReader(dir, () => [SECRET]);
-    expect(readPublishedManifestOutcomes(TARGET)).toHaveLength(1);
+    publishManifestOutcome(partial(), { dir, secret: SECRET, scope: SCOPE, target: TARGET });
+    configureManifestOutcomeReader(dir, () => [{ secret: SECRET, scope: SCOPE }]);
+    expect(readPublishedManifestOutcomes(TARGET, SCOPE, 0)).toHaveLength(1);
 
-    expect(publishManifestOutcome(null, { dir, secret: SECRET, target: TARGET })).toBe(true);
-    expect(readPublishedManifestOutcomes(TARGET)).toEqual([]);
+    expect(
+      publishManifestOutcome(null, { dir, secret: SECRET, scope: SCOPE, target: TARGET }),
+    ).toBe(true);
+    expect(readPublishedManifestOutcomes(TARGET, SCOPE, 0)).toEqual([]);
   });
 
   it("canonicalizes only safe HTTP target identities", () => {
     expect(canonicalManifestOutcomeTarget("http://127.0.0.1:8188/")).toBe(TARGET);
     expect(canonicalManifestOutcomeTarget("http://user:pass@127.0.0.1:8188")).toBeNull();
     expect(canonicalManifestOutcomeTarget("http://127.0.0.1:8188/?token=secret")).toBeNull();
+  });
+
+  it("does not let a valid credential for another scope annotate this scope", () => {
+    const otherSecret = "child-secret-for-other-scope";
+    const otherScope = "orchestrator::other";
+    expect(
+      publishManifestOutcome(partial("https://github.com/example/other-pack"), {
+        dir,
+        secret: otherSecret,
+        scope: otherScope,
+        target: TARGET,
+        operationId: "other-operation",
+      }),
+    ).toBe(true);
+    expect(
+      publishManifestOutcome(partial(), {
+        dir,
+        secret: SECRET,
+        scope: SCOPE,
+        target: TARGET,
+        operationId: "expected-operation",
+      }),
+    ).toBe(true);
+    configureManifestOutcomeReader(dir, () => [
+      { secret: SECRET, scope: SCOPE },
+      { secret: otherSecret, scope: otherScope },
+    ]);
+
+    expect(readPublishedManifestOutcomes(TARGET, SCOPE, 0)).toEqual([partial()]);
+    expect(readPublishedManifestOutcomes(TARGET, otherScope, 0)).toEqual([
+      partial("https://github.com/example/other-pack"),
+    ]);
   });
 
   afterEach(() => {

--- a/src/__tests__/services/manifest-outcome-channel.test.ts
+++ b/src/__tests__/services/manifest-outcome-channel.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  canonicalManifestOutcomeTarget,
+  configureManifestOutcomeReader,
+  publishManifestOutcome,
+  readPublishedManifestOutcomes,
+  resetManifestOutcomeReader,
+} from "../../services/manifest-outcome-channel.js";
+import { buildManifestPartial } from "../../services/manifest-partial.js";
+
+const TARGET = "http://127.0.0.1:8188";
+const SECRET = "child-secret-for-1129";
+
+function partial(id = "https://github.com/example/slow-pack") {
+  const value = buildManifestPartial({
+    source: "this inline manifest",
+    notStarted: [],
+    stillInstalling: [id],
+    outcomeUnknown: [id],
+  });
+  if (!value) throw new Error("expected partial fixture");
+  return value;
+}
+
+describe("manifest outcome cross-process channel (#1129)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cmcp-manifest-outcome-"));
+    resetManifestOutcomeReader();
+  });
+
+  it("publishes a child outcome that the configured orchestrator reader can consume", () => {
+    expect(
+      publishManifestOutcome(partial(), {
+        dir,
+        secret: SECRET,
+        scope: "orchestrator::codex",
+        target: TARGET,
+      }),
+    ).toBe(true);
+    configureManifestOutcomeReader(dir, () => [SECRET]);
+
+    expect(readPublishedManifestOutcomes(TARGET)).toEqual([partial()]);
+  });
+
+  it("publishes through the real stdio-child environment boundary", () => {
+    const value = partial();
+    const childSource = `
+      import { publishManifestOutcome } from "./src/services/manifest-outcome-channel.ts";
+      const ok = publishManifestOutcome(${JSON.stringify(value)});
+      if (!ok) process.exitCode = 1;
+    `;
+    const child = spawnSync(
+      process.execPath,
+      ["--import", "tsx/esm", "--input-type=module", "-e", childSource],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          COMFYUI_MCP_PROGRESS_DIR: dir,
+          COMFYUI_MCP_MANIFEST_OUTCOME_SECRET: SECRET,
+          COMFYUI_MCP_TAB: "orchestrator::codex",
+          COMFYUI_URL: TARGET,
+        },
+        encoding: "utf8",
+        windowsHide: true,
+      },
+    );
+    expect(child.status, child.stderr).toBe(0);
+
+    configureManifestOutcomeReader(dir, () => [SECRET]);
+    expect(readPublishedManifestOutcomes(TARGET)).toEqual([value]);
+  });
+
+  it("rejects forged, stale-target, and malformed records before annotation", () => {
+    expect(
+      publishManifestOutcome(partial(), {
+        dir,
+        secret: SECRET,
+        scope: "orchestrator::codex",
+        target: TARGET,
+      }),
+    ).toBe(true);
+    const file = join(dir, "cmcp-manifest-outcome-unknown.json");
+    writeFileSync(
+      file,
+      JSON.stringify({
+        version: 1,
+        scope: "attacker",
+        target: TARGET,
+        updated: Date.now(),
+        partial: partial("../../outside"),
+        signature: "0".repeat(64),
+      }),
+    );
+    configureManifestOutcomeReader(dir, () => [SECRET]);
+
+    expect(readPublishedManifestOutcomes("http://127.0.0.1:8189")).toEqual([]);
+    expect(readPublishedManifestOutcomes(TARGET)).toHaveLength(1);
+    expect(readFileSync(file, "utf8")).toContain("attacker");
+  });
+
+  it("removes the child record when the outcome settles", () => {
+    publishManifestOutcome(partial(), { dir, secret: SECRET, target: TARGET });
+    configureManifestOutcomeReader(dir, () => [SECRET]);
+    expect(readPublishedManifestOutcomes(TARGET)).toHaveLength(1);
+
+    expect(publishManifestOutcome(null, { dir, secret: SECRET, target: TARGET })).toBe(true);
+    expect(readPublishedManifestOutcomes(TARGET)).toEqual([]);
+  });
+
+  it("canonicalizes only safe HTTP target identities", () => {
+    expect(canonicalManifestOutcomeTarget("http://127.0.0.1:8188/")).toBe(TARGET);
+    expect(canonicalManifestOutcomeTarget("http://user:pass@127.0.0.1:8188")).toBeNull();
+    expect(canonicalManifestOutcomeTarget("http://127.0.0.1:8188/?token=secret")).toBeNull();
+  });
+
+  afterEach(() => {
+    resetManifestOutcomeReader();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -1608,8 +1608,10 @@ describe("applyManifest", () => {
     const prevBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
     process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";
     installCustomNodeMock.mockImplementationOnce(
-      (opts: { onLocalFallback?: () => void }) => {
-        opts.onLocalFallback?.();
+      (opts: { onLocalFallback?: (binding: unknown) => void; localFallbackBinding?: unknown }) => {
+        // Production-shaped ordering: node-management can select the fallback
+        // synchronously, before apply_manifest records its final aggregate.
+        opts.onLocalFallback?.(opts.localFallbackBinding);
         return new Promise(() => {});
       },
     );
@@ -1631,8 +1633,18 @@ describe("applyManifest", () => {
       expect(result.results[0].message).not.toMatch(/poll panel_node_queue_status/i);
       expect(result.partial).toMatchObject({
         not_started: ["next-pack"],
-        still_installing: [],
+        still_installing: ["https://github.com/example/local-fallback-pack"],
+        local_fallback: ["https://github.com/example/local-fallback-pack"],
       });
+      expect(result.partial?.message).toMatch(/Reconciliation:.*local direct-install fallback/i);
+      const binding = installCustomNodeMock.mock.calls[0]?.[0]?.localFallbackBinding;
+      expect(binding).toMatchObject({
+        itemId: "https://github.com/example/local-fallback-pack",
+        target: "http://127.0.0.1:8188",
+        targetGeneration: 0,
+      });
+      expect(binding.operationId).toEqual(expect.any(String));
+      expect(binding.scope).toEqual(expect.any(String));
       expect(installCustomNodeMock).toHaveBeenCalledWith(
         expect.objectContaining({ onLocalFallback: expect.any(Function) }),
       );

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1016,6 +1016,42 @@ describe("node-management service", () => {
       ).toBeDefined();
     });
 
+    it("carries the operation and target binding through local fallback phase hooks", async () => {
+      stubFetch({ queueOpStatus: 403 });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+      const binding = Object.freeze({
+        operationId: "operation-bound-to-node-management",
+        itemId: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        scope: "orchestrator::codex",
+        target: "http://127.0.0.1:8188",
+        targetGeneration: 7,
+      });
+      const selected = vi.fn();
+      const settled = vi.fn();
+
+      const res = await installCustomNode({
+        id: binding.itemId,
+        source: "git",
+        localFallbackBinding: binding,
+        onLocalFallback: selected,
+        onLocalFallbackSettled: settled,
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(selected).toHaveBeenCalledWith(binding);
+      expect(settled).toHaveBeenCalledWith(binding, "applied");
+    });
+
     it("keeps apply_manifest truthful when a late Manager drain selects local fallback (#1129)", async () => {
       const previousBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
       process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "80";

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -181,6 +181,7 @@ import {
 import { ProcessControlError, ValidationError } from "../../utils/errors.js";
 import { withPanelMutationLock } from "../../services/panel-pin-guard.js";
 import { applyManifest } from "../../services/manifest.js";
+import { getManifestPartialLeftover } from "../../services/manifest-partial.js";
 
 const mockedExec = vi.mocked(execFileSync);
 const mockedExists = vi.mocked(existsSync);
@@ -258,6 +259,8 @@ function stubFetch(opts: {
   queueOpEmpty?: boolean;
   /** Return JSON null for a custom-node install enqueue. */
   queueOpNull?: boolean;
+  /** Return JSON null from queue/status after the enqueue has been accepted. */
+  queueStatusNull?: boolean;
   /** Delay a custom-node install enqueue response to exercise apply_manifest's late race. */
   queueOpDelayMs?: number;
   /** Body for `https://api.comfy.org/nodes/:id` (registry-zip empty-pack fallback). */
@@ -297,6 +300,11 @@ function stubFetch(opts: {
         return jsonResponse(opts.installedBody ?? {});
       }
       if (path === "/v2/manager/queue/status" || path === "/manager/queue/status") {
+        if (opts.queueStatusNull) {
+          // This is intentionally a status response, not an enqueue response:
+          // the accepted task has already crossed the Manager boundary.
+          return jsonResponse(null);
+        }
         if (opts.managerQueueStatus === "absent") {
           return new Response("missing", { status: 404 });
         }
@@ -1100,10 +1108,48 @@ describe("node-management service", () => {
         expect(
           mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
         ).toBeDefined();
+        // cloneStarted is raised from inside the mocked synchronous git call;
+        // allow the surrounding async fallback promise to run its settle hook.
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+        const reconciled = getManifestPartialLeftover();
+        expect(reconciled?.not_started).toEqual(["next-pack"]);
+        expect(reconciled?.outcome_unknown).toBeUndefined();
+        expect(reconciled?.local_fallback).toBeUndefined();
       } finally {
         if (previousBudget === undefined) delete process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
         else process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = previousBudget;
       }
+    });
+
+    it("fails closed when an accepted warm-cache enqueue is followed by JSON null queue status (#1129)", async () => {
+      const fetchOptions = { queueStatusNull: false };
+      const { calls } = stubFetch(fetchOptions);
+
+      // Establish the same warm dialect cache used by the production path,
+      // then make only the later queue/status poll return JSON null. The
+      // enqueue remains acknowledged, so no local fallback may be selected.
+      await installModelViaManager({
+        name: "warmup.safetensors",
+        url: "https://example.com/warmup.safetensors",
+        filename: "warmup.safetensors",
+        type: "checkpoints",
+      });
+      fetchOptions.queueStatusNull = true;
+
+      await expect(
+        installCustomNode({
+          id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+          source: "git",
+        }),
+      ).rejects.toMatchObject({
+        details: { kind: "manager-queue-empty-status" },
+      });
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/status"))).toBe(true);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeUndefined();
     });
 
     it("does not authorize a late local clone when Manager enqueue eventually returns null (#1129)", async () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2294,7 +2294,11 @@ export async function runPanelOrchestrator(): Promise<void> {
         "127.0.0.1",
         workflowTargets,
         (promptIds) => runCompletionWatchdog?.markTicketed(promptIds),
-        (panelTabId) => agentKeyFor(panelTabId),
+        // The HTTP lane is keyed by the backend-qualified agent address already
+        // (makeHttpBackendMcpServers passes `key` to urlFor). Preserve that exact
+        // scope for the signed outcome reader; agentKeyFor() expects a real panel
+        // tab id and would remap non-default lanes to the wrong credential.
+        (agentKey) => agentKey,
         () => manifestOutcomeTarget,
       );
     } catch (err) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -290,6 +290,7 @@ import { AskAnswers, preview as previewQuestion } from "./ask-answer-journal.js"
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
 import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX, newestAttemptEpochs, isSupersededAttempt, downloadAttemptKey, markSupersededByLive, migrateInFlightJobs } from "../services/download-progress.js";
+import { configureManifestOutcomeReader } from "../services/manifest-outcome-channel.js";
 import { hasActiveTrainingJob, reconcileStaleTrainingJobs } from "../services/training-jobs.js";
 import {
   buildQueueStatusFrame,
@@ -1820,6 +1821,17 @@ export async function runPanelOrchestrator(): Promise<void> {
   // #2149 — a child may write to the shared progress directory, so its tab
   // identity must never come from request JSON. Capabilities are minted here,
   // injected into the child environment, and resolved only by this process.
+  const manifestOutcomeSecrets = new Set<string>();
+  const manifestOutcomeSecretByAgent = new Map<string, string>();
+  const manifestOutcomeSecretFor = (agentKey: string): string => {
+    const existing = manifestOutcomeSecretByAgent.get(agentKey);
+    if (existing) return existing;
+    const secret = randomBytes(32).toString("hex");
+    manifestOutcomeSecretByAgent.set(agentKey, secret);
+    manifestOutcomeSecrets.add(secret);
+    return secret;
+  };
+  configureManifestOutcomeReader(progressDir, () => manifestOutcomeSecrets);
   const panelImageRelaySecrets = new Map<string, string>();
   const panelImageRelaySecretFor = (agentKey: string): string => {
     const existing = [...panelImageRelaySecrets.entries()].find(([, key]) => key === agentKey)?.[0];
@@ -2348,6 +2360,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // downloads resolved to nobody and the owning conversation stalled).
         // `tabId` here IS the agent key (the scope address the lane binds).
         COMFYUI_MCP_TAB: tabId,
+        COMFYUI_MCP_MANIFEST_OUTCOME_SECRET: manifestOutcomeSecretFor(tabId),
         COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor(tabId),
         ...(panelImageRelayEndpoint ? { COMFYUI_MCP_RELAY_URL: panelImageRelayEndpoint } : {}),
         ...(panelTemplateRelayEndpoint
@@ -2693,6 +2706,9 @@ export async function runPanelOrchestrator(): Promise<void> {
         // child stamps its own COMFYUI_MCP_TAB into each progress row, and the
         // settle path resolves an agent-key-shaped stamp directly.
         ...(agentKey ? { COMFYUI_MCP_TAB: agentKey } : {}),
+        ...(agentKey
+          ? { COMFYUI_MCP_MANIFEST_OUTCOME_SECRET: manifestOutcomeSecretFor(agentKey) }
+          : {}),
         ...(agentKey ? { COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor(agentKey) } : {}),
         ...(agentKey && panelImageRelayEndpoint ? { COMFYUI_MCP_RELAY_URL: panelImageRelayEndpoint } : {}),
         ...(agentKey && panelTemplateRelayEndpoint

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1340,6 +1340,15 @@ export async function runPanelOrchestrator(): Promise<void> {
   // whatever ComfyUI (local or a RunPod proxy) the browser is actually on. No
   // `connect <url>` needed.
   let comfyuiUrl = process.env.COMFYUI_URL ?? "http://127.0.0.1:8188";
+  // Queue-status annotations use this orchestrator-owned target state rather
+  // than re-reading config's mutable global URL inside a poll. Retarget events
+  // update it synchronously before any new child is spawned or status reply is
+  // annotated; a poll that crosses the update is rejected by its generation
+  // check in panel-tools.
+  let manifestOutcomeTarget = {
+    url: comfyuiUrl,
+    generation: getComfyuiTargetGeneration(),
+  };
   // Dead-target guard: a `connect` aimed at a TERMINATED pod (an old URL
   // recalled from shell history) otherwise looks perfectly alive — bridge up,
   // tunnel up — while its advertise goes to a dead host, so the panel never
@@ -1821,17 +1830,17 @@ export async function runPanelOrchestrator(): Promise<void> {
   // #2149 — a child may write to the shared progress directory, so its tab
   // identity must never come from request JSON. Capabilities are minted here,
   // injected into the child environment, and resolved only by this process.
-  const manifestOutcomeSecrets = new Set<string>();
+  const manifestOutcomeCredentials = new Map<string, { secret: string; scope: string }>();
   const manifestOutcomeSecretByAgent = new Map<string, string>();
   const manifestOutcomeSecretFor = (agentKey: string): string => {
     const existing = manifestOutcomeSecretByAgent.get(agentKey);
     if (existing) return existing;
     const secret = randomBytes(32).toString("hex");
     manifestOutcomeSecretByAgent.set(agentKey, secret);
-    manifestOutcomeSecrets.add(secret);
+    manifestOutcomeCredentials.set(agentKey, { secret, scope: agentKey });
     return secret;
   };
-  configureManifestOutcomeReader(progressDir, () => manifestOutcomeSecrets);
+  configureManifestOutcomeReader(progressDir, () => manifestOutcomeCredentials.values());
   const panelImageRelaySecrets = new Map<string, string>();
   const panelImageRelaySecretFor = (agentKey: string): string => {
     const existing = [...panelImageRelaySecrets.entries()].find(([, key]) => key === agentKey)?.[0];
@@ -2285,6 +2294,8 @@ export async function runPanelOrchestrator(): Promise<void> {
         "127.0.0.1",
         workflowTargets,
         (promptIds) => runCompletionWatchdog?.markTicketed(promptIds),
+        (panelTabId) => agentKeyFor(panelTabId),
+        () => manifestOutcomeTarget,
       );
     } catch (err) {
       logger.error(
@@ -2360,6 +2371,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // downloads resolved to nobody and the owning conversation stalled).
         // `tabId` here IS the agent key (the scope address the lane binds).
         COMFYUI_MCP_TAB: tabId,
+        COMFYUI_MCP_TARGET_GENERATION: String(getComfyuiTargetGeneration()),
         COMFYUI_MCP_MANIFEST_OUTCOME_SECRET: manifestOutcomeSecretFor(tabId),
         COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor(tabId),
         ...(panelImageRelayEndpoint ? { COMFYUI_MCP_RELAY_URL: panelImageRelayEndpoint } : {}),
@@ -2702,6 +2714,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         COMFYUI_URL: comfyuiUrl,
         // Where download_model writes live progress for the panel tray.
         COMFYUI_MCP_PROGRESS_DIR: progressDir,
+        COMFYUI_MCP_TARGET_GENERATION: String(getComfyuiTargetGeneration()),
         // Self-scope downloads to the owning CONVERSATION (#547/#884) — the
         // child stamps its own COMFYUI_MCP_TAB into each progress row, and the
         // settle path resolves an agent-key-shaped stamp directly.
@@ -2750,6 +2763,7 @@ export async function runPanelOrchestrator(): Promise<void> {
             key,
             workflowTargets,
             (promptIds) => runCompletionWatchdog?.markTicketed(promptIds),
+            () => manifestOutcomeTarget,
           )
         : undefined,
     mcpServers: buildMcpServers(),
@@ -6882,6 +6896,10 @@ export async function runPanelOrchestrator(): Promise<void> {
   // a fresh tab knows the host without waiting for a switch.
   let lastRetargetUrl: string | null = comfyuiUrl; // seeded: a first same-URL event must not restart everything
   onComfyuiTargetChanged((url, isLocal) => {
+    manifestOutcomeTarget = {
+      url,
+      generation: getComfyuiTargetGeneration(),
+    };
     // ANY target event — a change OR a reaffirmation of the current target —
     // supersedes ALL pending auto-connects (codex findings: direct
     // setComfyuiTarget callers bypass applyComfyuiUrl, and an explicit

--- a/src/orchestrator/panel-mcp-http.ts
+++ b/src/orchestrator/panel-mcp-http.ts
@@ -82,6 +82,8 @@ export function startPanelMcpHttpServer(
   host = "127.0.0.1",
   workflowTargets?: WorkflowTargetStore,
   onRunTicketOpened?: (promptIds: readonly string[]) => void,
+  manifestOutcomeScopeForTab?: (tabId: string) => string | undefined,
+  manifestOutcomeTarget?: () => { url: string; generation: number } | undefined,
 ): Promise<PanelMcpHttpServer> {
   // tabId -> (sessionId -> Session). A tab can hold multiple Codex sessions
   // across reconnects; each is its own server+transport over the SAME tab ctx.
@@ -122,6 +124,8 @@ export function startPanelMcpHttpServer(
       server,
       makePanelToolCtx(bridge, tabId, workflowTargets, onRunTicketOpened, {
         inheritsUserMcpServers: false,
+        manifestOutcomeScope: manifestOutcomeScopeForTab?.(tabId),
+        ...(manifestOutcomeTarget ? { manifestOutcomeTarget } : {}),
       }),
     );
     const transport = new StreamableHTTPServerTransport({

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -66,6 +66,7 @@ import {
   formatQueueStatusPartialNote,
   getManifestPartialLeftover,
 } from "../services/manifest-partial.js";
+import { readPublishedManifestOutcomes } from "../services/manifest-outcome-channel.js";
 import { searchPanelNodes } from "../services/manager-node-search.js";
 import { listPanelNodes } from "../services/manager-node-list.js";
 import { isPanelAnsweredError } from "../services/panel-answered.js";
@@ -4853,18 +4854,25 @@ async function settleDroppedEnqueue(
  * name the outstanding entries on the object.
  */
 function annotateQueueStatusWithManifestPartial(res: ToolResult): ToolResult {
-  const leftover = getManifestPartialLeftover();
-  if (
-    !leftover ||
-    (leftover.not_started.length === 0 &&
-      leftover.still_installing.length === 0 &&
-      (leftover.outcome_unknown?.length ?? 0) === 0)
-  ) {
+  const local = getManifestPartialLeftover();
+  const published = readPublishedManifestOutcomes(getComfyUIBaseUrl());
+  const partials = [local, ...published].filter(
+    (partial): partial is NonNullable<typeof partial> => partial !== null,
+  );
+  const uniquePartials = partials.filter((partial, index, all) => {
+    const key = JSON.stringify(partial);
+    return all.findIndex((candidate) => JSON.stringify(candidate) === key) === index;
+  });
+  if (uniquePartials.length === 0) {
     return res;
   }
   if (res.isError) return res;
   const parsed = parseToolResultJson(res);
-  if (!parsed) return appendNote(res, formatQueueStatusPartialNote(leftover));
+  const leftover = uniquePartials[0];
+  const note = uniquePartials.length === 1
+    ? formatQueueStatusPartialNote(leftover)
+    : uniquePartials.map(formatQueueStatusPartialNote).join("\n\n");
+  if (!parsed) return appendNote(res, note);
   return {
     ...res,
     content: [
@@ -4874,6 +4882,7 @@ function annotateQueueStatusWithManifestPartial(res: ToolResult): ToolResult {
           {
             ...parsed,
             apply_manifest_partial: leftover,
+            ...(uniquePartials.length > 1 ? { apply_manifest_partials: uniquePartials } : {}),
             queue_complete_for_apply_manifest: false,
           },
           null,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4490,7 +4490,26 @@ function queueNeverSawATask(reply: Record<string, unknown> | null): boolean {
  */
 function panelIncarnation(ctx: PanelToolCtx, tabId: string): string | undefined {
   const b = ctx.bridge as { tabIncarnation?: (t: string) => string | undefined };
-  return typeof b?.tabIncarnation === "function" ? b.tabIncarnation(tabId) : undefined;
+  if (typeof b?.tabIncarnation !== "function") return undefined;
+
+  // Claude's in-process server is bound to the backend-qualified scope address
+  // (for example `orchestrator::claude`), not to a concrete bridge tab id. The
+  // bridge's scope resolver is the same canonical routing decision used by the
+  // subsequent queue read, so ask it for the real connection before reading its
+  // incarnation. Never pass an unresolved scope address to tabIncarnation: the
+  // UiBridge stores incarnations by real connection key, and a mock/legacy
+  // implementation must not make an unknown scope look identified.
+  const resolvedTab = isScopeAddress(tabId)
+    ? (() => {
+        const resolveSharedTabId = (ctx.bridge as BridgeProbe).resolveSharedTabId;
+        try {
+          return typeof resolveSharedTabId === "function" ? resolveSharedTabId(tabId) : undefined;
+        } catch {
+          return undefined;
+        }
+      })()
+    : tabId;
+  return resolvedTab === undefined ? undefined : b.tabIncarnation(resolvedTab);
 }
 
 type RegistryInstallSnapshot = {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -64,7 +64,7 @@ import {
 import { sanitizePanelUpdateNodeResult } from "../services/manager-update-error.js";
 import {
   formatQueueStatusPartialNote,
-  getManifestPartialLeftover,
+  readManifestPartials,
 } from "../services/manifest-partial.js";
 import { readPublishedManifestOutcomes } from "../services/manifest-outcome-channel.js";
 import { searchPanelNodes } from "../services/manager-node-search.js";
@@ -4853,12 +4853,19 @@ async function settleDroppedEnqueue(
  * Keep the panel payload parseable (do not append prose after the JSON) and
  * name the outstanding entries on the object.
  */
-function annotateQueueStatusWithManifestPartial(res: ToolResult): ToolResult {
-  const local = getManifestPartialLeftover();
-  const published = readPublishedManifestOutcomes(getComfyUIBaseUrl());
-  const partials = [local, ...published].filter(
-    (partial): partial is NonNullable<typeof partial> => partial !== null,
-  );
+function annotateQueueStatusWithManifestPartial(
+  res: ToolResult,
+  target: { url: string; generation: number } | undefined,
+  scope: string | undefined,
+): ToolResult {
+  // Both records are scoped to the target snapshot captured for this poll. An
+  // absent scope/target is UNKNOWN and therefore cannot authorize an annotation.
+  // In particular, do not fall back to getComfyUIBaseUrl() here: a retarget can
+  // occur while the panel status request is in flight.
+  if (!target || !scope) return res;
+  const local = readManifestPartials(target.url, scope, target.generation);
+  const published = readPublishedManifestOutcomes(target.url, scope, target.generation);
+  const partials = [...local, ...published];
   const uniquePartials = partials.filter((partial, index, all) => {
     const key = JSON.stringify(partial);
     return all.findIndex((candidate) => JSON.stringify(candidate) === key) === index;
@@ -14053,6 +14060,12 @@ export interface PanelToolCtx {
   modelInventoryDisclosure?: ModelInventoryDisclosureProbe;
   /** Per-tab workflow pin store (optional for tests). */
   workflowTarget?: WorkflowTargetStore;
+  /** Immutable lane identity used to read apply_manifest outcome records. */
+  manifestOutcomeScope?: string;
+  /** Capture the ComfyUI target at the start/end of a queue-status poll. */
+  manifestOutcomeTarget?: () =>
+    | { url: string; generation: number }
+    | undefined;
   /**
    * EXPLICIT self-heal: re-point THIS session at the currently active/sole
    * connected tab. The tabId captured at session creation is frozen; a full
@@ -14242,6 +14255,12 @@ export interface PanelToolCtxLane {
   inheritsUserMcpServers?: boolean;
   /** See {@link PanelToolCtx.userMcpServersAtSpawn}. */
   userMcpServersAtSpawn?: readonly string[];
+  /** Scope capability minted for this agent lane; never derive it from ctx.tabId. */
+  manifestOutcomeScope?: string;
+  /** Target resolver supplied by the owning orchestrator scope. */
+  manifestOutcomeTarget?: () =>
+    | { url: string; generation: number }
+    | undefined;
 }
 
 /** Build a tab-bound execution context shared by both transports. */
@@ -14270,6 +14289,12 @@ export function makePanelToolCtx(
     ...(lane?.userMcpServersAtSpawn === undefined
       ? {}
       : { userMcpServersAtSpawn: lane.userMcpServersAtSpawn }),
+    ...(lane?.manifestOutcomeScope === undefined
+      ? {}
+      : { manifestOutcomeScope: lane.manifestOutcomeScope }),
+    ...(lane?.manifestOutcomeTarget === undefined
+      ? {}
+      : { manifestOutcomeTarget: lane.manifestOutcomeTarget }),
   } as PanelToolCtx;
 
   // AUTO-HEAL an orphaned session in place. When THIS session's captured tabId no
@@ -23308,8 +23333,25 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         "those entries are verified (re-run apply_manifest only when the result authorizes it).",
       {},
       async (_args, ctx) => {
+        const targetBeforePoll = ctx.manifestOutcomeTarget?.();
         const res = await ctx.call({ cmd: "nodes_queue_status" }, 20000);
-        return annotateQueueStatusWithManifestPartial(res);
+        const targetAfterPoll = ctx.manifestOutcomeTarget?.();
+        // A status reply that crosses a retarget boundary is not attributable to
+        // either instance. Fail closed instead of annotating it with the old
+        // instance's partial.
+        if (
+          !targetBeforePoll ||
+          !targetAfterPoll ||
+          targetBeforePoll.generation !== targetAfterPoll.generation ||
+          targetBeforePoll.url !== targetAfterPoll.url
+        ) {
+          return res;
+        }
+        return annotateQueueStatusWithManifestPartial(
+          res,
+          targetBeforePoll,
+          ctx.manifestOutcomeScope,
+        );
       },
     ),
     def(
@@ -25738,6 +25780,9 @@ export function createPanelMcpServer(
   tabId: string,
   workflowTargets?: WorkflowTargetStore,
   onRunTicketOpened?: (promptIds: readonly string[]) => void,
+  manifestOutcomeTarget?: () =>
+    | { url: string; generation: number }
+    | undefined,
 ): McpSdkServerConfigWithInstance {
   // #2311 — record whether this agent was handed the user's own MCP servers, so
   // panel_list_mcp / panel_add_mcp report the session and not the config file.
@@ -25757,6 +25802,8 @@ export function createPanelMcpServer(
     keyBackend === undefined ? undefined : backendInheritsUserMcpServers(keyBackend);
   const ctx = makePanelToolCtx(bridge, tabId, workflowTargets, onRunTicketOpened, {
     inheritsUserMcpServers,
+    manifestOutcomeScope: tabId,
+    ...(manifestOutcomeTarget ? { manifestOutcomeTarget } : {}),
     // Snapshot the names THIS spawn was given, not the file. makeAgent() builds
     // `mcpServers` (which re-reads ~/.claude.json) and `panelServer` (this call)
     // as two properties of one synchronous object literal, so these are the same

--- a/src/services/manifest-outcome-channel.ts
+++ b/src/services/manifest-outcome-channel.ts
@@ -22,11 +22,14 @@ import {
 import { join } from "node:path";
 import type { ManifestPartialInstall } from "./manifest-partial.js";
 
-export const MANIFEST_OUTCOME_CHANNEL_VERSION = 1 as const;
+// The operation and target-generation fields make this incompatible with the
+// pre-follow-up envelope; stale version-1 files must never be interpreted here.
+export const MANIFEST_OUTCOME_CHANNEL_VERSION = 2 as const;
 export const MANIFEST_OUTCOME_TTL_MS = 6 * 60 * 60 * 1000;
 
 const FILE_PREFIX = "cmcp-manifest-outcome-";
 const MAX_RECORD_BYTES = 128 * 1024;
+const MAX_OPERATION_ID_LENGTH = 128;
 const MAX_SCOPE_LENGTH = 512;
 const MAX_TARGET_LENGTH = 2048;
 const MAX_SOURCE_LENGTH = 1024;
@@ -36,28 +39,38 @@ const MAX_ITEMS = 512;
 
 export interface ManifestOutcomeEnvelope {
   version: typeof MANIFEST_OUTCOME_CHANNEL_VERSION;
+  operation_id: string;
   scope: string;
   target: string;
+  target_generation: number;
   updated: number;
   partial: ManifestPartialInstall | null;
   signature: string;
 }
 
+export interface ManifestOutcomeReaderCredential {
+  /** Secret minted by this orchestrator for exactly one scope. */
+  secret: string;
+  /** The scope that this secret is authorized to read. */
+  scope: string;
+}
+
 interface ReaderConfig {
   dir: string;
-  secrets: () => Iterable<string>;
+  credentials: () => Iterable<ManifestOutcomeReaderCredential>;
 }
 
 let readerConfig: ReaderConfig | undefined;
 let writeSequence = 0;
 
-/** Configure the orchestrator-side reader. The callback keeps the secret set
- * live as new agent sessions are spawned, without exposing secrets to a file. */
+/** Configure the orchestrator-side reader. The callback keeps the scoped
+ * credentials live as new agent sessions are spawned, without exposing secrets
+ * to a file. A valid secret for another scope is deliberately not enough. */
 export function configureManifestOutcomeReader(
   dir: string,
-  secrets: () => Iterable<string>,
+  credentials: () => Iterable<ManifestOutcomeReaderCredential>,
 ): void {
-  readerConfig = { dir: dir.trim(), secrets };
+  readerConfig = { dir: dir.trim(), credentials };
 }
 
 function configuredWriterDir(): string {
@@ -70,6 +83,15 @@ function configuredWriterSecret(): string {
 
 function configuredWriterScope(): string {
   return process.env.COMFYUI_MCP_TAB?.trim() || `stdio:${process.pid}`;
+}
+
+function configuredWriterOperationId(): string {
+  return process.env.COMFYUI_MCP_MANIFEST_OPERATION?.trim() || "legacy";
+}
+
+function configuredWriterTargetGeneration(): number {
+  const value = Number(process.env.COMFYUI_MCP_TARGET_GENERATION);
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0;
 }
 
 /** Keep only the identity-bearing URL components. Query strings may contain
@@ -126,8 +148,10 @@ function validPartial(value: unknown): value is ManifestPartialInstall {
 function payloadFor(envelope: Omit<ManifestOutcomeEnvelope, "signature">): string {
   return JSON.stringify({
     version: envelope.version,
+    operation_id: envelope.operation_id,
     scope: envelope.scope,
     target: envelope.target,
+    target_generation: envelope.target_generation,
     updated: envelope.updated,
     partial: envelope.partial,
   });
@@ -137,8 +161,11 @@ function signatureFor(payload: string, secret: string): string {
   return createHmac("sha256", secret).update(payload).digest("hex");
 }
 
-function fileFor(dir: string, secret: string): string {
-  const key = createHash("sha256").update(secret).digest("hex").slice(0, 32);
+function fileFor(dir: string, secret: string, operationId: string): string {
+  const key = createHash("sha256")
+    .update(`${secret}\0${operationId}`)
+    .digest("hex")
+    .slice(0, 32);
   return join(dir, `${FILE_PREFIX}${key}.json`);
 }
 
@@ -162,23 +189,39 @@ export function publishManifestOutcome(
   options: {
     dir?: string;
     secret?: string;
+    operationId?: string;
     scope?: string;
     target?: string;
+    targetGeneration?: number;
   } = {},
 ): boolean {
   const dir = options.dir?.trim() ?? configuredWriterDir();
   const secret = options.secret?.trim() ?? configuredWriterSecret();
+  const operationId = options.operationId?.trim() ?? configuredWriterOperationId();
   const scope = options.scope?.trim() ?? configuredWriterScope();
+  const targetGeneration = options.targetGeneration ?? configuredWriterTargetGeneration();
   const target = canonicalManifestOutcomeTarget(
     options.target?.trim() || process.env.COMFYUI_URL?.trim() || "",
   );
-  if (!dir || !secret || !scope || scope.length > MAX_SCOPE_LENGTH || !target) return false;
+  if (
+    !dir ||
+    !secret ||
+    !operationId ||
+    operationId.length > MAX_OPERATION_ID_LENGTH ||
+    !scope ||
+    scope.length > MAX_SCOPE_LENGTH ||
+    !Number.isSafeInteger(targetGeneration) ||
+    targetGeneration < 0 ||
+    !target
+  ) return false;
   if (partial !== null && !validPartial(partial)) return false;
 
   const envelopeWithoutSignature = {
     version: MANIFEST_OUTCOME_CHANNEL_VERSION,
+    operation_id: operationId,
     scope,
     target,
+    target_generation: targetGeneration,
     updated: Date.now(),
     partial: copyPartial(partial),
   } satisfies Omit<ManifestOutcomeEnvelope, "signature">;
@@ -186,7 +229,7 @@ export function publishManifestOutcome(
     ...envelopeWithoutSignature,
     signature: signatureFor(payloadFor(envelopeWithoutSignature), secret),
   };
-  const finalPath = fileFor(dir, secret);
+  const finalPath = fileFor(dir, secret, operationId);
   try {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
     if (partial === null) {
@@ -216,10 +259,16 @@ function parseEnvelope(raw: unknown, secret: string): ManifestOutcomeEnvelope | 
   const envelope = raw as Partial<ManifestOutcomeEnvelope>;
   if (
     envelope.version !== MANIFEST_OUTCOME_CHANNEL_VERSION ||
+    typeof envelope.operation_id !== "string" ||
+    envelope.operation_id.length === 0 ||
+    envelope.operation_id.length > MAX_OPERATION_ID_LENGTH ||
     typeof envelope.scope !== "string" ||
     envelope.scope.length === 0 ||
     envelope.scope.length > MAX_SCOPE_LENGTH ||
     typeof envelope.target !== "string" ||
+    typeof envelope.target_generation !== "number" ||
+    !Number.isSafeInteger(envelope.target_generation) ||
+    envelope.target_generation < 0 ||
     typeof envelope.updated !== "number" ||
     !Number.isFinite(envelope.updated) ||
     typeof envelope.signature !== "string" ||
@@ -232,8 +281,10 @@ function parseEnvelope(raw: unknown, secret: string): ManifestOutcomeEnvelope | 
   if (!target || target !== envelope.target) return null;
   const unsigned = {
     version: envelope.version,
+    operation_id: envelope.operation_id,
     scope: envelope.scope,
     target: envelope.target,
+    target_generation: envelope.target_generation,
     updated: envelope.updated,
     partial: copyPartial(envelope.partial ?? null),
   } satisfies Omit<ManifestOutcomeEnvelope, "signature">;
@@ -248,10 +299,24 @@ function parseEnvelope(raw: unknown, secret: string): ManifestOutcomeEnvelope | 
 
 /** Read only records authenticated by the orchestrator and bound to its
  * current target. Invalid, stale, or foreign-target records are ignored. */
-export function readPublishedManifestOutcomes(target: string): ManifestPartialInstall[] {
+export function readPublishedManifestOutcomes(
+  target: string,
+  scope: string,
+  targetGeneration: number,
+): ManifestPartialInstall[] {
   const cfg = readerConfig;
   const expectedTarget = canonicalManifestOutcomeTarget(target);
-  if (!cfg?.dir || !expectedTarget) return [];
+  const expectedScope = scope.trim();
+  if (
+    !cfg?.dir ||
+    !expectedTarget ||
+    !expectedScope ||
+    expectedScope.length > MAX_SCOPE_LENGTH ||
+    !Number.isSafeInteger(targetGeneration) ||
+    targetGeneration < 0
+  ) {
+    return [];
+  }
   let files: string[];
   try {
     files = readdirSync(cfg.dir).filter(
@@ -261,7 +326,13 @@ export function readPublishedManifestOutcomes(target: string): ManifestPartialIn
     return [];
   }
 
-  const secrets = [...cfg.secrets()].filter((secret) => typeof secret === "string" && secret.length > 0);
+  const credentials = [...cfg.credentials()].filter(
+    (credential): credential is ManifestOutcomeReaderCredential =>
+      typeof credential?.secret === "string" &&
+      credential.secret.length > 0 &&
+      typeof credential.scope === "string" &&
+      credential.scope === expectedScope,
+  );
   const out: Array<{ updated: number; partial: ManifestPartialInstall }> = [];
   for (const name of files.slice(0, 128)) {
     let text: string;
@@ -279,9 +350,15 @@ export function readPublishedManifestOutcomes(target: string): ManifestPartialIn
     } catch {
       continue;
     }
-    for (const secret of secrets) {
-      const envelope = parseEnvelope(raw, secret);
-      if (!envelope || envelope.target !== expectedTarget) continue;
+    for (const credential of credentials) {
+      const envelope = parseEnvelope(raw, credential.secret);
+      if (
+        !envelope ||
+        envelope.scope !== credential.scope ||
+        envelope.scope !== expectedScope ||
+        envelope.target !== expectedTarget ||
+        envelope.target_generation !== targetGeneration
+      ) continue;
       if (Date.now() - envelope.updated > MANIFEST_OUTCOME_TTL_MS) {
         try {
           rmSync(join(cfg.dir, name), { force: true });

--- a/src/services/manifest-outcome-channel.ts
+++ b/src/services/manifest-outcome-channel.ts
@@ -1,0 +1,310 @@
+/**
+ * Cross-process handoff for apply_manifest's outstanding custom-node outcome.
+ *
+ * apply_manifest normally runs in a panel agent's stdio child while
+ * panel_node_queue_status runs in the orchestrator. The old process-local
+ * manifest-partial record therefore could never reach the queue-status reader.
+ * This channel uses the already nonce-scoped, mode-0700 progress directory,
+ * but adds a per-child HMAC so a stray file or an untrusted payload cannot turn
+ * into an annotation. Writes are atomic: readers see either the previous
+ * complete record or the next complete record, never a partial JSON document.
+ */
+
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import type { ManifestPartialInstall } from "./manifest-partial.js";
+
+export const MANIFEST_OUTCOME_CHANNEL_VERSION = 1 as const;
+export const MANIFEST_OUTCOME_TTL_MS = 6 * 60 * 60 * 1000;
+
+const FILE_PREFIX = "cmcp-manifest-outcome-";
+const MAX_RECORD_BYTES = 128 * 1024;
+const MAX_SCOPE_LENGTH = 512;
+const MAX_TARGET_LENGTH = 2048;
+const MAX_SOURCE_LENGTH = 1024;
+const MAX_MESSAGE_LENGTH = 16 * 1024;
+const MAX_ITEM_LENGTH = 1024;
+const MAX_ITEMS = 512;
+
+export interface ManifestOutcomeEnvelope {
+  version: typeof MANIFEST_OUTCOME_CHANNEL_VERSION;
+  scope: string;
+  target: string;
+  updated: number;
+  partial: ManifestPartialInstall | null;
+  signature: string;
+}
+
+interface ReaderConfig {
+  dir: string;
+  secrets: () => Iterable<string>;
+}
+
+let readerConfig: ReaderConfig | undefined;
+let writeSequence = 0;
+
+/** Configure the orchestrator-side reader. The callback keeps the secret set
+ * live as new agent sessions are spawned, without exposing secrets to a file. */
+export function configureManifestOutcomeReader(
+  dir: string,
+  secrets: () => Iterable<string>,
+): void {
+  readerConfig = { dir: dir.trim(), secrets };
+}
+
+function configuredWriterDir(): string {
+  return process.env.COMFYUI_MCP_PROGRESS_DIR?.trim() ?? "";
+}
+
+function configuredWriterSecret(): string {
+  return process.env.COMFYUI_MCP_MANIFEST_OUTCOME_SECRET?.trim() ?? "";
+}
+
+function configuredWriterScope(): string {
+  return process.env.COMFYUI_MCP_TAB?.trim() || `stdio:${process.pid}`;
+}
+
+/** Keep only the identity-bearing URL components. Query strings may contain
+ * credentials and are not part of the ComfyUI target identity. */
+export function canonicalManifestOutcomeTarget(input: string): string | null {
+  if (typeof input !== "string" || input.length === 0 || input.length > MAX_TARGET_LENGTH) {
+    return null;
+  }
+  try {
+    const url = new URL(input);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.username || url.password || url.search || url.hash) return null;
+    const path = url.pathname.replace(/\/+$/, "");
+    return `${url.protocol}//${url.host}${path}`;
+  } catch {
+    return null;
+  }
+}
+
+function validStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length <= MAX_ITEMS &&
+    value.every((item) => typeof item === "string" && item.length <= MAX_ITEM_LENGTH)
+  );
+}
+
+function validPartial(value: unknown): value is ManifestPartialInstall {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const partial = value as Record<string, unknown>;
+  if (
+    partial.kind !== "custom_nodes_not_started" ||
+    typeof partial.source !== "string" ||
+    partial.source.length > MAX_SOURCE_LENGTH ||
+    typeof partial.message !== "string" ||
+    partial.message.length > MAX_MESSAGE_LENGTH ||
+    !validStringArray(partial.not_started) ||
+    !validStringArray(partial.still_installing)
+  ) {
+    return false;
+  }
+  for (const key of ["outcome_unknown", "local_fallback", "local_fallback_failed"] as const) {
+    if (partial[key] !== undefined && !validStringArray(partial[key])) return false;
+  }
+  const stillInstalling = partial.still_installing as string[];
+  const outcomeUnknown = partial.outcome_unknown as string[] | undefined;
+  const localFallback = partial.local_fallback as string[] | undefined;
+  return (
+    (outcomeUnknown ?? []).every((id) => stillInstalling.includes(id)) &&
+    (localFallback ?? []).every((id) => stillInstalling.includes(id))
+  );
+}
+
+function payloadFor(envelope: Omit<ManifestOutcomeEnvelope, "signature">): string {
+  return JSON.stringify({
+    version: envelope.version,
+    scope: envelope.scope,
+    target: envelope.target,
+    updated: envelope.updated,
+    partial: envelope.partial,
+  });
+}
+
+function signatureFor(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+function fileFor(dir: string, secret: string): string {
+  const key = createHash("sha256").update(secret).digest("hex").slice(0, 32);
+  return join(dir, `${FILE_PREFIX}${key}.json`);
+}
+
+function copyPartial(partial: ManifestPartialInstall | null): ManifestPartialInstall | null {
+  if (!partial) return null;
+  return {
+    ...partial,
+    not_started: [...partial.not_started],
+    still_installing: [...partial.still_installing],
+    ...(partial.outcome_unknown ? { outcome_unknown: [...partial.outcome_unknown] } : {}),
+    ...(partial.local_fallback ? { local_fallback: [...partial.local_fallback] } : {}),
+    ...(partial.local_fallback_failed
+      ? { local_fallback_failed: [...partial.local_fallback_failed] }
+      : {}),
+  };
+}
+
+/** Publish from the stdio child, or from a test that supplies explicit seams. */
+export function publishManifestOutcome(
+  partial: ManifestPartialInstall | null,
+  options: {
+    dir?: string;
+    secret?: string;
+    scope?: string;
+    target?: string;
+  } = {},
+): boolean {
+  const dir = options.dir?.trim() ?? configuredWriterDir();
+  const secret = options.secret?.trim() ?? configuredWriterSecret();
+  const scope = options.scope?.trim() ?? configuredWriterScope();
+  const target = canonicalManifestOutcomeTarget(
+    options.target?.trim() || process.env.COMFYUI_URL?.trim() || "",
+  );
+  if (!dir || !secret || !scope || scope.length > MAX_SCOPE_LENGTH || !target) return false;
+  if (partial !== null && !validPartial(partial)) return false;
+
+  const envelopeWithoutSignature = {
+    version: MANIFEST_OUTCOME_CHANNEL_VERSION,
+    scope,
+    target,
+    updated: Date.now(),
+    partial: copyPartial(partial),
+  } satisfies Omit<ManifestOutcomeEnvelope, "signature">;
+  const envelope: ManifestOutcomeEnvelope = {
+    ...envelopeWithoutSignature,
+    signature: signatureFor(payloadFor(envelopeWithoutSignature), secret),
+  };
+  const finalPath = fileFor(dir, secret);
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    if (partial === null) {
+      rmSync(finalPath, { force: true });
+      return true;
+    }
+    const tempPath = `${finalPath}.${process.pid}-${writeSequence++}.tmp`;
+    writeFileSync(tempPath, JSON.stringify(envelope));
+    try {
+      renameSync(tempPath, finalPath);
+      return true;
+    } catch {
+      try {
+        rmSync(tempPath, { force: true });
+      } catch {
+        /* ignore a stray .tmp; readers only inspect .json */
+      }
+      return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+function parseEnvelope(raw: unknown, secret: string): ManifestOutcomeEnvelope | null {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const envelope = raw as Partial<ManifestOutcomeEnvelope>;
+  if (
+    envelope.version !== MANIFEST_OUTCOME_CHANNEL_VERSION ||
+    typeof envelope.scope !== "string" ||
+    envelope.scope.length === 0 ||
+    envelope.scope.length > MAX_SCOPE_LENGTH ||
+    typeof envelope.target !== "string" ||
+    typeof envelope.updated !== "number" ||
+    !Number.isFinite(envelope.updated) ||
+    typeof envelope.signature !== "string" ||
+    !/^[a-f0-9]{64}$/.test(envelope.signature) ||
+    (envelope.partial !== null && !validPartial(envelope.partial))
+  ) {
+    return null;
+  }
+  const target = canonicalManifestOutcomeTarget(envelope.target);
+  if (!target || target !== envelope.target) return null;
+  const unsigned = {
+    version: envelope.version,
+    scope: envelope.scope,
+    target: envelope.target,
+    updated: envelope.updated,
+    partial: copyPartial(envelope.partial ?? null),
+  } satisfies Omit<ManifestOutcomeEnvelope, "signature">;
+  const expected = Buffer.from(signatureFor(payloadFor(unsigned), secret), "hex");
+  const actual = Buffer.from(envelope.signature, "hex");
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return null;
+  return {
+    ...unsigned,
+    signature: envelope.signature,
+  };
+}
+
+/** Read only records authenticated by the orchestrator and bound to its
+ * current target. Invalid, stale, or foreign-target records are ignored. */
+export function readPublishedManifestOutcomes(target: string): ManifestPartialInstall[] {
+  const cfg = readerConfig;
+  const expectedTarget = canonicalManifestOutcomeTarget(target);
+  if (!cfg?.dir || !expectedTarget) return [];
+  let files: string[];
+  try {
+    files = readdirSync(cfg.dir).filter(
+      (name) => name.startsWith(FILE_PREFIX) && name.endsWith(".json"),
+    );
+  } catch {
+    return [];
+  }
+
+  const secrets = [...cfg.secrets()].filter((secret) => typeof secret === "string" && secret.length > 0);
+  const out: Array<{ updated: number; partial: ManifestPartialInstall }> = [];
+  for (const name of files.slice(0, 128)) {
+    let text: string;
+    try {
+      const path = join(cfg.dir, name);
+      const stat = readFileSync(path, "utf8");
+      if (Buffer.byteLength(stat, "utf8") > MAX_RECORD_BYTES) continue;
+      text = stat;
+    } catch {
+      continue;
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(text);
+    } catch {
+      continue;
+    }
+    for (const secret of secrets) {
+      const envelope = parseEnvelope(raw, secret);
+      if (!envelope || envelope.target !== expectedTarget) continue;
+      if (Date.now() - envelope.updated > MANIFEST_OUTCOME_TTL_MS) {
+        try {
+          rmSync(join(cfg.dir, name), { force: true });
+        } catch {
+          /* stale cleanup is best-effort */
+        }
+        break;
+      }
+      if (envelope.partial) out.push({ updated: envelope.updated, partial: envelope.partial });
+      break;
+    }
+  }
+  out.sort((a, b) => b.updated - a.updated);
+  const seen = new Set<string>();
+  return out.flatMap(({ partial }) => {
+    const key = JSON.stringify(partial);
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [copyPartial(partial)!];
+  });
+}
+
+/** Test seam for isolated channel tests. */
+export function resetManifestOutcomeReader(): void {
+  readerConfig = undefined;
+}

--- a/src/services/manifest-partial.ts
+++ b/src/services/manifest-partial.ts
@@ -13,7 +13,11 @@
  * boundary.
  */
 
-import { publishManifestOutcome } from "./manifest-outcome-channel.js";
+import { randomUUID } from "node:crypto";
+import {
+  canonicalManifestOutcomeTarget,
+  publishManifestOutcome,
+} from "./manifest-outcome-channel.js";
 
 export interface ManifestPartialInstall {
   kind: "custom_nodes_not_started";
@@ -37,112 +41,344 @@ export interface ManifestPartialInstall {
   message: string;
 }
 
-let leftover: ManifestPartialInstall | null = null;
-let lastRecordTarget: string | undefined;
+export interface ManifestPartialOperationBinding {
+  readonly operationId: string;
+  readonly itemId: string;
+  readonly scope: string;
+  readonly target: string;
+  readonly targetGeneration: number;
+}
 
+type FallbackPhase = "selected" | "applied" | "failed";
+
+interface OperationState {
+  readonly operationId: string;
+  readonly source: string;
+  readonly scope: string;
+  readonly target: string;
+  readonly targetGeneration: number;
+  readonly itemBindings: Map<string, ManifestPartialOperationBinding>;
+  readonly fallbackPhases: Map<string, FallbackPhase>;
+  basePartial: ManifestPartialInstall | null;
+  partial: ManifestPartialInstall | null;
+  updated: number;
+}
+
+/** A single apply_manifest operation and its immutable target identity. */
+export interface ManifestPartialOperation {
+  readonly operationId: string;
+  readonly scope: string;
+  readonly target: string;
+  readonly targetGeneration: number;
+  bindItem(itemId: string): ManifestPartialOperationBinding;
+  /** Record the current aggregate. Any fallback phase observed earlier is merged. */
+  record(partial: ManifestPartialInstall | null): ManifestPartialInstall | null;
+  /** Ignore callbacks that do not belong to this exact operation and target. */
+  reconcile(binding: ManifestPartialOperationBinding, state: FallbackPhase): boolean;
+  clear(): void;
+}
+
+const operations = new Map<string, OperationState>();
+let legacyOperation: ManifestPartialOperation | undefined;
+
+function clonePartial(partial: ManifestPartialInstall | null): ManifestPartialInstall | null {
+  if (!partial) return null;
+  return {
+    ...partial,
+    not_started: [...partial.not_started],
+    still_installing: [...partial.still_installing],
+    ...(partial.outcome_unknown ? { outcome_unknown: [...partial.outcome_unknown] } : {}),
+    ...(partial.local_fallback ? { local_fallback: [...partial.local_fallback] } : {}),
+    ...(partial.local_fallback_failed
+      ? { local_fallback_failed: [...partial.local_fallback_failed] }
+      : {}),
+  };
+}
+
+function normalizePartial(partial: ManifestPartialInstall | null): ManifestPartialInstall | null {
+  const copy = clonePartial(partial);
+  if (!copy) return null;
+  if (
+    copy.not_started.length === 0 &&
+    copy.still_installing.length === 0 &&
+    (copy.outcome_unknown?.length ?? 0) === 0 &&
+    (copy.local_fallback?.length ?? 0) === 0 &&
+    (copy.local_fallback_failed?.length ?? 0) === 0
+  ) {
+    return null;
+  }
+  if (!copy.outcome_unknown?.length) delete copy.outcome_unknown;
+  if (!copy.local_fallback?.length) delete copy.local_fallback;
+  if (!copy.local_fallback_failed?.length) delete copy.local_fallback_failed;
+  return copy;
+}
+
+function without(items: string[] | undefined, id: string): string[] {
+  return (items ?? []).filter((item) => item !== id);
+}
+
+function withItem(items: string[] | undefined, id: string): string[] {
+  return items?.includes(id) ? [...items] : [...(items ?? []), id];
+}
+
+function phaseIds(state: OperationState, phase: FallbackPhase): string[] {
+  return [...state.fallbackPhases.entries()]
+    .filter(([, value]) => value === phase)
+    .map(([id]) => id);
+}
+
+function syntheticPartial(state: OperationState): ManifestPartialInstall | null {
+  const selected = phaseIds(state, "selected");
+  const failed = phaseIds(state, "failed");
+  if (selected.length === 0 && failed.length === 0) return null;
+  return {
+    kind: "custom_nodes_not_started",
+    source: state.source,
+    not_started: [],
+    still_installing: selected,
+    ...(selected.length ? { local_fallback: selected } : {}),
+    ...(failed.length ? { local_fallback_failed: failed } : {}),
+    message:
+      `PARTIAL INSTALL of ${state.source}: a local direct-install fallback was selected ` +
+      `after the Manager outcome became unresolved. Do not use Manager queue status or ` +
+      `re-issue the node; wait for the fallback to settle and verify custom_nodes.`,
+  };
+}
+
+function augmentedPartial(state: OperationState): ManifestPartialInstall | null {
+  const base = normalizePartial(state.basePartial) ?? syntheticPartial(state);
+  if (!base) return null;
+  let partial = base;
+  for (const [id, phase] of state.fallbackPhases) {
+    if (phase === "selected") {
+      partial = {
+        ...partial,
+        still_installing: withItem(partial.still_installing, id),
+        outcome_unknown: without(partial.outcome_unknown, id),
+        local_fallback: withItem(partial.local_fallback, id),
+        local_fallback_failed: without(partial.local_fallback_failed, id),
+        message:
+          `${partial.message} Reconciliation: the earlier UNKNOWN outcome has now selected ` +
+          `a local direct-install fallback for "${id}". It is in progress; do not use ` +
+          `Manager queue status or re-issue the node while it runs.`,
+      };
+    } else if (phase === "applied") {
+      partial = {
+        ...partial,
+        still_installing: without(partial.still_installing, id),
+        outcome_unknown: without(partial.outcome_unknown, id),
+        local_fallback: without(partial.local_fallback, id),
+        local_fallback_failed: without(partial.local_fallback_failed, id),
+        message:
+          `${partial.message} Reconciliation: the local fallback for "${id}" completed; ` +
+          `the entry is no longer unresolved.`,
+      };
+    } else {
+      partial = {
+        ...partial,
+        still_installing: without(partial.still_installing, id),
+        outcome_unknown: without(partial.outcome_unknown, id),
+        local_fallback: without(partial.local_fallback, id),
+        local_fallback_failed: withItem(partial.local_fallback_failed, id),
+        message:
+          `${partial.message} Reconciliation: the local direct-install fallback for "${id}" ` +
+          `finished unsuccessfully. Inspect the filesystem/error before retrying.`,
+      };
+    }
+  }
+  return normalizePartial(partial);
+}
+
+function publishOperation(state: OperationState): void {
+  publishManifestOutcome(state.partial, {
+    operationId: state.operationId,
+    scope: state.scope,
+    target: state.target,
+    targetGeneration: state.targetGeneration,
+  });
+}
+
+function supersedePriorOperation(state: OperationState): void {
+  for (const prior of [...operations.values()]) {
+    if (
+      prior === state ||
+      prior.scope !== state.scope ||
+      prior.target !== state.target ||
+      prior.source !== state.source
+    ) {
+      continue;
+    }
+    operations.delete(prior.operationId);
+    publishManifestOutcome(null, {
+      operationId: prior.operationId,
+      scope: prior.scope,
+      target: prior.target,
+      targetGeneration: prior.targetGeneration,
+    });
+  }
+}
+
+function operationHandle(state: OperationState): ManifestPartialOperation {
+  const handle: ManifestPartialOperation = {
+    operationId: state.operationId,
+    scope: state.scope,
+    target: state.target,
+    targetGeneration: state.targetGeneration,
+    bindItem(itemId: string): ManifestPartialOperationBinding {
+      const normalized = itemId.trim();
+      const existing = state.itemBindings.get(normalized);
+      if (existing) return existing;
+      const binding = Object.freeze({
+        operationId: state.operationId,
+        itemId: normalized,
+        scope: state.scope,
+        target: state.target,
+        targetGeneration: state.targetGeneration,
+      });
+      state.itemBindings.set(normalized, binding);
+      return binding;
+    },
+    record(partial: ManifestPartialInstall | null): ManifestPartialInstall | null {
+      if (operations.get(state.operationId) !== state) return null;
+      // Preserve the historical "this apply replaces the previous partial"
+      // behavior, but do it by operation identity. Any callback from a prior
+      // apply now fails its binding check rather than changing this aggregate.
+      supersedePriorOperation(state);
+      state.basePartial = normalizePartial(partial);
+      state.partial = augmentedPartial(state);
+      state.updated = Date.now();
+      publishOperation(state);
+      return clonePartial(state.partial);
+    },
+    reconcile(binding: ManifestPartialOperationBinding, phase: FallbackPhase): boolean {
+      if (operations.get(state.operationId) !== state) return false;
+      const expected = state.itemBindings.get(binding.itemId);
+      if (
+        binding !== expected ||
+        !expected ||
+        expected.operationId !== binding.operationId ||
+        expected.scope !== binding.scope ||
+        expected.target !== binding.target ||
+        expected.targetGeneration !== binding.targetGeneration
+      ) {
+        return false;
+      }
+      state.fallbackPhases.set(binding.itemId, phase);
+      state.partial = augmentedPartial(state);
+      state.updated = Date.now();
+      // A callback may arrive before the final aggregate is recorded. Keep the
+      // phase in the operation state, but do not publish a null/empty record that
+      // could clear another observation from this process.
+      if (state.basePartial !== null || state.partial !== null) publishOperation(state);
+      return true;
+    },
+    clear(): void {
+      if (operations.get(state.operationId) === state) operations.delete(state.operationId);
+      publishManifestOutcome(null, {
+        operationId: state.operationId,
+        scope: state.scope,
+        target: state.target,
+        targetGeneration: state.targetGeneration,
+      });
+    },
+  };
+  return handle;
+}
+
+export function createManifestPartialOperation(opts: {
+  operationId?: string;
+  source: string;
+  scope: string;
+  target: string;
+  targetGeneration: number;
+}): ManifestPartialOperation {
+  const operationId = opts.operationId?.trim() || randomUUID();
+  const target = canonicalManifestOutcomeTarget(opts.target.trim()) ?? "";
+  const state: OperationState = {
+    operationId,
+    source: opts.source,
+    scope: opts.scope.trim(),
+    target,
+    targetGeneration: opts.targetGeneration,
+    itemBindings: new Map(),
+    fallbackPhases: new Map(),
+    basePartial: null,
+    partial: null,
+    updated: Date.now(),
+  };
+  operations.set(operationId, state);
+  return operationHandle(state);
+}
+
+/** Read only operation records bound to this exact scope and target. */
+export function readManifestPartials(
+  target: string,
+  scope: string,
+  targetGeneration: number,
+): ManifestPartialInstall[] {
+  const expectedTarget = canonicalManifestOutcomeTarget(target.trim());
+  const expectedScope = scope.trim();
+  if (!expectedTarget || !expectedScope || !Number.isSafeInteger(targetGeneration) || targetGeneration < 0) {
+    return [];
+  }
+  return [...operations.values()]
+    .filter(
+      (state) =>
+        state.target === expectedTarget &&
+        state.scope === expectedScope &&
+        state.targetGeneration === targetGeneration &&
+        state.partial !== null,
+    )
+    .sort((a, b) => b.updated - a.updated)
+    .map((state) => clonePartial(state.partial)!)
+    .filter((partial, index, all) => {
+      const key = JSON.stringify(partial);
+      return all.findIndex((candidate) => JSON.stringify(candidate) === key) === index;
+    });
+}
+
+/** Compatibility seam retained for existing local callers and tests. */
 export function recordManifestPartial(
   partial: ManifestPartialInstall | null,
-  options: { target?: string } = {},
+  options: { target?: string; scope?: string; operationId?: string; targetGeneration?: number } = {},
 ): void {
-  if (options.target !== undefined) lastRecordTarget = options.target;
-  leftover =
-    partial &&
-    (partial.not_started.length > 0 ||
-      partial.still_installing.length > 0 ||
-      (partial.outcome_unknown?.length ?? 0) > 0 ||
-      (partial.local_fallback?.length ?? 0) > 0 ||
-      (partial.local_fallback_failed?.length ?? 0) > 0)
-      ? {
-          ...partial,
-          not_started: [...partial.not_started],
-          still_installing: [...partial.still_installing],
-          ...(partial.outcome_unknown?.length
-            ? { outcome_unknown: [...partial.outcome_unknown] }
-            : {}),
-          ...(partial.local_fallback?.length
-            ? { local_fallback: [...partial.local_fallback] }
-            : {}),
-          ...(partial.local_fallback_failed?.length
-            ? { local_fallback_failed: [...partial.local_fallback_failed] }
-            : {}),
-        }
-      : null;
-  if (leftover) {
-    if (!leftover.outcome_unknown?.length) delete leftover.outcome_unknown;
-    if (!leftover.local_fallback?.length) delete leftover.local_fallback;
-    if (!leftover.local_fallback_failed?.length) delete leftover.local_fallback_failed;
+  const target = options.target ?? process.env.COMFYUI_URL?.trim() ?? "";
+  const scope = options.scope ?? process.env.COMFYUI_MCP_TAB?.trim() ?? `legacy:${process.pid}`;
+  if (
+    !legacyOperation ||
+    legacyOperation.target !== (canonicalManifestOutcomeTarget(target) ?? "") ||
+    legacyOperation.scope !== scope.trim()
+  ) {
+    legacyOperation = createManifestPartialOperation({
+      operationId: options.operationId ?? "legacy",
+      source: partial?.source ?? "this inline manifest",
+      scope,
+      target,
+      targetGeneration: options.targetGeneration ?? 0,
+    });
   }
-  publishManifestOutcome(leftover, { target: options.target ?? lastRecordTarget });
+  legacyOperation.record(partial);
 }
 
 export function getManifestPartialLeftover(): ManifestPartialInstall | null {
-  return leftover;
+  return [...operations.values()]
+    .sort((a, b) => b.updated - a.updated)
+    .map((state) => clonePartial(state.partial))
+    .find((partial): partial is ManifestPartialInstall => partial !== null) ?? null;
 }
 
-/** Test seam — production callers replace leftovers via recordManifestPartial. */
+/** Test seam — remove every operation-local record, including its child files. */
 export function clearManifestPartialLeftover(): void {
-  leftover = null;
-  publishManifestOutcome(null, { target: lastRecordTarget });
-}
-
-/**
- * Reconcile a timed-out git install when its late fallback actually changes
- * phase. The callback can run after apply_manifest has returned, so updating
- * only the result object would leave queue status permanently stale.
- */
-export function reconcileManifestPartialLocalFallback(
-  id: string,
-  state: "selected" | "applied" | "failed",
-): void {
-  if (!leftover) return;
-  const has = (items: string[] | undefined): boolean => items?.includes(id) === true;
-  if (
-    state === "selected" &&
-    !has(leftover.still_installing) &&
-    !has(leftover.outcome_unknown)
-  ) {
-    return;
+  for (const state of operations.values()) {
+    publishManifestOutcome(null, {
+      operationId: state.operationId,
+      scope: state.scope,
+      target: state.target,
+      targetGeneration: state.targetGeneration,
+    });
   }
-  const remove = (items: string[] | undefined): string[] =>
-    (items ?? []).filter((item) => item !== id);
-  const add = (items: string[] | undefined): string[] =>
-    has(items) ? [...(items ?? [])] : [...(items ?? []), id];
-
-  if (state === "selected") {
-    leftover = {
-      ...leftover,
-      outcome_unknown: remove(leftover.outcome_unknown),
-      local_fallback: add(leftover.local_fallback),
-      local_fallback_failed: remove(leftover.local_fallback_failed),
-      message:
-        `${leftover.message} Reconciliation: the earlier UNKNOWN outcome has now selected ` +
-        `a local direct-install fallback for "${id}". It is in progress; do not ` +
-        `use Manager queue status or re-issue the node while it runs.`,
-    };
-  } else if (state === "applied") {
-    leftover = {
-      ...leftover,
-      still_installing: remove(leftover.still_installing),
-      outcome_unknown: remove(leftover.outcome_unknown),
-      local_fallback: remove(leftover.local_fallback),
-      local_fallback_failed: remove(leftover.local_fallback_failed),
-      message:
-        `${leftover.message} Reconciliation: the local fallback for "${id}" completed; ` +
-        `the entry is no longer unresolved.`,
-    };
-  } else {
-    leftover = {
-      ...leftover,
-      still_installing: remove(leftover.still_installing),
-      outcome_unknown: remove(leftover.outcome_unknown),
-      local_fallback: remove(leftover.local_fallback),
-      local_fallback_failed: add(leftover.local_fallback_failed),
-      message:
-        `${leftover.message} Reconciliation: the local direct-install fallback for "${id}" ` +
-        `finished unsuccessfully. Inspect the filesystem/error before retrying.`,
-    };
-  }
-  recordManifestPartial(leftover);
+  operations.clear();
+  legacyOperation = undefined;
 }
 
 export function describeManifestSource(opts: {

--- a/src/services/manifest-partial.ts
+++ b/src/services/manifest-partial.ts
@@ -6,11 +6,14 @@
  * "pending" / "not started" and are NEVER enqueued; an accepted-but-ambiguous
  * operation can also remain unresolved. panel_node_queue_status then reports a
  * drained queue (total_count: 0, is_processing: false) which agents read as
- * "all installs finished". This module is the process-local record of both
- * unsubmitted and unresolved names so apply_manifest (which names the PARTIAL
- * INSTALL) and panel_node_queue_status (which refuses to look complete while
- * they remain) share one source of truth.
+ * "all installs finished". This module is the fast process-local record of
+ * both unsubmitted and unresolved names. Panel-spawned children also publish
+ * the same record through manifest-outcome-channel.ts so apply_manifest and
+ * panel_node_queue_status share one source of truth across their process
+ * boundary.
  */
+
+import { publishManifestOutcome } from "./manifest-outcome-channel.js";
 
 export interface ManifestPartialInstall {
   kind: "custom_nodes_not_started";
@@ -27,26 +30,49 @@ export interface ManifestPartialInstall {
    * this result.
    */
   outcome_unknown?: string[];
+  /** Entries whose local direct-install fallback was selected after a timeout. */
+  local_fallback?: string[];
+  /** Entries whose late local direct-install fallback finished unsuccessfully. */
+  local_fallback_failed?: string[];
   message: string;
 }
 
 let leftover: ManifestPartialInstall | null = null;
+let lastRecordTarget: string | undefined;
 
-export function recordManifestPartial(partial: ManifestPartialInstall | null): void {
+export function recordManifestPartial(
+  partial: ManifestPartialInstall | null,
+  options: { target?: string } = {},
+): void {
+  if (options.target !== undefined) lastRecordTarget = options.target;
   leftover =
     partial &&
     (partial.not_started.length > 0 ||
       partial.still_installing.length > 0 ||
-      (partial.outcome_unknown?.length ?? 0) > 0)
+      (partial.outcome_unknown?.length ?? 0) > 0 ||
+      (partial.local_fallback?.length ?? 0) > 0 ||
+      (partial.local_fallback_failed?.length ?? 0) > 0)
       ? {
           ...partial,
           not_started: [...partial.not_started],
           still_installing: [...partial.still_installing],
-          ...(partial.outcome_unknown
+          ...(partial.outcome_unknown?.length
             ? { outcome_unknown: [...partial.outcome_unknown] }
+            : {}),
+          ...(partial.local_fallback?.length
+            ? { local_fallback: [...partial.local_fallback] }
+            : {}),
+          ...(partial.local_fallback_failed?.length
+            ? { local_fallback_failed: [...partial.local_fallback_failed] }
             : {}),
         }
       : null;
+  if (leftover) {
+    if (!leftover.outcome_unknown?.length) delete leftover.outcome_unknown;
+    if (!leftover.local_fallback?.length) delete leftover.local_fallback;
+    if (!leftover.local_fallback_failed?.length) delete leftover.local_fallback_failed;
+  }
+  publishManifestOutcome(leftover, { target: options.target ?? lastRecordTarget });
 }
 
 export function getManifestPartialLeftover(): ManifestPartialInstall | null {
@@ -56,6 +82,67 @@ export function getManifestPartialLeftover(): ManifestPartialInstall | null {
 /** Test seam — production callers replace leftovers via recordManifestPartial. */
 export function clearManifestPartialLeftover(): void {
   leftover = null;
+  publishManifestOutcome(null, { target: lastRecordTarget });
+}
+
+/**
+ * Reconcile a timed-out git install when its late fallback actually changes
+ * phase. The callback can run after apply_manifest has returned, so updating
+ * only the result object would leave queue status permanently stale.
+ */
+export function reconcileManifestPartialLocalFallback(
+  id: string,
+  state: "selected" | "applied" | "failed",
+): void {
+  if (!leftover) return;
+  const has = (items: string[] | undefined): boolean => items?.includes(id) === true;
+  if (
+    state === "selected" &&
+    !has(leftover.still_installing) &&
+    !has(leftover.outcome_unknown)
+  ) {
+    return;
+  }
+  const remove = (items: string[] | undefined): string[] =>
+    (items ?? []).filter((item) => item !== id);
+  const add = (items: string[] | undefined): string[] =>
+    has(items) ? [...(items ?? [])] : [...(items ?? []), id];
+
+  if (state === "selected") {
+    leftover = {
+      ...leftover,
+      outcome_unknown: remove(leftover.outcome_unknown),
+      local_fallback: add(leftover.local_fallback),
+      local_fallback_failed: remove(leftover.local_fallback_failed),
+      message:
+        `${leftover.message} Reconciliation: the earlier UNKNOWN outcome has now selected ` +
+        `a local direct-install fallback for "${id}". It is in progress; do not ` +
+        `use Manager queue status or re-issue the node while it runs.`,
+    };
+  } else if (state === "applied") {
+    leftover = {
+      ...leftover,
+      still_installing: remove(leftover.still_installing),
+      outcome_unknown: remove(leftover.outcome_unknown),
+      local_fallback: remove(leftover.local_fallback),
+      local_fallback_failed: remove(leftover.local_fallback_failed),
+      message:
+        `${leftover.message} Reconciliation: the local fallback for "${id}" completed; ` +
+        `the entry is no longer unresolved.`,
+    };
+  } else {
+    leftover = {
+      ...leftover,
+      still_installing: remove(leftover.still_installing),
+      outcome_unknown: remove(leftover.outcome_unknown),
+      local_fallback: remove(leftover.local_fallback),
+      local_fallback_failed: add(leftover.local_fallback_failed),
+      message:
+        `${leftover.message} Reconciliation: the local direct-install fallback for "${id}" ` +
+        `finished unsuccessfully. Inspect the filesystem/error before retrying.`,
+    };
+  }
+  recordManifestPartial(leftover);
 }
 
 export function describeManifestSource(opts: {
@@ -167,6 +254,14 @@ export function formatQueueStatusPartialNote(partial: ManifestPartialInstall): s
           `no local direct-install fallback is authorized and queue idle is not proof ` +
           `of completion. Verify the custom_nodes directory before reissuing.`
         : " Do not treat queue idle as proof that this apply_manifest completed.")
+      : "";
+  const local = partial.local_fallback?.length
+    ? ` Local direct-install fallback is in progress for ${partial.local_fallback.join(", ")}. ` +
+      `This work is NOT on the Manager queue; wait for it to settle and do not re-issue it.`
     : "";
-  return `WARNING — PARTIAL INSTALL, QUEUE DRAIN IS NOT COMPLETION. ${unsubmitted}${unresolved}`;
+  const failed = partial.local_fallback_failed?.length
+    ? ` Local direct-install fallback failed for ${partial.local_fallback_failed.join(", ")}. ` +
+      `Queue status cannot determine that result; inspect the install error before retrying.`
+    : "";
+  return `WARNING — PARTIAL INSTALL, QUEUE DRAIN IS NOT COMPLETION. ${unsubmitted}${unresolved}${local}${failed}`;
 }

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -54,12 +54,11 @@ import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import {
   buildManifestPartial,
+  createManifestPartialOperation,
   describeManifestSource,
   formatLocalFallbackMessage,
   formatNotStartedMessage,
   formatStillInstallingMessage,
-  reconcileManifestPartialLocalFallback,
-  recordManifestPartial,
   type ManifestPartialInstall,
 } from "./manifest-partial.js";
 
@@ -997,6 +996,11 @@ function looksLikeGitManifestSource(id: string): boolean {
   return /^(?:https?:\/\/|git@|git\+)/i.test(candidate) || /\.git(?:[?#]|$)/i.test(candidate);
 }
 
+function manifestOutcomeTargetGeneration(fallback: number): number {
+  const configured = Number(process.env.COMFYUI_MCP_TARGET_GENERATION);
+  return Number.isSafeInteger(configured) && configured >= 0 ? configured : fallback;
+}
+
 async function resolveLocalManifestCustomNodesBase(): Promise<string | undefined> {
   if (isRemoteMode()) return undefined;
   try {
@@ -1054,6 +1058,17 @@ async function applyManifestSections(
   const localMode = !isRemoteMode();
   const hasLocalDataFs = localMode && Boolean(dataBase);
   const hasLocalCodeFs = localMode && Boolean(codeBase);
+
+  // Register the operation before the first install promise is created. The
+  // local fallback can select synchronously, before apply_manifest reaches its
+  // final aggregate record; its immutable binding keeps that early callback
+  // attached to this operation and target until the final record is written.
+  const partialOperation = createManifestPartialOperation({
+    source,
+    scope: process.env.COMFYUI_MCP_TAB?.trim() || `stdio:${process.pid}`,
+    target: managerBase,
+    targetGeneration: manifestOutcomeTargetGeneration(targetGeneration),
+  });
 
   // The data root answers where custom_nodes and the ordinary models/ tree live,
   // but it is not the complete answer for model downloads. A connected local
@@ -1211,6 +1226,7 @@ async function applyManifestSections(
     // git-clone / ref-checkout fallback writes into the tree the runtime scans
     // (#1715/#1770). Pip uses codeBase independently above.
     let localFallbackSelected = false;
+    const fallbackBinding = partialOperation.bindItem(normalizedId);
     const installOutcome = installCustomNode({
       id: normalizedId,
       ...(customNodesBase ? { comfyuiPath: customNodesBase } : {}),
@@ -1219,12 +1235,12 @@ async function applyManifestSections(
         : {}),
       managerBase,
       targetGeneration,
-      onLocalFallback: () => {
-        localFallbackSelected = true;
-        reconcileManifestPartialLocalFallback(normalizedId, "selected");
+      localFallbackBinding: fallbackBinding,
+      onLocalFallback: (binding) => {
+        localFallbackSelected = partialOperation.reconcile(binding, "selected");
       },
-      onLocalFallbackSettled: (state) => {
-        reconcileManifestPartialLocalFallback(normalizedId, state);
+      onLocalFallbackSettled: (binding, state) => {
+        partialOperation.reconcile(binding, state);
       },
     })
       .then((res) => ({ kind: "settled" as const, res }))
@@ -1669,7 +1685,7 @@ async function applyManifestSections(
     stillInstalling,
     outcomeUnknown,
   });
-  recordManifestPartial(partial, { target: getComfyUIBaseUrl() });
+  const recordedPartial = partialOperation.record(partial);
 
   return {
     // `success` means the manifest is APPLIED AND VERIFIED — nothing failed AND
@@ -1685,6 +1701,6 @@ async function applyManifestSections(
     success: summary.failed === 0 && summary.pending === 0,
     summary,
     results,
-    ...(partial ? { partial } : {}),
+    ...(recordedPartial ? { partial: recordedPartial } : {}),
   };
 }

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -58,6 +58,7 @@ import {
   formatLocalFallbackMessage,
   formatNotStartedMessage,
   formatStillInstallingMessage,
+  reconcileManifestPartialLocalFallback,
   recordManifestPartial,
   type ManifestPartialInstall,
 } from "./manifest-partial.js";
@@ -1220,6 +1221,10 @@ async function applyManifestSections(
       targetGeneration,
       onLocalFallback: () => {
         localFallbackSelected = true;
+        reconcileManifestPartialLocalFallback(normalizedId, "selected");
+      },
+      onLocalFallbackSettled: (state) => {
+        reconcileManifestPartialLocalFallback(normalizedId, state);
       },
     })
       .then((res) => ({ kind: "settled" as const, res }))
@@ -1664,7 +1669,7 @@ async function applyManifestSections(
     stillInstalling,
     outcomeUnknown,
   });
-  recordManifestPartial(partial);
+  recordManifestPartial(partial, { target: getComfyUIBaseUrl() });
 
   return {
     // `success` means the manifest is APPLIED AND VERIFIED — nothing failed AND

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3674,6 +3674,19 @@ async function cloneCustomNodeFallback(
 // Public API — install
 // ---------------------------------------------------------------------------
 
+export interface LocalFallbackBinding {
+  /** The apply_manifest operation that owns this fallback. */
+  readonly operationId: string;
+  /** The manifest custom_node entry bound to this fallback. */
+  readonly itemId: string;
+  /** The agent scope authorized to observe the operation. */
+  readonly scope: string;
+  /** The exact Manager target captured at operation entry. */
+  readonly target: string;
+  /** The monotonic target generation captured at operation entry. */
+  readonly targetGeneration: number;
+}
+
 export interface InstallOptions {
   id: string;
   source?: InstallSource;
@@ -3697,19 +3710,26 @@ export interface InstallOptions {
   managerBase?: string;
   /** Monotonic ComfyUI target generation captured with managerBase. */
   targetGeneration?: number;
+  /** Binding required by the internal fallback phase hooks. */
+  localFallbackBinding?: LocalFallbackBinding;
   /**
    * Internal apply_manifest phase hook. Called once when this operation has
    * selected its local git fallback, before it waits for the local writer lock.
    * It is observational only and does not change the install decision.
    */
-  onLocalFallback?: () => void;
+  onLocalFallback?: (binding: LocalFallbackBinding) => void;
   /** Internal apply_manifest hook called after a selected local fallback settles. */
-  onLocalFallbackSettled?: (state: "applied" | "failed") => void;
+  onLocalFallbackSettled?: (
+    binding: LocalFallbackBinding,
+    state: "applied" | "failed",
+  ) => void;
 }
 
 function notifyLocalFallbackSelected(opts: InstallOptions): void {
+  const binding = opts.localFallbackBinding;
+  if (!binding) return;
   try {
-    opts.onLocalFallback?.();
+    opts.onLocalFallback?.(binding);
   } catch (err) {
     // This is an observational hook used by apply_manifest; a reporting
     // callback must never prevent the selected local fallback from running.
@@ -3723,8 +3743,10 @@ function notifyLocalFallbackSettled(
   opts: InstallOptions,
   state: "applied" | "failed",
 ): void {
+  const binding = opts.localFallbackBinding;
+  if (!binding) return;
   try {
-    opts.onLocalFallbackSettled?.(state);
+    opts.onLocalFallbackSettled?.(binding, state);
   } catch (err) {
     // This is an observational hook used by apply_manifest; a reporting
     // callback must never change the install result.

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3703,6 +3703,8 @@ export interface InstallOptions {
    * It is observational only and does not change the install decision.
    */
   onLocalFallback?: () => void;
+  /** Internal apply_manifest hook called after a selected local fallback settles. */
+  onLocalFallbackSettled?: (state: "applied" | "failed") => void;
 }
 
 function notifyLocalFallbackSelected(opts: InstallOptions): void {
@@ -3712,6 +3714,21 @@ function notifyLocalFallbackSelected(opts: InstallOptions): void {
     // This is an observational hook used by apply_manifest; a reporting
     // callback must never prevent the selected local fallback from running.
     logger.debug("Ignoring local fallback phase-hook failure", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function notifyLocalFallbackSettled(
+  opts: InstallOptions,
+  state: "applied" | "failed",
+): void {
+  try {
+    opts.onLocalFallbackSettled?.(state);
+  } catch (err) {
+    // This is an observational hook used by apply_manifest; a reporting
+    // callback must never change the install result.
+    logger.debug("Ignoring local fallback settle-hook failure", {
       error: err instanceof Error ? err.message : String(err),
     });
   }
@@ -4065,7 +4082,8 @@ async function installCustomNodeImpl(
           wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
         );
       }
-      if (!isRemoteMode()) notifyLocalFallbackSelected(opts);
+      const localFallback = !isRemoteMode();
+      if (localFallback) notifyLocalFallbackSelected(opts);
       const managerUnavailable =
         refusedBy === undefined &&
         isManagerQueueDetectionFailure(err) &&
@@ -4106,10 +4124,17 @@ async function installCustomNodeImpl(
       // Manager task that resolves no pack reaches cloneCustomNodeFallback only
       // to receive its authoritative remote-target refusal; do not make that
       // refusal wait behind an unrelated local writer.
-      const cloned = isRemoteMode()
-        ? await clone()
-        : await withLocalInstallMutationLock(targetGeneration, managerBase, clone);
-      assertInstallTargetStable(targetGeneration, managerBase);
+      let cloned: NodeOpResult;
+      try {
+        cloned = localFallback
+          ? await withLocalInstallMutationLock(targetGeneration, managerBase, clone)
+          : await clone();
+        assertInstallTargetStable(targetGeneration, managerBase);
+      } catch (err) {
+        if (localFallback) notifyLocalFallbackSettled(opts, "failed");
+        throw err;
+      }
+      if (localFallback) notifyLocalFallbackSettled(opts, "applied");
       return withCliNote(cloned);
     }
     assertInstallTargetStable(targetGeneration, managerBase);
@@ -4133,7 +4158,8 @@ async function installCustomNodeImpl(
         wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
       );
     }
-    if (!isRemoteMode()) notifyLocalFallbackSelected(opts);
+    const localFallback = !isRemoteMode();
+    if (localFallback) notifyLocalFallbackSelected(opts);
     const clone = () => cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
       refFromVersion,
       allowSharedWorkspaceFallback: cliWorkspace !== undefined,
@@ -4141,10 +4167,17 @@ async function installCustomNodeImpl(
     // An accepted remote Manager task that resolves no pack still reaches this
     // helper only for its authoritative remote-target refusal; it is not a
     // local write and must not wait on the local writer lock.
-    const cloned = isRemoteMode()
-      ? await clone()
-      : await withLocalInstallMutationLock(targetGeneration, managerBase, clone);
-    assertInstallTargetStable(targetGeneration, managerBase);
+    let cloned: NodeOpResult;
+    try {
+      cloned = localFallback
+        ? await withLocalInstallMutationLock(targetGeneration, managerBase, clone)
+        : await clone();
+      assertInstallTargetStable(targetGeneration, managerBase);
+    } catch (err) {
+      if (localFallback) notifyLocalFallbackSettled(opts, "failed");
+      throw err;
+    }
+    if (localFallback) notifyLocalFallbackSettled(opts, "applied");
     return withCliNote(cloned);
   }
 


### PR DESCRIPTION
## Summary

Follow-up for #1129 / merged #2509 review findings:

- Adds a nonce-scoped, mode-0700, HMAC-authenticated atomic outcome channel from panel-spawned stdio children to the orchestrator.
- Makes `panel_node_queue_status` consume authenticated child partials for the current ComfyUI target, while retaining the process-local path.
- Reconciles stored UNKNOWN partials when a timed-out local fallback is selected, applied, or fails.
- Adds a real post-enqueue JSON-null queue/status regression and a separate-process writer-to-orchestrator reader regression.

## Validation

- Focused: 230 passed across the three affected suites.
- Full Vitest: 704 files; 13,058 passed; 6 skipped.
- Build, lint, anti-slop, docs generation, docs links/locale/MDX, i18n, vocabulary, unknown-collapse, vocab export, and post-build asset counts passed.
- The full `npm test` wrapper still reports the existing changelog guard omissions for merged #2509 and #2552. No changelog or unrelated release files were changed.

## Design limits

- Authenticated records are conservatively aggregated by current target, so an unresolved record from another active agent on the same target can keep queue status non-complete.
- Records survive a child crash until overwritten or the six-hour TTL expires; this fails closed rather than claiming completion.
- This PR does not expand `panel_install_node` behavior or authorize fallback for remote targets.