### PR TITLE
fix: list_templates via live panel when origin is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- list_templates uses the live panel when the configured origin is unreachable (#2196)
 - panel_free_vram reports VRAM after CUDA release settles (#2050)
 - panel_open_workflow treats nested opened.routing_key as unsaved-open proof instead of failing a proven tmp: open as an unconfirmed filename (#2477)
 

--- a/src/__tests__/orchestrator/panel-template-relay-production.test.ts
+++ b/src/__tests__/orchestrator/panel-template-relay-production.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createServer, type Server } from "node:http";
 import { createServer as createSocketServer } from "node:net";
 import { createPanelTemplateRelayWiring } from "../../orchestrator/index.js";
@@ -433,6 +433,57 @@ describe("orchestrator panel template relay wiring (#2196)", () => {
     // the origin-gate clause goes, even while the deeper one still refuses.
     expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
     expect(wiring.resolvePanelUrl("tab-1", target)).toBeUndefined();
+  });
+
+  it("serves a remote matching origin through the live panel instead of HTTP (#2196)", async () => {
+    const seen: Array<{ cmd: string; operation?: string }> = [];
+    const remoteCalls: string[] = [];
+    const realFetch = globalThis.fetch;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.startsWith("http://127.0.0.1:")) return realFetch(input, init);
+      remoteCalls.push(url);
+      return Promise.reject(new Error("matching remote must not be fetched by the orchestrator"));
+    });
+    try {
+      const index = { "remote-pack": [{ name: "live-template" }] };
+      const body = JSON.stringify(index);
+      const target = "https://remote.example/comfyapi";
+      const observedOrigin = "https://remote.example";
+      const bridge = {
+        canReach: () => true,
+        resolveFailure: () => undefined,
+        resolveSharedTabId: () => "tab-1",
+        tabServerOrigin: () => observedOrigin,
+        send: async (command: { cmd: "fetch_comfyui_read"; operation: "workflow_templates" }) => {
+          seen.push(command);
+          return {
+            operation: "workflow_templates" as const,
+            body,
+            contentType: "application/json",
+            bytes: Buffer.byteLength(body, "utf8"),
+          };
+        },
+      };
+      const wiring = createPanelTemplateRelayWiring({
+        bridge,
+        currentTarget: () => target,
+        currentTargetGeneration: () => 0,
+        secrets: new Map([[SECRET, "orchestrator::codex"]]),
+      });
+      // HTTP authorization stays loopback-only; the native path must not need it.
+      expect(wiring.resolveAllowedPanelOrigin("tab-1", target)).toBeUndefined();
+      const relay = await startPanelTemplateRelayServer({ bridge, ...wiring });
+      servers.push(relay);
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+      await expect(requestPanelTemplateIndex()).resolves.toEqual(index);
+      expect(seen).toEqual([{ cmd: "fetch_comfyui_read", operation: "workflow_templates" }]);
+      expect(remoteCalls).toEqual([]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("still authorizes an https LITERAL loopback origin, which has no name to re-resolve (#2392)", async () => {

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -216,6 +216,154 @@ describe("authenticated panel template relay (#2196)", () => {
     await expect(requestPanelTemplateIndex()).resolves.toBeUndefined();
   });
 
+  function nativeIndex(index: Record<string, unknown>) {
+    const body = JSON.stringify(index);
+    return {
+      operation: "workflow_templates" as const,
+      body,
+      contentType: "application/json",
+      bytes: Buffer.byteLength(body, "utf8"),
+    };
+  }
+
+  it("asks the live panel for the template index when the origin is remote (#2196)", async () => {
+    const seen: Array<{ cmd: string; operation?: string; tabId?: string }> = [];
+    const remoteCalls: string[] = [];
+    const realFetch = globalThis.fetch;
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.startsWith("http://127.0.0.1:")) return realFetch(input, init);
+      remoteCalls.push(url);
+      return Promise.reject(new Error("the orchestrator must not fetch the remote origin"));
+    });
+
+    const relay = await startPanelTemplateRelayServer({
+      bridge: {
+        canReach: () => true,
+        send: async (command, options) => {
+          seen.push({ ...command, tabId: options.tabId });
+          return nativeIndex({ "remote-pack": [{ name: "from-panel" }] });
+        },
+      },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: "https://remote.example/comfyapi", generation: 0 }),
+      resolvePanelUrl: () => {
+        throw new Error("panel-native fetch must not resolve a remote HTTP URL");
+      },
+      resolveAllowedPanelOrigin: () => {
+        throw new Error("panel-native fetch must not authorize a remote HTTP origin");
+      },
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).resolves.toEqual({
+      "remote-pack": [{ name: "from-panel" }],
+    });
+    expect(seen).toEqual([{ cmd: "fetch_comfyui_read", operation: "workflow_templates", tabId: "tab-1" }]);
+    expect(remoteCalls).toEqual([]);
+  });
+
+  it("asks the live panel when localhost and 127.0.0.1 are a mixed pair (#2196)", async () => {
+    const seen: string[] = [];
+    const relay = await startPanelTemplateRelayServer({
+      bridge: {
+        canReach: () => true,
+        send: async (command) => {
+          seen.push(command.operation);
+          return nativeIndex({ "mixed-pack": [{ name: "from-browser" }] });
+        },
+      },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: "http://127.0.0.1:8188/comfyapi", generation: 0 }),
+      resolvePanelUrl: () => currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi"),
+      resolveAllowedPanelOrigin: () =>
+        currentPanelTemplateOrigin("http://localhost:8188", "http://127.0.0.1:8188/comfyapi"),
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).resolves.toEqual({
+      "mixed-pack": [{ name: "from-browser" }],
+    });
+    expect(seen).toEqual(["workflow_templates"]);
+  });
+
+  it("rejects a native reply after the ComfyUI target retargets (#2196)", async () => {
+    let generation = 0;
+    let currentTarget = "https://remote.example/comfyapi";
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const relay = await startPanelTemplateRelayServer({
+      bridge: {
+        canReach: () => true,
+        send: async () => {
+          markStarted();
+          await held;
+          return nativeIndex({ "stale-pack": [{ name: "too-late" }] });
+        },
+      },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: currentTarget, generation }),
+      resolvePanelUrl: () => undefined,
+      resolveAllowedPanelOrigin: () => undefined,
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    const pending = requestPanelTemplateIndex();
+    await started;
+    currentTarget = "https://other.example/comfyapi";
+    generation += 1;
+    release();
+    await expect(pending).rejects.toMatchObject<PanelTemplateRelayError>({ code: "STALE_TARGET" });
+  });
+
+  it("falls back to loopback HTTP when the panel does not implement workflow_templates", async () => {
+    let panelRequests = 0;
+    const panel = createServer((_req, res) => {
+      panelRequests += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ "fallback-pack": [{ name: "from-http" }] }));
+    });
+    const panelOrigin = await listen(panel);
+    servers.push({ close: () => closeServer(panel) });
+
+    const relay = await startPanelTemplateRelayServer({
+      bridge: {
+        canReach: () => true,
+        send: async () => {
+          throw new Error("fetch_comfyui_read rejected the operation: operation must be one of history, system_stats, logs");
+        },
+      },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: panelOrigin, generation: 0 }),
+      resolvePanelUrl: () => `${panelOrigin}/api/workflow_templates`,
+      resolveAllowedPanelOrigin: () => panelOrigin,
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).resolves.toEqual({
+      "fallback-pack": [{ name: "from-http" }],
+    });
+    expect(panelRequests).toBe(1);
+  });
+
   it("only authorizes a loopback origin corroborated by the current target", () => {
     expect(currentPanelTemplateOrigin("https://remote.example:443", "https://remote.example/comfyapi")).toBeUndefined();
     expect(currentPanelTemplateOrigin("http://127.0.0.1:8188", "http://127.0.0.1:8188/comfyapi")).toBe("http://127.0.0.1:8188");

--- a/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
+++ b/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
@@ -209,4 +209,58 @@ describe("list_packs -> panel template relay production boundary (#2196)", () =>
     // COMFYUI_URL fetch that a retarget could leave stale.
     expect(state.headlessCalls).toBe(0);
   });
+
+  it("serves list_templates from a bound remote panel without touching COMFYUI_URL (#2196)", async () => {
+    const index = { "remote-pack": [{ name: "live-template" }] };
+    const body = JSON.stringify(index);
+    const remoteCalls: string[] = [];
+    const realFetch = globalThis.fetch;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.startsWith("http://127.0.0.1:")) return realFetch(input, init);
+      remoteCalls.push(url);
+      return Promise.reject(new Error("list_templates must not fetch the remote origin"));
+    });
+    try {
+      state.baseUrl = "https://remote.example/comfyapi";
+      const bridge = {
+        canReach: () => true,
+        resolveFailure: () => undefined,
+        resolveSharedTabId: () => "tab-1",
+        tabServerOrigin: () => "https://remote.example",
+        send: async () => ({
+          operation: "workflow_templates",
+          body,
+          contentType: "application/json",
+          bytes: Buffer.byteLength(body, "utf8"),
+        }),
+      };
+      const relay = await startPanelTemplateRelayServer({
+        bridge,
+        ...createPanelTemplateRelayWiring({
+          bridge,
+          currentTarget: () => state.baseUrl,
+          currentTargetGeneration: () => 0,
+          secrets: new Map([[SECRET, "orchestrator::codex"]]),
+        }),
+      });
+      servers.push(relay);
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+      const result = await listPacksHandler()({ action: "list_templates" });
+      const text = result.content.map((block) => block.text).join(" ");
+      expect(result.isError ?? false).toBe(false);
+      expect(text).not.toContain("NO_PANEL_ORIGIN");
+      expect(JSON.parse(text)).toMatchObject({
+        source_count: 1,
+        template_count: 1,
+        templates: { "remote-pack": [{ name: "live-template" }] },
+      });
+      expect(remoteCalls).toEqual([]);
+      expect(state.headlessCalls).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -8,10 +8,11 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
  *
  * The list_packs child cannot reach the panel bridge directly. It sends only a
  * capability-bound request to the orchestrator; the orchestrator resolves the
- * live panel tab and fetches the fixed /api/workflow_templates route from that
- * tab's server-observed origin, but only when it is the current ComfyUI target.
- * No configured ComfyUI credentials or caller-supplied URL crosses this
- * boundary.
+ * live panel tab and asks that tab to fetch same-origin /api/workflow_templates
+ * (the SSRF-safe path for a remote or mixed-alias origin). Loopback HTTP to a
+ * corroborated origin remains a fallback for older panels that do not implement
+ * the workflow_templates read. No configured ComfyUI credentials or
+ * caller-supplied URL crosses this boundary.
  */
 export const PANEL_TEMPLATE_RELAY_VERSION = 1;
 export const PANEL_TEMPLATE_RELAY_TIMEOUT_MS = 8_000;
@@ -96,9 +97,21 @@ type Success = {
 type ResponseBody = Failure | Success;
 type TransportResponse = ResponseBody & { responseMac: string };
 
+export const PANEL_TEMPLATE_READ_OPERATION = "workflow_templates" as const;
+
 export interface PanelTemplateRelayBridge {
   canReach(tabId: string): boolean;
   resolveFailure?: (tabId: string) => "ambiguous" | "unresolved" | undefined;
+  /**
+   * Preferred production path: the authenticated panel fetches same-origin
+   * /api/workflow_templates. Optional so unit tests can exercise the loopback
+   * HTTP fallback without a live bridge.
+   */
+  send?(
+    command: { cmd: "fetch_comfyui_read"; operation: typeof PANEL_TEMPLATE_READ_OPERATION },
+    options: { tabId: string; timeoutMs: number },
+    // oxlint-disable-next-line anti-slop/no-unknown-returns -- UiBridge.send is Promise<unknown>; validatePanelTemplateReadPayload parses the reply
+  ): Promise<unknown>;
 }
 
 export interface PanelTemplateRelayResolvedAgent {
@@ -637,6 +650,91 @@ function isConnectionRefused(error: unknown): boolean {
   return false;
 }
 
+function isUnsupportedPanelTemplateRead(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    /operation must be one of/i.test(message) ||
+    /unknown command/i.test(message) ||
+    /does not implement/i.test(message) ||
+    /too old for/i.test(message)
+  );
+}
+
+function validatePanelTemplateReadPayload(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    !hasOnlyKeys(record, ["operation", "body", "contentType", "bytes"]) ||
+    record.operation !== PANEL_TEMPLATE_READ_OPERATION ||
+    typeof record.body !== "string" ||
+    record.body.length === 0 ||
+    Buffer.byteLength(record.body, "utf8") > PANEL_TEMPLATE_RELAY_MAX_RESPONSE_BYTES ||
+    (record.contentType !== null &&
+      (typeof record.contentType !== "string" || !isSafeText(record.contentType, 128)))
+  ) return undefined;
+  const bytes = record.bytes;
+  if (
+    typeof bytes !== "number" ||
+    !Number.isSafeInteger(bytes) ||
+    bytes < 0 ||
+    bytes > PANEL_TEMPLATE_RELAY_MAX_RESPONSE_BYTES ||
+    Buffer.byteLength(record.body, "utf8") !== bytes
+  ) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(record.body);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  return record.body;
+}
+
+async function fetchPanelNativeIndex(
+  bridge: PanelTemplateRelayBridge,
+  panelTab: string,
+  deadlineAt: number,
+): Promise<string> {
+  if (typeof bridge.send !== "function") {
+    throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
+  }
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) throw new PanelTemplateRelayError("The panel template relay timed out.", "TIMEOUT");
+  const reply = await bridge.send(
+    { cmd: "fetch_comfyui_read", operation: PANEL_TEMPLATE_READ_OPERATION },
+    { tabId: panelTab, timeoutMs: Math.min(PANEL_TEMPLATE_RELAY_TIMEOUT_MS, remaining) },
+  );
+  const body = validatePanelTemplateReadPayload(reply);
+  if (!body) {
+    throw new PanelTemplateRelayError("The connected panel could not fetch the workflow-template index.", "PANEL_FETCH_FAILED");
+  }
+  return body;
+}
+
+async function fetchLivePanelIndex(
+  options: PanelTemplateRelayServerOptions,
+  panelTab: string,
+  currentTarget: string,
+  deadlineAt: number,
+): Promise<string> {
+  if (typeof options.bridge.send === "function") {
+    try {
+      return await fetchPanelNativeIndex(options.bridge, panelTab, deadlineAt);
+    } catch (error) {
+      // An older panel implements fetch_comfyui_read but not this operation.
+      // Keep the loopback HTTP fallback rather than failing closed on a
+      // version skew the child cannot see.
+      if (!isUnsupportedPanelTemplateRead(error)) throw error;
+    }
+  }
+  const allowedOrigin = options.resolveAllowedPanelOrigin(panelTab, currentTarget);
+  const panelUrl = safePanelTemplateUrl(options.resolvePanelUrl(panelTab, currentTarget), allowedOrigin);
+  if (!panelUrl) {
+    throw new PanelTemplateRelayError("The panel template relay refused a non-loopback destination.", "NO_PANEL_ORIGIN");
+  }
+  return fetchPinnedPanelIndex(panelUrl, deadlineAt);
+}
+
 async function fetchPanelIndex(url: URL, deadlineAt: number): Promise<string> {
   const remaining = deadlineAt - Date.now();
   if (remaining <= 0) throw new PanelTemplateRelayError("The panel template relay timed out.", "TIMEOUT");
@@ -729,25 +827,17 @@ export async function startPanelTemplateRelayServer(
           const targetAtStart = options.resolveCurrentTarget();
           const panelTab = options.resolvePanelTab(auth.agentKey);
           const panelReachable = panelTab ? options.bridge.canReach(panelTab) : false;
-          const allowedOrigin = panelTab && panelReachable
-            ? options.resolveAllowedPanelOrigin(panelTab, targetAtStart.url)
-            : undefined;
-          const panelUrl = panelTab && panelReachable
-            ? safePanelTemplateUrl(options.resolvePanelUrl(panelTab, targetAtStart.url), allowedOrigin)
-            : undefined;
           if (!panelTab || !panelReachable) {
             response = failureResponse(
               request.requestId,
               options.bridge.resolveFailure?.(auth.agentKey) === "ambiguous" ? "AMBIGUOUS_REQUESTER" : "NO_LIVE_PANEL",
             );
-          } else if (!panelUrl) {
-            // Any configured relay refusal is authoritative. Returning a
-            // sentinel here would let the child fall through to a stale
-            // getComfyUIBaseUrl() target after a mid-turn retarget.
-            response = failureResponse(request.requestId, "NO_PANEL_ORIGIN");
           } else {
             try {
-              const body = await withinDeadline(fetchPinnedPanelIndex(panelUrl, requestDeadline(request)), requestDeadline(request));
+              const body = await withinDeadline(
+                fetchLivePanelIndex(options, panelTab, targetAtStart.url, requestDeadline(request)),
+                requestDeadline(request),
+              );
               const targetNow = options.resolveCurrentTarget();
               if (targetNow.url !== targetAtStart.url || targetNow.generation !== targetAtStart.generation) {
                 throw new PanelTemplateRelayError(


### PR DESCRIPTION
Fixes #2196

## Recurrence

Current-release report on comfyui-mcp 0.52.146 / panel 0.15.124: `panel_graph_outline` shows a bound canvas and `panel_*` mutations work, but `list_packs(action:list_templates)` returns `The connected panel template relay failed (NO_PANEL_ORIGIN)`. This is the same failure as the 2026-08-26 remote-ComfyUI report after #2230/#2376.

The relay would only HTTP-fetch a corroborated **loopback** origin. A live sidebar on a remote host, LAN IP, or mixed `localhost`/`127.0.0.1` pair is reachable over the bridge but unauthorized as a fetch destination, so the child fail-closes instead of listing templates.

## Fix

- Prefer the authenticated panel `fetch_comfyui_read` path with operation `workflow_templates` so the **browser** fetches same-origin `/api/workflow_templates`. The orchestrator never HTTP-fetches a remote origin (SSRF-closed).
- Keep the existing loopback HTTP fetch as a fallback when the connected panel does not implement that operation.
- Generation fence is unchanged: a retarget while the native read is in flight is still `STALE_TARGET`.
- HTTP authorization stays loopback-only and exact-origin. Forged / mismatched origins are still refused on the fallback path.

## Tests

Unfixed behavior: a bound remote or mixed-alias panel with no native send yields `NO_PANEL_ORIGIN` (existing tests still pin that for the HTTP path). Shipped behavior: native send returns the live index with zero remote HTTP and zero `COMFYUI_URL` fallback.

```
npx vitest run src/__tests__/tools/skills-access.test.ts src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts src/__tests__/services/panel-template-relay.test.ts src/__tests__/orchestrator/panel-template-relay-production.test.ts src/__tests__/orchestrator/panel-image-relay-wiring.test.ts src/__tests__/services/panel-template-relay-dns-pin.test.ts src/__tests__/tools/html-instead-of-json.test.ts src/__tests__/tools/template-index-timeout.test.ts
```

8 files, 79 passed.

`npm run lint` (tsc --noEmit + anti-slop) passed. `git diff --check` passed.

Do not merge automatically; this PR is intentionally left for review.