### PR TITLE
fix(codex): retry graph reads after enter or panel_run

### DIFF
--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -13,6 +13,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { waitFor } from "../helpers/wait-for.js";
 import type { AgentEvent } from "../../orchestrator/agent-backend.js";
+import { QUEUE_BUSY_READ_TOOLS } from "../../services/panel-graph-cmd-tools.js";
 
 vi.mock("../../utils/logger.js", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -22,10 +23,16 @@ type BackendModule = typeof import("../../orchestrator/codex-backend.js");
 type Backend = InstanceType<BackendModule["CodexBackend"]>;
 
 let CodexBackend: BackendModule["CodexBackend"];
+let PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS: BackendModule["PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS"];
+let PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS: BackendModule["PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS"];
 
 beforeAll(async () => {
   vi.resetModules();
-  ({ CodexBackend } = await import("../../orchestrator/codex-backend.js"));
+  ({
+    CodexBackend,
+    PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS,
+    PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS,
+  } = await import("../../orchestrator/codex-backend.js"));
 });
 
 afterAll(() => vi.unstubAllEnvs());
@@ -115,6 +122,9 @@ interface Drive {
       | "unrelated-transport"
       | "panel-read-retry-outline-success"
       | "panel-read-retry-query-success"
+      | "panel-read-retry-find-success"
+      | "panel-read-retry-after-run-find-success"
+      | "panel-read-retry-enter-mutate-run-find-success"
       | "panel-read-retry-failure"
       | "panel-read-retry-amplified"
       | "panel-read-retry-inactive"
@@ -126,7 +136,8 @@ interface Drive {
       | "panel-mutation-before-read-no-retry"
       | "panel-read-retry-mutation-error"
       | "panel-unrelated-read-no-retry"
-      | "panel-read-no-enter-no-retry",
+      | "panel-read-no-enter-no-retry"
+      | "panel-run-no-retry",
   ): Promise<void>;
   releaseInterrupt(): void;
   waitForIdle(): Promise<void>;
@@ -252,12 +263,17 @@ function startDrive(opts: {
         kind === "panel-mutation-before-read-no-retry" ||
         kind === "panel-read-retry-mutation-error" ||
         kind === "panel-unrelated-read-no-retry" ||
-        kind === "panel-read-no-enter-no-retry"
+        kind === "panel-read-no-enter-no-retry" ||
+        kind === "panel-run-no-retry"
       ) {
         const notify = (method: string, params: Record<string, unknown>) =>
           client.notificationHandler?.({ method, params: { threadId: "thread-1", turnId, ...params } });
         const enter = { type: "mcpToolCall", id: "enter-1", server: "panel", tool: "panel_enter_subgraph" };
-        if (kind !== "panel-read-no-enter-no-retry") {
+        if (
+          kind !== "panel-read-no-enter-no-retry" &&
+          kind !== "panel-read-retry-after-run-find-success" &&
+          kind !== "panel-run-no-retry"
+        ) {
           notify("item/started", { item: enter });
           notify("item/completed", { item: { ...enter, status: "completed" } });
         }
@@ -302,8 +318,44 @@ function startDrive(opts: {
             error: { message: WORKER_TRANSPORT_FAILURE },
             willRetry: true,
           });
+        } else if (kind === "panel-run-no-retry") {
+          const run = { type: "mcpToolCall", id: "run-1", server: "panel", tool: "panel_run" };
+          notify("item/started", { item: run });
+          notify("error", {
+            itemId: run.id,
+            error: { message: EVENT_NOTIFICATION_TRANSPORT_FAILURE },
+            willRetry: true,
+          });
+        } else if (
+          kind === "panel-read-retry-after-run-find-success" ||
+          kind === "panel-read-retry-enter-mutate-run-find-success"
+        ) {
+          const mutation = { type: "mcpToolCall", id: "mutation-1", server: "panel", tool: "panel_set_widget" };
+          const run = { type: "mcpToolCall", id: "run-1", server: "panel", tool: "panel_run" };
+          const read = { type: "mcpToolCall", id: "read-1", server: "panel", tool: "panel_find_nodes" };
+          notify("item/started", { item: mutation });
+          notify("item/completed", { item: { ...mutation, status: "completed" } });
+          notify("item/started", { item: run });
+          notify("item/completed", { item: { ...run, status: "completed" } });
+          notify("item/started", { item: read });
+          notify("error", {
+            itemId: read.id,
+            error: { message: EVENT_NOTIFICATION_TRANSPORT_FAILURE },
+            willRetry: true,
+          });
+          notify("item/completed", { item: { ...read, status: "completed" } });
+          notify("turn/completed", { turn: { id: turnId, status: "completed" } });
         } else {
-          const readTool = kind === "panel-read-retry-query-success" ? "panel_query_graph" : "panel_graph_outline";
+          const readTool =
+            kind === "panel-read-retry-query-success"
+              ? "panel_query_graph"
+              : kind === "panel-read-retry-find-success"
+                ? "panel_find_nodes"
+                : "panel_graph_outline";
+          const transportFailure =
+            kind === "panel-read-retry-find-success"
+              ? EVENT_NOTIFICATION_TRANSPORT_FAILURE
+              : WORKER_TRANSPORT_FAILURE;
           const read = { type: "mcpToolCall", id: "read-1", server: "panel", tool: readTool };
           notify("item/started", { item: read });
           if (kind === "panel-read-retry-interleaved") {
@@ -322,12 +374,13 @@ function startDrive(opts: {
             if (kind === "panel-read-retry-inactive") client.exitError = new Error("app-server connection closed");
             notify("error", {
               itemId: read.id,
-              error: { message: WORKER_TRANSPORT_FAILURE },
+              error: { message: transportFailure },
               willRetry: true,
             });
             if (
               kind === "panel-read-retry-outline-success" ||
-              kind === "panel-read-retry-query-success"
+              kind === "panel-read-retry-query-success" ||
+              kind === "panel-read-retry-find-success"
             ) {
               notify("item/completed", { item: { ...read, status: "completed" } });
               notify("turn/completed", { turn: { id: turnId, status: "completed" } });
@@ -423,6 +476,16 @@ function startDrive(opts: {
 }
 
 describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
+  it("pins the outer transport retry allowlist and arming tools (#2395)", () => {
+    expect([...PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS].sort()).toEqual(
+      [...QUEUE_BUSY_READ_TOOLS].sort(),
+    );
+    expect([...PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS]).toEqual([
+      "panel_enter_subgraph",
+      "panel_run",
+    ]);
+  });
+
   it("retries a live panel_graph_outline once after panel_enter_subgraph (#2395)", async () => {
     const drive = startDrive({ listings: [PANEL_UP] });
     await drive.endTurn("panel-read-retry-outline-success");
@@ -442,6 +505,54 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
   it("retries a live panel_query_graph once after panel_enter_subgraph (#2395)", async () => {
     const drive = startDrive({ listings: [PANEL_UP] });
     await drive.endTurn("panel-read-retry-query-success");
+
+    expect(drive.reloadCalls).toBe(0);
+    expect(drive.interruptCalls).toBe(0);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
+
+    await drive.finish();
+  });
+
+  it("retries a live panel_find_nodes once after panel_enter_subgraph (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-find-success");
+
+    expect(drive.reloadCalls).toBe(0);
+    expect(drive.interruptCalls).toBe(0);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
+
+    await drive.finish();
+  });
+
+  it("retries panel_find_nodes once after mutations and a completed panel_run (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-after-run-find-success");
+
+    expect(drive.reloadCalls).toBe(0);
+    expect(drive.interruptCalls).toBe(0);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
+
+    await drive.finish();
+  });
+
+  it("re-arms the read retry after enter is invalidated by mutations then panel_run (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-enter-mutate-run-find-success");
 
     expect(drive.reloadCalls).toBe(0);
     expect(drive.interruptCalls).toBe(0);
@@ -629,6 +740,23 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
     expect(drive.interruptCalls).toBe(1);
     expect(drive.reloadCalls).toBe(1);
     expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    await drive.finish();
+  });
+
+  it("does not retry a failed panel_run after a transport failure (#2395)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-run-no-retry");
+
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    const failures = drive.events.filter(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0].message).toMatch(/did not retry the request/i);
+    expect(failures[0].message).not.toMatch(/retried this read once/i);
     await drive.finish();
   });
 

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -626,10 +626,22 @@ export function toolNameOf(item: Record<string, unknown> | undefined): string | 
 // has to classify the in-flight app-server item before deciding whether the
 // transport may issue its one retry. Keep this allowlist intentionally narrower
 // than the panel tool catalog: scope navigation and every mutation must never
-// be replayed from an opaque outer transport error.
-const PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS = new Set([
+// be replayed from an opaque outer transport error. Membership is the graph
+// inspect reads from QUEUE_BUSY_READ_TOOLS — including panel_find_nodes, which
+// is the #2395 recurrence after a completed panel_run.
+export const PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS = new Set([
   "panel_graph_outline",
   "panel_query_graph",
+  "panel_find_nodes",
+  "panel_get_errors",
+]);
+
+// Completing these can leave the Codex HTTP MCP client in a racy state.
+// Arm a one-shot window for the immediate next allowlisted read. The tools
+// themselves stay off the retry allowlist so a failed enter or run is fenced.
+export const PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS = new Set([
+  "panel_enter_subgraph",
+  "panel_run",
 ]);
 
 type PanelMcpToolItem = {
@@ -1725,7 +1737,7 @@ export class CodexBackend implements AgentBackend {
     let mcpTransportFencePending = false;
     let turnFenced = false;
     type PanelMcpRequest = PanelMcpToolItem & {
-      afterEnterItemId: string | null;
+      afterArmItemId: string | null;
       completed: boolean;
     };
     type PanelReadRetry = {
@@ -1739,15 +1751,15 @@ export class CodexBackend implements AgentBackend {
     const panelReadRetries = new Map<string, PanelReadRetry>();
     const inFlightMcpItemIds = new Set<string>();
     let unkeyedMcpItems = 0;
-    let panelEnterCandidate: { itemId: string; laterPanelRequestStarted: boolean } | null = null;
-    let immediatePanelReadAfterEnter: string | null = null;
+    let panelArmCandidate: { itemId: string; laterPanelRequestStarted: boolean } | null = null;
+    let immediatePanelReadAfterArm: string | null = null;
 
     // Retry contract: only the next panel request after a successful
-    // panel_enter_subgraph completion can be an eligible graph read. The
-    // one-shot sequence is consumed at request start; a mutation or unrelated
-    // panel request therefore invalidates it before a later read can qualify.
-    // Correlation must resolve the transport error to that request; ambiguity
-    // is fail-closed. Mutations and unrelated reads use normal fencing.
+    // panel_enter_subgraph or panel_run completion can be an eligible graph
+    // read. The one-shot sequence is consumed at request start; a mutation or
+    // unrelated panel request therefore invalidates it before a later read can
+    // qualify. Correlation must resolve the transport error to that request;
+    // ambiguity is fail-closed. Mutations and unrelated reads use normal fencing.
 
     // LIVENESS (watchdog re-arm): re-arm PanelAgent's idle watchdog ONLY for
     // notifications that represent work or an outcome for THIS active turn. A
@@ -1826,7 +1838,7 @@ export class CodexBackend implements AgentBackend {
 
     const trackPanelMcpItem = (
       item: PanelMcpToolItem,
-      afterEnterItemId: string | null,
+      afterArmItemId: string | null,
     ): PanelMcpRequest => {
       const existing = panelMcpRequests.get(item.itemId);
       if (existing) {
@@ -1838,7 +1850,7 @@ export class CodexBackend implements AgentBackend {
       }
       const request: PanelMcpRequest = {
         ...item,
-        afterEnterItemId,
+        afterArmItemId,
         completed: false,
       };
       panelMcpRequests.set(item.itemId, request);
@@ -2144,20 +2156,20 @@ export class CodexBackend implements AgentBackend {
           const panelTool = panelMcpToolItemOf(item);
           if (panelTool) {
             const isNewPanelRequest = !panelMcpRequests.has(panelTool.itemId);
-            let afterEnterItemId: string | null = null;
+            let afterArmItemId: string | null = null;
             if (isNewPanelRequest) {
-              if (panelTool.name === "panel_enter_subgraph") {
-                immediatePanelReadAfterEnter = null;
-                panelEnterCandidate = { itemId: panelTool.itemId, laterPanelRequestStarted: false };
+              if (PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS.has(panelTool.name)) {
+                immediatePanelReadAfterArm = null;
+                panelArmCandidate = { itemId: panelTool.itemId, laterPanelRequestStarted: false };
               } else {
-                if (panelEnterCandidate) panelEnterCandidate.laterPanelRequestStarted = true;
-                if (immediatePanelReadAfterEnter && PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS.has(panelTool.name)) {
-                  afterEnterItemId = immediatePanelReadAfterEnter;
+                if (panelArmCandidate) panelArmCandidate.laterPanelRequestStarted = true;
+                if (immediatePanelReadAfterArm && PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS.has(panelTool.name)) {
+                  afterArmItemId = immediatePanelReadAfterArm;
                 }
-                immediatePanelReadAfterEnter = null;
+                immediatePanelReadAfterArm = null;
               }
             }
-            const request = trackPanelMcpItem(panelTool, afterEnterItemId);
+            const request = trackPanelMcpItem(panelTool, afterArmItemId);
             for (const [originItemId, retry] of panelReadRetries) {
               if (
                 request.name === retry.tool &&
@@ -2194,14 +2206,15 @@ export class CodexBackend implements AgentBackend {
               item?.status !== "error" &&
               item?.status !== "declined" &&
               item?.error == null;
-            if (request.name === "panel_enter_subgraph") {
-              immediatePanelReadAfterEnter =
-                completedSuccessfully &&
-                panelEnterCandidate?.itemId === request.itemId &&
-                !panelEnterCandidate.laterPanelRequestStarted
+            if (
+              PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS.has(request.name) &&
+              panelArmCandidate?.itemId === request.itemId
+            ) {
+              immediatePanelReadAfterArm =
+                completedSuccessfully && !panelArmCandidate.laterPanelRequestStarted
                   ? request.itemId
                   : null;
-              panelEnterCandidate = null;
+              panelArmCandidate = null;
             }
 
             const retryMatch = panelReadRetryForRequest(request);
@@ -2270,7 +2283,7 @@ export class CodexBackend implements AgentBackend {
               !retryAttempted &&
               params.willRetry === true &&
               request != null &&
-              request.afterEnterItemId != null &&
+              request.afterArmItemId != null &&
               PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS.has(request.name) &&
               appServerConnectionIsActive()
             ) {


### PR DESCRIPTION
## Summary

Fixes #2395

- Recurrence on 0.52.146 / panel 0.15.124: after several panel mutations and a completed `panel_run`, read-only `panel_find_nodes` failed before dispatch with `EventNotificationTransport` / HTTP send failure; the next graph read succeeded immediately.
- Expand the outer Codex transport retry allowlist to the graph-inspect reads (`QUEUE_BUSY_READ_TOOLS`), including `panel_find_nodes` and `panel_get_errors`.
- Arm the same one-shot immediate-next-read window after a successful `panel_run` as after `panel_enter_subgraph`. Mutations still consume the window; `panel_run` / `panel_enter_subgraph` themselves are never replayed.
- Keep per-item correlation, original-error preservation, cancellation/timeout/no-amplification, and fail-closed fencing for mutations and unrelated reads.

## Validation

- `npx vitest run src/__tests__/orchestrator/codex-mcp-reconnect.test.ts` — 36 passed
- `npx tsc --noEmit` passed
- `git diff --check` passed

No merge or release performed.
