### PR TITLE
fix(2481): settle an unacked set_todo with a tray read-back and mutation receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- panel_set_todo reconciles a missing ACK with a todo read-back and mutation receipt instead of leaving the outcome as a guess (#2481)
+
 ## [0.52.149] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/orchestrator/set-todo-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/set-todo-ack-timeout.test.ts
@@ -1,0 +1,239 @@
+// #2481 — panel_set_todo delivered to the tab but no ACK within 15000 ms.
+//
+// The generic mutating-delivery disclosure then left the caller guessing:
+// "may have been applied … a blind retry can apply it twice", with no
+// mutation receipt, no idempotency key, and no read-back. Later graph
+// mutations on the same tab succeeded — a transient ACK failure, not a dead
+// tab. set_todo is a full-replace, so the tray is locally observable: after
+// a tagged no-reply we take ONE get_todo read and report applied /
+// not-applied, or return the original timeout WITH a mutation receipt when
+// the read cannot answer.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+const OTHER_TAB = "99999999-8888-7777-6666-555555555555";
+const DESKTOP = "desktop-tab";
+const MOBILE = "mobile-tab";
+const MUTATION_RID = "rid-set-todo-2481";
+
+const ITEMS = [
+  { text: "load workflow", status: "done" },
+  { text: "run refine", status: "active" },
+  { text: "save result", status: "pending" },
+];
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ");
+
+const ackTimeout = (cmd: string, ms: number): Error =>
+  new Error(
+    `Panel tab ${TAB} did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be ` +
+      `backgrounded or frozen. This command MUTATES and was already delivered to the tab, so it ` +
+      `may have been applied despite the missing reply — check the current state before ` +
+      `re-issuing it; a blind retry can apply it twice`,
+  );
+
+let sent: Array<{ cmd: string; tabId?: string; timeoutMs?: number }> = [];
+
+function bridge(opts: {
+  setReply?: "timeout" | "acked-error" | "acked-error-timeout-worded" | "ok";
+  probeItems?: typeof ITEMS | "timeout" | "other";
+  loseTabAfterSet?: boolean;
+  headlessRedirect?: boolean;
+}) {
+  let tabGone = false;
+  return {
+    send: async (
+      cmd: Record<string, unknown>,
+      o?: { timeoutMs?: number; tabId?: string; onDispatchedRid?: (rid: string) => void },
+    ) => {
+      sent.push({
+        cmd: String(cmd.cmd),
+        tabId: o?.tabId,
+        timeoutMs: o?.timeoutMs,
+      });
+      if (cmd.cmd === "set_todo") {
+        if (opts.setReply === "acked-error") {
+          throw new Error("Executor refused: footer tray is disabled");
+        }
+        if (opts.setReply === "acked-error-timeout-worded") {
+          throw new Error(
+            `Panel tab ${TAB} did not reply to "set_todo" within 15000 ms — the ` +
+              `ComfyUI tab may be backgrounded or frozen. Reported by the tray owner: ` +
+              `nothing was applied.`,
+          );
+        }
+        if (opts.setReply === "ok" || opts.setReply === undefined) {
+          o?.onDispatchedRid?.(MUTATION_RID);
+          return { ok: true, count: Array.isArray(cmd.items) ? cmd.items.length : 0 };
+        }
+        if (opts.loseTabAfterSet) tabGone = true;
+        o?.onDispatchedRid?.(MUTATION_RID);
+        throw markReplyTimeout(ackTimeout("set_todo", 15000));
+      }
+      if (cmd.cmd === "get_todo") {
+        if (opts.probeItems === "timeout") throw ackTimeout("get_todo", 8000);
+        if (opts.probeItems === "other") {
+          return { items: [{ text: "stale leftover", status: "pending" }] };
+        }
+        return { items: opts.probeItems ?? ITEMS };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => {
+      if (opts.headlessRedirect) return id === MOBILE || id === DESKTOP;
+      if (tabGone) return id === OTHER_TAB;
+      return id === TAB;
+    },
+    isHeadless: (id: string) => (opts.headlessRedirect ? id === MOBILE : false),
+    tabs: () => {
+      if (opts.headlessRedirect) {
+        return [
+          { tab_id: MOBILE, title: "phone", connected_at: 0 },
+          { tab_id: DESKTOP, title: "wf", connected_at: 0 },
+        ];
+      }
+      return tabGone
+        ? [{ tab_id: OTHER_TAB, title: "other", connected_at: 0 }]
+        : [{ tab_id: TAB, title: "wf", connected_at: 0 }];
+    },
+    resolveActiveTabId: () => {
+      if (opts.headlessRedirect) return DESKTOP;
+      return tabGone ? OTHER_TAB : TAB;
+    },
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as PanelToolCtx["bridge"];
+}
+
+async function runSetTodo(
+  opts: Parameters<typeof bridge>[0],
+  args: Record<string, unknown> = { items: ITEMS },
+): Promise<{ text: string; isError: boolean; boundTab: string }> {
+  const tab = opts.headlessRedirect ? MOBILE : TAB;
+  const ctx = makePanelToolCtx(bridge(opts), tab, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_todo");
+  if (!def) throw new Error("panel_set_todo is not registered");
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return { text: textOf(res), isError: res.isError === true, boundTab: ctx.tabId };
+}
+
+beforeEach(() => {
+  sent = [];
+});
+
+describe("an unacknowledged set_todo is settled by a read, not by a guess (#2481)", () => {
+  it("reports the write as applied when the tray holds the delivered list", async () => {
+    const out = await runSetTodo({ setReply: "timeout", probeItems: ITEMS });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["set_todo", "get_todo"]);
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/CHECKED FOR YOU/);
+    expect(out.text).toMatch(/"applied": true/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).toMatch(/not evidence the write failed/);
+    expect(out.text).not.toMatch(/a blind retry can apply it twice/);
+  });
+
+  it("reports the write as NOT applied when the tray holds a different list", async () => {
+    const out = await runSetTodo({ setReply: "timeout", probeItems: "other" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["set_todo", "get_todo"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"applied": false/);
+    expect(out.text).toMatch(/does NOT show the list/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).toMatch(/full-replace/);
+    expect(out.text).toMatch(/stale leftover/);
+    expect(out.text).not.toMatch(/a blind retry can apply it twice/);
+  });
+
+  it("returns a mutation receipt when the tray read itself cannot answer", async () => {
+    const out = await runSetTodo({ setReply: "timeout", probeItems: "timeout" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["set_todo", "get_todo"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/may have been applied despite the missing reply/);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).toMatch(/"requested"/);
+    expect(out.text).toMatch(/run refine/);
+    expect(out.text).toMatch(/full-replace: re-issuing that exact list cannot duplicate it/);
+  });
+
+  it("does not second-guess an ACKED executor error", async () => {
+    const out = await runSetTodo({ setReply: "acked-error" });
+
+    expect(sent.map((s) => s.cmd)).not.toContain("get_todo");
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/footer tray is disabled/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/mutation_id/);
+  });
+
+  it("does not settle an ACKED error reproducing the canonical sentence VERBATIM", async () => {
+    const out = await runSetTodo({ setReply: "acked-error-timeout-worded" });
+
+    expect(out.text).toMatch(
+      /did not reply to "set_todo" within 15000 ms — the ComfyUI tab may be backgrounded or frozen/,
+    );
+    expect(sent.map((s) => s.cmd)).not.toContain("get_todo");
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/nothing was applied/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+
+  it("claims nothing when the probe lands on a DIFFERENT tab", async () => {
+    const out = await runSetTodo({
+      setReply: "timeout",
+      probeItems: ITEMS,
+      loseTabAfterSet: true,
+    });
+
+    expect(out.boundTab).toBe(OTHER_TAB);
+    expect(sent.some((s) => s.cmd === "get_todo")).toBe(true);
+    expect(out.isError).toBe(true);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/"applied": true/);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+  });
+
+  it("does not take a tray read on a successful ACK", async () => {
+    const out = await runSetTodo({ setReply: "ok" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["set_todo"]);
+    expect(out.isError).toBe(false);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+
+  it("probes the desktop tab a redirected set_todo was delivered to", async () => {
+    const out = await runSetTodo({
+      setReply: "timeout",
+      probeItems: ITEMS,
+      headlessRedirect: true,
+    });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["set_todo", "get_todo"]);
+    expect(sent[0]?.tabId).toBe(DESKTOP);
+    expect(sent[1]?.tabId).toBe(DESKTOP);
+    expect(out.boundTab).toBe(MOBILE);
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/"applied": true/);
+  });
+});

--- a/src/__tests__/orchestrator/todo-state.test.ts
+++ b/src/__tests__/orchestrator/todo-state.test.ts
@@ -18,10 +18,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   __resetTodoState,
+  canonicalTodoEntries,
   planInFlight,
   recordTodo,
   runCompletionDirective,
   todoFor,
+  todoListsMatch,
 } from "../../orchestrator/todo-state.js";
 
 const item = (text: string, status: string) => ({ text, status });
@@ -216,5 +218,39 @@ describe("#2369: replayed completions omit the CONTINUE instruction", () => {
     __resetTodoState();
     const noPlan = runCompletionDirective("t1");
     expect(replayed).toBe(noPlan);
+  });
+});
+
+describe("#2481: a delivered checklist can be compared to a later tray read", () => {
+  it("treats a missing status as pending, matching the schema default", () => {
+    expect(todoListsMatch([{ text: "a" }], [{ text: "a", status: "pending" }])).toBe(true);
+    expect(canonicalTodoEntries([{ text: "a" }])).toEqual([{ text: "a", status: "pending" }]);
+  });
+
+  it("folds content/text and status aliases before comparing", () => {
+    expect(
+      todoListsMatch(
+        [{ text: "a", status: "in_progress" }],
+        [{ content: "a", status: "active" }],
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat a different list as a match", () => {
+    expect(todoListsMatch([{ text: "a" }], [{ text: "b" }])).toBe(false);
+    expect(todoListsMatch([{ text: "a" }], [{ text: "a" }, { text: "b" }])).toBe(false);
+    expect(todoListsMatch([{ text: "a", status: "done" }], [{ text: "a", status: "active" }])).toBe(
+      false,
+    );
+  });
+
+  it("accepts two empty lists as the same cleared tray", () => {
+    expect(todoListsMatch([], [])).toBe(true);
+  });
+
+  it("refuses a payload that is not a checklist", () => {
+    expect(canonicalTodoEntries("nope")).toBeNull();
+    expect(canonicalTodoEntries([{ status: "pending" }])).toBeNull();
+    expect(todoListsMatch([{ text: "a" }], { items: [{ text: "a" }] })).toBe(false);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -391,7 +391,13 @@ import {
 } from "../services/panel-secrets.js";
 import { flattenUiWorkflow } from "../services/flatten-workflow.js";
 import { describeUnappliedFilters } from "./civitai-filter-guard.js";
-import { recordTodo, normalizeTodoItems, TODO_STATUS_INPUTS } from "./todo-state.js";
+import {
+  recordTodo,
+  normalizeTodoItems,
+  TODO_STATUS_INPUTS,
+  canonicalTodoEntries,
+  todoListsMatch,
+} from "./todo-state.js";
 import { applyCapturedWidgetValues } from "../services/live-widget-overlay.js";
 import { listWorkflowLibraryKeys, userdataFetch } from "../services/userdata-library.js";
 import {
@@ -3764,6 +3770,138 @@ async function settleExitSubgraphAfterAckTimeout(
     };
   }
   return timedOut;
+}
+
+// ---- panel_set_todo settle-after-ack-timeout (#2481) ----------------------
+// set_todo was delivered but the tab did not ACK. The generic mutating
+// disclosure then leaves the caller guessing and warns that a retry may
+// duplicate — even though set_todo is a full-replace. Take ONE get_todo
+// read on the same tab and report applied / not-applied, or return the
+// original timeout WITH a mutation receipt when the read cannot answer.
+
+/** Same elective probe budget as the graph_query / graph_serialize reads. */
+const SET_TODO_RECONCILE_MS = 8_000;
+
+function setTodoAppliedNote(): string {
+  return (
+    `CHECKED FOR YOU: the tab did not ACKNOWLEDGE the checklist write within the window, but a ` +
+    `todo read taken immediately afterwards, on that same tab, reports the exact list this call ` +
+    `delivered. No recovery step is needed and a retry would be wasted work. A missing ` +
+    `acknowledgement is not evidence the write failed; here it is evidence the tab was too busy ` +
+    `to answer in time. set_todo is a full-replace, so re-issuing this same list is a no-op.`
+  );
+}
+
+function setTodoNotAppliedNote(): string {
+  return (
+    `CHECKED FOR YOU: a todo read taken immediately after the missing acknowledgement does NOT ` +
+    `show the list this call delivered. The write has not applied (or was overwritten). ` +
+    `Re-issuing the same list is safe — set_todo is a full-replace, not an append.`
+  );
+}
+
+function setTodoUnknownNote(): string {
+  return (
+    `The tray could not be read after the missing acknowledgement, so this result cannot say ` +
+    `whether the write applied. mutation_id is the delivery receipt for this attempt; requested ` +
+    `is the list that was sent. set_todo is a full-replace: re-issuing that exact list cannot ` +
+    `duplicate it. Do not guess.`
+  );
+}
+
+function todoItemsFromProbe(res: ToolResult): unknown[] | null {
+  const parsed = parseToolResultValue(res);
+  if (Array.isArray(parsed)) return parsed;
+  if (!parsed || typeof parsed !== "object") return null;
+  const rec = parsed as Record<string, unknown>;
+  if (Array.isArray(rec.items)) return rec.items;
+  if (Array.isArray(rec.todos)) return rec.todos;
+  return null;
+}
+
+async function readTodoFromTab(ctx: PanelToolCtx, tabId: string): Promise<ToolResult> {
+  if (tabId === ctx.tabId) return ctx.call({ cmd: "get_todo" }, SET_TODO_RECONCILE_MS);
+  return dispatchToTab(ctx, tabId, { cmd: "get_todo" }, SET_TODO_RECONCILE_MS);
+}
+
+function setTodoTimeoutUnknown(
+  timedOut: ToolResult,
+  sentItems: unknown,
+  mutationId: string | undefined,
+): ToolResult {
+  return appendReplyNote(
+    timedOut,
+    JSON.stringify(
+      {
+        applied: "unknown",
+        acknowledged: false,
+        mutation_id: mutationId ?? null,
+        requested: canonicalTodoEntries(sentItems) ?? sentItems,
+        note: setTodoUnknownNote(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+/**
+ * After an ack timeout on `set_todo`, take ONE todo read and report whether the
+ * tray holds the list that was delivered. Returns the original timeout plus a
+ * mutation receipt when the read cannot answer — #1473's rule: an unknown
+ * answer claims nothing in either direction.
+ */
+async function settleSetTodoAfterAckTimeout(
+  ctx: PanelToolCtx,
+  timedOut: ToolResult,
+  sentItems: unknown,
+  mutationId: string | undefined,
+  dispatchTab: string,
+): Promise<ToolResult> {
+  // Probe the tab the write was DISPATCHED to. A desktop redirect writes to a
+  // different tab than ctx.tabId; a silent rebind of an unpinned session would
+  // otherwise let a different tab's tray certify this write.
+  const probeOnSessionTab = ctx.tabId === dispatchTab;
+  const probe = await readTodoFromTab(ctx, dispatchTab);
+  if (probeOnSessionTab && ctx.tabId !== dispatchTab) {
+    return setTodoTimeoutUnknown(timedOut, sentItems, mutationId);
+  }
+  const observed = todoItemsFromProbe(probe);
+  if (observed === null) return setTodoTimeoutUnknown(timedOut, sentItems, mutationId);
+  const requested = canonicalTodoEntries(sentItems) ?? sentItems;
+  const observedCanonical = canonicalTodoEntries(observed);
+  if (todoListsMatch(sentItems, observed)) {
+    return ok({
+      ok: true,
+      applied: true,
+      acknowledged: false,
+      mutation_id: mutationId ?? null,
+      items: observedCanonical ?? observed,
+      confirmed_by: "todo read after ack timeout",
+      note: setTodoAppliedNote(),
+    });
+  }
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            applied: false,
+            acknowledged: false,
+            mutation_id: mutationId ?? null,
+            requested,
+            items: observedCanonical ?? observed,
+            confirmed_by: "todo read after ack timeout",
+            note: setTodoNotAppliedNote(),
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
 }
 
 // ---- panel_free_vram: verifiable when the canvas tab is frozen (#1249) -----
@@ -16021,9 +16159,12 @@ async function dispatchToTab(
   cmd: Record<string, unknown>,
   timeoutMs: number,
   reResolve?: () => string | undefined,
+  onDispatchedRid?: (rid: string) => void,
 ): Promise<ToolResult> {
   try {
-    return ok(await ctx.bridge.send(cmd as { cmd: string }, { tabId, timeoutMs }));
+    return ok(
+      await ctx.bridge.send(cmd as { cmd: string }, { tabId, timeoutMs, onDispatchedRid }),
+    );
   } catch (err) {
     if (
       isRetrySafeCmd(cmd) &&
@@ -16033,12 +16174,18 @@ async function dispatchToTab(
       try {
         await sleep(retrySettleMs());
         const fresh = reResolve?.() ?? tabId;
-        return ok(await ctx.bridge.send(cmd as { cmd: string }, { tabId: fresh, timeoutMs }));
+        return ok(
+          await ctx.bridge.send(cmd as { cmd: string }, {
+            tabId: fresh,
+            timeoutMs,
+            onDispatchedRid,
+          }),
+        );
       } catch (err2) {
-        return fail(err2);
+        return carryReplyTimeoutMark(err2, fail(err2));
       }
     }
-    return fail(err);
+    return carryReplyTimeoutMark(err, fail(err));
   }
 }
 
@@ -21216,24 +21363,34 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const items = normalizeTodoItems(keyed.value as Array<{ text?: unknown; status?: unknown }>);
         const redirect = desktopCanvasRedirect(ctx, "panel_set_todo");
         if (redirect?.error) return fail(redirect.error);
-        if (redirect?.tabId) {
-          // #977 — the desktop redirect writes the checklist to ANOTHER tab, so
-          // record it against that one. Keying it on ctx.tabId would leave the
-          // tab that actually holds the plan looking planless.
-          recordTodo(redirect.tabId, items);
-          return dispatchToTab(
-            ctx,
-            redirect.tabId,
-            { cmd: "set_todo", items },
-            15000,
-            () => reResolveDesktopTab(ctx, "panel_set_todo"),
-          );
-        }
         // #977 — retain what the agent DECLARED, so a later render completion can
         // tell "you are mid-sweep" from "that was the last thing you were doing".
         // The panel keeps the UI copy; this is the orchestrator's own record.
-        recordTodo(ctx.tabId, items);
-        return ctx.call({ cmd: "set_todo", items }, 15000);
+        // The desktop redirect writes the checklist to ANOTHER tab, so record it
+        // against that one. Keying it on ctx.tabId would leave the tab that
+        // actually holds the plan looking planless.
+        const targetTab = redirect?.tabId ?? ctx.tabId;
+        recordTodo(targetTab, items);
+        let mutationId: string | undefined;
+        const observeRid = (rid: string): void => {
+          mutationId = rid;
+        };
+        const cmd = { cmd: "set_todo", items };
+        const res = redirect?.tabId
+          ? await dispatchToTab(
+              ctx,
+              redirect.tabId,
+              cmd,
+              15000,
+              () => reResolveDesktopTab(ctx, "panel_set_todo"),
+              observeRid,
+            )
+          : await ctx.call(cmd, 15000, observeRid);
+        // #2481 — ONLY a no-reply is settled by a read. An acked executor error
+        // is a definite outcome; re-deciding it from a later tray read would
+        // overwrite a better-informed verdict.
+        if (!isReplyTimeoutResult(res)) return res;
+        return settleSetTodoAfterAckTimeout(ctx, res, items, mutationId, targetTab);
       },
     ),
     def(

--- a/src/orchestrator/todo-state.ts
+++ b/src/orchestrator/todo-state.ts
@@ -185,3 +185,52 @@ export function normalizeTodoItems<T extends { status?: unknown }>(items: T[]): 
     typeof item?.status === "string" ? { ...item, status: normalizeTodoStatus(item.status) } : item,
   );
 }
+
+/** One checklist row after the aliases and the implied default are folded away.
+ *  Used to compare a delivered `set_todo` against a later `get_todo` read (#2481). */
+export interface CanonicalTodoEntry {
+  text: string;
+  status: string;
+}
+
+function todoStatusOrDefault(status: unknown): string {
+  return typeof status === "string" && status.trim() !== ""
+    ? normalizeTodoStatus(status)
+    : "pending";
+}
+
+function todoTextOf(entry: Record<string, unknown>): string | null {
+  if (typeof entry.text === "string") return entry.text;
+  if (typeof entry.content === "string") return entry.content;
+  return null;
+}
+
+/**
+ * Fold a checklist into comparable `{text, status}` rows, or null when the
+ * payload is not a list of items with a step description. Empty is valid (clear
+ * the tray). Missing status is `pending` — the schema's default, which the panel
+ * applies even when the caller omitted it.
+ */
+export function canonicalTodoEntries(items: unknown): CanonicalTodoEntry[] | null {
+  if (!Array.isArray(items)) return null;
+  const out: CanonicalTodoEntry[] = [];
+  for (const entry of items) {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return null;
+    const rec = entry as Record<string, unknown>;
+    const text = todoTextOf(rec);
+    if (text === null) return null;
+    out.push({ text, status: todoStatusOrDefault(rec.status) });
+  }
+  return out;
+}
+
+/** True when both payloads describe the same ordered checklist. */
+export function todoListsMatch(sent: unknown, observed: unknown): boolean {
+  const a = canonicalTodoEntries(sent);
+  const b = canonicalTodoEntries(observed);
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].text !== b[i].text || a[i].status !== b[i].status) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Closes #2481

## What happened

A live-canvas `panel_set_todo` was delivered to the connected workflow tab, but the tab did not ACK within 15000 ms. The tool returned the generic mutating-delivery warning (`may have been applied` / `a blind retry can apply it twice`) with no mutation receipt, no idempotency key, and no read-back. Later graph mutations on the same tab succeeded, so this was a transient ACK failure, not a dead tab.

## Gap this PR closes

After a tagged no-reply on `set_todo`, take one bounded `get_todo` read on the **same tab** and report the tray:

- tray matches the delivered list → success (`applied: true`, `mutation_id`, `CHECKED FOR YOU`)
- tray holds a different list → error (`applied: false`, `mutation_id`, requested vs observed)
- the read cannot answer (timeout, rebind, unreadable) → keep the original timeout **plus** a receipt (`mutation_id` + `requested`) and state that `set_todo` is a full-replace, so re-issuing that exact list cannot duplicate it

Acked executor errors are not re-decided from a later tray read. A desktop redirect probes the desktop tab the write was delivered to, not the session tab.

## Tests

`npx vitest run src/__tests__/orchestrator/set-todo-ack-timeout.test.ts src/__tests__/orchestrator/todo-state.test.ts`

Fails on an ambiguous timeout-after-delivery; passes on the shipped receipt/read-back.
