### PR TITLE
chore: release v0.52.148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.148] - 2026-08-29
+
+### MCP
+
+#### Fixed
+- bound compact identity probes
+- fence same-type transient writes
+- fence transient promoted reads
+- omit the unexpose reindex warning when the panel already reindexed
+
+
 ## [0.52.147] - 2026-08-28
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
-- bound compact identity probes
+- bound compact identity probes (#2513, #2478)
 - fence same-type transient writes
 - fence transient promoted reads
-- omit the unexpose reindex warning when the panel already reindexed
+- omit the unexpose reindex warning when the panel already reindexed (#2474)
+- keep the causal line above a native fault and stop blaming a pass-through node (#2508)
+- direct-clone local git installs when Manager queue is unavailable (#2509)
+- make the Kimi Code backend usable (#2552)
+- reconcile release citations (#2519, #2520)
 
 
 ## [0.52.147] - 2026-08-28

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.147",
+  "version": "0.52.148",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.147",
+      "version": "0.52.148",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.147",
+  "version": "0.52.148",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release MCP v0.52.148.\n\nIncludes the merged #2478 paired promoted-subgraph identity repair and current release changelog reconciliation. Version metadata and generated changelog were updated by the repository release flow.