### PR TITLE
fix(1845): retry the live origin after restart instead of a dead 8188

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- after a confirmed restart, load_workflow retries the live panel origin and loopback alias instead of a dead 8188 (#1845)
 - list_local_models does not treat a /models/unet 404 as proof the file is under diffusion_models (#2480)
 - panel_set_todo reconciles a missing ACK with a todo read-back and mutation receipt instead of leaving the outcome as a guess (#2481)
 - recognise ComfyUI Desktop-2 (`Comfy Desktop.exe` under `Programs/ComfyUI`, `.comfyui-desktop-2` / `.launcher/snapshots`, parent process) so `restart_comfyui action:"stop"` records a start path and does not report `stopped:false` when the server is already gone (#2482)

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -32,12 +32,13 @@ import { join, sep } from "node:path";
 // the client's headers are still applied.
 const fetchApi = vi.fn();
 const fetchInit = vi.fn();
+const clientApi = vi.hoisted(() => ({ prefix: "" }));
 vi.mock("../../comfyui/client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../comfyui/client.js")>();
   return {
     ...actual,
     getClient: () => ({
-      apiURL: (route: string) => route,
+      apiURL: (route: string) => `${clientApi.prefix}${route}`,
       apiHeaders: () => ({ "Comfy-User": "default", Accept: "*/*" }),
       fetch: (url: string, init?: unknown) => {
         fetchInit(init);
@@ -55,6 +56,8 @@ const { WORKFLOW_LIBRARY_LISTING_ROUTE, __userdataLibraryTestHooks } = await imp
 );
 import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
 import { config } from "../../config.js";
+import { setConnectedPanelOrigins } from "../../comfyui/fetch.js";
+import { __resetPanelBaseCache, __setPanelBaseForTests } from "../../services/panel-workspace.js";
 
 type Forwarded = Record<string, unknown>;
 function makeCtx(opts?: { panelOrigin?: string }): { ctx: PanelToolCtx; calls: Forwarded[] } {
@@ -93,6 +96,7 @@ let savedConfigPath: string | undefined;
 beforeEach(() => {
   fetchApi.mockReset();
   fetchInit.mockReset();
+  clientApi.prefix = "";
   savedComfyPath = process.env.COMFYUI_PATH;
   savedConfigPath = config.comfyuiPath;
   // No local COMFYUI_PATH → the guessed workflows dirs are empty, so a relative
@@ -109,6 +113,8 @@ afterEach(() => {
   config.comfyuiPath = savedConfigPath;
   __userdataLibraryTestHooks.setRetryDelays(null);
   __userdataLibraryTestHooks.setSleep(null);
+  setConnectedPanelOrigins(null);
+  __resetPanelBaseCache();
 });
 
 describe("panel_load_workflow: userdata fallback for a custom --user-directory (#202)", () => {
@@ -1285,6 +1291,92 @@ describe("panel_load_workflow after a confirmed restart (#1845)", () => {
       expect(res.isError).toBeUndefined();
       expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
     expect(graphLoadCall(calls).graph).toMatchObject(staged);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retries the live loopback alias instead of staying on a dead 127.0.0.1:8188", async () => {
+    // Production-shaped client: apiURL is the full headless URL, not a relative
+    // route. After a confirmed restart 8188 stays refused; the browser's
+    // localhost spelling is the live origin. #1850 only retried opts.panelOrigin
+    // when the string differed, so this path never left 8188.
+    clientApi.prefix = "http://127.0.0.1:8188";
+    const graph = { nodes: [{ id: 3, type: "LoopbackAliasLoad" }], links: [] };
+    fetchApi.mockImplementation(async (url: string) => {
+      if (String(url).startsWith("http://localhost:8188/")) {
+        return { ok: true, status: 200, text: async () => JSON.stringify(graph) };
+      }
+      throw Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8188"), { code: "ECONNREFUSED" });
+    });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler(
+      { path: "workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json" },
+      ctx,
+    );
+
+    expect(res.isError).toBeUndefined();
+    expect(fetchApi).toHaveBeenCalledWith(
+      `http://localhost:8188/api/userdata/${encodeURIComponent("workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json")}`,
+    );
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
+  });
+
+  it("retries a published live panel origin when the tab origin is still the dead 8188", async () => {
+    clientApi.prefix = "http://127.0.0.1:8188";
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8000"]);
+    const graph = { nodes: [{ id: 4, type: "PublishedOriginLoad" }], links: [] };
+    fetchApi.mockImplementation(async (url: string) => {
+      if (String(url).startsWith("http://127.0.0.1:8000/")) {
+        return { ok: true, status: 200, text: async () => JSON.stringify(graph) };
+      }
+      throw Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8188"), { code: "ECONNREFUSED" });
+    });
+
+    const { ctx, calls } = makeCtx({ panelOrigin: "http://127.0.0.1:8188" });
+    const res = await loadWorkflow().handler(
+      { path: "workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json" },
+      ctx,
+    );
+
+    expect(res.isError).toBeUndefined();
+    expect(fetchApi).toHaveBeenCalledWith(
+      `http://127.0.0.1:8000/api/userdata/${encodeURIComponent("workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json")}`,
+    );
+    expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
+    expect(graphLoadCall(calls).graph).toMatchObject(graph);
+  });
+
+  it("does not claim COMFYUI_PATH is unset when the primed panel workspace is known", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-primed-ws-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      const staged = { nodes: [{ id: 11, type: "PrimedWorkspaceNode" }], links: [] };
+      writeFileSync(
+        join(defaultDir, "minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json"),
+        JSON.stringify(staged),
+        "utf8",
+      );
+      // Env and config both unset — the same shape as the reporter, where
+      // install_comfyui environment had already named this tree via the panel.
+      __setPanelBaseForTests(root);
+      fetchApi.mockRejectedValue(
+        Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8188"), { code: "ECONNREFUSED" }),
+      );
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler(
+        { path: "workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json" },
+        ctx,
+      );
+
+      expect(res.isError).toBeUndefined();
+      expect(JSON.stringify(res)).not.toMatch(/COMFYUI_PATH not set/);
+      expect(calls.filter((c) => c.cmd === "graph_load")).toHaveLength(1);
+      expect(graphLoadCall(calls).graph).toMatchObject(staged);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/__tests__/services/graph-command-effect.test.ts
+++ b/src/__tests__/services/graph-command-effect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,6 +18,20 @@ import {
 } from "../../services/ui-bridge.js";
 import { compareSemver } from "../../services/self-update.js";
 import { buildPanelToolDefs } from "../../orchestrator/panel-tools.js";
+import { __userdataLibraryTestHooks } from "../../services/userdata-library.js";
+
+// Driving the real tool surface with `path: "workflows/x.json"` reaches
+// userdataFetch. Default restart-race delays plus a localhost alias would
+// stack toward this file's 30s budget (the CI failure on #2573). This probe
+// classifies commands; it is not the #1845 retry test.
+beforeEach(() => {
+  __userdataLibraryTestHooks.setRetryDelays([]);
+  __userdataLibraryTestHooks.setSleep(async () => {});
+});
+afterEach(() => {
+  __userdataLibraryTestHooks.setRetryDelays(null);
+  __userdataLibraryTestHooks.setSleep(null);
+});
 
 /**
  * #778 — a READ blocked by a WRITE gate, and the reason it could happen at all.

--- a/src/services/panel-workspace.ts
+++ b/src/services/panel-workspace.ts
@@ -404,9 +404,20 @@ function targetGeneration(): number {
  * The already-resolved panel ComfyUI base, or undefined when nothing is cached.
  * Sync on purpose: panel_load_workflow's local fallback must not issue HTTP
  * after the userdata library has just been unreachable (#1845).
+ *
+ * Same-URL generation bumps are ignored here on purpose. `setComfyuiTarget`
+ * increments generation on a restart even when the address did not change,
+ * and dropping the last-known tree in that window is what made the fallback
+ * claim "COMFYUI_PATH not set" while install_comfyui environment still named
+ * that workspace. Mutation callers still go through `cachedResolution()`,
+ * which keeps the generation fence. A different URL still invalidates via
+ * `targetKey()`.
  */
 export function peekResolvedPanelBase(): string | undefined {
-  return cachedResolution()?.base;
+  if (!cached) return undefined;
+  if (cached.target !== targetKey()) return undefined;
+  if (Date.now() - cached.at > PANEL_BASE_TTL_MS) return undefined;
+  return cached.resolution.base;
 }
 
 function cachedResolution(): PanelBaseResolution | undefined {

--- a/src/services/userdata-library.ts
+++ b/src/services/userdata-library.ts
@@ -13,6 +13,7 @@
 // for #202) while get_workflow (action:"list") did not, which is exactly the drift a shared helper
 // removes.
 import { getClient } from "../comfyui/client.js";
+import { connectedPanelOriginsNow } from "../comfyui/fetch.js";
 import { getComfyUIBasePath } from "../config.js";
 import { describeFetchFailure } from "../utils/errors.js";
 
@@ -66,10 +67,14 @@ export const WORKFLOW_LIBRARY_LISTING_ROUTE =
  * #1845 — a confirmed ComfyUI restart can still leave the next userdata GET
  * racing the listener (ECONNREFUSED on 127.0.0.1:8188 while the panel tab is
  * already talking to the same server). Transient connection failures retry a
- * bounded number of times. When a connected panel origin is supplied AND its
- * spelling differs from the headless client URL (localhost vs 127.0.0.1, a
- * different port), that origin is tried after the headless URL is exhausted —
- * the browser's origin is the one that just proved reachable.
+ * bounded number of times. After the headless URL is exhausted, the live
+ * connected-panel origins are tried: the optional tab origin, then the
+ * published reconnect set (`connectedPanelOriginsNow`), then the loopback
+ * alias (127.0.0.1 ↔ localhost). Those are different TCP endpoints on Windows
+ * even when they name one ComfyUI, and the browser origin is the one that just
+ * proved reachable. The #1850 pass only retried `opts.panelOrigin` when its
+ * string differed from the headless URL, so a same-spelling 8188 or a missing
+ * tab origin after restart never left the dead default.
  */
 export async function userdataFetch(
   route: string,
@@ -77,13 +82,7 @@ export async function userdataFetch(
 ): Promise<Response> {
   const client = getClient();
   const headers = client.apiHeaders();
-  const primary = client.apiURL(route);
-  const urls = [primary];
-  const origin = opts?.panelOrigin?.trim();
-  if (origin) {
-    const alt = userdataUrlAtOrigin(origin, route);
-    if (alt && alt !== primary) urls.push(alt);
-  }
+  const urls = userdataRetryUrls(client.apiURL(route), route, opts?.panelOrigin);
 
   let lastErr: unknown;
   for (const url of urls) {
@@ -99,6 +98,28 @@ export async function userdataFetch(
     }
   }
   throw lastErr;
+}
+
+/** Headless URL first, then every distinct live-origin spelling of the same route. */
+function userdataRetryUrls(
+  primary: string,
+  route: string,
+  panelOrigin: string | undefined,
+): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  const add = (url: string | undefined): void => {
+    if (!url || seen.has(url)) return;
+    seen.add(url);
+    urls.push(url);
+  };
+  add(primary);
+  add(panelOrigin?.trim() ? userdataUrlAtOrigin(panelOrigin.trim(), route) : undefined);
+  for (const origin of connectedPanelOriginsNow()) {
+    add(userdataUrlAtOrigin(origin, route));
+  }
+  add(loopbackAliasUrl(primary));
+  return urls;
 }
 
 /** Connection-level failures that a just-restarted listener commonly produces. */
@@ -118,6 +139,26 @@ function userdataUrlAtOrigin(origin: string, route: string): string {
   }
   const path = route.startsWith("/") ? route : `/${route}`;
   return `${origin.replace(/\/$/, "")}${basePath}${path}`;
+}
+
+/**
+ * 127.0.0.1 and localhost are one ComfyUI by origin identity, and different
+ * sockets on Windows (IPv4 vs IPv6). After a restart the browser often reaches
+ * the live spelling while the headless client is still pinned to 8188's other
+ * form. A relative apiURL (tests, misconfigured client) is not a URL, so there
+ * is no alias to try.
+ */
+function loopbackAliasUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    if (host === "127.0.0.1") parsed.hostname = "localhost";
+    else if (host === "localhost") parsed.hostname = "127.0.0.1";
+    else return undefined;
+    return parsed.href;
+  } catch {
+    return undefined;
+  }
 }
 
 const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [200, 600, 1500];

--- a/src/services/userdata-library.ts
+++ b/src/services/userdata-library.ts
@@ -85,12 +85,26 @@ export async function userdataFetch(
   const urls = userdataRetryUrls(client.apiURL(route), route, opts?.panelOrigin);
 
   let lastErr: unknown;
-  for (const url of urls) {
+  const alias = loopbackAliasUrl(urls[0] ?? "");
+  for (let i = 0; i < urls.length; i++) {
+    const url = urls[i];
+    if (!url) continue;
+    // Alternates are one-shot with a short ceiling. The headless URL already
+    // spent the restart-race retries; re-waiting 200/600/1500ms per alias
+    // (and letting localhost sit on the 120s comfyuiFetch ceiling) is what
+    // hung GRAPH_CMD_EFFECT's tool-surface probe on Windows after #1850 —
+    // 127.0.0.1 refuses immediately, then ::1/localhost black-holes.
+    const fallback = i > 0;
+    const ceilingMs = url === alias ? LOOPBACK_ALIAS_TIMEOUT_MS : FALLBACK_TIMEOUT_MS;
     for (let attempt = 0; ; attempt++) {
       try {
-        return await client.fetch(url, { headers });
+        return await client.fetch(url, {
+          headers,
+          ...(fallback ? { signal: AbortSignal.timeout(ceilingMs) } : {}),
+        });
       } catch (err) {
         lastErr = err;
+        if (fallback) break;
         if (!isTransientUnreachable(err)) throw err;
         if (attempt >= retryDelaysMs.length) break;
         await sleepImpl(retryDelaysMs[attempt]!);
@@ -162,6 +176,12 @@ function loopbackAliasUrl(url: string): string | undefined {
 }
 
 const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [200, 600, 1500];
+/** Published/tab origin GET. A live listener answers in milliseconds. */
+const FALLBACK_TIMEOUT_MS = 2_000;
+/** Dual-stack localhost can black-hole for the full comfyuiFetch ceiling.
+ *  Keep this tight: several panel tools reach userdataFetch, and 2s each
+ *  stacked past the 30s GRAPH_CMD_EFFECT probe. */
+const LOOPBACK_ALIAS_TIMEOUT_MS = 400;
 let retryDelaysMs: readonly number[] = DEFAULT_RETRY_DELAYS_MS;
 let sleepImpl = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Fixes #1845

## Recurrence

#1850 shipped in v0.52.26. After `panel_restart_comfyui` reports server_ready / graph_tools_ready / panel_tab_reconnected, `panel_refresh_nodes` still works while `panel_load_workflow` ECONNREFUSED `127.0.0.1:8188` and then claims COMFYUI_PATH is unset even though `install_comfyui` environment already showed the trusted local install.

## Gap this PR closes

- **Dead 8188 after ready** — `#1850` retried the headless userdata GET and `opts.panelOrigin` only when that string differed from the client URL. After restart the tab origin is often the same `127.0.0.1:8188` spelling, so the alt was skipped and the request never left the dead default.
- **Live origin unused** — the published reconnect set (`connectedPanelOriginsNow`) is the origin the panel tab is already talking to. `userdataFetch` now retries it after the headless URL is exhausted.
- **Loopback alias** — `127.0.0.1` and `localhost` are one ComfyUI by origin identity and different TCP endpoints on Windows. The live spelling is tried instead of staying on the refused one.
- **COMFYUI_PATH claim** — a same-URL generation bump after restart dropped the primed panel workspace, so the local fallback pretended no tree was known. `peekResolvedPanelBase` now keeps that last-known tree for this read-only fallback.

## Tests

`npx vitest run src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts src/__tests__/services/panel-base-clear-epoch.test.ts`

58 passed. Unfixed code fails the loopback-alias and published-origin cases (ECONNREFUSED stays on 8188). Shipped retry loads the graph; primed workspace does not claim COMFYUI_PATH unset.