### PR TITLE
fix(2393): map official-template promoted COMBOs via the unique rail-backed inner widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- a root SubgraphNode promoted COMBO write uses the unique rail-backed inner mapping when the terminal witness is incomplete after loading an official template (#2393)
 - get_image action:"list_outputs" lists completed VHS mp4 outputs written to ComfyUI's temp/ (save_output unchecked), tagged type:"temp" (#2370)
 - panel_expose_subgraph_input retries Anything Everywhere? wildcard sockets against the live LiteGraph slot array after Convert to Subgraph (#2493)
 - panel_search_nodes and panel_list_nodes serve host Manager HTTP when the panel's browser Manager request does not complete (Failed to fetch) (#2492)

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -967,6 +967,53 @@ const QWEN_EDIT_INCOMPLETE_PROMOTED_SUBGRAPH = {
   ],
 };
 
+/** #2393 recurrence — official-template COMBO `unet_name` on a root SubgraphNode.
+ * The own-entry is incomplete (parent rail is a name-only stub) and the live
+ * immediate ids can point at the WRONG inner node after input-count drift.
+ * Query maps through input-rail output 6 to UNETLoader 37. */
+const UNet_COMBO_TEMPLATE_SUBGRAPH = {
+  subgraph_of: { node_id: 472, title: "Official Template" },
+  node_count: 2,
+  nodes: [
+    {
+      id: 37,
+      type: "UNETLoader",
+      widgets: { unet_name: "model.safetensors", weight_dtype: "default" },
+      inputs: [
+        { slot: 0, name: "unet_name", type: "COMBO", connected_from: { node_id: -10, output_slot: 6 } },
+        { slot: 1, name: "weight_dtype", type: "COMBO" },
+      ],
+    },
+    {
+      id: 38,
+      type: "CLIPLoader",
+      widgets: { clip_name: "clip.safetensors" },
+      inputs: [
+        { slot: 0, name: "clip_name", type: "COMBO", connected_from: { node_id: -10, output_slot: 7 } },
+      ],
+    },
+  ],
+  promoted_terminals: [
+    {
+      widget: "unet_name",
+      immediate_node_id: 99,
+      immediate_widget: "value",
+      error: "the promoted parent rail was missing, externally linked, or not authoritative",
+    },
+    {
+      widget: "lora_name",
+      error:
+        "properties.proxyWidgets named a promoted relation that had no live node.widgets/_subgraphSlot projection",
+    },
+  ],
+};
+
+const UNet_COMBO_TEMPLATE_DETAIL = {
+  text:
+    '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+    '{"id":472,"type":"SubgraphNode","is_subgraph":true}',
+};
+
 describe("panel_set_widget coordinated promoted-widget fixes (#2393, #2394)", () => {
   it("refreshes one incomplete post-template terminal witness before the guarded inner write (#2393)", async () => {
     const { isError, calls, mutations } = await setWidget(
@@ -3470,6 +3517,98 @@ describe("#2393 promoted-terminal witness is judged on the requested alias", () 
     expect(isError).toBe(true);
     expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+});
+
+describe("#2393 promoted COMBO unet_name after official template load", () => {
+  it("maps the unique rail-backed UNETLoader, not the drifted immediate id", () => {
+    expect(resolveInnerPromotedTarget(UNet_COMBO_TEMPLATE_SUBGRAPH, "unet_name", 472)).toEqual({
+      innerNodeId: 37,
+      widget: "unet_name",
+      terminal: {
+        nodeId: 37,
+        nodeType: "UNETLoader",
+        widget: "unet_name",
+        inputs: [
+          { name: "unet_name", type: "COMBO" },
+          { name: "weight_dtype", type: "COMBO" },
+        ],
+        chainDepth: 0,
+      },
+    });
+  });
+
+  it("still refuses when two inner UNETLoaders are rail-backed on the same alias", () => {
+    const ambiguous = {
+      ...UNet_COMBO_TEMPLATE_SUBGRAPH,
+      node_count: 3,
+      nodes: [
+        ...UNet_COMBO_TEMPLATE_SUBGRAPH.nodes,
+        {
+          id: 39,
+          type: "UNETLoader",
+          widgets: { unet_name: "other.safetensors" },
+          inputs: [
+            { slot: 0, name: "unet_name", type: "COMBO", connected_from: { node_id: -10, output_slot: 8 } },
+          ],
+        },
+      ],
+    };
+    expect(resolveInnerPromotedTarget(ambiguous, "unet_name", 472)).toBeNull();
+  });
+
+  it("writes the rail-backed inner COMBO instead of refusing the incomplete own-entry", async () => {
+    const { isError, calls, mutations } = await setWidget(
+      { node_id: 472, widget: "unet_name", value: "model.safetensors" },
+      {
+        ownerNodeId: 472,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: UNet_COMBO_TEMPLATE_DETAIL,
+        subgraph: UNet_COMBO_TEMPLATE_SUBGRAPH,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 37, widget: "unet_name", value: "model.safetensors" }),
+    ]);
+    const write = calls.find((call) => call.cmd === "graph_set_widget");
+    const scope = write?.expected_scope as Record<string, unknown> | undefined;
+    expect(scope?.parent_rail).toBeUndefined();
+    expect(scope?.terminal).toEqual(
+      expect.objectContaining({ node_id: 37, type: "UNETLoader", widget: "unet_name" }),
+    );
+    expect(calls.some((call) => call.cmd === "graph_set_widget" && call.node_id === 99)).toBe(false);
+  });
+
+  it("still refuses the incomplete own-entry when the inner COMBO is not rail-backed", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 472, widget: "unet_name", value: "model.safetensors" },
+      {
+        ownerNodeId: 472,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: UNet_COMBO_TEMPLATE_DETAIL,
+        subgraph: {
+          ...UNet_COMBO_TEMPLATE_SUBGRAPH,
+          nodes: [
+            {
+              id: 37,
+              type: "UNETLoader",
+              widgets: { unet_name: "model.safetensors" },
+              inputs: [{ slot: 0, name: "unet_name", type: "COMBO" }],
+            },
+            UNet_COMBO_TEMPLATE_SUBGRAPH.nodes[1],
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was incomplete or unresolved/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7668,14 +7668,24 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity",
     );
   }
-  const terminalEvidenceError = promotedTerminalEvidenceError(payload, widget);
-  if (terminalEvidenceError) return promotedWriteRefusal(widget, terminalEvidenceError);
   const inner = resolvePromotedWriteTarget(
     payload,
     widget,
     nodeId as number | string,
     publishesCompleteTerminalWitness,
   );
+  const terminalEvidenceError = promotedTerminalEvidenceError(payload, widget);
+  if (terminalEvidenceError) {
+    // #2393 — an incomplete OWN entry may still uniquely name a rail-backed
+    // inner COMBO. Any other witness error, including an unadvertised duplicate
+    // that would otherwise fall through to the legacy same-name scan, stays a
+    // hard refusal.
+    const railBackedCombo =
+      terminalEvidenceError === "the promoted-terminal witness was incomplete or unresolved" &&
+      inner?.terminal?.chainDepth === 0 &&
+      !inner.parentRail;
+    if (!railBackedCombo) return promotedWriteRefusal(widget, terminalEvidenceError);
+  }
   if (!inner) {
     if (publishesCompleteTerminalWitness) {
       const terminalAliases = promotedTerminalAliasCount(payload, widget);
@@ -7705,10 +7715,16 @@ async function preparePromotedWidgetWrite(
     );
   }
   if (publishesCompleteTerminalWitness && !inner.parentRail) {
-    return promotedWriteRefusal(
-      widget,
-      "the current promoted-terminal witness did not prove an authoritative parent rail",
-    );
+    // #2393 — official-template COMBOs can load with a name-only host stub, so
+    // the parent rail is unauthenticatable while the unique rail-backed inner
+    // widget is still the subgraph-definition store. Nested promotions still
+    // require the parent rail; a one-hop terminal is the only exception.
+    if (!inner.terminal || inner.terminal.chainDepth !== 0) {
+      return promotedWriteRefusal(
+        widget,
+        "the current promoted-terminal witness did not prove an authoritative parent rail",
+      );
+    }
   }
   const scopeError = currentPromotedScopeError(ctx, scope);
   if (scopeError) return promotedWriteRefusal(widget, scopeError);

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -211,6 +211,77 @@ function widgetNamesOnInner(node: Record<string, unknown>): string[] {
   return Object.keys(widgets as Record<string, unknown>).filter((n) => n.length > 0);
 }
 
+/** True when `widget` is an inner input that is wired from another node — the
+ * subgraph input-rail shape official templates use for promoted COMBOs. */
+function innerWidgetIsRailBacked(node: Record<string, unknown>, widget: string): boolean {
+  const inputs = node.inputs;
+  if (!Array.isArray(inputs)) return false;
+  const wanted = widget.toLowerCase();
+  for (const raw of inputs) {
+    if (!isRecord(raw) || typeof raw.name !== "string" || raw.name.toLowerCase() !== wanted) continue;
+    const from = raw.connected_from;
+    if (!isRecord(from)) continue;
+    if (from.node_id === undefined || from.node_id === null) continue;
+    if (typeof from.node_id !== "number" && typeof from.node_id !== "string") continue;
+    return true;
+  }
+  return false;
+}
+
+function terminalInputsFromInnerNode(node: Record<string, unknown>): PromotedTerminalInput[] | null {
+  if (!Object.prototype.hasOwnProperty.call(node, "inputs")) return [];
+  const inputs = node.inputs;
+  if (!Array.isArray(inputs)) return null;
+  const out: PromotedTerminalInput[] = [];
+  for (const raw of inputs) {
+    if (!isRecord(raw) || typeof raw.name !== "string" || raw.name.length === 0) return null;
+    if (raw.type !== undefined && typeof raw.type !== "string") return null;
+    out.push({ name: raw.name, ...(raw.type !== undefined ? { type: raw.type } : {}) });
+  }
+  return out;
+}
+
+/**
+ * #2393 recurrence — after an official template load, a promoted COMBO such as
+ * `unet_name` can publish an incomplete own-entry (the host rail is a name-only
+ * stub, so `_subgraphSlot` / parent-rail authentication fail) while the inner
+ * listing still uniquely names the rail-backed loader. That inner widget is the
+ * subgraph-definition store the queue reads when no per-instance widgetId exists.
+ * Do not reuse an error entry's `immediate_node_id`: the live slot can point at
+ * a different inner node after instance/definition input-count drift.
+ */
+function resolveRailBackedInnerFromEnvelope(
+  envelope: { nodes: Array<Record<string, unknown>> },
+  displayedWidget: string,
+): InnerPromotedTarget | null {
+  const hits: Array<{ node: Record<string, unknown>; id: number | string; widget: string }> = [];
+  for (const node of envelope.nodes) {
+    const id = innerNodeId(node);
+    if (id == null) continue;
+    const matched = matchListedName(displayedWidget, widgetNamesOnInner(node));
+    if (!matched || !innerWidgetIsRailBacked(node, matched)) continue;
+    hits.push({ node, id, widget: matched });
+  }
+  if (hits.length !== 1) return null;
+  const hit = hits[0];
+  const nodeType = hit.node.type;
+  if (typeof nodeType !== "string" || nodeType.length === 0) return null;
+  const inputs = terminalInputsFromInnerNode(hit.node);
+  if (!inputs) return null;
+  return {
+    innerNodeId: hit.id,
+    widget: hit.widget,
+    ...(typeof hit.node.node_identity === "string" ? { nodeIdentity: hit.node.node_identity } : {}),
+    terminal: {
+      nodeId: hit.id,
+      nodeType,
+      widget: hit.widget,
+      inputs,
+      chainDepth: 0,
+    },
+  };
+}
+
 function innerNodeId(node: Record<string, unknown>): number | string | null {
   const id = node.id;
   return isNodeId(id) ? id : null;
@@ -494,8 +565,11 @@ export function resolveInnerPromotedTarget(
     );
     if (entries.length !== 1) return null;
     const entry = entries[0];
+    // A complete own-entry is still the preferred mapping. An incomplete own-entry
+    // is not authorization to trust its immediate ids — those can be the drifted
+    // live slot. Fall back only to a unique rail-backed same-name inner widget.
+    if (entry.error) return resolveRailBackedInnerFromEnvelope(envelope, displayedWidget);
     if (
-      entry.error ||
       !entry.terminal ||
       !entry.parentRail ||
       entry.immediateNodeId === undefined ||


### PR DESCRIPTION
Fixes #2393

## Diagnosis

Reopened 2026-08-30 on comfyui-mcp 0.52.146 / panel 0.15.124. After loading an official template, `panel_query_graph` uniquely maps a root SubgraphNode promoted COMBO `unet_name` through input-rail output 6 to inner UNETLoader node 37, but `panel_set_widget` refused with the incomplete/unresolved promoted-terminal-witness error and dispatched no `graph_set_widget`.

#2400 already judges the witness on the requested alias. This recurrence is the **own-entry** being incomplete: official templates load the host COMBO as a name-only stub, so `_subgraphSlot` / parent-rail authentication fail. The live `immediate_node_id` on that error entry can also be the **wrong** inner node after instance/definition input-count drift. Re-reading cannot clear a structural stub.

The serialized value in that shape lives on the inner widget (subgraph-definition store; no per-instance `widgetId`). The unique rail-backed same-name inner listing is the mapping the query path already had.

## Fix

- When the requested alias's own terminal entry carries an error, do not trust its immediate ids.
- If the subgraph envelope uniquely names a same-name inner widget whose matching input is `connected_from` a rail, use that as the promoted write target (one-hop terminal, no parent rail).
- Keep every other witness error fail-closed: duplicates, a miss against a damaged array, two rail-backed loaders, and an incomplete own-entry with no rail-backed inner.

## Validation

```
npx vitest run src/__tests__/orchestrator/promoted-widget.test.ts
```

168 passed.

```
npm run lint
```

passed (`tsc --noEmit` + anti-slop, none added).

Do not merge; parent merges after the swarm.