### PR TITLE
fix(ui-bridge): harden #619 command probe against inherited keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project are documented here. This project adheres to
 - direct-clone local git installs when Manager queue is unavailable (#2509)
 - make the Kimi Code backend usable (#2552)
 - reconcile release citations (#2519, #2520)
+- rewrite a panel's bare `unknown <cmd>` (and a missing `panel_version`) into the same actionable version-skew error as `Unknown command "…"` (#619)
 
 
 ## [0.52.147] - 2026-08-28
@@ -41,7 +42,6 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - omit the unexpose reindex warning when the panel already reindexed (#2474)
 - keep the causal line above a native fault and stop blaming a pass-through node (#2508) (#2519) (#2520) (#2478) (#2509) (#2552)
-- rewrite a panel's bare `unknown <cmd>` (and a missing `panel_version`) into the same actionable version-skew error as `Unknown command "…"` (#619)
 
 
 ## [0.52.146] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ All notable changes to this project are documented here. This project adheres to
 - direct-clone local git installs when Manager queue is unavailable (#2509)
 - make the Kimi Code backend usable (#2552)
 - reconcile release citations (#2519, #2520)
-- rewrite a panel's bare `unknown <cmd>` (and a missing `panel_version`) into the same actionable version-skew error as `Unknown command "…"` (#619)
 
 
 ## [0.52.147] - 2026-08-28
@@ -42,6 +41,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - omit the unexpose reindex warning when the panel already reindexed (#2474)
 - keep the causal line above a native fault and stop blaming a pass-through node (#2508) (#2519) (#2520) (#2478) (#2509) (#2552)
+- rewrite a panel's bare `unknown <cmd>` (and a missing `panel_version`) into the same actionable version-skew error as `Unknown command "…"` (#619)
 
 
 ## [0.52.146] - 2026-08-27

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -17,6 +17,7 @@ import {
   HEADLESS_RECENCY_MS,
   BRIDGE_READ_DEFAULT_TIMEOUT_MS,
   BRIDGE_READONLY_CMDS,
+  BRIDGE_CMD_MIN_PANEL_VERSION,
   isMutatingGraphCommand,
   requiresWorkflowStampEnforcement,
   BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
@@ -163,7 +164,11 @@ async function startBridgeOnFreePort(
 function connectPanel(
   tabId?: string,
   title = "workflow-a",
-  opts: { tabSessionId?: string; expectedNodeIdentityFence?: boolean } = {},
+  opts: {
+    tabSessionId?: string;
+    expectedNodeIdentityFence?: boolean;
+    panelVersion?: string;
+  } = {},
 ): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const sock = new WebSocket(`ws://127.0.0.1:${port}`);
@@ -184,6 +189,7 @@ function connectPanel(
             enforces_expected_scope_at_write: true,
             enforces_expected_scope_graph_identity_at_write: true,
             enforces_promoted_parent_rail_at_write: true,
+            ...(opts.panelVersion ? { panel_version: opts.panelVersion } : {}),
             // The panel's sessionStorage-backed browser-tab identity: unique per
             // browser tab, stable across a reload (#486/#709).
             ...(opts.tabSessionId ? { tab_session_id: opts.tabSessionId } : {}),
@@ -4894,6 +4900,36 @@ describe("makeUnknownCommandError (old-panel version gate)", () => {
     expect(isUnknownCommandReply("node 5 not found")).toBe(false);
   });
 
+  it("does not classify inherited object keys as bridge commands (#619 follow-up)", () => {
+    expect(Object.getPrototypeOf(BRIDGE_CMD_MIN_PANEL_VERSION)).toBeNull();
+    for (const cmd of ["toString", "constructor"]) {
+      // These names are inherited from Object.prototype, not entries in the
+      // bridge minimum table. They must remain ordinary unknown dispatcher text.
+      expect(minPanelVersionForCmd(cmd)).toBe(MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS);
+      expect(panelVersionProvesUnsupported(cmd, "0.0.1")).toBe(false);
+      for (const raw of [`unknown ${cmd}`, `Error: unknown ${cmd}`]) {
+        expect(isUnknownCommandReply(raw), raw).toBe(false);
+        expect(makeUnknownCommandError(raw), raw).toBeNull();
+        // Supplying a parseable panel version must not send an inherited
+        // function to compareSemver or fabricate a supported-command verdict.
+        expect(makeUnknownCommandError(raw, "0.11.21"), raw).toBeNull();
+      }
+    }
+  });
+
+  it("keeps the bare unknown-command rewrite version-aware for normal commands (#619)", () => {
+    const withoutVersion = makeUnknownCommandError("unknown graph_query");
+    expect(withoutVersion?.message).toMatch(/does not implement "graph_query"/i);
+    expect(withoutVersion?.message).toContain("detected panel unknown");
+    expect(withoutVersion?.message).toContain("0.7.0");
+
+    const oldPanel = makeUnknownCommandError("unknown graph_query", "0.6.8");
+    expect(oldPanel?.message).toMatch(/too old for "graph_query"/i);
+    expect(oldPanel?.message).toContain("detected panel 0.6.8");
+    expect(oldPanel?.message).toContain("0.7.0");
+    expect(makeUnknownCommandError("unknown graph_query", "0.7.0")).toBeNull();
+  });
+
 });
 
 describe("panelVersionProvesUnsupported (#392 proactive version gate)", () => {
@@ -5019,6 +5055,29 @@ describe("isPanelCmdUnsupportedError (#413 structured unsupported-command detect
 });
 
 describe("UiBridge.send (graceful gate end-to-end)", () => {
+  it("passes inherited object keys through as raw unknown-command errors (#619 follow-up)", async () => {
+    const sock = await connectPanel("prototype-command-tab", "wf", { panelVersion: "0.11.21" });
+    const dispatched: string[] = [];
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        dispatched.push(msg.cmd);
+        sock.send(JSON.stringify({ rid: msg.rid, ok: false, error: `unknown ${msg.cmd}` }));
+      }
+    });
+    await waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "prototype-command-tab")).toBe(true),
+    );
+
+    for (const cmd of ["toString", "constructor"]) {
+      await expect(bridge.send({ cmd }, { tabId: "prototype-command-tab" })).rejects.toThrow(
+        `unknown ${cmd}`,
+      );
+    }
+    expect(dispatched).toEqual(["toString", "constructor"]);
+    sock.close();
+  });
+
   it("surfaces an actionable message (with panel version) when an old panel rejects a bridge command", async () => {
     const sock = await connectPanel(undefined);
     // Old panel: advertises its version, then rejects unknown bridge commands.

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -323,44 +323,46 @@ export const MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS = "0.11.4";
  *  graph_outline has existed since panel 0.4.6, so a "too old — update to ≥0.11.4"
  *  verdict for it is a false, inflated requirement (#352). Anything not listed
  *  falls back to MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS (the full-set baseline). */
-export const BRIDGE_CMD_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
-  graph_outline: "0.4.6",
-  graph_find_nodes: "0.4.6",
-  graph_query: "0.7.0",
-  graph_serialize: "0.8.2",
-  // #1006 — the panel serving its OWN /object_info first shipped in panel 0.13.0. An
-  // AUTHORITATIVE entry, because without one the command falls back to the bridge
-  // baseline and an older panel answers the raw dispatch error `Unknown command
-  // "graph_get_object_info"`, which reads like a broken ComfyUI rather than an old panel.
-  //
-  // Established from the release commit, not from tags: this repo does not tag its
-  // releases (`git tag --contains` finds nothing), so ancestry would have pointed at the
-  // first tag that happens to exist and named a version four releases too late.
-  graph_get_object_info: "0.13.0",
-  // #608 forced-refresh executor shipped in panel 0.11.28. Older panels (e.g. the
-  // 0.11.20 in #619) register no `refresh_nodes` handler and reply with the raw
-  // dispatch error `Unknown command "refresh_nodes"`. Without this AUTHORITATIVE
-  // entry the command falls back to the 0.11.4 baseline, which a 0.11.20 panel
-  // already exceeds — so makeUnknownCommandError's false-negative guard mistook it
-  // for "new enough" and leaked the opaque raw error instead of an actionable
-  // "update your panel to ≥0.11.28" verdict. Listing it here also lets the #392
-  // PROACTIVE gate reject the very first call on a <0.11.28 panel before dispatch.
-  refresh_nodes: "0.11.28",
-  // #619 recurrence — panel_resize_node's bridge executor shipped in panel 0.11.25
-  // (panel CHANGELOG: "panel_resize_node resizes a node on the live canvas", #530).
-  // The reporter's 0.11.21 panel predates it, but untabled the command inherited the
-  // 0.11.4 baseline, producing the self-contradictory verdict `too old for
-  // "graph_resize_node" (detected 0.11.21) — update … to ≥0.11.4`. Tabled, it quotes
-  // the true minimum and the #392 proactive gate rejects the first call pre-dispatch.
-  graph_resize_node: "0.11.25",
-  // #1400 — the panel serving its frontend's VIRTUAL-type registry ships in the
-  // panel release carrying the `graph_get_virtual_types` executor. The entry is
-  // deliberately on the LOW side of whatever that release turns out to be: the
-  // only caller (the orchestrator's hello-time pull) degrades silently on an
-  // unknown-command reply, so a too-low floor can never produce a wrong verdict —
-  // it just lets an old panel answer "Unknown command", which the pull swallows.
-  graph_get_virtual_types: "0.15.11",
-};
+export const BRIDGE_CMD_MIN_PANEL_VERSION: Readonly<Record<string, string>> = Object.freeze(
+  Object.assign(Object.create(null) as Record<string, string>, {
+    graph_outline: "0.4.6",
+    graph_find_nodes: "0.4.6",
+    graph_query: "0.7.0",
+    graph_serialize: "0.8.2",
+    // #1006 — the panel serving its OWN /object_info first shipped in panel 0.13.0. An
+    // AUTHORITATIVE entry, because without one the command falls back to the bridge
+    // baseline and an older panel answers the raw dispatch error `Unknown command
+    // "graph_get_object_info"`, which reads like a broken ComfyUI rather than an old panel.
+    //
+    // Established from the release commit, not from tags: this repo does not tag its
+    // releases (`git tag --contains` finds nothing), so ancestry would have pointed at the
+    // first tag that happens to exist and named a version four releases too late.
+    graph_get_object_info: "0.13.0",
+    // #608 forced-refresh executor shipped in panel 0.11.28. Older panels (e.g. the
+    // 0.11.20 in #619) register no `refresh_nodes` handler and reply with the raw
+    // dispatch error `Unknown command "refresh_nodes"`. Without this AUTHORITATIVE
+    // entry the command falls back to the 0.11.4 baseline, which a 0.11.20 panel
+    // already exceeds — so makeUnknownCommandError's false-negative guard mistook it
+    // for "new enough" and leaked the opaque raw error instead of an actionable
+    // "update your panel to ≥0.11.28" verdict. Listing it here also lets the #392
+    // PROACTIVE gate reject the very first call on a <0.11.28 panel before dispatch.
+    refresh_nodes: "0.11.28",
+    // #619 recurrence — panel_resize_node's bridge executor shipped in panel 0.11.25
+    // (panel CHANGELOG: "panel_resize_node resizes a node on the live canvas", #530).
+    // The reporter's 0.11.21 panel predates it, but untabled the command inherited the
+    // 0.11.4 baseline, producing the self-contradictory verdict `too old for
+    // "graph_resize_node" (detected 0.11.21) — update … to ≥0.11.4`. Tabled, it quotes
+    // the true minimum and the #392 proactive gate rejects the first call pre-dispatch.
+    graph_resize_node: "0.11.25",
+    // #1400 — the panel serving its frontend's VIRTUAL-type registry ships in the
+    // panel release carrying the `graph_get_virtual_types` executor. The entry is
+    // deliberately on the LOW side of whatever that release turns out to be: the
+    // only caller (the orchestrator's hello-time pull) degrades silently on an
+    // unknown-command reply, so a too-low floor can never produce a wrong verdict —
+    // it just lets an old panel answer "Unknown command", which the pull swallows.
+    graph_get_virtual_types: "0.15.11",
+  }),
+);
 
 /**
  * The panel version each non-command bridge capability was ACTUALLY introduced


### PR DESCRIPTION
Follow-up for issue #619 and merged PR #2555.

## Changes
- Make the bridge minimum-version command table a frozen null-prototype table so probe membership and version lookups cannot treat Object.prototype keys such as toString or constructor as commands.
- Preserve supported command minimums and existing panel-version gating behavior.
- Add helper and live WebSocket regressions for toString/constructor, normal bare unknown commands with and without panel_version, and raw passthrough without fabricated version-skew output.
- Move the #619 citation exactly once from released 0.52.147 into current 0.52.148, preserving the other release citations.

## Validation
- npm.cmd exec -- vitest run src/__tests__/services/ui-bridge.test.ts — 254 passed
- npm.cmd run lint — passed (tsc plus anti-slop)

The changelog guard was also run. It remains red on the current main history because 0.52.148 contains a duplicate existing #2515 citation and the #619 follow-up merge is after the v0.52.148 tag; those release-history conditions are preserved as requested.

Do not merge this PR from the follow-up branch.