### PR TITLE
fix(2419): re-point Save-As routing after pinned tmp: first save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- first save of a pinned tmp: workflow re-points panel_set_todo and panel_canvas onto the dest tab even while the tmp: address still reaches (#2419)
 - a root SubgraphNode promoted COMBO write uses the unique rail-backed inner mapping when the terminal witness is incomplete after loading an official template (#2393)
 - get_image action:"list_outputs" lists completed VHS mp4 outputs written to ComfyUI's temp/ (save_output unchecked), tagged type:"temp" (#2370)
 - panel_expose_subgraph_input retries Anything Everywhere? wildcard sockets against the live LiteGraph slot array after Convert to Subgraph (#2493)

--- a/src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts
+++ b/src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts
@@ -46,14 +46,17 @@ function harness(opts: {
   active?: string;
   headless?: string[];
   backendOf?: (t: string) => string;
+  aliases?: Record<string, string>;
 }) {
   const repinTo = vi.fn();
   const reachable = new Set(opts.reachable ?? opts.tabs);
+  const aliases = opts.aliases ?? {};
   const bridge: ScopeRepinBridge = {
-    canReach: (t) => reachable.has(t),
+    canReach: (t) => Boolean(aliases[t]) || reachable.has(t),
     resolveActiveScopeTab: () => opts.active,
     isHeadless: (t) => (opts.headless ?? []).includes(t),
     tabs: () => opts.tabs.map((tab_id) => ({ tab_id })),
+    liveTabIdFor: (t) => aliases[t] ?? (reachable.has(t) ? t : undefined),
   };
   const handler = makeScopeRepinHandler({
     bridge,
@@ -113,6 +116,40 @@ describe("#888 a HEALTHY pin is still never displaced", () => {
     const out = handler(KEY, PATH_B);
     expect(typeof out).toBe("object");
     expect((out as { reason: string }).reason).toMatch(/still reaches a live tab/);
+    expect(repinTo).not.toHaveBeenCalled();
+  });
+});
+
+describe("#2419 a tmp: predecessor pin is rewritten onto the named save dest", () => {
+  const TMP = "tmp:2522828d-unsaved";
+
+  it("rewrites a still-reachable tmp: pin onto the unique dest tab", () => {
+    const { handler, repinTo } = harness({
+      pin: TMP,
+      tabs: [TAB_A],
+      reachable: [TMP, TAB_A],
+    });
+
+    expect(handler(KEY, PATH_A)).toBe(TAB_A);
+    expect(repinTo).toHaveBeenCalledWith(KEY, TAB_A);
+  });
+
+  it("rewrites a tmp: pin that only reaches dest through a same-socket alias", () => {
+    const { handler, repinTo } = harness({
+      pin: TMP,
+      tabs: [TAB_A],
+      reachable: [TAB_A],
+      aliases: { [TMP]: TAB_A },
+    });
+
+    expect(handler(KEY, PATH_A)).toBe(TAB_A);
+    expect(repinTo).toHaveBeenCalledWith(KEY, TAB_A);
+  });
+
+  it("does not treat a live saved pin as a tmp: predecessor", () => {
+    const { handler, repinTo } = harness({ pin: TAB_A, tabs: [TAB_A, TAB_B] });
+    const out = handler(KEY, PATH_B);
+    expect(typeof out).toBe("object");
     expect(repinTo).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts
+++ b/src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts
@@ -8,7 +8,9 @@
 //
 // The two updates are separate. The fence is already repaired. This file
 // drives the ROUTING half: re-point the session onto the dest tab when the
-// current address is dead. A live pin is left alone (#1917 / #884).
+// current address is dead, aliases onto dest, or is the unsaved tmp:
+// predecessor of dest. A live pin on a different saved tab is left alone
+// (#1917 / #884).
 //
 // Workaround that already worked: panel_set_workflow_target({mode:"current"}).
 // That tool is the only writer of the routing target; this makes Save-As do
@@ -31,6 +33,8 @@ const OLD_TAB = "wf:src-route:workflows/Untitled 1.json";
 const NEW_TAB = "wf:dest-route:workflows/photo_to_anime_main.json";
 const DEST_PATH = "workflows/photo_to_anime_main.json";
 const SCOPE = "orchestrator::codex";
+const TMP_TAB = "tmp:2522828d-unsaved";
+const TMP_PIN_PATH = "tmp:2522828d-unsaved";
 
 const SAVE_AS_REPLY = {
   saved: true,
@@ -71,7 +75,14 @@ function afterSaveAsLive(): void {
   reachable = new Set([NEW_TAB]);
 }
 
-function bridgeFor(opts?: { keepOldTab?: boolean }): PanelToolCtx["bridge"] {
+function bridgeFor(opts?: {
+  keepOldTab?: boolean;
+  /** Same-socket alias: retired id still canReach, but liveTabIdFor names dest. */
+  alias?: Record<string, string>;
+  /** First-save reply publishes a bare workflows/ routing_key, as production does. */
+  firstSaveRoutingKey?: string;
+}): PanelToolCtx["bridge"] {
+  const aliases = opts?.alias ?? {};
   return {
     send: async (c: Record<string, unknown>, extra?: { tabId?: string }) => {
       sent.push(c);
@@ -82,7 +93,16 @@ function bridgeFor(opts?: { keepOldTab?: boolean }): PanelToolCtx["bridge"] {
       }
       if (c.cmd === "workflow_save") {
         if (!opts?.keepOldTab) afterSaveAsLive();
-        return { saved: true, workflow: "photo_to_anime_main", ...SAVE_AS_REPLY };
+        const routing_key = opts?.firstSaveRoutingKey ?? SAVE_AS_REPLY.routing_key;
+        return {
+          saved: true,
+          first_save: true,
+          workflow: "photo_to_anime_main",
+          path: DEST_PATH,
+          routing_key,
+          workflow_uuid: NEW_UUID,
+          workflow_instance_changed: true,
+        };
       }
       if (c.cmd === "workflow_list") {
         return {
@@ -109,8 +129,21 @@ function bridgeFor(opts?: { keepOldTab?: boolean }): PanelToolCtx["bridge"] {
     },
     push: () => 1,
     canReach: (id: string) => {
-      if (id === SCOPE) return reachable.has(scopePin);
-      return reachable.has(id);
+      if (id === SCOPE) {
+        return reachable.has(scopePin) || Boolean(aliases[scopePin] && reachable.has(aliases[scopePin]));
+      }
+      if (reachable.has(id)) return true;
+      return Boolean(aliases[id] && reachable.has(aliases[id]));
+    },
+    liveTabIdFor: (id: string) => {
+      if (id === SCOPE) {
+        if (reachable.has(scopePin)) return scopePin;
+        const aliased = aliases[scopePin];
+        return aliased && reachable.has(aliased) ? aliased : undefined;
+      }
+      if (reachable.has(id)) return id;
+      const aliased = aliases[id];
+      return aliased && reachable.has(aliased) ? aliased : undefined;
     },
     isHeadless: () => false,
     tabs: () => liveTabs,
@@ -153,7 +186,7 @@ describe("#2419 Save-As re-points a dead real-tab address onto the dest canvas",
     expect(saved).toBe(true);
     expect(ctx.tabId).toBe(NEW_TAB);
     expect(ctx.tabId).not.toBe(OLD_TAB);
-    expect(targets.get(NEW_TAB)).toMatchObject({ mode: "pinned", path: "workflows/Untitled 1.json" });
+    expect(targets.get(NEW_TAB)).toMatchObject({ mode: "pinned", path: DEST_PATH });
     expect(targets.get(OLD_TAB)).toEqual({ mode: "current" });
   });
 
@@ -221,6 +254,90 @@ describe("#2419 Save-As re-points a dead SCOPE pin onto the dest canvas", () => 
 
     expect(scopeRepins).toEqual([]);
     expect(scopePin).toBe(OLD_TAB);
+  });
+});
+
+describe("#2419 first save of a pinned tmp: canvas follows dest even while tmp: still reaches", () => {
+  it("re-points a still-reachable tmp: tab onto dest after workflow_save (bare workflows/ routing_key)", async () => {
+    const targets = new WorkflowTargetStore();
+    targets.set(TMP_TAB, { mode: "pinned", path: TMP_PIN_PATH, filename: "Unsaved Workflow" });
+    liveTabs = [{ tab_id: TMP_TAB, title: "Unsaved Workflow", connected_at: 0 }];
+    reachable = new Set([TMP_TAB]);
+    const ctx = makePanelToolCtx(
+      bridgeFor({
+        alias: { [TMP_TAB]: NEW_TAB },
+        firstSaveRoutingKey: DEST_PATH,
+      }),
+      TMP_TAB,
+      targets,
+    );
+
+    const res = await toolNamed("panel_save_workflow").handler({}, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(ctx.tabId).toBe(NEW_TAB);
+    expect(targets.get(NEW_TAB)).toMatchObject({ mode: "pinned", path: DEST_PATH });
+    expect(targets.get(TMP_TAB)).toEqual({ mode: "current" });
+
+    sent = [];
+    sentTab = [];
+    const todo = await toolNamed("panel_set_todo").handler(
+      { items: [{ text: "continue", status: "active" }] },
+      ctx,
+    );
+    const canvas = await toolNamed("panel_canvas").handler({ action: "fit" }, ctx);
+    expect(todo.isError, textOf(todo)).toBeFalsy();
+    expect(canvas.isError, textOf(canvas)).toBeFalsy();
+    expect(sentTab.every((id) => id === NEW_TAB)).toBe(true);
+    expect(sentTab).not.toContain(TMP_TAB);
+  });
+
+  it("re-points when the tmp: tab stays listed next to dest (not only via alias)", async () => {
+    const targets = new WorkflowTargetStore();
+    targets.set(TMP_TAB, { mode: "pinned", path: TMP_PIN_PATH });
+    liveTabs = [{ tab_id: TMP_TAB, title: "Unsaved Workflow", connected_at: 0 }];
+    reachable = new Set([TMP_TAB]);
+    const b = bridgeFor({ firstSaveRoutingKey: DEST_PATH });
+    const origSend = b.send;
+    b.send = async (c, extra) => {
+      const out = await origSend(c, extra);
+      if (c.cmd === "workflow_save") {
+        liveTabs = [
+          { tab_id: TMP_TAB, title: "Unsaved Workflow", connected_at: 0 },
+          { tab_id: NEW_TAB, title: "photo_to_anime_main", connected_at: 1 },
+        ];
+        reachable = new Set([TMP_TAB, NEW_TAB]);
+      }
+      return out;
+    };
+    const ctx = makePanelToolCtx(b, TMP_TAB, targets);
+
+    await toolNamed("panel_save_workflow").handler({}, ctx);
+
+    expect(ctx.tabId).toBe(NEW_TAB);
+    expect(targets.get(NEW_TAB)).toMatchObject({ mode: "pinned", path: DEST_PATH });
+  });
+
+  it("re-points a SCOPE session whose turn pin is the tmp: predecessor", async () => {
+    liveTabs = [{ tab_id: TMP_TAB, title: "Unsaved Workflow", connected_at: 0 }];
+    reachable = new Set([TMP_TAB]);
+    scopePin = TMP_TAB;
+    const targets = new WorkflowTargetStore();
+    targets.set(SCOPE, { mode: "pinned", path: TMP_PIN_PATH });
+    const ctx = makePanelToolCtx(
+      bridgeFor({
+        alias: { [TMP_TAB]: NEW_TAB },
+        firstSaveRoutingKey: DEST_PATH,
+      }),
+      SCOPE,
+      targets,
+    );
+
+    await toolNamed("panel_save_workflow").handler({}, ctx);
+
+    expect(scopeRepins).toEqual([{ scope: SCOPE, path: DEST_PATH }]);
+    expect(scopePin).toBe(NEW_TAB);
+    expect(targets.get(SCOPE)).toMatchObject({ mode: "pinned", path: DEST_PATH });
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10395,20 +10395,28 @@ function refreshFenceFromOwnReply(ctx: PanelToolCtx, reply: ToolResult): Workflo
 /**
  * #2419 — the PATH the save reply names as the dest canvas.
  *
- * `routing_key` is the precise identity (`wf:<path>` handle, or a full
- * `wf:<route>:<path>` tab id). `path` / `workflow` / `filename` are fallbacks
- * for older replies that only named the new file. Empty / unreadable →
- * undefined, so the caller leaves routing alone rather than guessing.
+ * `routing_key` is the precise identity: a `wf:<path>` handle, a full
+ * `wf:<route>:<path>` tab id, or (first save of a tmp: canvas) the bare
+ * `workflows/…` path the panel publishes after persist. `path` / `workflow` /
+ * `filename` are fallbacks for older replies that only named the new file.
+ * Empty / unreadable / still-tmp → undefined, so the caller leaves routing
+ * alone rather than guessing.
  */
 function saveDestWorkflowPath(parsed: Record<string, unknown>): string | undefined {
   const routing = parsed.routing_key;
-  if (typeof routing === "string" && routing.startsWith("wf:")) {
-    const rest = routing.slice(3);
-    const sep = rest.indexOf(":");
-    const pathPart =
-      sep >= 0 && rest.slice(sep + 1).includes("/") ? rest.slice(sep + 1) : rest;
-    const fromRouting = canonicalSavedWorkflowPath(pathPart);
-    if (fromRouting) return fromRouting;
+  if (typeof routing === "string" && routing.trim()) {
+    const trimmed = routing.trim();
+    if (trimmed.startsWith("wf:")) {
+      const rest = trimmed.slice(3);
+      const sep = rest.indexOf(":");
+      const pathPart =
+        sep >= 0 && rest.slice(sep + 1).includes("/") ? rest.slice(sep + 1) : rest;
+      const fromRouting = canonicalSavedWorkflowPath(pathPart);
+      if (fromRouting) return fromRouting;
+    } else if (!trimmed.startsWith("tmp:")) {
+      const fromRouting = canonicalSavedWorkflowPath(trimmed);
+      if (fromRouting) return fromRouting;
+    }
   }
   for (const v of [parsed.path, parsed.workflow, parsed.filename]) {
     if (typeof v !== "string") continue;
@@ -10434,17 +10442,85 @@ function uniqueLiveTabForSaveDest(ctx: PanelToolCtx, destPath: string): string |
   return matches.length === 1 ? matches[0] : undefined;
 }
 
+/** The live tab `ctx.tabId` currently routes to, if any. */
+function liveRoutingTab(ctx: PanelToolCtx): string | undefined {
+  if (typeof ctx.bridge.liveTabIdFor === "function") {
+    try {
+      return ctx.bridge.liveTabIdFor(ctx.tabId);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof ctx.bridge.canReach === "function" && ctx.bridge.canReach(ctx.tabId)) {
+    return ctx.tabId;
+  }
+  return undefined;
+}
+
+/**
+ * #2419 recurrence — a PINNED unsaved canvas (`tmp:<uuid>` tab id or pin path).
+ * First persist changes the routing key to `workflows/…` but the tmp: address
+ * often still `canReach` via the same-socket migration alias, which is what
+ * made the original dead-address-only re-point a no-op.
+ */
+function routingIsUnsavedPredecessor(ctx: PanelToolCtx): boolean {
+  if (ctx.tabId.startsWith("tmp:")) return true;
+  const pin = ctx.workflowTarget?.get(ctx.tabId);
+  return typeof pin?.path === "string" && pin.path.startsWith("tmp:");
+}
+
+function destPinnedTarget(
+  pinned: { path?: string; filename?: string },
+  destPath: string,
+  parsed: Record<string, unknown>,
+): { mode: "pinned"; path: string; filename?: string } {
+  let filename: string | undefined;
+  for (const v of [parsed.filename, parsed.workflow]) {
+    if (typeof v === "string" && v.trim()) {
+      filename = v.trim().replace(/\.json$/i, "");
+      break;
+    }
+  }
+  if (!filename) {
+    const base = destPath.split("/").pop();
+    filename = base ? base.replace(/\.json$/i, "") : pinned.filename;
+  }
+  return { mode: "pinned", path: destPath, filename };
+}
+
+function adoptPinnedDestPath(
+  ctx: PanelToolCtx,
+  destPath: string,
+  parsed: Record<string, unknown>,
+  destTab?: string,
+): void {
+  if (!ctx.workflowTarget) return;
+  const previous = ctx.tabId;
+  const pinned = ctx.workflowTarget.get(previous);
+  if (pinned?.mode !== "pinned") return;
+  const next = destPinnedTarget(pinned, destPath, parsed);
+  if (destTab && destTab !== previous && !isScopeAddress(previous)) {
+    ctx.workflowTarget.clear(previous);
+    ctx.workflowTarget.set(destTab, next);
+    return;
+  }
+  ctx.workflowTarget.set(previous, next);
+}
+
 /**
  * #2419 — after Save-As (or a first save) mints a new tab id, the command
  * fence is already refreshed from the reply, but session-scoped commands
  * (`panel_set_todo`, `panel_canvas`) still address the old id.
  *
- * Re-point ONLY when the current routing address is dead. A live pin
- * elsewhere is left alone — that is #1917 / #884: this recovery must not
- * take a routing target out from under a pin another command in the same
- * turn is relying on. Matching is on the dest path the save reply proved,
- * and only when exactly one live canvas carries it, so this cannot silently
- * redirect to a different workflow.
+ * Follow dest when the current address is dead, when it already aliases onto
+ * dest (same-socket tmp:→wf: / Save-As rename), or when it is the unsaved
+ * predecessor of dest (pinned tmp: canvas whose first save published a
+ * `workflows/…` routing key). A live pin on a DIFFERENT saved tab is left
+ * alone — that is #1917 / #884.
+ *
+ * Matching is on the dest path the save reply proved, and only when exactly
+ * one live canvas carries it, so this cannot silently redirect to a different
+ * workflow.
  *
  * Best-effort by construction: the file WAS written. A re-point that cannot
  * happen must not retract the save.
@@ -10454,24 +10530,26 @@ function repointRoutingAfterSave(ctx: PanelToolCtx, reply: ToolResult): void {
   if (!parsed) return;
   const destPath = saveDestWorkflowPath(parsed);
   if (!destPath) return;
-  if (typeof ctx.bridge.canReach === "function" && ctx.bridge.canReach(ctx.tabId)) return;
   const destTab = uniqueLiveTabForSaveDest(ctx, destPath);
-  if (!destTab) return;
+  if (!destTab) {
+    if (routingIsUnsavedPredecessor(ctx)) adoptPinnedDestPath(ctx, destPath, parsed);
+    return;
+  }
+  const live = liveRoutingTab(ctx);
+  const follow =
+    !live || live === destTab || routingIsUnsavedPredecessor(ctx);
+  if (!follow) return;
   if (isScopeAddress(ctx.tabId)) {
     try {
       ctx.bridge.repinScopeToWorkflow?.(ctx.tabId, destPath);
     } catch {
       // never worse than the pre-#2419 silence; the save already succeeded
     }
+    adoptPinnedDestPath(ctx, destPath, parsed);
     return;
   }
+  adoptPinnedDestPath(ctx, destPath, parsed, destTab);
   if (destTab === ctx.tabId) return;
-  const previous = ctx.tabId;
-  const pinned = ctx.workflowTarget?.get(previous);
-  if (ctx.workflowTarget && pinned?.mode === "pinned") {
-    ctx.workflowTarget.clear(previous);
-    ctx.workflowTarget.set(destTab, pinned);
-  }
   ctx.tabId = destTab;
 }
 
@@ -22048,9 +22126,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // #2419 — BEFORE the fence refresh so the stamp lands on the dest
         // address. Save-As mints a new tab id; the fence repair re-stamps
         // graph commands, but session-scoped commands (set_todo, graph_canvas)
-        // still address the old id unless routing is re-pointed. Only when
-        // the current address is dead — a live pin elsewhere is left alone
-        // (#1917 / #884).
+        // still address the old id unless routing is re-pointed. Follow dest
+        // when the current address is dead, aliases onto dest, or is the
+        // unsaved tmp: predecessor of dest. A live pin on a different saved
+        // tab is left alone (#1917 / #884).
         repointRoutingAfterSave(ctx, res);
         const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
         let canMutateNow: boolean | undefined;

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -697,6 +697,8 @@ export interface ScopeRepinBridge {
   resolveActiveScopeTab(): string | undefined;
   isHeadless?(tabId: string): boolean;
   tabs(): Array<{ tab_id: string }>;
+  /** Canonical live id a (possibly retired/aliased) tab currently routes to. */
+  liveTabIdFor?(tabId: string): string | undefined;
 }
 
 /**
@@ -798,14 +800,40 @@ export function makeScopeRepinHandler(opts: {
 }): (scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome {
   return (scopeId, preferredWorkflowPath) => {
     const key = opts.scopeAgentKeyOf(scopeId);
+    const backend = opts.backendOfKey(key);
+    const eligible = opts.bridge
+      .tabs()
+      .map((t) => t.tab_id)
+      .filter((t) => opts.bridge.isHeadless?.(t) !== true && opts.backendForTab(t) === backend);
+    const namedDest = (path: string | undefined): string | undefined => {
+      if (!path) return undefined;
+      const matches = eligible.filter((t) => tabRouteCarriesPath(t, path));
+      return matches.length === 1 ? matches[0] : undefined;
+    };
     // RECOVERY ONLY: a pin that still reaches a live tab OF THIS conversation
     // is healthy — never displace it (null = ambiguous/ownership-refused and
     // absent = no pin are both recoverable). resolvedPinOf, not raw pinOf: a
     // pin whose tab was revived by another backend "reaches" but is NOT
     // healthy — treating it as healthy would deadlock the advertised recovery
     // against the resolution-time refusal (codex gate-4 delta).
+    //
+    // #2419 — exception: a named dest that this pin ALREADY routes to (same-
+    // socket alias) or a tmp: predecessor of that dest is the SAME canvas
+    // under its new identity, not a steal. Rewrite the stored pin onto the
+    // canonical dest id so session-scoped commands stop addressing the retired
+    // tmp: / Untitled handle.
     const existing = opts.tracker.resolvedPinOf(key);
     if (typeof existing === "string" && opts.bridge.canReach(existing)) {
+      const named = namedDest(preferredWorkflowPath);
+      const live = opts.bridge.liveTabIdFor?.(existing) ?? existing;
+      const predecessor = existing.startsWith("tmp:");
+      if (named && existing !== named && (live === named || predecessor)) {
+        opts.tracker.repinTo(key, named);
+        opts.info(
+          `[panel-orchestrator] ${key} re-pinned onto ${named.slice(0, 8)} as the save dest successor of ${existing.slice(0, 8)} (#2419)`,
+        );
+        return named;
+      }
       return {
         repinned: false,
         reason:
@@ -814,11 +842,6 @@ export function makeScopeRepinHandler(opts: {
           `pin that is dead or ambiguous`,
       };
     }
-    const backend = opts.backendOfKey(key);
-    const eligible = opts.bridge
-      .tabs()
-      .map((t) => t.tab_id)
-      .filter((t) => opts.bridge.isHeadless?.(t) !== true && opts.backendForTab(t) === backend);
     // #888 — a NAMED workflow decides which tab, where "current" cannot.
     //
     // The refusal below already tells the agent to do exactly this ("Name the


### PR DESCRIPTION
## Summary
After pinning an unsaved `tmp:` workflow, the first `panel_save_workflow` publishes a `workflows/…` routing key and refreshes the graph fence, but `panel_set_todo` / `panel_canvas` stayed on the retired tab. The previous #2419 recovery only re-pointed when `canReach` was false, so a still-reachable same-socket alias (or leftover tmp: tab) was treated as a live pin elsewhere (#1917) and skipped.

This follows dest when the current address is dead, already aliases onto dest, or is the unsaved `tmp:` predecessor of dest. A live pin on a different saved tab is left alone. Bare `workflows/…` routing keys from first save are parsed as dest paths, and the pinned path is updated so later graph `workflow_path` injection matches.

## Test plan
- `npx vitest run src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts`
- 24 passed, including: pinned tmp: first save with still-reachable alias; tmp: listed next to dest; SCOPE tmp: predecessor; healthy saved pin still not stolen (#1917)

Fixes #2419