### PR TITLE
chore: release v0.52.149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,8 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
-- graph tools inherit a live bound/current tab after a multi-workflow reconnect instead of requiring a manual rebind (#1001)
-
-### MCP
-
-#### Fixed
-- inherit a live bound/current tab after multi-workflow reconnect (#2557)
-- rewrite bare unknown <cmd> when panel_version is missing (#619) (#2555)
+- graph tools inherit a live bound/current tab after a multi-workflow reconnect instead of requiring a manual rebind (#1001, #2557)
+- rewrite a panel's bare `unknown <cmd>` (and a missing `panel_version`) into the same actionable version-skew error as `Unknown command "…"` (#619, #2555)
 
 #### Changed
 - raise the filing bar, drop the beta reporting bias (#2554)
@@ -36,7 +31,6 @@ All notable changes to this project are documented here. This project adheres to
 - keep the causal line above a native fault and stop blaming a pass-through node (#2508)
 - direct-clone local git installs when Manager queue is unavailable (#2509)
 - make the Kimi Code backend usable (#2552)
-- only list history assets fetchable through /view (#2515)
 - reconcile release citations (#2519, #2520)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.149] - 2026-08-30
+
 ### MCP
 
 #### Fixed
 - graph tools inherit a live bound/current tab after a multi-workflow reconnect instead of requiring a manual rebind (#1001)
+
+### MCP
+
+#### Fixed
+- inherit a live bound/current tab after multi-workflow reconnect (#2557)
+- rewrite bare unknown <cmd> when panel_version is missing (#619) (#2555)
+
+#### Changed
+- raise the filing bar, drop the beta reporting bias (#2554)
 
 
 ## [0.52.148] - 2026-08-29

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.148",
+  "version": "0.52.149",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.148",
+      "version": "0.52.149",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.148",
+  "version": "0.52.149",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release MCP v0.52.149.

Includes swarm-16: version-skew rewrite for bare unknown <cmd> / missing panel_version (#619) and inherit a live bound/current tab after multi-workflow reconnect (#1001). Also cites #2515 in 0.52.148.