### PR TITLE
fix(2283): relay object_info through connected panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project are documented here. This project adheres to
 - retry graph reads after enter or panel_run (#2395, #2567)
 - harden #619 command probe lookup (#2564)
 - do not refuse promoted writes when the connection fingerprint is missing (#2475)
+- use the authenticated connected panel for headless `/object_info` reads when the configured ComfyUI route is unreachable (#2283)
 
 ## [0.52.149] - 2026-08-30
 
@@ -1957,11 +1958,6 @@ _No user-facing changes._
   ComfyUI you did not mean to touch, not merely find nothing there (#1233, panel#851)
 
 ## Unreleased
-
-### MCP
-
-#### Fixed
-- use the authenticated connected panel for headless `/object_info` reads when the configured ComfyUI route is unreachable (#2283)
 
 ## [0.52.43] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - persist subgraph viewing scope across panel tool calls so interior mutations do not silently fall back to root (#2553)
-
+- use the authenticated connected panel for headless `/object_info` reads when the configured ComfyUI route is unreachable (#2283)
 
 ## [0.52.151] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ All notable changes to this project are documented here. This project adheres to
 - retry graph reads after enter or panel_run (#2395, #2567)
 - harden #619 command probe lookup (#2564)
 - do not refuse promoted writes when the connection fingerprint is missing (#2475)
-- use the authenticated connected panel for headless `/object_info` reads when the configured ComfyUI route is unreachable (#2283)
 
 ## [0.52.149] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1958,6 +1958,11 @@ _No user-facing changes._
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- use the authenticated connected panel for headless `/object_info` reads when the configured ComfyUI route is unreachable (#2283)
+
 ## [0.52.43] - 2026-08-20
 
 ### MCP

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -31,6 +31,10 @@ vi.mock("@stable-canvas/comfyui-client", () => ({
       return await fetchApi(url, init);
     }
 
+    async getNodeDefs(): Promise<Record<string, unknown>> {
+      return await fetchApi("/object_info");
+    }
+
     fetchApi = fetchApi;
     close() {}
   },
@@ -47,7 +51,9 @@ import {
   fetchImage,
   getHistory,
   getLogs,
+  getObjectInfo,
   getSystemStats,
+  resetObjectInfoCache,
   resetClient,
 } from "../../comfyui/client.js";
 import { PanelComfyUIReadRelayError } from "../../services/panel-image-relay.js";
@@ -63,6 +69,7 @@ beforeEach(() => {
   fetchApi.mockReset();
   panelRead.mockReset();
   resetClient();
+  resetObjectInfoCache();
   vi.stubGlobal("fetch", vi.fn(async () => { throw transportFailure(); }));
 });
 
@@ -101,6 +108,20 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
       "system_stats",
       "logs",
     ]);
+  });
+
+  it("maps a transport-failed /object_info retry to the authenticated panel and parses the registry", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    const body = JSON.stringify({ KSampler: { input: { required: {} } } });
+    panelRead.mockResolvedValue({
+      operation: "object_info",
+      body,
+      contentType: "application/json",
+      bytes: Buffer.byteLength(body, "utf8"),
+    });
+
+    await expect(getObjectInfo()).resolves.toEqual(JSON.parse(body));
+    expect(panelRead).toHaveBeenCalledWith("object_info");
   });
 
   it("does not use the panel for a configured-route HTTP error, timeout, or prompt-scoped history", async () => {

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -3,6 +3,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const panelRead = vi.hoisted(() => vi.fn());
 const fetchApi = vi.hoisted(() => vi.fn());
 
+const VALID_OBJECT_INFO = {
+  KSampler: {
+    input: { required: {} },
+    output: ["MODEL"],
+    output_is_list: [false],
+    output_name: ["model"],
+    name: "KSampler",
+    display_name: "KSampler",
+    description: "",
+    category: "sampling",
+    output_node: false,
+  },
+};
+
 vi.mock("../../config.js", async () => {
   const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
   return {
@@ -112,7 +126,7 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
 
   it("maps a transport-failed /object_info retry to the authenticated panel and parses the registry", async () => {
     fetchApi.mockRejectedValue(transportFailure());
-    const body = JSON.stringify({ KSampler: { input: { required: {} } } });
+    const body = JSON.stringify(VALID_OBJECT_INFO);
     panelRead.mockResolvedValue({
       operation: "object_info",
       body,
@@ -122,6 +136,35 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
 
     await expect(getObjectInfo()).resolves.toEqual(JSON.parse(body));
     expect(panelRead).toHaveBeenCalledWith("object_info");
+  });
+
+  it.each([
+    ["an error envelope", { error: "upstream unavailable" }],
+    ["a status envelope", { status: "ok" }],
+    ["a message envelope", { message: "not a node registry" }],
+  ])("does not cache %s as object_info", async (_label, invalidBody) => {
+    fetchApi.mockRejectedValue(transportFailure());
+    const invalid = JSON.stringify(invalidBody);
+    const valid = JSON.stringify(VALID_OBJECT_INFO);
+    panelRead
+      .mockResolvedValueOnce({
+        operation: "object_info",
+        body: invalid,
+        contentType: "application/json",
+        bytes: Buffer.byteLength(invalid, "utf8"),
+      })
+      .mockResolvedValueOnce({
+        operation: "object_info",
+        body: valid,
+        contentType: "application/json",
+        bytes: Buffer.byteLength(valid, "utf8"),
+      });
+
+    await expect(getObjectInfo()).rejects.toThrow(
+      /not a ComfyUI \/object_info node registry object/,
+    );
+    await expect(getObjectInfo()).resolves.toEqual(JSON.parse(valid));
+    expect(panelRead).toHaveBeenCalledTimes(2);
   });
 
   it("does not use the panel for a configured-route HTTP error, timeout, or prompt-scoped history", async () => {

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -70,7 +70,11 @@ import {
   resetObjectInfoCache,
   resetClient,
 } from "../../comfyui/client.js";
-import { PanelComfyUIReadRelayError } from "../../services/panel-image-relay.js";
+import {
+  PanelComfyUIReadRelayError,
+  PANEL_COMFYUI_READ_MAX_BYTES,
+  PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES,
+} from "../../services/panel-image-relay.js";
 
 function transportFailure(): TypeError {
   return new TypeError(
@@ -135,6 +139,27 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
     });
 
     await expect(getObjectInfo()).resolves.toEqual(JSON.parse(body));
+    expect(panelRead).toHaveBeenCalledWith("object_info");
+  });
+
+  it("parses a production-sized relayed /object_info body above the generic read cap", async () => {
+    const body = JSON.stringify({
+      KSampler: {
+        ...VALID_OBJECT_INFO.KSampler,
+        description: "x".repeat(PANEL_COMFYUI_READ_MAX_BYTES + 1),
+      },
+    });
+    expect(Buffer.byteLength(body, "utf8")).toBeGreaterThan(PANEL_COMFYUI_READ_MAX_BYTES);
+    expect(Buffer.byteLength(body, "utf8")).toBeLessThanOrEqual(PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES);
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockResolvedValue({
+      operation: "object_info",
+      body,
+      contentType: "application/json",
+      bytes: Buffer.byteLength(body, "utf8"),
+    });
+
+    await expect(getObjectInfo()).resolves.toMatchObject({ KSampler: { name: "KSampler" } });
     expect(panelRead).toHaveBeenCalledWith("object_info");
   });
 

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -164,6 +164,7 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
   });
 
   it.each([
+    ["an empty registry", {}],
     ["an error envelope", { error: "upstream unavailable" }],
     ["a status envelope", { status: "ok" }],
     ["a message envelope", { message: "not a node registry" }],

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -781,6 +781,7 @@ describe("authenticated loopback panel image relay", () => {
         output_node: false,
       },
     });
+    let bridgeTimeoutMs = 0;
     const server = await startPanelImageRelayServer({
       resolvePanelAgent: (value) =>
         "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
@@ -789,7 +790,8 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelTab: () => "panel-tab",
       bridge: {
         canReach: () => true,
-        send: async (command) => {
+        send: async (command, options) => {
+          bridgeTimeoutMs = options.timeoutMs;
           if (command.operation === "object_info") {
             await new Promise((resolve) => setTimeout(resolve, 8_050));
             return { operation: "object_info", body, contentType: "application/json", bytes: Buffer.byteLength(body, "utf8") };
@@ -805,6 +807,8 @@ describe("authenticated loopback panel image relay", () => {
         operation: "object_info",
         bytes: body.length,
       });
+      expect(bridgeTimeoutMs).toBeGreaterThan(PANEL_IMAGE_RELAY_TIMEOUT_MS);
+      expect(bridgeTimeoutMs).toBeLessThanOrEqual(PANEL_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS);
     } finally {
       await server.close();
     }

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   PANEL_COMFYUI_READ_MAX_BYTES,
+  PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES,
+  PANEL_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS,
   PANEL_IMAGE_RELAY_MAX_BYTES,
   PANEL_IMAGE_RELAY_MAX_CONCURRENT,
   PANEL_IMAGE_RELAY_MAX_PENDING_REQUESTS,
@@ -763,6 +765,69 @@ describe("authenticated loopback panel image relay", () => {
     }
   });
 
+  it("allows a documented large and slow object_info registry without widening other reads", async () => {
+    expect(PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES).toBeGreaterThan(25_104_088);
+    expect(PANEL_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS).toBeGreaterThan(20_840);
+    const body = JSON.stringify({
+      KSampler: {
+        input: { required: {} },
+        output: ["MODEL"],
+        output_is_list: [false],
+        output_name: ["model"],
+        name: "KSampler",
+        display_name: "KSampler",
+        description: "x".repeat(25_104_088),
+        category: "sampling",
+        output_node: false,
+      },
+    });
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) =>
+        "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
+          ? { agentKey: "orchestrator::claude", secret: SECRET }
+          : undefined,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async (command) => command.operation === "object_info"
+          ? { operation: "object_info", body, contentType: "application/json", bytes: Buffer.byteLength(body, "utf8") }
+          : { operation: "history", body: "{}", contentType: "application/json", bytes: 2 },
+      },
+    });
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+      await expect(requestPanelComfyUIRead("object_info")).resolves.toMatchObject({
+        operation: "object_info",
+        bytes: body.length,
+      });
+    } finally {
+      await server.close();
+    }
+  }, 45_000);
+
+  it("fails closed for an object_info body over its route-specific cap", async () => {
+    const body = "x".repeat(PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES + 1);
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) =>
+        "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
+          ? { agentKey: "orchestrator::claude", secret: SECRET }
+          : undefined,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async () => ({ operation: "object_info", body, contentType: "application/json", bytes: body.length }),
+      },
+    });
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+      await expect(requestPanelComfyUIRead("object_info")).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
+    } finally {
+      await server.close();
+    }
+  }, 45_000);
+
   it("applies the read relay deadline to the authenticated bridge command", async () => {
     let timeoutMs = 0;
     const server = await startPanelImageRelayServer({
@@ -795,6 +860,37 @@ describe("authenticated loopback panel image relay", () => {
       expect(await response.json()).toMatchObject({ ok: false, error: "TIMEOUT", requestId: short.requestId });
       expect(timeoutMs).toBeGreaterThan(0);
       expect(timeoutMs).toBeLessThanOrEqual(30);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("fails closed when a slow object_info read reaches its caller deadline", async () => {
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) =>
+        "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
+          ? { agentKey: "orchestrator::claude", secret: SECRET }
+          : undefined,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          return { operation: "object_info", body: "{}", contentType: "application/json", bytes: 2 };
+        },
+      },
+    });
+    try {
+      const short = readRequest("short-object-info-deadline", "object_info");
+      short.deadlineAt = short.createdAt + 30;
+      short.capability = makePanelComfyUIReadRelayCapability(SECRET, short);
+      const response = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(short),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ ok: false, error: "TIMEOUT", requestId: short.requestId });
     } finally {
       await server.close();
     }

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -38,8 +38,9 @@ const PRODUCTION_OBJECT_INFO_DELAY_MS = 20_841;
 
 /** Model the Panel bridge's command dispatcher at the wire boundary: the MCP
  * relay must send the authenticated command, tab binding, and route-specific
- * deadline through this call before a Panel reply can exist. The Panel repo
- * separately drives the real helper/dispatcher implementation. */
+ * deadline through this call before a Panel reply can exist. The delayed
+ * producer honors that deadline, so a regression to the generic 8s budget
+ * fails this documented 20.841s success case instead of merely recording it. */
 function productionShapedPanelDispatcher(
   body: string,
   recordTimeout: (timeoutMs: number) => void,
@@ -48,12 +49,34 @@ function productionShapedPanelDispatcher(
     expect(command).toEqual({ cmd: "fetch_comfyui_read", operation: "object_info" });
     expect(options.tabId).toBe("panel-tab");
     recordTimeout(options.timeoutMs);
-    await new Promise((resolve) => setTimeout(resolve, PRODUCTION_OBJECT_INFO_DELAY_MS));
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let deadlineTimer: ReturnType<typeof setTimeout>;
+      let producerTimer: ReturnType<typeof setTimeout>;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(deadlineTimer);
+        clearTimeout(producerTimer);
+        if (error) reject(error);
+        else resolve();
+      };
+      deadlineTimer = setTimeout(
+        () => finish(Object.assign(new Error("Panel bridge command timed out"), { code: "TIMEOUT" })),
+        options.timeoutMs,
+      );
+      producerTimer = setTimeout(() => finish(), PRODUCTION_OBJECT_INFO_DELAY_MS);
+    });
     return {
       operation: "object_info",
       body,
       contentType: "application/json",
       bytes: Buffer.byteLength(body, "utf8"),
+      viewing: {
+        scope: "root",
+        workflow_uuid: "workflow-live-2283",
+        graph_identity: "graph:live-2283",
+      },
     };
   };
 }

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -667,7 +667,7 @@ describe("authenticated loopback panel image relay", () => {
     }
   });
 
-  it.each(["history", "system_stats", "logs"] as const)(
+  it.each(["history", "system_stats", "logs", "object_info"] as const)(
     "relays the fixed %s ComfyUI read and authenticates/parses its reply",
     async (operation) => {
       const seen: Array<{ cmd: string; operation?: string }> = [];

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -34,6 +34,29 @@ import {
 
 const dirs: string[] = [];
 const SECRET = "a".repeat(64);
+const PRODUCTION_OBJECT_INFO_DELAY_MS = 20_841;
+
+/** Model the Panel bridge's command dispatcher at the wire boundary: the MCP
+ * relay must send the authenticated command, tab binding, and route-specific
+ * deadline through this call before a Panel reply can exist. The Panel repo
+ * separately drives the real helper/dispatcher implementation. */
+function productionShapedPanelDispatcher(
+  body: string,
+  recordTimeout: (timeoutMs: number) => void,
+): (command: { cmd: string; operation: string }, options: { tabId: string; timeoutMs: number }) => Promise<Record<string, unknown>> {
+  return async (command, options) => {
+    expect(command).toEqual({ cmd: "fetch_comfyui_read", operation: "object_info" });
+    expect(options.tabId).toBe("panel-tab");
+    recordTimeout(options.timeoutMs);
+    await new Promise((resolve) => setTimeout(resolve, PRODUCTION_OBJECT_INFO_DELAY_MS));
+    return {
+      operation: "object_info",
+      body,
+      contentType: "application/json",
+      bytes: Buffer.byteLength(body, "utf8"),
+    };
+  };
+}
 
 function tempChannel(): string {
   const dir = mkdtempSync(join(tmpdir(), "comfyui-mcp-image-relay-"));
@@ -790,14 +813,7 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelTab: () => "panel-tab",
       bridge: {
         canReach: () => true,
-        send: async (command, options) => {
-          bridgeTimeoutMs = options.timeoutMs;
-          if (command.operation === "object_info") {
-            await new Promise((resolve) => setTimeout(resolve, 8_050));
-            return { operation: "object_info", body, contentType: "application/json", bytes: Buffer.byteLength(body, "utf8") };
-          }
-          return { operation: "history", body: "{}", contentType: "application/json", bytes: 2 };
-        },
+        send: productionShapedPanelDispatcher(body, (timeoutMs) => { bridgeTimeoutMs = timeoutMs; }),
       },
     });
     try {

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -671,7 +671,23 @@ describe("authenticated loopback panel image relay", () => {
     "relays the fixed %s ComfyUI read and authenticates/parses its reply",
     async (operation) => {
       const seen: Array<{ cmd: string; operation?: string }> = [];
-      const body = operation === "logs" ? "ERROR: render failed\n" : JSON.stringify({ operation });
+      const body = operation === "logs"
+        ? "ERROR: render failed\n"
+        : operation === "object_info"
+          ? JSON.stringify({
+              KSampler: {
+                input: { required: {} },
+                output: ["MODEL"],
+                output_is_list: [false],
+                output_name: ["model"],
+                name: "KSampler",
+                display_name: "KSampler",
+                description: "",
+                category: "sampling",
+                output_node: false,
+              },
+            })
+          : JSON.stringify({ operation });
       const server = await startPanelImageRelayServer({
         resolvePanelAgent: (value) =>
           "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
@@ -687,6 +703,17 @@ describe("authenticated loopback panel image relay", () => {
               body,
               contentType: operation === "logs" ? "text/plain" : "application/json",
               bytes: Buffer.byteLength(body, "utf8"),
+              ...(operation === "object_info"
+                ? {
+                    // This is the exact metadata shape added by the Panel's
+                    // withViewingWitness dispatcher wrapper.
+                    viewing: {
+                      scope: "root",
+                      workflow_uuid: "workflow-live-2283",
+                      graph_identity: "graph:live-2283",
+                    },
+                  }
+                : {}),
             };
           },
         },
@@ -707,6 +734,34 @@ describe("authenticated loopback panel image relay", () => {
       }
     },
   );
+
+  it("rejects an invalid viewing witness instead of widening the read contract", async () => {
+    const body = JSON.stringify({ KSampler: { input: { required: {} } } });
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) =>
+        "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
+          ? { agentKey: "orchestrator::claude", secret: SECRET }
+          : undefined,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async () => ({
+          operation: "object_info",
+          body,
+          contentType: "application/json",
+          bytes: Buffer.byteLength(body, "utf8"),
+          viewing: { scope: "root", graph_identity: 17 },
+        }),
+      },
+    });
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+      await expect(requestPanelComfyUIRead("object_info")).rejects.toMatchObject({ code: "MALFORMED_REPLY" });
+    } finally {
+      await server.close();
+    }
+  });
 
   it("applies the read relay deadline to the authenticated bridge command", async () => {
     let timeoutMs = 0;

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -789,9 +789,13 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelTab: () => "panel-tab",
       bridge: {
         canReach: () => true,
-        send: async (command) => command.operation === "object_info"
-          ? { operation: "object_info", body, contentType: "application/json", bytes: Buffer.byteLength(body, "utf8") }
-          : { operation: "history", body: "{}", contentType: "application/json", bytes: 2 },
+        send: async (command) => {
+          if (command.operation === "object_info") {
+            await new Promise((resolve) => setTimeout(resolve, 8_050));
+            return { operation: "object_info", body, contentType: "application/json", bytes: Buffer.byteLength(body, "utf8") };
+          }
+          return { operation: "history", body: "{}", contentType: "application/json", bytes: 2 };
+        },
       },
     });
     try {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -225,13 +225,14 @@ function looksLikeSystemStats(body: unknown): boolean {
   return (b.system != null && typeof b.system === "object") || Array.isArray(b.devices);
 }
 
-/** A relayed /object_info document must be an object registry, not an HTML or
- * gateway JSON envelope that happens to parse successfully. Empty registries
- * are valid for a backend with no installed node definitions; every non-empty
+/** A relayed /object_info document must be a non-empty object registry, not an
+ * HTML or gateway JSON envelope that happens to parse successfully. Every
  * entry must retain the required ComfyUI node-definition fields. */
 function looksLikeObjectInfo(body: unknown): boolean {
   if (!body || typeof body !== "object" || Array.isArray(body)) return false;
-  return Object.entries(body as Record<string, unknown>).every(([nodeType, definition]) => {
+  const entries = Object.entries(body as Record<string, unknown>);
+  if (entries.length === 0) return false;
+  return entries.every(([nodeType, definition]) => {
     if (!nodeType.trim() || !definition || typeof definition !== "object" || Array.isArray(definition)) return false;
     const def = definition as Record<string, unknown>;
     const input = def.input;

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -226,9 +226,29 @@ function looksLikeSystemStats(body: unknown): boolean {
 
 /** A relayed /object_info document must be an object registry, not an HTML or
  * gateway JSON envelope that happens to parse successfully. Empty registries
- * are valid for a backend with no installed node definitions. */
+ * are valid for a backend with no installed node definitions; every non-empty
+ * entry must retain the required ComfyUI node-definition fields. */
 function looksLikeObjectInfo(body: unknown): boolean {
-  return Boolean(body && typeof body === "object" && !Array.isArray(body));
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  return Object.entries(body as Record<string, unknown>).every(([nodeType, definition]) => {
+    if (!nodeType.trim() || !definition || typeof definition !== "object" || Array.isArray(definition)) return false;
+    const def = definition as Record<string, unknown>;
+    const input = def.input;
+    return Boolean(
+      Object.prototype.hasOwnProperty.call(def, "input") &&
+      input &&
+      typeof input === "object" &&
+      !Array.isArray(input) &&
+      Array.isArray(def.output) &&
+      Array.isArray(def.output_is_list) &&
+      Array.isArray(def.output_name) &&
+      typeof def.name === "string" &&
+      typeof def.display_name === "string" &&
+      typeof def.description === "string" &&
+      typeof def.category === "string" &&
+      typeof def.output_node === "boolean",
+    );
+  });
 }
 
 function panelReadResponse(read: PanelComfyUIReadSuccess): Response {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -30,6 +30,7 @@ import {
 import {
   PanelComfyUIReadRelayError,
   PanelImageRelayError,
+  PANEL_COMFYUI_READ_MAX_BYTES,
   requestPanelComfyUIRead,
   requestPanelImage,
   type PanelComfyUIReadSuccess,
@@ -223,6 +224,13 @@ function looksLikeSystemStats(body: unknown): boolean {
   return (b.system != null && typeof b.system === "object") || Array.isArray(b.devices);
 }
 
+/** A relayed /object_info document must be an object registry, not an HTML or
+ * gateway JSON envelope that happens to parse successfully. Empty registries
+ * are valid for a backend with no installed node definitions. */
+function looksLikeObjectInfo(body: unknown): boolean {
+  return Boolean(body && typeof body === "object" && !Array.isArray(body));
+}
+
 function panelReadResponse(read: PanelComfyUIReadSuccess): Response {
   const headers = new Headers();
   if (read.contentType) headers.set("content-type", read.contentType);
@@ -232,7 +240,7 @@ function panelReadResponse(read: PanelComfyUIReadSuccess): Response {
 /** Ask the authenticated panel only after the configured headless route failed
  * at the transport layer. No browser origin is selected or contacted here. */
 async function panelReadFallback(
-  operation: "history" | "system_stats" | "logs",
+  operation: "history" | "system_stats" | "logs" | "object_info",
   primaryError: unknown,
 ): Promise<PanelComfyUIReadSuccess | undefined> {
   try {
@@ -484,6 +492,18 @@ export async function getObjectInfo(): Promise<ObjectInfo> {
       try {
         return commit((await getClient().getNodeDefs()) as ObjectInfo);
       } catch (retryErr) {
+        if (isComfyTransportFailure(err) && isComfyTransportFailure(retryErr)) {
+          const relayed = await panelReadFallback("object_info", retryErr);
+          if (relayed) {
+            const info = await readComfyJson<ObjectInfo>(panelReadResponse(relayed), {
+              url: "/object_info",
+              maxBytes: PANEL_COMFYUI_READ_MAX_BYTES,
+              expectShape: looksLikeObjectInfo,
+              shapeHint: "a ComfyUI /object_info node registry object",
+            });
+            return commit(info);
+          }
+        }
         // The client library parses JSON itself, so an HTML body reaches us as a
         // bare "Unexpected token '<'" naming neither the URL nor the responder
         // (#828). Re-probe the endpoint ONCE to say what actually answered; if

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -31,6 +31,7 @@ import {
   PanelComfyUIReadRelayError,
   PanelImageRelayError,
   PANEL_COMFYUI_READ_MAX_BYTES,
+  PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES,
   requestPanelComfyUIRead,
   requestPanelImage,
   type PanelComfyUIReadSuccess,
@@ -517,7 +518,7 @@ export async function getObjectInfo(): Promise<ObjectInfo> {
           if (relayed) {
             const info = await readComfyJson<ObjectInfo>(panelReadResponse(relayed), {
               url: "/object_info",
-              maxBytes: PANEL_COMFYUI_READ_MAX_BYTES,
+              maxBytes: PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES,
               expectShape: looksLikeObjectInfo,
               shapeHint: "a ComfyUI /object_info node registry object",
             });

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -39,11 +39,11 @@ const RELAY_ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const RELAY_CAPABILITY_RE = /^[a-f0-9]{64}$/;
 const RELAY_SECRET_RE = /^[a-f0-9]{64}$/;
 const IMAGE_TYPES = new Set<PanelImageType>(["output", "input", "temp"]);
-const READ_OPERATIONS = new Set<PanelComfyUIReadOperation>(["history", "system_stats", "logs"]);
+const READ_OPERATIONS = new Set<PanelComfyUIReadOperation>(["history", "system_stats", "logs", "object_info"]);
 const MIME_RE = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}$/;
 
 export type PanelImageType = "output" | "input" | "temp";
-export type PanelComfyUIReadOperation = "history" | "system_stats" | "logs";
+export type PanelComfyUIReadOperation = "history" | "system_stats" | "logs" | "object_info";
 
 export interface PanelImageRelayRequest {
   version: typeof PANEL_IMAGE_RELAY_VERSION;

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -85,6 +85,18 @@ export interface PanelComfyUIReadSuccess {
   bytes: number;
 }
 
+/** The Panel dispatcher appends this witness to successful object results.
+ * It is context metadata, not relay authorization: the HMAC and resolved tab
+ * remain the authority. The relay validates this known shape, then drops it
+ * while normalizing the four-field ComfyUI read contract. */
+interface PanelComfyUIReadViewingWitness {
+  scope: "root" | "subgraph";
+  owner_node_id?: number | string | null;
+  title?: string;
+  workflow_uuid?: string;
+  graph_identity?: string;
+}
+
 interface PanelImageRelayResponseFailure {
   version: typeof PANEL_IMAGE_RELAY_VERSION;
   requestId: string;
@@ -397,13 +409,33 @@ function validateReadPayload(value: unknown): PanelComfyUIReadSuccess | undefine
   if (!value || typeof value !== "object") return undefined;
   const record = value as Record<string, unknown>;
   if (
-    !hasOnlyKeys(record, ["operation", "body", "contentType", "bytes"]) ||
+    !hasOnlyKeys(record, ["operation", "body", "contentType", "bytes", "viewing"]) ||
     typeof record.operation !== "string" ||
     !READ_OPERATIONS.has(record.operation as PanelComfyUIReadOperation) ||
     typeof record.body !== "string" ||
     (record.contentType !== null &&
       (typeof record.contentType !== "string" || !isSafeText(record.contentType, 128)))
   ) return undefined;
+  if (hasOwn(record, "viewing")) {
+    const viewing = record.viewing;
+    if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return undefined;
+    const witness = viewing as PanelComfyUIReadViewingWitness & Record<string, unknown>;
+    if (
+      !hasOnlyKeys(witness, ["scope", "owner_node_id", "title", "workflow_uuid", "graph_identity"]) ||
+      (witness.scope !== "root" && witness.scope !== "subgraph")
+    ) return undefined;
+    if (hasOwn(witness, "owner_node_id")) {
+      const owner = witness.owner_node_id;
+      if (
+        owner !== null &&
+        !(typeof owner === "number" && Number.isSafeInteger(owner)) &&
+        !(typeof owner === "string" && isSafeText(owner, 256))
+      ) return undefined;
+    }
+    if (hasOwn(witness, "title") && !isSafeText(witness.title, 256)) return undefined;
+    if (hasOwn(witness, "workflow_uuid") && !isSafeText(witness.workflow_uuid, 256)) return undefined;
+    if (hasOwn(witness, "graph_identity") && !isSafeText(witness.graph_identity, 256)) return undefined;
+  }
   const bytes = record.bytes;
   if (
     typeof bytes !== "number" ||

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -24,6 +24,8 @@ export const PANEL_IMAGE_RELAY_STALE_MS = 15_000;
 export const PANEL_IMAGE_RELAY_MAX_REQUEST_FILE_BYTES = 16 * 1024;
 export const PANEL_IMAGE_RELAY_MAX_RESPONSE_FILE_BYTES = 48 * 1024 * 1024;
 export const PANEL_COMFYUI_READ_MAX_BYTES = 16 * 1024 * 1024;
+export const PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES = 32 * 1024 * 1024;
+export const PANEL_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS = 30_000;
 export const PANEL_IMAGE_RELAY_MAX_CONCURRENT = 4;
 export const PANEL_IMAGE_RELAY_MAX_REQUESTS_PER_TICK = 4;
 export const PANEL_IMAGE_RELAY_MAX_DIRECTORY_ENTRIES_PER_TICK = 128;
@@ -441,7 +443,7 @@ function validateReadPayload(value: unknown): PanelComfyUIReadSuccess | undefine
     typeof bytes !== "number" ||
     !Number.isSafeInteger(bytes) ||
     bytes < 0 ||
-    bytes > PANEL_COMFYUI_READ_MAX_BYTES ||
+    bytes > readMaxBytes(record.operation as PanelComfyUIReadOperation) ||
     Buffer.byteLength(record.body, "utf8") !== bytes
   ) return undefined;
   return {
@@ -492,13 +494,25 @@ function validateReadRequest(value: unknown, requestId: string): PanelComfyUIRea
     !Number.isSafeInteger(createdAt) ||
     !Number.isSafeInteger(deadlineAt) ||
     deadlineAt < createdAt ||
-    deadlineAt - createdAt > PANEL_IMAGE_RELAY_TIMEOUT_MS
+    deadlineAt - createdAt > readTimeoutMs(record.operation as PanelComfyUIReadOperation)
   ) return undefined;
   return record as unknown as PanelComfyUIReadRelayRequest;
 }
 
 function isReadRelayRequest(request: PanelRelayRequest): request is PanelComfyUIReadRelayRequest {
   return "operation" in request;
+}
+
+function readTimeoutMs(operation: PanelComfyUIReadOperation): number {
+  return operation === "object_info" ? PANEL_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS : PANEL_IMAGE_RELAY_TIMEOUT_MS;
+}
+
+function readMaxBytes(operation: PanelComfyUIReadOperation): number {
+  return operation === "object_info" ? PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES : PANEL_COMFYUI_READ_MAX_BYTES;
+}
+
+function requestTimeoutMs(request: PanelRelayRequest): number {
+  return isReadRelayRequest(request) ? readTimeoutMs(request.operation) : PANEL_IMAGE_RELAY_TIMEOUT_MS;
 }
 
 function validateResponse(value: unknown, requestId: string): PanelImageRelayResponse {
@@ -743,7 +757,7 @@ async function readHttpResponseBounded(response: Response, maxBytes: number): Pr
 }
 
 function requestDeadline(request: PanelRelayRequest): number {
-  return Math.min(request.deadlineAt, request.createdAt + PANEL_IMAGE_RELAY_TIMEOUT_MS);
+  return Math.min(request.deadlineAt, request.createdAt + requestTimeoutMs(request));
 }
 
 function errorCodeFromHttpBody(value: unknown, status: number): string {
@@ -982,7 +996,7 @@ export async function startPanelImageRelayServer(
     })();
   });
   server.headersTimeout = 2_000;
-  server.requestTimeout = PANEL_IMAGE_RELAY_TIMEOUT_MS + 1_000;
+  server.requestTimeout = PANEL_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS + 1_000;
   await new Promise<void>((resolve, reject) => {
     const onError = (error: Error) => {
       server.removeListener("listening", onListening);
@@ -1097,13 +1111,14 @@ export async function requestPanelComfyUIRead(
   const secret = process.env.COMFYUI_MCP_RELAY_SECRET;
   if (!endpoint || !isSafeRelaySecret(secret)) return undefined;
   const createdAt = Date.now();
+  const timeoutMs = readTimeoutMs(operation);
   const request: PanelComfyUIReadRelayRequest = {
     version: PANEL_IMAGE_RELAY_VERSION,
     requestId: `${Date.now().toString(36)}-${process.pid.toString(36)}-${randomBytes(8).toString("hex")}`,
     capability: "",
     operation,
     createdAt,
-    deadlineAt: createdAt + PANEL_IMAGE_RELAY_TIMEOUT_MS,
+    deadlineAt: createdAt + timeoutMs,
   };
   request.capability = makePanelComfyUIReadRelayCapability(secret, request);
   const body = Buffer.from(JSON.stringify(request), "utf8");
@@ -1117,7 +1132,7 @@ export async function requestPanelComfyUIRead(
       headers: { "content-type": "application/json", "content-length": String(body.byteLength) },
       body,
       redirect: "error",
-      signal: AbortSignal.timeout(PANEL_IMAGE_RELAY_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (error) {
     if (error instanceof PanelComfyUIReadRelayError) throw error;

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -946,7 +946,7 @@ export async function startPanelImageRelayServer(
                     isReadRelayRequest(request)
                       ? { cmd: "fetch_comfyui_read", operation: request.operation }
                       : { cmd: "fetch_image", filename: request.filename, subfolder: request.subfolder, type: request.type },
-                    { tabId: panelTab, timeoutMs: Math.min(PANEL_IMAGE_RELAY_TIMEOUT_MS, remainingMs) },
+                    { tabId: panelTab, timeoutMs: Math.min(requestTimeoutMs(request), remainingMs) },
                   ),
                   requestDeadline(request),
                 );


### PR DESCRIPTION
Follow-up for #2283 recurrence. When the configured headless ComfyUI route cannot be reached, authenticated fixed-operation panel relay now covers /object_info as well as history/system_stats/logs. getObjectInfo parses and caches the relayed registry with the same bounded JSON guard. Adds relay/client regressions and current Unreleased citation. Paired with artokun/comfyui-mcp-panel#2283.