### PR TITLE
fix(2477): treat nested opened.routing_key as unsaved-open proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- panel_open_workflow treats nested opened.routing_key as unsaved-open proof instead of failing a proven tmp: open as an unconfirmed filename (#2477)
+
 ## [0.52.150] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/orchestrator/open-workflow-unsaved-refresh.test.ts
+++ b/src/__tests__/orchestrator/open-workflow-unsaved-refresh.test.ts
@@ -46,20 +46,32 @@ let stamps: string[];
 
 const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
 
-function openReply(opts: { routingKey: string; withUuid: boolean }): Record<string, unknown> {
-  return {
+function openReply(opts: {
+  routingKey: string;
+  withUuid: boolean;
+  /** #2477 — some successful replies nest the key under `opened` only. */
+  nestRoutingKey?: boolean;
+  /** Synthetic saved-looking path the live panel can publish for an unsaved tab. */
+  openedPath?: string | null;
+}): Record<string, unknown> {
+  const opened: Record<string, unknown> = {
     // An UNSAVED workflow has no real path — the panel's own reply shape, per
     // web/js/comfyui-mcp-panel.js: `opened: { path: target.path, filename }`
     // with `target.path` undefined for a tmp: tab.
-    opened: { path: null, filename: null },
-    routing_key: opts.routingKey,
+    path: opts.openedPath === undefined ? null : opts.openedPath,
+    filename: opts.openedPath ? "Unsaved Workflow" : null,
+  };
+  if (opts.nestRoutingKey) opened.routing_key = opts.routingKey;
+  return {
+    opened,
+    ...(opts.nestRoutingKey ? {} : { routing_key: opts.routingKey }),
     ...(opts.withUuid ? { workflow_uuid: OPENED_UUID } : {}),
     modified: false,
     open_seq: 3,
   };
 }
 
-function bridgeFor(reply: Record<string, unknown>) {
+function bridgeFor(reply: Record<string, unknown>, list?: Record<string, unknown>) {
   return {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(cmd);
@@ -68,6 +80,7 @@ function bridgeFor(reply: Record<string, unknown>) {
       // creation. The fix must not depend on this call succeeding, or ever
       // being made at all for the unsaved path — asserted explicitly below.
       if (cmd.cmd === "workflow_list") {
+        if (list) return list;
         throw new Error(
           "workflow instance mismatch: this command targets a different workflow than the active canvas",
         );
@@ -203,5 +216,68 @@ describe("#812 end to end — the reporter's exact sequence", () => {
     // The fence is now the NEW tab's instance — every subsequent panel_* call
     // this session sends will carry the correct stamp.
     expect(fence).toBe(OPENED_UUID);
+  });
+});
+
+describe("#2477 nested opened.routing_key is still unsaved-target proof", () => {
+  it("adopts the reply uuid when routing_key lives only under opened", async () => {
+    const res = await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(bridgeFor(openReply({ routingKey: TAB_TOKEN, withUuid: true, nestRoutingKey: true }))),
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(fence).toBe(OPENED_UUID);
+    expect(sent.map((c) => c.cmd)).not.toContain("workflow_list");
+  });
+
+  it("does not reject a proven tmp: open as an unresolved filename when opened.path looks saved", async () => {
+    // Reporter shape: workflow_open applied, routing_key only under opened, and
+    // opened.path is the live synthetic unsaved path. The #1639 filename-alias
+    // guard then asked workflow_list, whose unsaved active record has no
+    // canonical saved identity, and the tool failed with UNKNOWN canvas.
+    const list = {
+      active_confirmed: true,
+      active: {
+        path: null,
+        filename: null,
+        title: "Unsaved Workflow",
+        routing_key: TAB_TOKEN,
+        workflow_uuid: OPENED_UUID,
+      },
+    };
+    const res = await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(
+        bridgeFor(
+          openReply({
+            routingKey: TAB_TOKEN,
+            withUuid: true,
+            nestRoutingKey: true,
+            openedPath: "workflows/Unsaved Workflow.json",
+          }),
+          list,
+        ),
+      ),
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).not.toMatch(/unconfirmed active workflow after resolving this filename/i);
+    expect(textOf(res)).not.toMatch(/active canvas is UNKNOWN/i);
+    expect(fence).toBe(OPENED_UUID);
+    expect(sent.map((c) => c.cmd)).not.toContain("workflow_list");
+  });
+
+  it("adopts nothing when the nested key names a different unsaved tab", async () => {
+    const res = await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(
+        bridgeFor(openReply({ routingKey: OTHER_TAB_TOKEN, withUuid: true, nestRoutingKey: true })),
+      ),
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11900,10 +11900,25 @@ async function refreshOpenWorkflowUuid(
     parsedOpen.routedTo === ctx.tabId &&
     (typeof ctx.bridge.canReach !== "function" || ctx.bridge.canReach(ctx.tabId));
   const opened = parsedOpen?.opened;
-  const openedPath =
-    opened && typeof opened === "object" && typeof (opened as { path?: unknown }).path === "string"
-      ? (opened as { path: string }).path
+  const openedRecord =
+    opened && typeof opened === "object" && !Array.isArray(opened)
+      ? (opened as Record<string, unknown>)
       : undefined;
+  const openedPath = typeof openedRecord?.path === "string" ? openedRecord.path : undefined;
+  // #2477 — some successful workflow_open replies nest routing_key under
+  // `opened` rather than at the top level. A tmp: request is never a filename
+  // alias, so prove that identity first; otherwise the #1639 unresolved-
+  // filename path rejects a canvas the panel already bound.
+  const requestedUnsaved = canonicalUnsavedWorkflowIdentity(requestedPath);
+  if (requestedUnsaved) {
+    const openedRoutingKey =
+      (typeof parsedOpen?.routing_key === "string" ? parsedOpen.routing_key : undefined) ??
+      (typeof openedRecord?.routing_key === "string" ? openedRecord.routing_key : undefined);
+    if (requestedUnsaved === openedRoutingKey) {
+      refreshWorkflowUuid(ctx, parsedOpen) || refreshWorkflowUuid(ctx, openedRecord);
+    }
+    return null;
+  }
   // The caller's original token is the fence target. A panel can resolve an
   // alias/basename to a path, but that reply must never retroactively turn the
   // alias into a UUID-refresh authorization. Require the reply to corroborate
@@ -12017,22 +12032,6 @@ async function refreshOpenWorkflowUuid(
       };
     }
 
-    // #812 — the SAVED corroboration above can never succeed for an unsaved
-    // target (there is no path), so try the parallel UNSAVED identity: the
-    // caller's literal token against the panel's own proven routing_key for
-    // the tab it just opened. Exact equality only — see
-    // canonicalUnsavedWorkflowIdentity for why that carries no alias risk.
-    //
-    // Trust level matches the EXISTING "could not ask" fallback below exactly:
-    // adopt the reply's own workflow_uuid directly, which the panel published
-    // only after its own final synchronous check that this target was still
-    // the active workflow (#716). No extra workflow_list round trip — that
-    // read is itself refused by the exact wedge this exists to repair
-    // (#1071), which is the same trap `panel_new_workflow`'s recovery hit.
-    const requestedUnsaved = canonicalUnsavedWorkflowIdentity(requestedPath);
-    if (requestedUnsaved && requestedUnsaved === parsedOpen?.routing_key) {
-      refreshWorkflowUuid(ctx, parsedOpen);
-    }
     return null;
   }
 


### PR DESCRIPTION
Fixes #2477

## Diagnosis

`refreshOpenWorkflowUuid` treated a `tmp:` open as proven only when `parsedOpen.routing_key` matched the caller token. Some successful `workflow_open` replies nest that key under `opened.routing_key`. Missing the proof sent the open into the #1639 unresolved-filename path, which then failed with an unconfirmed/UNKNOWN canvas even though the panel had already applied the open and bound the requested routing key.

## Fix

Prove unsaved `tmp:` identity first, from top-level `routing_key` or `opened.routing_key`. A matching key adopts the reply uuid and never enters the filename-alias unverified path. A mismatched `tmp:` key still adopts nothing.

## Validation

- `npx vitest run src/__tests__/orchestrator/open-workflow-unsaved-refresh.test.ts` — 12 passed (2 new cases failed on the unfixed behavior: nested key did not adopt the fence; synthetic `opened.path` rejected the open as UNKNOWN).
- Nearby open-path files also passed (69 tests): `open-workflow-unsaved-refresh.test.ts`, `open-workflow-drift-surfaced.test.ts`, `open-workflow-fence-unreadable.test.ts`, `open-reconnect-false-mismatch.test.ts`, `open-clears-fence-on-drift.test.ts`.
- `npx tsc --noEmit` — passed.

Do not merge from this PR: parent merges.