### PR TITLE
fix(2050): panel_free_vram reports VRAM after CUDA release settles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_free_vram reports VRAM after CUDA release settles (#2050)
 - panel_open_workflow treats nested opened.routing_key as unsaved-open proof instead of failing a proven tmp: open as an unconfirmed filename (#2477)
 
 ## [0.52.150] - 2026-08-30

--- a/src/__tests__/orchestrator/free-vram-pinned-device.test.ts
+++ b/src/__tests__/orchestrator/free-vram-pinned-device.test.ts
@@ -39,6 +39,10 @@ import { getBootLocalComfyUIBaseUrl, getComfyUIBaseUrl, setComfyuiTarget } from 
 import { markReplyTimeout } from "../../services/ui-bridge.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import {
+  VRAM_SETTLE_INTERVAL_MS,
+  VRAM_SETTLE_TIMEOUT_MS,
+} from "../../services/vram-settle.js";
 
 const TAB = "11111111-2222-3333-4444-555555555555";
 const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
@@ -93,6 +97,11 @@ function bridge(opts: {
   } as unknown as PanelToolCtx["bridge"];
 }
 
+async function flushVramSettle<T>(pending: Promise<T>): Promise<T> {
+  await vi.advanceTimersByTimeAsync(VRAM_SETTLE_TIMEOUT_MS + VRAM_SETTLE_INTERVAL_MS);
+  return await pending;
+}
+
 async function run(
   reply: "timeout" | "ok",
   opts?: { origin?: string | null },
@@ -100,7 +109,7 @@ async function run(
   const ctx = makePanelToolCtx(bridge({ reply, origin: opts?.origin }), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_free_vram");
   if (!def) throw new Error("panel_free_vram is not registered");
-  const res: ToolResult = await def.handler({} as never, ctx);
+  const res: ToolResult = await flushVramSettle(def.handler({} as never, ctx));
   return { text: textOf(res), isError: res.isError === true, ctx };
 }
 
@@ -126,7 +135,8 @@ function setDevices(
 function expectQueriedProven(ctx: PanelToolCtx): void {
   const proven = __panelToolsTestHooks.captureRebootHealthBase(ctx);
   expect(proven).toBeTruthy();
-  expect(queriedBases).toEqual([proven]);
+  expect(queriedBases.length).toBeGreaterThan(0);
+  expect(queriedBases.every((b) => b === proven)).toBe(true);
 }
 
 const FREED_ACK_BODY = { freed: true, unload_models: true, free_memory: true };
@@ -184,9 +194,12 @@ beforeEach(() => {
   sent = [];
   queriedBases = [];
   originalTarget = getComfyUIBaseUrl();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-29T00:00:00Z"));
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   setComfyuiTarget(originalTarget);
   __panelToolsTestHooks.setFreeVramDirect(null);
   __panelToolsTestHooks.setReadVramDevices(null);
@@ -265,7 +278,8 @@ describe("panel_free_vram reads occupancy from this tab's server, not the global
     const proven = __panelToolsTestHooks.captureRebootHealthBase(out.ctx);
     expect(proven).toBeTruthy();
     expect(__panelToolsTestHooks.sameHttpBase(proven, getComfyUIBaseUrl())).toBe(false);
-    expect(queriedBases).toEqual([proven]);
+    expect(queriedBases.length).toBeGreaterThan(0);
+    expect(queriedBases.every((b) => b === proven)).toBe(true);
     // Occupancy is THIS tab's GPU 2, not whatever the retargeted host would show.
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/"index": 2/);
@@ -356,7 +370,7 @@ describe("annotateFreeVramAck discloses occupied-but-not-torch-pinned (#1895)", 
   it("keeps isError false, names device 0, and prints the live 795579336 counter", async () => {
     setDevices(otherProcessHoldsCard);
     const ctx = makePanelToolCtx(bridge({ reply: "ok" }), TAB, new WorkflowTargetStore());
-    const out = await __panelToolsTestHooks.annotateFreeVramAck(ctx, ackFreed());
+    const out = await flushVramSettle(__panelToolsTestHooks.annotateFreeVramAck(ctx, ackFreed()));
 
     expectQueriedProven(ctx);
     expect(out.isError === true).toBe(false);
@@ -379,12 +393,13 @@ describe("annotateFreeVramAck discloses occupied-but-not-torch-pinned (#1895)", 
     setDevices(otherProcessHoldsCard);
     expect(setComfyuiTarget(OTHER_BASE)).toBe(true);
     const ctx = makePanelToolCtx(bridge({ reply: "ok" }), TAB, new WorkflowTargetStore());
-    const out = await __panelToolsTestHooks.annotateFreeVramAck(ctx, ackFreed());
+    const out = await flushVramSettle(__panelToolsTestHooks.annotateFreeVramAck(ctx, ackFreed()));
 
     const proven = __panelToolsTestHooks.captureRebootHealthBase(ctx);
     expect(proven).toBeTruthy();
     expect(__panelToolsTestHooks.sameHttpBase(proven, getComfyUIBaseUrl())).toBe(false);
-    expect(queriedBases).toEqual([proven]);
+    expect(queriedBases.length).toBeGreaterThan(0);
+    expect(queriedBases.every((b) => b === proven)).toBe(true);
     expect(out.isError === true).toBe(false);
     expect(textOf(out)).toContain("795579336");
   });
@@ -397,7 +412,7 @@ describe("annotateFreeVramAck discloses occupied-but-not-torch-pinned (#1895)", 
       new WorkflowTargetStore(),
     );
     const ack = ackFreed();
-    const out = await __panelToolsTestHooks.annotateFreeVramAck(ctx, ack);
+    const out = await flushVramSettle(__panelToolsTestHooks.annotateFreeVramAck(ctx, ack));
 
     expect(__panelToolsTestHooks.captureRebootHealthBase(ctx)).toBeNull();
     expect(queriedBases).toEqual([]);

--- a/src/__tests__/orchestrator/free-vram-stale-report.test.ts
+++ b/src/__tests__/orchestrator/free-vram-stale-report.test.ts
@@ -1,0 +1,234 @@
+// #2050 recurrence — panel_free_vram on 0.52.146 / panel 0.15.124 reported
+// freed:true, a ~32 MB torch pool, and occupied_devices:[cuda:0] at 1.2 GB
+// free; a health read ~0.2s later showed 10.7 GB free. The MCP clear_vram
+// path already polls after /free (#2052); the panel path printed the first
+// /system_stats sample. These tests drive the registered panel_free_vram
+// handler. The mock occupancy answers as a lagging CUDA driver would.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  comfyuiFetch: vi.fn(),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (...args: unknown[]) => mocks.comfyuiFetch(...args),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import {
+  VRAM_SETTLE_INTERVAL_MS,
+  VRAM_SETTLE_TIMEOUT_MS,
+} from "../../services/vram-settle.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+const ackTimeout = (cmd: string, ms: number): Error =>
+  new Error(
+    `Panel tab ${TAB} did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be ` +
+      `backgrounded or frozen. This command MUTATES and was already delivered to the tab, so it ` +
+      `may have been applied despite the missing reply — check the current state before ` +
+      `re-issuing it; a blind retry can apply it twice`,
+  );
+
+let sent: string[] = [];
+
+function bridge(reply: "timeout" | "ok"): PanelToolCtx["bridge"] {
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- test double for the panel bridge, not a live UiBridge
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(String(cmd.cmd));
+      if (cmd.cmd !== "free_vram") return { ok: true };
+      if (reply === "ok") return { freed: true, unload_models: true, free_memory: true };
+      throw markReplyTimeout(ackTimeout("free_vram", 15000));
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    tabIsLocal: () => true,
+    tabServerOrigin: () => BOOT_BASE,
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function run(reply: "timeout" | "ok"): Promise<{ text: string; isError: boolean }> {
+  const ctx = makePanelToolCtx(bridge(reply), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_free_vram");
+  if (!def) throw new Error("panel_free_vram is not registered");
+  const pending = def.handler({} as never, ctx);
+  await vi.advanceTimersByTimeAsync(VRAM_SETTLE_TIMEOUT_MS + VRAM_SETTLE_INTERVAL_MS);
+  const res: ToolResult = await pending;
+  return { text: textOf(res), isError: res.isError === true };
+}
+
+const GIB = 1024 * 1024 * 1024;
+/** Reporter: RTX 4070 SUPER 12 GB. */
+const TOTAL = 12 * GIB;
+/** Immediate post-/free sample: 1.2 GB free. */
+const STALE_FREE = Math.round(1.2 * GIB);
+/** Health read ~0.2s later: 10.7 GB free. */
+const SETTLED_FREE = Math.round(10.7 * GIB);
+/** Tiny leftover torch pool (~32 MB) — not a torch pin. */
+const TORCH = 32 * 1024 * 1024;
+/** Still globally occupied after a partial climb (2 GB / 12 GB = 16.7% < 20%). */
+const STILL_OCCUPIED_FREE = 2 * GIB;
+
+type Device = {
+  name: string;
+  index: number;
+  vram_total: number;
+  vram_free: number;
+  torch_vram_total: number;
+  torch_vram_free: number;
+};
+
+function gpu(vramFree: number): Device {
+  return {
+    name: "cuda:0",
+    index: 0,
+    vram_total: TOTAL,
+    vram_free: vramFree,
+    torch_vram_total: TORCH,
+    torch_vram_free: 0,
+  };
+}
+
+const STALE = [gpu(STALE_FREE)];
+const SETTLED = [gpu(SETTLED_FREE)];
+const STILL_OCCUPIED = [gpu(STILL_OCCUPIED_FREE)];
+
+function setDevicesOverTime(sampleAt: (elapsedMs: number) => Device[] | null): void {
+  const started = Date.now();
+  __panelToolsTestHooks.setReadVramDevices(async () => sampleAt(Date.now() - started));
+}
+
+beforeEach(() => {
+  sent = [];
+  mocks.comfyuiFetch.mockReset();
+  mocks.comfyuiFetch.mockResolvedValue({ status: 200 });
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-29T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  __panelToolsTestHooks.setFreeVramDirect(null);
+  __panelToolsTestHooks.setReadVramDevices(null);
+});
+
+describe("panel_free_vram post-unload VRAM (#2050)", () => {
+  it("does not report occupied_devices from the immediate 1.2 GB sample", async () => {
+    // CUDA still reports the pre-release occupancy until 200ms after /free —
+    // the 0.52.146 recurrence window. A single read would name cuda:0 occupied
+    // at 1.2 GB free next to a 32 MB torch pool.
+    setDevicesOverTime((elapsed) => (elapsed < 200 ? STALE : SETTLED));
+
+    const out = await run("ok");
+
+    expect(sent).toEqual(["free_vram"]);
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/"freed": false/);
+    expect(out.text).not.toMatch(/occupied_devices/);
+    expect(out.text).not.toContain(String(STALE_FREE));
+    expect(out.text).not.toMatch(/STILL PINNED/);
+  });
+
+  it("does not treat two equal stale reads inside the min wait as settled", async () => {
+    // CUDA still reports 1.2 GB free until 600ms — inside two 250ms polls,
+    // before VRAM_SETTLE_MIN_MS. Without the min wait, two equal stale reads
+    // would print occupied_devices at 1.2 GB and return.
+    setDevicesOverTime((elapsed) => (elapsed < 600 ? STALE : SETTLED));
+
+    const out = await run("ok");
+
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/occupied_devices/);
+    expect(out.text).not.toContain(String(STALE_FREE));
+  });
+
+  it("keeps polling while VRAM is still climbing past the min wait", async () => {
+    setDevicesOverTime((elapsed) => {
+      if (elapsed >= 1_500) return SETTLED;
+      const t = elapsed / 1_500;
+      return [gpu(STALE_FREE + (SETTLED_FREE - STALE_FREE) * t)];
+    });
+
+    const out = await run("ok");
+
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/occupied_devices/);
+    expect(out.text).not.toContain(String(STALE_FREE));
+  });
+
+  it("reports occupied_devices from the settled sample when the card stays occupied", async () => {
+    setDevicesOverTime((elapsed) => (elapsed < 200 ? STALE : STILL_OCCUPIED));
+
+    const out = await run("ok");
+
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).toMatch(/occupied_devices/);
+    expect(out.text).toContain(String(STILL_OCCUPIED_FREE));
+    expect(out.text).not.toContain(String(STALE_FREE));
+    expect(out.text).toMatch(/device 0/);
+  });
+
+  it("omits occupied_devices when a later stats read fails", async () => {
+    let n = 0;
+    __panelToolsTestHooks.setReadVramDevices(async () => {
+      n += 1;
+      return n === 1 ? STALE : null;
+    });
+
+    const out = await run("ok");
+
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).not.toMatch(/occupied_devices/);
+    expect(out.text).not.toContain(String(STALE_FREE));
+  });
+
+  it("settles vram_after on the frozen-tab server-side path too", async () => {
+    setDevicesOverTime((elapsed) => (elapsed < 200 ? STALE : SETTLED));
+
+    const out = await run("timeout");
+
+    expect(mocks.comfyuiFetch).toHaveBeenCalled();
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"freed": true/);
+    expect(out.text).toMatch(/"verified": "server-side"/);
+    expect(out.text).not.toMatch(/occupied_devices/);
+    const payload = JSON.parse(out.text) as {
+      vram_before?: Array<{ vram_free?: number }>;
+      vram_after?: Array<{ vram_free?: number }>;
+    };
+    // before is the pre-/free snapshot (can still be the 1.2 GB occupancy).
+    expect(payload.vram_before?.[0]?.vram_free).toBe(STALE_FREE);
+    expect(payload.vram_after?.[0]?.vram_free).toBe(SETTLED_FREE);
+  });
+});

--- a/src/__tests__/orchestrator/free-vram-stale-report.test.ts
+++ b/src/__tests__/orchestrator/free-vram-stale-report.test.ts
@@ -28,7 +28,7 @@ const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks } = await im
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
 import { markReplyTimeout } from "../../services/ui-bridge.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
-import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import type { ToolResult } from "../../orchestrator/panel-tools.js";
 import {
   VRAM_SETTLE_INTERVAL_MS,
   VRAM_SETTLE_TIMEOUT_MS,
@@ -50,8 +50,7 @@ const ackTimeout = (cmd: string, ms: number): Error =>
 
 let sent: string[] = [];
 
-function bridge(reply: "timeout" | "ok"): PanelToolCtx["bridge"] {
-  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- test double for the panel bridge, not a live UiBridge
+function bridge(reply: "timeout" | "ok") {
   return {
     send: async (cmd: Record<string, unknown>) => {
       sent.push(String(cmd.cmd));
@@ -70,11 +69,11 @@ function bridge(reply: "timeout" | "ok"): PanelToolCtx["bridge"] {
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     tabIsLocal: () => true,
     tabServerOrigin: () => BOOT_BASE,
-  } as unknown as PanelToolCtx["bridge"];
+  };
 }
 
 async function run(reply: "timeout" | "ok"): Promise<{ text: string; isError: boolean }> {
-  const ctx = makePanelToolCtx(bridge(reply), TAB, new WorkflowTargetStore());
+  const ctx = makePanelToolCtx(bridge(reply) as never, TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_free_vram");
   if (!def) throw new Error("panel_free_vram is not registered");
   const pending = def.handler({} as never, ctx);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -52,6 +52,7 @@ import {
 import { extname, isAbsolute, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
+import { settleUntilStable } from "../services/vram-settle.js";
 import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
 import {
   findPackOnDisk,
@@ -4137,6 +4138,29 @@ async function readVramDevicesMaybe(
   return (readVramDevicesOverride ?? readVramDevices)(base, timeoutMs);
 }
 
+/** Device 0-N occupancy signature — any GPU's vram or torch pool changing is not settled. */
+function vramDevicesSignature(devices: VramDeviceSample[]): string {
+  return devices
+    .map((d) => `${d.index ?? d.name ?? ""}:${d.vram_free ?? ""}:${d.torch_vram_free ?? ""}`)
+    .join("|");
+}
+
+/**
+ * #2050 — POST /free returns when ComfyUI drops model refs; CUDA can still be
+ * releasing. The 0.52.146 recurrence: panel_free_vram reported freed:true, a
+ * ~32 MB torch pool, occupied_devices:[cuda:0] at 1.2 GB free; a health read
+ * 0.2s later showed 10.7 GB free. Poll until the counters stop changing.
+ */
+async function readSettledVramDevices(
+  base: string,
+  timeoutMs: number,
+): Promise<VramDeviceSample[] | null> {
+  return settleUntilStable(
+    () => readVramDevicesMaybe(base, timeoutMs),
+    vramDevicesSignature,
+  );
+}
+
 interface FreeVramDirectOutcome {
   ok: boolean;
   /** Failure detail when !ok (HTTP status / transport error), already worded
@@ -4174,7 +4198,7 @@ async function freeVramDirect(base: string): Promise<FreeVramDirectOutcome> {
   } finally {
     clearTimeout(timer);
   }
-  const after = await readVramDevicesMaybe(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
+  const after = await readSettledVramDevices(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
   return { ok: true, before, after };
 }
 
@@ -4263,9 +4287,10 @@ async function settleFreeVramAfterAckTimeout(
 
 /**
  * #1866 — a panel ack of `{freed:true}` is the /free HTTP 2xx, not a measured
- * GPU. After the tab says it posted /free, re-read /system_stats and refuse to
- * claim VRAM was freed when a device is still occupied. Unreadable stats leave
- * the original ack UNTOUCHED: an unknown answer claims nothing extra.
+ * GPU. After the tab says it posted /free, re-read /system_stats (after CUDA
+ * occupancy settles — #2050) and refuse to claim VRAM was freed when a device
+ * is still occupied. Unreadable stats leave the original ack UNTOUCHED: an
+ * unknown answer claims nothing extra.
  *
  * #1887 — occupancy is read from the same proven local base the frozen-tab
  * settle uses (`captureRebootHealthBase(ctx)`), never `getComfyUIBaseUrl()`.
@@ -4290,7 +4315,7 @@ async function annotateFreeVramAck(ctx: PanelToolCtx, res: ToolResult): Promise<
       note: UNOBSERVED_OCCUPANCY_NOTE,
     });
   }
-  const devices = await readVramDevicesMaybe(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
+  const devices = await readSettledVramDevices(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
   if (devices == null) return res;
   const pinned = pinnedVramDevices(devices);
   if (pinned.length > 0) {

--- a/src/services/vram-settle.ts
+++ b/src/services/vram-settle.ts
@@ -1,0 +1,56 @@
+/** Poll interval between /system_stats reads after /free (#2050). */
+export const VRAM_SETTLE_INTERVAL_MS = 250;
+/** Do not treat an unchanged first reading as settled — CUDA may not have started releasing yet. */
+export const VRAM_SETTLE_MIN_MS = 1_000;
+/** Hard cap so a card that never plateaus still returns a number. */
+export const VRAM_SETTLE_TIMEOUT_MS = 5_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * /free answers when ComfyUI drops model refs; CUDA/driver release can lag.
+ * Poll `read` until `signatureOf` stops changing (or the cap) so the value
+ * matches a follow-up get_system_stats (action:"stats") (#2050).
+ *
+ * A failed or null read returns null rather than the previous sample: /free
+ * may have released memory between the two, so returning the prior sample
+ * would report a known-stale VRAM figure as if it were current.
+ */
+export async function settleUntilStable<T>(
+  read: () => Promise<T | null>,
+  signatureOf: (value: T) => string,
+): Promise<T | null> {
+  const started = Date.now();
+  const deadline = started + VRAM_SETTLE_TIMEOUT_MS;
+  let lastSig: string | null = null;
+  let sawChange = false;
+
+  for (;;) {
+    let current: T | null;
+    try {
+      current = await read();
+    } catch {
+      return null;
+    }
+    if (current == null) return null;
+
+    const sig = signatureOf(current);
+    const elapsed = Date.now() - started;
+    if (lastSig !== null && sig !== lastSig) sawChange = true;
+    const stable = lastSig !== null && sig === lastSig;
+    lastSig = sig;
+
+    if (stable && (sawChange || elapsed >= VRAM_SETTLE_MIN_MS)) {
+      return current;
+    }
+    if (elapsed >= VRAM_SETTLE_TIMEOUT_MS) {
+      return current;
+    }
+
+    const wait = Math.min(VRAM_SETTLE_INTERVAL_MS, Math.max(0, deadline - Date.now()));
+    if (wait <= 0) return current;
+    await sleep(wait);
+  }
+}

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -6,17 +6,13 @@ import type { SystemStats } from "../comfyui/types.js";
 import { ComfyUIError, errorToToolResult } from "../utils/errors.js";
 import { bodyPrefixOf, describeStatus } from "../comfyui/json-guard.js";
 import { logger } from "../utils/logger.js";
+import { settleUntilStable } from "../services/vram-settle.js";
 
-/** Poll interval between /system_stats reads after /free (#2050). */
-export const CLEAR_VRAM_SETTLE_INTERVAL_MS = 250;
-/** Do not treat an unchanged first reading as settled — CUDA may not have started releasing yet. */
-export const CLEAR_VRAM_SETTLE_MIN_MS = 1_000;
-/** Hard cap so a card that never plateaus still returns a number. */
-export const CLEAR_VRAM_SETTLE_TIMEOUT_MS = 5_000;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+export {
+  VRAM_SETTLE_INTERVAL_MS as CLEAR_VRAM_SETTLE_INTERVAL_MS,
+  VRAM_SETTLE_MIN_MS as CLEAR_VRAM_SETTLE_MIN_MS,
+  VRAM_SETTLE_TIMEOUT_MS as CLEAR_VRAM_SETTLE_TIMEOUT_MS,
+} from "../services/vram-settle.js";
 
 /** The counters `clear_vram` prints — device 0's VRAM + torch pool. */
 function vramSignature(stats: SystemStats): string {
@@ -41,41 +37,13 @@ function formatVramStats(stats: SystemStats): string {
  * printed value matches a follow-up get_system_stats (action:"stats") (#2050).
  */
 async function readSettledSystemStats(): Promise<SystemStats | null> {
-  const started = Date.now();
-  const deadline = started + CLEAR_VRAM_SETTLE_TIMEOUT_MS;
-  let last: SystemStats | null = null;
-  let lastSig: string | null = null;
-  let sawChange = false;
-
-  for (;;) {
-    let current: SystemStats;
+  return settleUntilStable(async () => {
     try {
-      current = await getSystemStats();
+      return await getSystemStats();
     } catch {
-      // A prior sample is not a valid substitute for the current one: /free may
-      // have released memory between the two reads, so returning `last` would
-      // print a known-stale VRAM figure as if it were current.
       return null;
     }
-
-    const sig = vramSignature(current);
-    const elapsed = Date.now() - started;
-    if (lastSig !== null && sig !== lastSig) sawChange = true;
-    const stable = lastSig !== null && sig === lastSig;
-    last = current;
-    lastSig = sig;
-
-    if (stable && (sawChange || elapsed >= CLEAR_VRAM_SETTLE_MIN_MS)) {
-      return current;
-    }
-    if (elapsed >= CLEAR_VRAM_SETTLE_TIMEOUT_MS) {
-      return current;
-    }
-
-    const wait = Math.min(CLEAR_VRAM_SETTLE_INTERVAL_MS, Math.max(0, deadline - Date.now()));
-    if (wait <= 0) return current;
-    await sleep(wait);
-  }
+  }, vramSignature);
 }
 
 export function registerMemoryManagementTools(server: McpServer): void {


### PR DESCRIPTION
Fixes #2050

`#2052` already made `clear_vram` poll `/system_stats` until occupancy stopped changing. The production `panel_free_vram` path still classified the first sample after `POST /free`. Recurrence on comfyui-mcp 0.52.146 / panel 0.15.124: `freed:true`, a ~32 MB torch pool, and `occupied_devices:[cuda:0]` at 1.2 GB free; a health read ~0.2s later showed 10.7 GB free with the queue idle.

`/free` returns when ComfyUI drops model refs; CUDA can still be releasing. Both the panel ack path and the frozen-tab server-side `/free` after-read now share the same settle poller as `clear_vram` (min 1s so two equal stale reads are not treated as settled, cap 5s). A failed later stats read omits occupancy rather than printing the previous sample.

Targeted vitest: `npx vitest run src/__tests__/orchestrator/free-vram-stale-report.test.ts src/__tests__/orchestrator/free-vram-pinned-device.test.ts src/__tests__/orchestrator/free-vram-frozen-tab.test.ts src/__tests__/tools/clear-vram-stale-report.test.ts` — 4 files, 37 passed. The new tests fail on a one-shot post-`/free` read (occupied_devices at 1.2 GB) and pass with the settle.

Do not merge from this PR: independent review and the release gate are required.