### PR TITLE
fix(1001): inherit a live bound/current tab after multi-workflow reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - bound compact identity probes (#2513, #2478)
+- only list history assets fetchable through /view (#2515)
 - fence same-type transient writes
 - fence transient promoted reads
 - omit the unexpose reindex warning when the panel already reindexed (#2474)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- graph tools inherit a live bound/current tab after a multi-workflow reconnect instead of requiring a manual rebind (#1001)
+
+
 ## [0.52.148] - 2026-08-29
 
 ### MCP

--- a/src/__tests__/orchestrator/multi-workflow-rebind.test.ts
+++ b/src/__tests__/orchestrator/multi-workflow-rebind.test.ts
@@ -1,0 +1,271 @@
+// #1001 recurrence — after reconnect, mixed-origin completions (or a turn with
+// several workflow-origin blocks) must route graph tools to the live bound /
+// current / unique tab instead of failing closed as AMBIGUOUS or wrapping the
+// refusal as "still reconnecting". Tests drive the shipped TurnOriginTracker
+// + makeScopeTargetResolver + panel_graph_outline path.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+
+import { UiBridge } from "../../services/ui-bridge.js";
+import { SHARED_SESSION_SCOPE } from "../../services/session-scope.js";
+import {
+  TurnOriginTracker,
+  makeScopeRepinHandler,
+  makeScopeTargetResolver,
+} from "../../orchestrator/turn-origins.js";
+import { buildPanelToolDefs, makePanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const SCOPE_KEY = `${SHARED_SESSION_SCOPE}::claude`;
+const CODEX_KEY = `${SHARED_SESSION_SCOPE}::codex`;
+const TAB_LIVE = "wf:tab-live:workflows/a.json";
+const TAB_A = "wf:tab-one:workflows/a.json";
+const TAB_B = "wf:tab-two:workflows/b.json";
+const PATH = "workflows/a.json";
+const UUID = "11111111-1111-4111-8111-111111111111";
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join("\n");
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+async function startBridge(): Promise<{ bridge: UiBridge; port: number }> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const p = await freePort();
+    const b = new UiBridge(p);
+    b.start();
+    if (await b.whenReady()) return { bridge: b, port: p };
+    lastErr = `bind to ${p} lost a close→rebind race`;
+    await b.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+function connectPanel(port: number, tabId: string, title: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sock.on("open", () => {
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: tabId,
+          title,
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+        }),
+      );
+      resolve(sock);
+    });
+    sock.on("error", reject);
+  });
+}
+
+function autoReply(sock: WebSocket, path: string): void {
+  sock.on("message", (buf) => {
+    const msg = JSON.parse(buf.toString());
+    if (!msg.rid || !msg.cmd) return;
+    if (msg.cmd === "workflow_list") {
+      sock.send(
+        JSON.stringify({
+          rid: msg.rid,
+          ok: true,
+          result: {
+            active: {
+              path,
+              routing_key: `wf:${path}`,
+              workflow_uuid: UUID,
+              active: true,
+            },
+            workflows: [
+              {
+                path,
+                routing_key: `wf:${path}`,
+                workflow_uuid: UUID,
+                active: true,
+              },
+            ],
+          },
+        }),
+      );
+      return;
+    }
+    sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { cmd: msg.cmd, from: path } }));
+  });
+}
+
+describe("#1001 mixed-origin reconnect inherits the live bound tab", () => {
+  let bridge: UiBridge;
+  let port: number;
+  let tracker: TurnOriginTracker;
+  let tabBackends: Map<string, string>;
+  let scopeKey: string;
+
+  beforeEach(async () => {
+    ({ bridge, port } = await startBridge());
+    bridge.setTabWorkflowUuidResolver(() => UUID);
+    tabBackends = new Map();
+    scopeKey = SCOPE_KEY;
+    const backendOfKey = (key: string): string =>
+      key.includes("::") ? key.slice(key.lastIndexOf("::") + 2) : "claude";
+    const backendForTab = (tab: string): string => tabBackends.get(tab) ?? "claude";
+    tracker = new TurnOriginTracker({
+      backendForTab,
+      backendOfKey,
+      uuidOfTab: () => UUID,
+      liveTabOf: (tab) => bridge.liveTabIdFor(tab),
+      currentTabOf: (key) => {
+        const active = bridge.liveLastActiveTabId();
+        if (!active || bridge.isHeadless(active)) return undefined;
+        return backendForTab(active) === backendOfKey(key) ? active : undefined;
+      },
+      uniqueLiveTabOf: (key) => {
+        const backend = backendOfKey(key);
+        const interactive = bridge
+          .tabs()
+          .map((t) => t.tab_id)
+          .filter((t) => !bridge.isHeadless(t));
+        const eligible = interactive.filter((t) => backendForTab(t) === backend);
+        if (eligible.length === 1) return eligible[0];
+        if (eligible.length === 0 && interactive.length === 1) return interactive[0];
+        return undefined;
+      },
+      claimTab: (tab, backend) => {
+        tabBackends.set(tab, backend);
+      },
+      warn: () => {},
+    });
+    const scopeAgentKeyOf = (scopeId: string): string =>
+      scopeId === SHARED_SESSION_SCOPE ? scopeKey : scopeId;
+    bridge.setScopeTargetResolver(makeScopeTargetResolver({ tracker, scopeAgentKeyOf }));
+    bridge.setScopeRepinHandler(
+      makeScopeRepinHandler({
+        bridge,
+        tracker,
+        scopeAgentKeyOf,
+        backendForTab,
+        backendOfKey,
+        info: () => {},
+        claimTab: (tab, backend) => {
+          tabBackends.set(tab, backend);
+        },
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+  });
+
+  function tools(key = SCOPE_KEY) {
+    const defs = buildPanelToolDefs();
+    const ctx = makePanelToolCtx(bridge, key, new WorkflowTargetStore());
+    return {
+      ctx,
+      outline: defs.find((d) => d.name === "panel_graph_outline")!,
+    };
+  }
+
+  async function replayTwoWorkflows(key: string): Promise<void> {
+    const e1 = tracker.mintInjectionOrigin(TAB_A);
+    const e2 = tracker.mintInjectionOrigin(TAB_B);
+    tracker.onSeen(key, e1);
+    tracker.onSeen(key, e2);
+    await waitFor(() => expect(tracker.pinOf(key)).not.toBeUndefined());
+  }
+
+  it("one connected tab: graph_outline succeeds after mixed injected origins without a manual rebind", async () => {
+    const sock = await connectPanel(port, TAB_LIVE, "live");
+    autoReply(sock, PATH);
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+
+    await replayTwoWorkflows(SCOPE_KEY);
+    expect(tracker.pinOf(SCOPE_KEY)).toBe(TAB_LIVE);
+    expect(tracker.resolvedPinOf(SCOPE_KEY)).toBe(TAB_LIVE);
+
+    const { ctx, outline } = tools();
+    const res = await outline.handler({}, ctx);
+    expect(res.isError, textOf(res as ToolResult)).toBeFalsy();
+    expect(textOf(res as ToolResult)).not.toContain("issued from multiple workflows at once");
+    expect(textOf(res as ToolResult)).not.toContain("still reconnecting");
+    sock.close();
+  });
+
+  it("two live tabs and none bound: graph_outline still refuses as AMBIGUOUS", async () => {
+    const a = await connectPanel(port, TAB_A, "a");
+    const b = await connectPanel(port, TAB_B, "b");
+    autoReply(a, PATH);
+    autoReply(b, "workflows/b.json");
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+
+    tracker.recordForMid("m-a", UUID, TAB_A);
+    tracker.recordForMid("m-b", UUID, TAB_B);
+    tracker.onSeen(SCOPE_KEY, "m-a");
+    tracker.onSeen(SCOPE_KEY, "m-b");
+    await waitFor(() => expect(tracker.pinOf(SCOPE_KEY)).toBeNull());
+
+    const { ctx, outline } = tools();
+    const res = await outline.handler({}, ctx);
+    expect(res.isError).toBe(true);
+    expect(textOf(res as ToolResult)).toContain("issued from multiple workflows at once");
+    expect(textOf(res as ToolResult)).not.toContain("still reconnecting");
+    a.close();
+    b.close();
+  });
+
+  it("Codex reconnect: unique canvas attributed to the default backend is adopted; outline is not 'still reconnecting'", async () => {
+    scopeKey = CODEX_KEY;
+    const sock = await connectPanel(port, TAB_LIVE, "live");
+    autoReply(sock, PATH);
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    tabBackends.set(TAB_A, "codex");
+    tabBackends.set(TAB_B, "codex");
+    // Hello omitted backend — the unique canvas joined the default conversation.
+    tabBackends.set(TAB_LIVE, "claude");
+
+    await replayTwoWorkflows(CODEX_KEY);
+    expect(tracker.pinOf(CODEX_KEY)).toBe(TAB_LIVE);
+    expect(tabBackends.get(TAB_LIVE)).toBe("codex");
+
+    const { ctx, outline } = tools(CODEX_KEY);
+    const res = await outline.handler({}, ctx);
+    const text = textOf(res as ToolResult);
+    expect(res.isError, text).toBeFalsy();
+    expect(text).not.toContain("issued from multiple workflows at once");
+    expect(text).not.toContain("still reconnecting");
+    sock.close();
+  });
+
+  it("routing-time adopt: mixed origins close as null, then the unique hello un-wedges graph_outline", async () => {
+    const e1 = tracker.mintInjectionOrigin(TAB_A);
+    const e2 = tracker.mintInjectionOrigin(TAB_B);
+    tracker.onSeen(SCOPE_KEY, e1);
+    tracker.onSeen(SCOPE_KEY, e2);
+    await waitFor(() => expect(tracker.pinOf(SCOPE_KEY)).toBeNull());
+
+    const sock = await connectPanel(port, TAB_LIVE, "live");
+    autoReply(sock, PATH);
+    await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+
+    const { ctx, outline } = tools();
+    const res = await outline.handler({}, ctx);
+    const text = textOf(res as ToolResult);
+    expect(res.isError, text).toBeFalsy();
+    expect(tracker.resolvedPinOf(SCOPE_KEY)).toBe(TAB_LIVE);
+    expect(text).not.toContain("still reconnecting");
+    sock.close();
+  });
+});

--- a/src/__tests__/orchestrator/shared-session-invariant.test.ts
+++ b/src/__tests__/orchestrator/shared-session-invariant.test.ts
@@ -201,6 +201,9 @@ describe("sessions are orchestrator-scoped, never workflow-scoped (#884)", () =>
     // ever names A) — is caught too.
     expect((src.match(/turnOrigins\.tabChangedBackend\(panelTab\);/g) ?? []).length).toBe(2);
     expect(src).toContain("liveTabOf: (tab) => bridge.liveTabIdFor(tab),");
+    expect(src).toContain("currentTabOf:");
+    expect(src).toContain("uniqueLiveTabOf:");
+    expect(src).toContain("bridge.liveLastActiveTabId()");
     // A cancelled queued message's origin dies with it.
     expect(src).toContain("turnOrigins.cancelMid(mid);");
     // The panel MCP servers bind the backend-QUALIFIED scope address so the

--- a/src/__tests__/orchestrator/turn-origins.test.ts
+++ b/src/__tests__/orchestrator/turn-origins.test.ts
@@ -27,7 +27,12 @@ const KEY = "orchestrator::claude";
 /** A tracker over a mutable backend map — mirrors index.ts's wiring exactly:
  *  backendForTab reads the live tabBackends map, backendOfKey splits the
  *  composite key, uuidOfTab reads the live command-stamp map. */
-function makeTracker(opts?: { defaultBackend?: string }) {
+function makeTracker(opts?: {
+  defaultBackend?: string;
+  currentTabOf?: (key: string) => string | undefined;
+  uniqueLiveTabOf?: (key: string) => string | undefined;
+  claimTab?: (tab: string, backend: string) => void;
+}) {
   const tabBackends = new Map<string, string>();
   const tabUuids = new Map<string, string>();
   // Retired id → the live id it currently ROUTES to (mirrors the bridge's
@@ -46,6 +51,12 @@ function makeTracker(opts?: { defaultBackend?: string }) {
     liveTabOf: (tab) => {
       const a = tabAliases.get(tab);
       return a === null ? undefined : (a ?? tab);
+    },
+    currentTabOf: opts?.currentTabOf,
+    uniqueLiveTabOf: opts?.uniqueLiveTabOf,
+    claimTab: (tab, backend) => {
+      tabBackends.set(tab, backend);
+      opts?.claimTab?.(tab, backend);
     },
     warn: (msg) => warnings.push(msg),
   });
@@ -649,28 +660,38 @@ describe("TurnOriginTracker — an ALL-INJECTED multi-origin batch inherits, nev
     expect(tracker.pinOf(KEY)).toBe("tab-a");
   });
 
-  it("a USER message mixed with another tab's injected event still fails BOTH closed — the laundering P0 is untouched", async () => {
+  it("a USER message mixed with another tab's injected event pins the USER tab — notifications are not a second request (#1001)", async () => {
     const { tracker, warnings } = makeTracker();
     tracker.recordForMid("m-user", "uuid-a", "tab-a");
     const e1 = tracker.mintInjectionOrigin("tab-b");
     tracker.onSeen(KEY, "m-user");
     tracker.onSeen(KEY, e1);
     await flushMicrotasks();
-    expect(tracker.pinOf(KEY)).toBeNull();
-    expect(tracker.stampOf(KEY)).toBeUndefined();
-    expect(warnings.join("\n")).toMatch(/mixed\/unknown-origin/);
+    expect(tracker.pinOf(KEY)).toBe("tab-a");
+    expect(tracker.stampOf(KEY)).toBe("uuid-a");
+    expect(warnings.join("\n")).toMatch(/pinning the user tab/);
   });
 
-  it("a mid-less USER message (synthetic mid, userMessage:true) mixed with another tab's event also fails closed", async () => {
+  it("a mid-less USER message (synthetic mid, userMessage:true) mixed with another tab's event also pins the user tab", async () => {
     // index.ts mints a synthetic origin mid for a mid-less user message; the
-    // mid is synthetic but the REQUEST is the user's, so it must count as a
-    // user contribution — otherwise two mid-less user messages from different
-    // tabs would inherit instead of refusing, re-opening the laundering P0.
-    const { tracker, warnings } = makeTracker();
+    // mid is synthetic but the REQUEST is the user's, so it counts as the
+    // unique user origin. Two mid-less user messages from different tabs still
+    // fail closed (the laundering P0) — see the two-user test below.
+    const { tracker } = makeTracker();
     const mUser = tracker.mintInjectionOrigin("tab-a", { userMessage: true });
     const e1 = tracker.mintInjectionOrigin("tab-b");
     tracker.onSeen(KEY, mUser);
     tracker.onSeen(KEY, e1);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBe("tab-a");
+  });
+
+  it("TWO USER messages from different tabs still fail closed when no live bound tab exists", async () => {
+    const { tracker, warnings } = makeTracker();
+    tracker.recordForMid("m-a", "uuid-a", "tab-a");
+    tracker.recordForMid("m-b", "uuid-b", "tab-b");
+    tracker.onSeen(KEY, "m-a");
+    tracker.onSeen(KEY, "m-b");
     await flushMicrotasks();
     expect(tracker.pinOf(KEY)).toBeNull();
     expect(tracker.stampOf(KEY)).toBeUndefined();
@@ -698,6 +719,122 @@ describe("TurnOriginTracker — an ALL-INJECTED multi-origin batch inherits, nev
     await flushMicrotasks();
     expect(tracker.pinOf(KEY)).toBe("tab-c");
     expect(tracker.stampOf(KEY)).toBe("uuid-c");
+  });
+
+  it("with NO established origin, a unique live tab is inherited instead of wedging (#1001 reconnect)", async () => {
+    const { tracker, tabUuids, warnings } = makeTracker({
+      uniqueLiveTabOf: () => "tab-live",
+    });
+    tabUuids.set("tab-live", "uuid-live");
+    const e1 = tracker.mintInjectionOrigin("tab-a");
+    const e2 = tracker.mintInjectionOrigin("tab-b");
+    tracker.onSeen(KEY, e1);
+    tracker.onSeen(KEY, e2);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBe("tab-live");
+    expect(tracker.stampOf(KEY)).toBe("uuid-live");
+    expect(warnings.join("\n")).toMatch(/live bound\/current tab/);
+  });
+
+  it("an unroutable last origin after reconnect inherits the unique live tab, not a dead pin (#1001 cause 2)", async () => {
+    const { tracker, tabBackends, tabAliases, tabUuids } = makeTracker({
+      uniqueLiveTabOf: () => "tab-live",
+    });
+    tabBackends.set("tab-gone", "claude");
+    tabUuids.set("tab-gone", "uuid-gone");
+    tabUuids.set("tab-live", "uuid-live");
+    tracker.recordForMid("m-user", "uuid-gone", "tab-gone");
+    tracker.onSeen(KEY, "m-user");
+    await flushMicrotasks();
+    tracker.turnEnded(KEY);
+    tabAliases.set("tab-gone", null);
+    tabBackends.delete("tab-gone");
+
+    const e1 = tracker.mintInjectionOrigin("tab-a");
+    const e2 = tracker.mintInjectionOrigin("tab-b");
+    tracker.onSeen(KEY, e1);
+    tracker.onSeen(KEY, e2);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBe("tab-live");
+    expect(tracker.stampOf(KEY)).toBe("uuid-live");
+    expect(tracker.resolvedPinOf(KEY)).toBe("tab-live");
+  });
+
+  it("an unroutable last origin inherits the current tab when no unique canvas is named", async () => {
+    const { tracker, tabAliases, tabUuids } = makeTracker({
+      currentTabOf: () => "tab-current",
+    });
+    tabUuids.set("tab-current", "uuid-current");
+    tracker.recordForMid("m-user", "uuid-gone", "tab-gone");
+    tracker.onSeen(KEY, "m-user");
+    await flushMicrotasks();
+    tracker.turnEnded(KEY);
+    tabAliases.set("tab-gone", null);
+
+    const e1 = tracker.mintInjectionOrigin("tab-a");
+    const e2 = tracker.mintInjectionOrigin("tab-b");
+    tracker.onSeen(KEY, e1);
+    tracker.onSeen(KEY, e2);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBe("tab-current");
+    expect(tracker.stampOf(KEY)).toBe("uuid-current");
+  });
+
+  it("TWO live tabs with none bound stay AMBIGUOUS — genuine mixed user origins are not guessed", async () => {
+    const { tracker } = makeTracker({
+      uniqueLiveTabOf: () => undefined,
+      currentTabOf: () => undefined,
+    });
+    tracker.recordForMid("m-a", "uuid-a", "tab-a");
+    tracker.recordForMid("m-b", "uuid-b", "tab-b");
+    tracker.onSeen(KEY, "m-a");
+    tracker.onSeen(KEY, "m-b");
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBeNull();
+    expect(tracker.resolvedPinOf(KEY)).toBeNull();
+  });
+
+  it("a Codex unique canvas attributed to the default backend is claimed and inherited (panel#1557 at batch close)", async () => {
+    const KEY_CODEX = "orchestrator::codex";
+    const { tracker, tabBackends, tabUuids } = makeTracker({
+      defaultBackend: "claude",
+      uniqueLiveTabOf: () => "tab-live",
+    });
+    tabBackends.set("tab-live", "claude");
+    tabBackends.set("tab-a", "codex");
+    tabBackends.set("tab-b", "codex");
+    tabUuids.set("tab-live", "uuid-live");
+    const e1 = tracker.mintInjectionOrigin("tab-a");
+    const e2 = tracker.mintInjectionOrigin("tab-b");
+    tracker.onSeen(KEY_CODEX, e1);
+    tracker.onSeen(KEY_CODEX, e2);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY_CODEX)).toBe("tab-live");
+    expect(tabBackends.get("tab-live")).toBe("codex");
+    expect(tracker.resolvedPinOf(KEY_CODEX)).toBe("tab-live");
+  });
+
+  it("routing-time adopt recovers a null pin once a unique live tab exists (reconnect after batch close)", async () => {
+    let unique: string | undefined;
+    const { tracker, tabUuids } = makeTracker({
+      uniqueLiveTabOf: () => unique,
+    });
+    tabUuids.set("tab-live", "uuid-live");
+    const e1 = tracker.mintInjectionOrigin("tab-a");
+    const e2 = tracker.mintInjectionOrigin("tab-b");
+    tracker.onSeen(KEY, e1);
+    tracker.onSeen(KEY, e2);
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBeNull();
+
+    unique = "tab-live";
+    const resolve = makeScopeTargetResolver({
+      tracker,
+      scopeAgentKeyOf: (id) => (id === "orchestrator" ? KEY : id),
+    });
+    expect(resolve("orchestrator")).toBe("tab-live");
+    expect(tracker.pinOf(KEY)).toBe("tab-live");
+    expect(tracker.stampOf(KEY)).toBe("uuid-live");
   });
 });
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1904,6 +1904,28 @@ export async function runPanelOrchestrator(): Promise<void> {
     // The provider-switch pin invalidation judges a pin by where the BRIDGE
     // routes it (path-compressed migration aliases included) — codex gate 4.
     liveTabOf: (tab) => bridge.liveTabIdFor(tab),
+    // #1001 — mixed-origin inherit: last established origin if it still
+    // routes, else the current/unique live canvas so graph tools do not need
+    // a manual rebind after reconnect re-delivers several workflow events.
+    currentTabOf: (key) => {
+      const active = bridge.liveLastActiveTabId();
+      if (!active || bridge.isHeadless(active)) return undefined;
+      return backendForTab(active) === backendOf(key) ? active : undefined;
+    },
+    uniqueLiveTabOf: (key) => {
+      const backend = backendOf(key);
+      const interactive = bridge
+        .tabs()
+        .map((t) => t.tab_id)
+        .filter((t) => !bridge.isHeadless(t));
+      const eligible = interactive.filter((t) => backendForTab(t) === backend);
+      if (eligible.length === 1) return eligible[0];
+      if (eligible.length === 0 && interactive.length === 1) return interactive[0];
+      return undefined;
+    },
+    claimTab: (tab, backend) => {
+      tabBackends.set(tab, backend);
+    },
     warn: (msg) => logger.warn(msg),
   });
   // #884 — ROUTING for agent output: every connected tab participating in this

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -13,9 +13,10 @@
 // asserted source strings against index.ts and could not fail):
 //   - per-mid issue-time origins (recorded at receipt, applied at DEQUEUE);
 //   - the dispatch-batch aggregation (one turn may batch several messages; only
-//     an AGREEING batch pins/stamps — a mixed batch with a user message, or an
-//     unknown origin, fails closed; an all-injected mixed batch inherits the
-//     last established origin, #1001);
+//     an AGREEING batch pins/stamps — unknown origins fail closed; two USER
+//     origins fail closed unless a live bound/current tab exists; a unique
+//     user origin plus injected events pins the user tab; an all-injected
+//     mixed batch inherits last established origin, else current/unique, #1001);
 //   - the turn-target pin + issue-time stamp + last-established origin;
 //   - the explicit-repin recovery and the scope target resolver the UiBridge
 //     consults (built here so tests drive the REAL handlers, not test stand-ins).
@@ -47,6 +48,20 @@ export interface TurnOriginDeps {
    *  still resolve onto the switched tab (codex gate 4). Optional only for
    *  lightweight test trackers; production always wires it. */
   liveTabOf?: (tabId: string) => string | undefined;
+  /** The conversation's current/active canvas tab, if it belongs to this
+   *  backend. Used when a mixed-origin batch has no usable last established
+   *  origin — typically after reconnect, when lastOrigin names a gone id
+   *  (#1001). Optional; omitting it keeps the fail-closed inherit of older
+   *  tests. */
+  currentTabOf?: (key: string) => string | undefined;
+  /** Exactly one live interactive canvas for this conversation (this backend's
+   *  sole tab, or the unique canvas after a hello that omitted `backend`).
+   *  Same unique-canvas rule as makeScopeRepinHandler (panel#1557), applied at
+   *  batch close / routing so a single connected tab is not AMBIGUOUS. */
+  uniqueLiveTabOf?: (key: string) => string | undefined;
+  /** Re-attribute a unique live canvas to this conversation when recovery
+   *  adopts it (hello after reload often omits `backend`). */
+  claimTab?: (tabId: string, backend: string) => void;
   warn: (msg: string) => void;
 }
 
@@ -76,8 +91,15 @@ interface PendingBatch {
    *  workflows (see onSeen). */
   routes: Set<string>;
   /** At least one contribution came from a USER message (not an injected
-   *  event). Only then does a multi-route batch fail closed (#1001). */
+   *  event). Only then does a multi-route batch fail closed (#1001) — and
+   *  only when no unique user origin / live bound tab can take the pin. */
   user: boolean;
+  /** Recorded tab ids of USER contributions (not injected). */
+  userTabs: Set<string>;
+  /** USER origins resolved to the tab they ROUTE TO today. */
+  userRoutes: Set<string>;
+  /** UUIDs of USER contributions, for stamping a unique-user pin. */
+  userKnown: Array<string | undefined>;
   unknown: boolean;
 }
 
@@ -186,6 +208,96 @@ export class TurnOriginTracker {
     return typeof live === "string" && live ? live : last.uuid;
   }
 
+  /** lastOrigin only if it still ROUTES to a live tab of this backend. A gone
+   *  id (reconnect) must not inherit a dead pin that then reads as
+   *  "still reconnecting" (#1001 cause 2). */
+  private lastOriginStillLive(key: string): { tab: string; uuid: string | undefined } | undefined {
+    const last = this.lastOriginByKey.get(key);
+    if (!last) return undefined;
+    const live = this.deps.liveTabOf ? this.deps.liveTabOf(last.tab) : last.tab;
+    if (!live) return undefined;
+    if (this.deps.backendForTab(live) !== this.deps.backendOfKey(key)) return undefined;
+    return last;
+  }
+
+  /** Current/active tab, else the unique live canvas, for this conversation. */
+  private pickCurrentOrUnique(key: string): string | undefined {
+    const backend = this.deps.backendOfKey(key);
+    const current = this.deps.currentTabOf?.(key);
+    if (current && this.deps.backendForTab(current) === backend) return current;
+    return this.deps.uniqueLiveTabOf?.(key);
+  }
+
+  private claimAndPin(key: string, tab: string, uuid: string | undefined): void {
+    const backend = this.deps.backendOfKey(key);
+    if (this.deps.backendForTab(tab) !== backend) {
+      this.deps.claimTab?.(tab, backend);
+    }
+    this.lastTurnUuidByKey.set(key, uuid);
+    this.turnTargetTabByKey.set(key, tab);
+  }
+
+  private failClosed(key: string, msg: string): void {
+    this.lastTurnUuidByKey.set(key, undefined);
+    this.turnTargetTabByKey.set(key, null);
+    this.deps.warn(msg);
+  }
+
+  private mixedOriginRefusal(key: string): string {
+    return (
+      `[panel-orchestrator] ${key} dispatched a mixed/unknown-origin batch — no single workflow stamp/target is honest for it, so scope routing and graph mutations FAIL CLOSED until the agent opens/pins a workflow or the next single-origin message (#884)`
+    );
+  }
+
+  /**
+   * Inherit a live bound tab instead of leaving the pin AMBIGUOUS.
+   * Order: last established origin (if it still routes), then current/active,
+   * then the unique live canvas. Two live tabs and none of those → false.
+   */
+  private applyBoundFallback(key: string, originCount: number): boolean {
+    const last = this.lastOriginStillLive(key);
+    if (last) {
+      this.claimAndPin(key, last.tab, this.inheritedStampOf(last));
+      if (originCount > 1) {
+        this.deps.warn(
+          `[panel-orchestrator] ${key} dispatched re-delivered events from ${originCount} workflows in one turn — no user message to pin on, so the turn inherits the conversation's last established origin (${last.tab.slice(0, 8)}) instead of refusing; name a workflow explicitly to work on one of the others (#1001)`,
+        );
+      }
+      return true;
+    }
+    const tab = this.pickCurrentOrUnique(key);
+    if (!tab) return false;
+    this.claimAndPin(key, tab, this.inheritedStampOf({ tab, uuid: this.deps.uuidOfTab(tab) }));
+    if (originCount > 1) {
+      this.deps.warn(
+        `[panel-orchestrator] ${key} dispatched re-delivered events from ${originCount} workflows in one turn — no usable last origin, so the turn inherits the live bound/current tab (${tab.slice(0, 8)}) instead of refusing (#1001)`,
+      );
+    }
+    return true;
+  }
+
+  /**
+   * Routing-time recovery: an already-AMBIGUOUS pin (`null`) adopts a live
+   * bound/current tab if one exists. A unique canvas that hellos AFTER batch
+   * close (reconnect) can unwedge graph tools without a manual rebind.
+   * Idle (no pin) and a healthy string pin are returned unchanged.
+   */
+  adoptAmbiguousPin(key: string): string | null | undefined {
+    const pin = this.resolvedPinOf(key);
+    if (pin !== null) return pin;
+    // Do NOT inherit lastOrigin here: that is a PREVIOUS turn's binding, and
+    // recovering it would undo a mixed-USER fail-closed (send-now A+B). Only
+    // a current/unique live canvas that exists NOW may unwedge reconnect.
+    const tab = this.pickCurrentOrUnique(key);
+    if (!tab) return null;
+    this.claimAndPin(key, tab, this.inheritedStampOf({ tab, uuid: this.deps.uuidOfTab(tab) }));
+    this.deps.warn(
+      `[panel-orchestrator] ${key} adopted the live bound/current tab (${tab.slice(0, 8)}) for an ambiguous pin instead of refusing (#1001)`,
+    );
+    const adopted = this.resolvedPinOf(key);
+    return typeof adopted === "string" ? adopted : null;
+  }
+
   /** Record a message's issue-time origin, keyed by its mid, to be applied at
    *  dequeue. Captures the tab's backend NOW so the application can verify the
    *  tab still belongs to the same conversation then. `injected` marks an
@@ -260,7 +372,16 @@ export class TurnOriginTracker {
     let batch = this.pendingBatchStamp.get(key);
     const opensBatch = !batch;
     if (!batch) {
-      batch = { known: [], tabs: new Set<string>(), routes: new Set<string>(), user: false, unknown: false };
+      batch = {
+        known: [],
+        tabs: new Set<string>(),
+        routes: new Set<string>(),
+        user: false,
+        userTabs: new Set<string>(),
+        userRoutes: new Set<string>(),
+        userKnown: [],
+        unknown: false,
+      };
       this.pendingBatchStamp.set(key, batch);
     }
     // A mid's origin comes from the LIVE record (first dequeue) or the APPLIED
@@ -329,11 +450,15 @@ export class TurnOriginTracker {
         // closed — only the aliases of ONE tab collapse.
         batch.tabs.add(rec.tab);
         batch.routes.add(liveOrigin);
-        // #1001 — remember whether any contribution is a USER message. Only a
-        // user request can be laundered onto the wrong tab, so only a batch
-        // containing one fails closed on disagreement; an all-injected batch
-        // (re-delivered completions/answers/events) inherits instead.
-        if (!rec.injected) batch.user = true;
+        // #1001 — remember whether any contribution is a USER message. Two
+        // USER origins still fail closed unless a live bound tab exists; a
+        // unique user origin plus injected notifications pins the user tab.
+        if (!rec.injected) {
+          batch.user = true;
+          batch.userTabs.add(rec.tab);
+          batch.userRoutes.add(liveOrigin);
+          batch.userKnown.push(rec.uuid);
+        }
         this.turnUuidByMid.delete(mid);
         this.noteAppliedTurnMid(mid, rec); // keeps its origin for a re-queue
       }
@@ -349,21 +474,8 @@ export class TurnOriginTracker {
       queueMicrotask(() => {
         this.pendingBatchStamp.delete(key);
         const distinct = new Set(closed.known);
-        if (closed.unknown || (closed.routes.size > 1 && closed.user)) {
-          // Mixed/unknown-TAB batch involving a USER message: no single stamp
-          // or target is honest for it — fail BOTH closed (the bridge refuses
-          // routing; the panel fence refuses mutations) until an explicit
-          // target or the next single-origin message. The `user` qualifier is
-          // #1001: the laundering P0 this gate exists for is a user REQUEST
-          // re-aimed onto another tab's graph. A batch of orchestrator-
-          // INJECTED events carries no request — nothing to launder — so it
-          // falls through to the inherit branch below instead of wedging every
-          // scope-addressed tool until a manual rebind.
-          this.lastTurnUuidByKey.set(key, undefined);
-          this.turnTargetTabByKey.set(key, null);
-          this.deps.warn(
-            `[panel-orchestrator] ${key} dispatched a mixed/unknown-origin batch — no single workflow stamp/target is honest for it, so scope routing and graph mutations FAIL CLOSED until the agent opens/pins a workflow or the next single-origin message (#884)`,
-          );
+        if (closed.unknown) {
+          this.failClosed(key, this.mixedOriginRefusal(key));
         } else if (closed.routes.size === 1) {
           // TURN-TARGET PIN (confirming gate P0): this turn's tool calls route
           // to the tab the turn was ISSUED from — never re-resolved mid-turn —
@@ -375,74 +487,42 @@ export class TurnOriginTracker {
           this.lastTurnUuidByKey.set(key, uuid);
           this.turnTargetTabByKey.set(key, tab);
           this.lastOriginByKey.set(key, { tab, uuid });
-        } else {
-          // NO user origin to pin on. Two shapes land here:
-          //
-          //   routes.size === 0 — a deliberately origin-less injected turn
-          //     (a coalesced download_done; re-queued items contribute their
-          //     own origin, see appliedTurnMids).
-          //
-          //   routes.size > 1, all injected — #1001: journaled run completions
-          //     / ask answers from SEVERAL workflows replayed into ONE turn at
-          //     a delivery opportunity (a fresh spawn, a reconnect sweep of
-          //     flushAllJournaledEvents). Each origin is real, but the batch is
-          //     a stack of NOTIFICATIONS, not a request — refusing here wedged
-          //     panel_graph_outline / panel_list_workflows / panel_get_errors
-          //     with "issued from multiple workflows at once" until a manual
-          //     panel_set_workflow_target rebind, on sessions with as few as
-          //     ONE live tab (observed on mcp 0.50.52 and again on 0.51.38).
-          //
-          // Both inherit the conversation's LAST ESTABLISHED origin — NEVER
-          // "whatever tab is active" (confirming gate 2, P0). The inherited tab
-          // must STILL belong to this conversation's backend (confirming gate
-          // 3, P0); no established/valid origin at all → refuse. A follow-up
-          // mutation stays honest: it is stamped with the LIVE uuid of that
-          // inherited tab at THIS turn's start (panel#1209), so the panel fence
-          // (and the dispatch-time stamp-target agreement gate, #1656) refuse
-          // it loudly if the routed canvas is not the one the stamp names.
-          //
-          // Ownership is judged on the tab the inherited origin ROUTES to
-          // today (routedTabOf), NOT on the id it was recorded under — the
-          // same view the message-origin check above and resolvedPinOf() have
-          // always used, and the one place that was still left on the raw id
-          // (panel#1292 recurrence). The last established origin is written at
-          // batch close and keeps its issue-time identity, so a same-socket
-          // migration after it — a WORKFLOW SWITCH, the exact thing the report
-          // starts with — leaves it naming a retired id that `tabBackends` no
-          // longer knows. `backendForTab` then answers with the DEFAULT
-          // backend, so every conversation NOT on the default backend read its
-          // own healthy tab as another backend's and failed the turn closed:
-          // an async download completing after a workflow switch nulled the
-          // pin, and panel_refresh_nodes / panel_graph_outline /
-          // panel_list_workflows all hit "no connected tab can be chosen …
-          // issued from multiple workflows at once" until an explicit
-          // mode:"current" rebind. Cross-backend safety is untouched: the
-          // bridge resolves an id a live foreign tab currently holds to THAT
-          // tab (exact match beats the migration alias), and an origin that
-          // resolves nowhere still falls back to its raw id and fails closed.
-          const last = this.lastOriginByKey.get(key);
-          if (last && this.deps.backendForTab(this.routedTabOf(last.tab)) === this.deps.backendOfKey(key)) {
-            this.lastTurnUuidByKey.set(key, this.inheritedStampOf(last));
-            this.turnTargetTabByKey.set(key, last.tab);
-            if (closed.routes.size > 1) {
-              this.deps.warn(
-                `[panel-orchestrator] ${key} dispatched re-delivered events from ${closed.routes.size} workflows in one turn — no user message to pin on, so the turn inherits the conversation's last established origin (${last.tab.slice(0, 8)}) instead of refusing; name a workflow explicitly to work on one of the others (#1001)`,
-              );
-            }
-          } else {
-            this.lastTurnUuidByKey.set(key, undefined);
-            this.turnTargetTabByKey.set(key, null);
+        } else if (closed.userRoutes.size === 1) {
+          // One USER request plus injected notifications from other workflows
+          // (#1001 recurrence: completions re-delivered into the same turn as
+          // an active-workflow event). The request is the pin; extras are not
+          // a second user origin and must not fail closed.
+          const tab = closed.userTabs.values().next().value as string;
+          const live = this.deps.liveTabOf ? this.deps.liveTabOf(tab) : tab;
+          if (live && this.deps.backendForTab(live) === this.deps.backendOfKey(key)) {
+            const userDistinct = new Set(closed.userKnown);
+            const uuid = userDistinct.size === 1 ? userDistinct.values().next().value : undefined;
+            this.lastTurnUuidByKey.set(key, uuid);
+            this.turnTargetTabByKey.set(key, tab);
+            this.lastOriginByKey.set(key, { tab, uuid });
             this.deps.warn(
-              last
-                ? `[panel-orchestrator] ${key} dispatched ${closed.routes.size > 1 ? "a multi-workflow event replay (#1001)" : "an origin-less turn"} whose last established origin tab ${last.tab.slice(0, 8)}${
-                    // Name the tab the verdict was actually reached on. Judging
-                    // moved to the ROUTED id (panel#1292), so reporting only the
-                    // recorded one would blame an id this branch never looked at.
-                    this.routedTabOf(last.tab) !== last.tab ? ` (routing to ${this.routedTabOf(last.tab).slice(0, 8)})` : ""
-                  } now belongs to another backend's conversation — scope routing FAILS CLOSED until an explicit target or an origin-bearing message (#884 confirming gate 3)`
-                : `[panel-orchestrator] ${key} dispatched a turn with no ${closed.routes.size > 1 ? "user origin (a multi-workflow event replay, #1001) and no" : "origin and no"} established prior origin — scope routing FAILS CLOSED until an explicit target or an origin-bearing message (#884)`,
+              `[panel-orchestrator] ${key} dispatched a user origin plus re-delivered events from other workflows — pinning the user tab (${tab.slice(0, 8)}); name a workflow explicitly to work on one of the others (#1001)`,
             );
+          } else if (!this.applyBoundFallback(key, closed.routes.size)) {
+            this.failClosed(key, this.mixedOriginRefusal(key));
           }
+        } else if (closed.userRoutes.size > 1) {
+          // Two USER requests from different tabs — the laundering P0. A live
+          // lastOrigin from a PREVIOUS turn must not pick a winner for this
+          // batch (send-now merging A+B would otherwise re-aim B onto A).
+          this.failClosed(key, this.mixedOriginRefusal(key));
+        } else if (!this.applyBoundFallback(key, closed.routes.size)) {
+          // Injected multi-origin or origin-less, and no live bound/current/
+          // unique tab to inherit.
+          const last = this.lastOriginByKey.get(key);
+          this.failClosed(
+            key,
+            last
+              ? `[panel-orchestrator] ${key} dispatched ${closed.routes.size > 1 ? "a multi-workflow event replay (#1001)" : "an origin-less turn"} whose last established origin tab ${last.tab.slice(0, 8)}${
+                  this.routedTabOf(last.tab) !== last.tab ? ` (routing to ${this.routedTabOf(last.tab).slice(0, 8)})` : ""
+                } now belongs to another backend's conversation — scope routing FAILS CLOSED until an explicit target or an origin-bearing message (#884 confirming gate 3)`
+              : `[panel-orchestrator] ${key} dispatched a turn with no ${closed.routes.size > 1 ? "user origin (a multi-workflow event replay, #1001) and no" : "origin and no"} established prior origin — scope routing FAILS CLOSED until an explicit target or an origin-bearing message (#884)`,
+          );
         }
       });
     }
@@ -601,14 +681,14 @@ export class TurnOriginTracker {
 /** The scope target resolver the UiBridge consults while resolving a
  *  scope-addressed command: the in-flight turn's pin (string), an ambiguous
  *  or ownership-refused origin (`null` → refuse loudly), or no turn in flight
- *  (undefined → active-tab resolution). Goes through resolvedPinOf so the
- *  pin's OWNERSHIP is verified at every use (codex gate-4 delta, P0). Built
- *  here so tests drive the REAL resolver. */
+ *  (undefined → active-tab resolution). Goes through adoptAmbiguousPin so a
+ *  null pin can still take a unique live/current tab after reconnect (#1001)
+ *  and ownership is verified at every use (codex gate-4 delta, P0). */
 export function makeScopeTargetResolver(opts: {
   tracker: TurnOriginTracker;
   scopeAgentKeyOf: (scopeId: string) => string;
 }): (scopeId: string) => string | null | undefined {
-  return (scopeId) => opts.tracker.resolvedPinOf(opts.scopeAgentKeyOf(scopeId));
+  return (scopeId) => opts.tracker.adoptAmbiguousPin(opts.scopeAgentKeyOf(scopeId));
 }
 
 /** The slice of UiBridge the repin recovery consults. */

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -5283,6 +5283,15 @@ export class UiBridge {
     }
   }
 
+  /** The tab the user last talked from, if that tab is still connected.
+   *  Unlike {@link resolveActiveScopeTab}, this does NOT fall back to the most
+   *  recently connected canvas — that fallback is a guess among 2+ tabs and
+   *  must not auto-clear an AMBIGUOUS pin (#1001). */
+  liveLastActiveTabId(): string | undefined {
+    if (this.lastActiveTabId && this.conns.has(this.lastActiveTabId)) return this.lastActiveTabId;
+    return undefined;
+  }
+
   /** The LIVE connection for a (possibly RETIRED) canonical tab id, scoped to the SOCKET
    *  that produced the reply. Returns the conn under `tabId` when it is STILL that exact
    *  socket, else the socket-scoped migration target it was renamed to (tmp:→wf:). Used


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1001

## Recurrence

Previous merges (#1016, #1685, #1047) still left a wedge: after reconnect, a turn carrying re-delivered completions from several workflows (or a unique user origin plus injected extras) made panel_graph_outline / graph tools fail with "issued from multiple workflows at once" and sometimes "still reconnecting", even with one live canvas. Manual panel_set_workflow_target({mode:"current"}) recovered it.

## Gap this PR closes

- **No last origin after reconnect** — an all-injected mixed batch with a unique live tab (or current/active tab) now inherits that tab instead of failing closed as AMBIGUOUS.
- **Dead last origin** — inherit no longer pins an unroutable id (which then read as reconnect). It falls through to the unique/current canvas.
- **Unique user origin + injected extras** — the user request is the pin; re-delivered completions from other workflows are not a second request.
- **Routing-time adopt** — if the unique canvas hellos after batch close, makeScopeTargetResolver adopts it on the next graph call so reconnect readiness is not reported before the route is usable.
- **Genuine ambiguity preserved** — two USER origins from different tabs with none bound still fail closed (send-now A+B is not laundered onto lastOrigin).

## Tests

`npx vitest run src/__tests__/orchestrator/turn-origins.test.ts src/__tests__/orchestrator/multi-workflow-rebind.test.ts`

Unfixed code fails the unique-live / reconnect-adopt / graph_outline cases; they pass with this inherit. Two-tab none-bound still refuses.
