### PR TITLE
fix(2482): recognise Desktop-2 so stop records a start path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - panel_set_todo reconciles a missing ACK with a todo read-back and mutation receipt instead of leaving the outcome as a guess (#2481)
+- recognise ComfyUI Desktop-2 (`Comfy Desktop.exe` under `Programs/ComfyUI`, `.comfyui-desktop-2` / `.launcher/snapshots`, parent process) so `restart_comfyui action:"stop"` records a start path and does not report `stopped:false` when the server is already gone (#2482)
 
 ## [0.52.149] - 2026-08-30
 

--- a/src/__tests__/services/desktop2-restart-info.test.ts
+++ b/src/__tests__/services/desktop2-restart-info.test.ts
@@ -1,0 +1,398 @@
+// ComfyUI Desktop-2 (#2482): the Windows layout is
+//   core     ~/ComfyUI-Installs/ComfyUI/ComfyUI
+//   venv     ~/Documents/ComfyUI/.venv
+//   launcher ~/AppData/Local/Programs/ComfyUI/Comfy Desktop/Comfy Desktop.exe
+//
+// The python argv has no "Comfy Desktop" token, so stop used to kill the
+// backend (or a child PID already gone), report stopped:false +
+// has_restart_info:false, and leave start with no launcher — agents then
+// guessed the legacy v1 ComfyUI.exe and broke the 0.34 core.
+
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function noListener(): Error {
+  const err = new Error("no listener") as Error & {
+    status?: number;
+    stdout?: string;
+    stderr?: string;
+  };
+  err.status = 1;
+  err.stdout =
+    "lsof: Internet address not located: TCP:8188\nlsof: TCP state not located: LISTEN\n";
+  err.stderr = "";
+  return err;
+}
+
+class FakeChild extends EventEmitter {
+  unref = vi.fn();
+  pid: number | undefined = 8800;
+}
+
+const DESKTOP2_EXE =
+  "C:\\Users\\x\\AppData\\Local\\Programs\\ComfyUI\\Comfy Desktop\\Comfy Desktop.exe";
+const LEGACY_V1_EXE = "C:\\Users\\x\\AppData\\Local\\Programs\\ComfyUI\\ComfyUI.exe";
+const MAIN = "C:\\Users\\x\\ComfyUI-Installs\\ComfyUI\\ComfyUI\\main.py";
+const PYTHON = "C:\\Users\\x\\Documents\\ComfyUI\\.venv\\Scripts\\python.exe";
+const MARKER = "C:\\Users\\x\\ComfyUI-Installs\\ComfyUI\\.comfyui-desktop-2";
+const SNAP_DIR = "C:\\Users\\x\\ComfyUI-Installs\\ComfyUI\\.launcher\\snapshots";
+const SERVER_ARGV = [MAIN, "--listen", "127.0.0.1", "--port", "8188"];
+const SHELL_PID = 300;
+const SERVER_PID = 4321;
+
+const mockConfig = vi.hoisted(() => ({
+  resolvedPort: 8188,
+  comfyuiPath: undefined as string | undefined,
+}));
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockGetSystemStats = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn((_p: string) => false));
+const mockReaddirSync = vi.hoisted(() => vi.fn((_p: string): string[] => []));
+const mockFindComfyuiPython = vi.hoisted(() => vi.fn());
+
+vi.mock("../../config.js", () => ({
+  config: mockConfig,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyuiTargetGeneration: () => 0,
+  getComfyUIAuthHeaders: () => ({}),
+  isRemoteMode: () => false,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: mockExecSync,
+  spawn: mockSpawn,
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: (p: string) => mockExistsSync(String(p)),
+  lstatSync: vi.fn((p: string) => {
+    if (!mockExistsSync(String(p))) throw new Error("ENOENT");
+    return { isDirectory: () => true, isFile: () => true, isSymbolicLink: () => false };
+  }),
+  readlinkSync: vi.fn(() => {
+    throw new Error("no /proc in test");
+  }),
+  readFileSync: vi.fn(() => {
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
+  }),
+  readdirSync: (p: string) => mockReaddirSync(String(p)),
+  statSync: vi.fn((p: string) => {
+    if (!mockExistsSync(String(p))) throw new Error("ENOENT");
+    return { isFile: () => true, isDirectory: () => false };
+  }),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: mockGetSystemStats,
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../services/env-capabilities.js", () => ({
+  findComfyuiPython: mockFindComfyuiPython,
+}));
+
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => undefined,
+  liveRootFromArgv: () => undefined,
+  resolveLiveServerRoot: () => ({ source: "unresolved" }),
+  markLocalComfyUILaunched: vi.fn(),
+  resetLocalComfyUILaunchState: vi.fn(),
+}));
+
+vi.mock("../../services/instance-witness.js", async () => ({
+  ...(await vi.importActual("../../services/instance-witness.js")),
+  acquireInstanceWitness: async () => undefined,
+}));
+
+import {
+  __processControlTestHooks,
+  startComfyUI,
+  stopComfyUI,
+} from "../../services/process-control.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function onDisk(...paths: string[]): void {
+  const allowed = new Set(paths.map((p) => p.replace(/\\/g, "/").toLowerCase()));
+  mockExistsSync.mockImplementation((p: string) =>
+    allowed.has(String(p).replace(/\\/g, "/").toLowerCase()),
+  );
+}
+
+function mockLivePortThenFree(opts?: {
+  onKill?: (cmd: string) => void;
+}): { killed: () => boolean } {
+  let killed = false;
+  mockExecSync.mockImplementation((cmd: string) => {
+    if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+      killed = true;
+      opts?.onKill?.(cmd);
+      return "";
+    }
+    if (/tasklist/i.test(cmd)) return "";
+    if (/pgrep/i.test(cmd)) {
+      const err = new Error("no match") as Error & { status?: number };
+      err.status = 1;
+      throw err;
+    }
+    if (/if exist/i.test(cmd)) {
+      if (cmd.includes("Comfy Desktop") && cmd.includes("Programs\\ComfyUI")) return "found";
+      return "";
+    }
+    if (/netstat/i.test(cmd)) {
+      return killed ? "" : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${SERVER_PID}`;
+    }
+    if (/lsof/i.test(cmd)) {
+      if (killed) throw noListener();
+      return `p${SERVER_PID}\nn127.0.0.1:8188\n`;
+    }
+    return "";
+  });
+  return { killed: () => killed };
+}
+
+function installDesktop2Tree(): void {
+  __processControlTestHooks.setProcessIdentityResolver((pid) => {
+    if (pid === SHELL_PID) {
+      return {
+        executablePath: DESKTOP2_EXE,
+        commandLine: `"${DESKTOP2_EXE}"`,
+        argv: [DESKTOP2_EXE],
+        startedAt: "2000",
+      };
+    }
+    if (pid === SERVER_PID) {
+      return {
+        startedAt: "5000",
+        parentPid: SHELL_PID,
+        commandLine: `"${PYTHON}" "${MAIN}" --listen 127.0.0.1 --port 8188`,
+        argv: [PYTHON, ...SERVER_ARGV],
+      };
+    }
+    return undefined;
+  });
+  __processControlTestHooks.setParentPidResolver((pid) =>
+    pid === SERVER_PID ? SHELL_PID : undefined,
+  );
+  __processControlTestHooks.setProcessExistsProbe((pid) => pid === SERVER_PID || pid === SHELL_PID);
+}
+
+function spawnDesktop(): void {
+  mockSpawn.mockImplementation(() => new FakeChild());
+}
+
+function expectSpawnedDesktop2(): void {
+  expect(mockSpawn).toHaveBeenCalled();
+  const dumped = JSON.stringify(mockSpawn.mock.calls[0]);
+  expect(dumped).toContain("Comfy Desktop.exe");
+  expect(dumped).not.toMatch(/ComfyUI\.exe/i);
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  process.env.LOCALAPPDATA = "C:\\Users\\x\\AppData\\Local";
+  process.env.USERPROFILE = "C:\\Users\\x";
+  process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+  process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "1";
+  process.env.COMFYUI_PORT_FREE_TIMEOUT_S = "1";
+  mockConfig.resolvedPort = 8188;
+  mockConfig.comfyuiPath = undefined;
+  mockFindComfyuiPython.mockReturnValue(PYTHON);
+  mockReaddirSync.mockImplementation(() => {
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
+  });
+  onDisk(MAIN, PYTHON, DESKTOP2_EXE);
+  mockGetSystemStats.mockResolvedValue({ system: { argv: [...SERVER_ARGV] } });
+  vi.spyOn(process, "kill").mockImplementation(() => true);
+  vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true }) as Response));
+  __processControlTestHooks.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  __processControlTestHooks.reset();
+});
+
+describe("restart_comfyui — Desktop-2 recognition and stop/start (#2482)", () => {
+  it("records the Desktop-2 launcher from the parent process so start can relaunch it", async () => {
+    mockLivePortThenFree();
+    installDesktop2Tree();
+    spawnDesktop();
+
+    const stopped = await stopComfyUI();
+    expect(stopped.stopped).toBe(true);
+    expect(stopped.has_restart_info).toBe(true);
+    expect(stopped.launch?.exe).toBe(DESKTOP2_EXE);
+    expect(stopped.message).not.toMatch(/left as it was/i);
+
+    const started = await startComfyUI();
+    expect(started.started).toBe(true);
+    expectSpawnedDesktop2();
+  });
+
+  it("recognises Desktop-2 via the .comfyui-desktop-2 marker when argv has no Desktop token", async () => {
+    mockLivePortThenFree();
+    onDisk(MAIN, PYTHON, DESKTOP2_EXE, MARKER);
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "5000",
+      commandLine: `"${PYTHON}" "${MAIN}" --listen 127.0.0.1 --port 8188`,
+      argv: [PYTHON, ...SERVER_ARGV],
+    }));
+    spawnDesktop();
+
+    const stopped = await stopComfyUI();
+    expect(stopped.stopped).toBe(true);
+    expect(stopped.has_restart_info).toBe(true);
+    expect(stopped.launch?.exe).toBe(DESKTOP2_EXE);
+
+    const started = await startComfyUI();
+    expect(started.started).toBe(true);
+    expectSpawnedDesktop2();
+  });
+
+  it("recognises Desktop-2 via .launcher/snapshots/*.json", async () => {
+    mockLivePortThenFree();
+    onDisk(MAIN, PYTHON, DESKTOP2_EXE, SNAP_DIR);
+    mockReaddirSync.mockImplementation((p: string) => {
+      if (String(p).replace(/\\/g, "/").toLowerCase().includes(".launcher/snapshots")) {
+        return ["auto-2026-08-30.json"];
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "5000",
+      commandLine: `"${PYTHON}" "${MAIN}" --listen 127.0.0.1 --port 8188`,
+      argv: [PYTHON, ...SERVER_ARGV],
+    }));
+    spawnDesktop();
+
+    const stopped = await stopComfyUI();
+    expect(stopped.stopped).toBe(true);
+    expect(stopped.has_restart_info).toBe(true);
+    expect(stopped.launch?.exe).toBe(DESKTOP2_EXE);
+  });
+
+  it("does not report stopped:false when taskkill fails but the port is already free", async () => {
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill/i.test(cmd) || /pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        const err = new Error(`Command failed: taskkill /PID 47224 /T /F`) as Error & {
+          stderr?: string;
+        };
+        err.stderr =
+          'ERROR: The process with PID 47224 could not be terminated.\nReason: Access is denied.\n';
+        throw err;
+      }
+      if (/tasklist/i.test(cmd)) {
+        return '"Comfy Desktop.exe","47224","Console","1","200,000 K"\n';
+      }
+      if (/pgrep/i.test(cmd)) return "47224\n";
+      if (/if exist/i.test(cmd)) {
+        return cmd.includes("Comfy Desktop") && cmd.includes("Programs\\ComfyUI") ? "found" : "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed ? "" : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${SERVER_PID}`;
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw noListener();
+        return `p${SERVER_PID}\nn127.0.0.1:8188\n`;
+      }
+      return "";
+    });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      killed = true;
+      const err = new Error("kill EPERM") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    });
+    installDesktop2Tree();
+    spawnDesktop();
+
+    const stopped = await stopComfyUI();
+    expect(stopped.stopped).toBe(true);
+    expect(stopped.has_restart_info).toBe(true);
+    expect(stopped.launch?.exe).toBe(DESKTOP2_EXE);
+    expect(stopped.message).not.toMatch(/left as it was/i);
+    expect(stopped.message).not.toMatch(/Could not stop ComfyUI/i);
+
+    const started = await startComfyUI();
+    expect(started.started).toBe(true);
+    expectSpawnedDesktop2();
+  });
+
+  it("still reports stopped:false when the kill fails and the original pid owns the port", async () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill/i.test(cmd) || /pkill|\bkill\b/i.test(cmd)) {
+        const err = new Error(`Command failed: taskkill /PID ${SERVER_PID} /T /F`) as Error & {
+          stderr?: string;
+        };
+        err.stderr = "ERROR: Access is denied.\n";
+        throw err;
+      }
+      if (/tasklist/i.test(cmd)) return "";
+      if (/pgrep/i.test(cmd)) {
+        const err = new Error("no match") as Error & { status?: number };
+        err.status = 1;
+        throw err;
+      }
+      if (/netstat/i.test(cmd)) {
+        return `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${SERVER_PID}`;
+      }
+      if (/lsof/i.test(cmd)) return `p${SERVER_PID}\nn127.0.0.1:8188\n`;
+      return "";
+    });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const err = new Error("kill EPERM") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    });
+    installDesktop2Tree();
+
+    const stopped = await stopComfyUI();
+    expect(stopped.stopped).toBe(false);
+    expect(stopped.has_restart_info).toBe(false);
+    expect(stopped.message).toMatch(/left as it was/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it.skipIf(process.platform !== "win32")(
+    "prefers the Desktop-2 launcher over legacy ComfyUI.exe when both exist on disk",
+    async () => {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) return "";
+      if (/tasklist/i.test(cmd)) return "";
+      if (/pgrep/i.test(cmd)) {
+        const err = new Error("no match") as Error & { status?: number };
+        err.status = 1;
+        throw err;
+      }
+      if (/if exist/i.test(cmd)) {
+        if (cmd.includes("Comfy Desktop.exe") || cmd.includes("ComfyUI.exe")) return "found";
+        return "";
+      }
+      if (/netstat/i.test(cmd) || /lsof/i.test(cmd)) throw noListener();
+      return "";
+    });
+    onDisk(DESKTOP2_EXE, LEGACY_V1_EXE);
+    spawnDesktop();
+
+    const started = await startComfyUI();
+    expect(started.started).toBe(true);
+    expectSpawnedDesktop2();
+    const dumped = JSON.stringify(mockSpawn.mock.calls[0]);
+    expect(dumped).not.toContain(LEGACY_V1_EXE.replace(/\\/g, "\\\\"));
+    },
+  );
+});

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -843,6 +843,10 @@ function looksLikeDesktop2Root(dir: string): boolean {
   );
 }
 
+function looksLikeDesktop2Argv(argv: string[]): boolean {
+  return argv.some((tok) => Boolean(tok && looksLikePath(tok) && looksLikeDesktop2Root(tok)));
+}
+
 function desktop2InstallFromArgv(argv: string[]): boolean {
   for (const tok of argv) {
     if (!tok || !looksLikePath(tok)) continue;
@@ -903,19 +907,24 @@ function detectDesktopLaunch(
   argv: string[],
 ): { isDesktopApp: boolean; desktopExePath?: string } {
   const fromArgv = isDesktopApp(argv);
-  const fromParent = desktopExeFromAncestor(pid);
   const fromMarkers = desktop2InstallFromArgv(argv);
+  const desktop2Argv = looksLikeDesktop2Argv(argv);
+  // Walking ancestors calls resolveProcessIdentity. Doing that on every gather
+  // consumes identity-sequence steps, so a later creation-time change is never
+  // seen and a recycled PID is killed (#776). Only walk when THIS argv already
+  // names a Desktop-2 layout.
+  const fromParent =
+    fromMarkers || desktop2Argv ? desktopExeFromAncestor(pid) : undefined;
   const isDesktop = fromArgv || Boolean(fromParent) || fromMarkers;
   if (!isDesktop) return { isDesktopApp: false };
 
   if (fromParent && fileExists(fromParent)) {
     return { isDesktopApp: true, desktopExePath: fromParent };
   }
-  if (fromMarkers || fromParent) {
-    const located = IS_WIN
-      ? (desktop2WindowsExeCandidates().find((p) => fileExists(p)) ??
-        findDesktopExeFromCommonPaths())
-      : findDesktopExeFromCommonPaths();
+  // fileExists, not `if exist` / `test -d`: POSIX findDesktopExeFromCommonPaths
+  // treats a stubbed execSync success as "the .app is there".
+  if (fromMarkers || fromParent || desktop2Argv) {
+    const located = desktop2WindowsExeCandidates().find((p) => fileExists(p));
     if (located) return { isDesktopApp: true, desktopExePath: located };
     if (fromParent) return { isDesktopApp: true, desktopExePath: fromParent };
   }

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -262,6 +262,12 @@ interface StopResult {
    * what its name says: a relaunch command was BUILT AND VALIDATED before the kill.
    */
   has_restart_info: boolean;
+  /**
+   * The Desktop launcher to spawn on `action:"start"`, when one was observed
+   * (parent process or a known Desktop-2 install path). Distinct from
+   * `restart_hint`, which is the recovery instruction for a human.
+   */
+  launch?: { exe: string };
   /** Present whenever a hand-restart may be needed — always on a refusal. */
   restart_hint?: RecoveryHint;
   /** Why a relaunch could not be validated, when it could not. */
@@ -609,6 +615,29 @@ function findPythonProcessPids(): ProcessListProbe {
   return { pids: [...pids], complete };
 }
 
+/**
+ * Did a kill fail because the target was already gone?
+ *
+ * Windows `taskkill /T` often kills the Python server as a child, then exits
+ * non-zero because a helper PID in the same tree is already absent. The
+ * message is frequently "There is no running instance of the task" — which
+ * does not contain "not found" — so matching only the latter left stop
+ * reporting `stopped:false` after the port had already closed (#2482).
+ */
+function killOutput(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const chunks = [err.message];
+  if ("stderr" in err && typeof err.stderr === "string") chunks.push(err.stderr);
+  if ("stdout" in err && typeof err.stdout === "string") chunks.push(err.stdout);
+  return chunks.join("\n");
+}
+
+function killErrorLooksAlreadyGone(err: unknown): boolean {
+  return /not found|no such process|does not exist|no running instance|esrch/i.test(
+    killOutput(err),
+  );
+}
+
 function killProcessTree(pid: number): void {
   try {
     if (IS_WIN) {
@@ -634,11 +663,11 @@ function killProcessTree(pid: number): void {
       }
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    // "not found" / "no such process" are fine — process already dead
-    if (!/not found|no such process|does not exist/i.test(msg)) {
-      throw new ProcessControlError(`Failed to kill process ${pid}: ${msg}`);
-    }
+    // "not found" / "no such process" / a vanished Windows task are fine —
+    // the process is already dead. Callers still re-probe the port (#2482).
+    if (killErrorLooksAlreadyGone(err)) return;
+    const msg = killOutput(err);
+    throw new ProcessControlError(`Failed to kill process ${pid}: ${msg}`);
   }
 }
 
@@ -763,8 +792,137 @@ function isDesktopApp(argv: string[]): boolean {
     // Current branding ("Comfy Desktop\Comfy Desktop.exe", "Comfy Desktop.app")
     // and the electron-era install dir.
     joined.includes("comfy desktop") ||
+    // Desktop-2 data root (`%LOCALAPPDATA%\Comfy-Desktop\…`) and the install
+    // marker `.comfyui-desktop-2` when it appears on argv.
+    joined.includes("comfy-desktop") ||
+    joined.includes("comfyui-desktop-2") ||
     joined.includes("@comfyorgcomfyui-electron")
   );
+}
+
+/**
+ * Parent directory that works for both Windows and POSIX spellings, even when
+ * this process is running on the other OS (tests feed Windows paths on Linux).
+ */
+function parentOfPath(p: string): string {
+  const trimmed = p.replace(/[/\\]+$/, "");
+  const slash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  if (slash <= 0) return "";
+  return trimmed.slice(0, slash);
+}
+
+function joinOnPath(dir: string, ...parts: string[]): string {
+  const sep = dir.includes("\\") ? "\\" : "/";
+  return [dir.replace(/[/\\]+$/, ""), ...parts].join(sep);
+}
+
+/**
+ * Desktop-2 writes `<install>/.comfyui-desktop-2` and snapshot JSON under
+ * `<install>/.launcher/snapshots/`. Either is enough to identify the layout
+ * when argv has no "Comfy Desktop" token (#2482).
+ */
+function hasDesktop2Markers(dir: string): boolean {
+  if (!dir) return false;
+  if (fileExists(joinOnPath(dir, ".comfyui-desktop-2"))) return true;
+  const snapDir = joinOnPath(dir, ".launcher", "snapshots");
+  try {
+    if (!existsSync(snapDir)) return false;
+    return readdirSync(snapDir).some((name) => name.endsWith(".json"));
+  } catch {
+    return false;
+  }
+}
+
+function looksLikeDesktop2Root(dir: string): boolean {
+  const n = dir.replace(/\\/g, "/").toLowerCase();
+  return (
+    n.includes("/comfyui-installs/") ||
+    n.endsWith("/comfyui-installs") ||
+    n.includes("/comfy-desktop/") ||
+    n.includes("comfyui-desktop-2")
+  );
+}
+
+function desktop2InstallFromArgv(argv: string[]): boolean {
+  for (const tok of argv) {
+    if (!tok || !looksLikePath(tok)) continue;
+    let dir = /\.[A-Za-z0-9]+$/.test(tok.replace(/[/\\]+$/, "")) ? parentOfPath(tok) : tok;
+    for (let i = 0; i < 6 && dir; i++) {
+      // Only probe markers on a Desktop-2-shaped root. existsSync is stubbed
+      // true in several process-control suites, so a global marker walk would
+      // reclassify ordinary python installs as Desktop.
+      if (looksLikeDesktop2Root(dir) && hasDesktop2Markers(dir)) return true;
+      const next = parentOfPath(dir);
+      if (!next || next === dir) break;
+      dir = next;
+    }
+  }
+  return false;
+}
+
+/** Windows Desktop-2 NSIS layout: `…\Programs\ComfyUI\Comfy Desktop\Comfy Desktop.exe`. */
+function desktop2WindowsExeCandidates(): string[] {
+  const localAppData = process.env.LOCALAPPDATA;
+  const userProfile = process.env.USERPROFILE;
+  const out: string[] = [];
+  if (localAppData) {
+    out.push(`${localAppData}\\Programs\\ComfyUI\\Comfy Desktop\\Comfy Desktop.exe`);
+  }
+  if (userProfile) {
+    out.push(
+      `${userProfile}\\AppData\\Local\\Programs\\ComfyUI\\Comfy Desktop\\Comfy Desktop.exe`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Walk a few ancestors of the backend PID looking for the Electron shell.
+ * Desktop-2's usual tree is `Comfy Desktop.exe` → python → server python (#2482).
+ */
+function desktopExeFromAncestor(pid: number): string | undefined {
+  let current = pid;
+  const seen = new Set<number>();
+  for (let hop = 0; hop < 5; hop++) {
+    if (seen.has(current)) return undefined;
+    seen.add(current);
+    const parent = readParentPid(current);
+    if (parent == null || parent <= 1 || parent === current) return undefined;
+    const identity = resolveProcessIdentity(parent);
+    if (identity && isDesktopSupervisorProcess(identity)) {
+      const exe = identity.executablePath ?? identity.argv?.[0];
+      if (exe) return exe;
+    }
+    current = parent;
+  }
+  return undefined;
+}
+
+function detectDesktopLaunch(
+  pid: number,
+  argv: string[],
+): { isDesktopApp: boolean; desktopExePath?: string } {
+  const fromArgv = isDesktopApp(argv);
+  const fromParent = desktopExeFromAncestor(pid);
+  const fromMarkers = desktop2InstallFromArgv(argv);
+  const isDesktop = fromArgv || Boolean(fromParent) || fromMarkers;
+  if (!isDesktop) return { isDesktopApp: false };
+
+  if (fromParent && fileExists(fromParent)) {
+    return { isDesktopApp: true, desktopExePath: fromParent };
+  }
+  if (fromMarkers || fromParent) {
+    const located = IS_WIN
+      ? (desktop2WindowsExeCandidates().find((p) => fileExists(p)) ??
+        findDesktopExeFromCommonPaths())
+      : findDesktopExeFromCommonPaths();
+    if (located) return { isDesktopApp: true, desktopExePath: located };
+    if (fromParent) return { isDesktopApp: true, desktopExePath: fromParent };
+  }
+  return {
+    isDesktopApp: true,
+    desktopExePath: findDesktopExePath(argv),
+  };
 }
 
 /**
@@ -956,11 +1114,19 @@ function expectedDesktopExecutablePaths(): string[] {
       ...(localAppData
         ? [
             `${localAppData}/Programs/Comfy Desktop/Comfy Desktop.exe`,
+            // Desktop-2 NSIS: …\Programs\ComfyUI\Comfy Desktop\Comfy Desktop.exe
+            // MUST outrank the legacy v1 …\Programs\ComfyUI\ComfyUI.exe (#2482).
+            `${localAppData}/Programs/ComfyUI/Comfy Desktop/Comfy Desktop.exe`,
             `${localAppData}/Programs/@comfyorgcomfyui-electron/ComfyUI.exe`,
             `${localAppData}/Programs/ComfyUI/ComfyUI.exe`,
           ]
         : []),
-      ...(userProfile ? [`${userProfile}/Programs/ComfyUI/ComfyUI.exe`] : []),
+      ...(userProfile
+        ? [
+            `${userProfile}/AppData/Local/Programs/ComfyUI/Comfy Desktop/Comfy Desktop.exe`,
+            `${userProfile}/Programs/ComfyUI/ComfyUI.exe`,
+          ]
+        : []),
     ];
   }
   const home = homedir();
@@ -1036,6 +1202,10 @@ function findDesktopExeFromCommonPaths(): string | undefined {
       // Current branding: "Comfy Desktop" (per-machine and per-user installs)
       `C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe`,
       `${process.env.LOCALAPPDATA}\\Programs\\Comfy Desktop\\Comfy Desktop.exe`,
+      // Desktop-2 NSIS layout. Checked BEFORE legacy ComfyUI.exe — both can
+      // exist after an upgrade, and spawning v1 against the shared Desktop-2
+      // venv downgrades packages and breaks the 0.34+ core (#2482).
+      `${process.env.LOCALAPPDATA}\\Programs\\ComfyUI\\Comfy Desktop\\Comfy Desktop.exe`,
       // Electron-era install dir
       `${process.env.LOCALAPPDATA}\\Programs\\@comfyorgcomfyui-electron\\ComfyUI.exe`,
       // Legacy names
@@ -1081,7 +1251,11 @@ function findDesktopExePath(argv: string[]): string | undefined {
     const match = joined.match(
       /([A-Za-z]:[\\\/].*?[\\\/]Programs[\\\/]ComfyUI)[\\\/]resources/i,
     );
-    if (match) return `${match[1]}\\ComfyUI.exe`;
+    if (match) {
+      const desktop2 = `${match[1]}\\Comfy Desktop\\Comfy Desktop.exe`;
+      if (fileExists(desktop2)) return desktop2;
+      return `${match[1]}\\ComfyUI.exe`;
+    }
   } else {
     // macOS: /Applications/ComfyUI.app/...
     const match = joined.match(/(\/.*?ComfyUI\.app)/);
@@ -3888,8 +4062,13 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // as an ordinary Python install — and would then be KILLED, which is the one thing
   // the Desktop path exists to never do (#400).
   const identifyingArgv = argv.length > 0 ? argv : (osArgv ?? []);
-  const desktop = isDesktopApp(identifyingArgv);
-  const desktopExe = desktop ? findDesktopExePath(identifyingArgv) : undefined;
+  // Desktop-2's python argv often has no "Comfy Desktop" token (core lives
+  // under ~/ComfyUI-Installs, venv under ~/Documents/ComfyUI). Recognise the
+  // parent `Comfy Desktop.exe` and the `.comfyui-desktop-2` / snapshot
+  // markers so stop can record a relaunch path (#2482).
+  const desktopLaunch = detectDesktopLaunch(pid, identifyingArgv);
+  const desktop = desktopLaunch.isDesktopApp;
+  const desktopExe = desktopLaunch.desktopExePath;
   // Capture the live process cwd NOW, while the pid is guaranteed alive — the
   // `/proc/<pid>/cwd` symlink is gone the instant a later stop kills it (#535).
   //
@@ -4192,20 +4371,36 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
       killProcessTree(info.pid);
     }
   } catch (err) {
-    deliberateStop = false;
     const msg = err instanceof Error ? err.message : String(err);
-    logger.warn("Stop aborted: the kill failed, so nothing was torn down", {
-      pid: info.pid,
-      error: msg,
-    });
-    return {
-      stopped: false,
-      message:
-        `Could not stop ComfyUI (PID ${info.pid}): ${msg}. The server was left as it was — ` +
-        "its crash supervision and launch record are untouched. This is usually a " +
-        "permissions problem: stop it from the launcher/console that owns it.",
-      has_restart_info: false,
-    };
+    // `taskkill /T` can kill the Python server (port closes) and still throw
+    // because a helper PID in the same tree was already gone. Re-probe before
+    // claiming the server was left untouched (#2482).
+    const probe = probePortOwner(info.port);
+    const originalGone = processExists(info.pid) === false;
+    const portFree = probe.state === "free";
+    const portMovedOn = probe.state === "owned" && probe.pid !== info.pid;
+    if (portFree || originalGone || portMovedOn) {
+      logger.warn("Kill command failed but the server is gone", {
+        pid: info.pid,
+        port: info.port,
+        probe: probe.state,
+        error: msg,
+      });
+    } else {
+      deliberateStop = false;
+      logger.warn("Stop aborted: the kill failed, so nothing was torn down", {
+        pid: info.pid,
+        error: msg,
+      });
+      return {
+        stopped: false,
+        message:
+          `Could not stop ComfyUI (PID ${info.pid}): ${msg}. The server was left as it was — ` +
+          "its crash supervision and launch record are untouched. This is usually a " +
+          "permissions problem: stop it from the launcher/console that owns it.",
+        has_restart_info: false,
+      };
+    }
   }
 
   // A KILL THAT RETURNED IS STILL NOT PROOF THE PROCESS DIED (codex gate). On
@@ -4306,6 +4501,7 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
     // The one claim #767 was about: it now means a relaunch command was built AND
     // validated, not merely that some process info was stored.
     has_restart_info: relaunch.ok,
+    launch: info.desktopExePath ? { exe: info.desktopExePath } : undefined,
     relaunch_blocked: relaunch.ok ? undefined : relaunch.reason,
     restart_hint: hint,
     auto_restart: supervisorResult(info),


### PR DESCRIPTION
Closes artokun/comfyui-mcp#2482

## Recurrence

Windows ComfyUI Desktop-2 (core `~/ComfyUI-Installs/ComfyUI/ComfyUI`, venv `~/Documents/ComfyUI/.venv`, launcher `~/AppData/Local/Programs/ComfyUI/Comfy Desktop/Comfy Desktop.exe`) was not recognised as Desktop. `restart_comfyui action:"stop"` killed the python server (port closed) but reported `stopped:false` (`taskkill /PID <child> /T /F` → process not found) and `has_restart_info:false`. `action:"start"` had no launch path; the agent guessed the legacy v1 `ComfyUI.exe` and booted 0.22.3 against the shared venv, breaking 0.34.2.

## Gap this PR closes

- **Desktop-2 recognition** — parent `Comfy Desktop.exe`, `.comfyui-desktop-2`, `.launcher/snapshots/*.json`, and the `Programs/ComfyUI/Comfy Desktop/Comfy Desktop.exe` NSIS path (ranked above legacy `ComfyUI.exe`).
- **Restart info** — stop records `launch.exe` as that Desktop-2 launcher so start can spawn it.
- **Honest stop** — if the kill command fails, re-probe the port / original pid; never report `stopped:false` / "left as it was" when the server is already gone. Still `stopped:false` when the original pid still owns the port.

## Tests

`npx vitest run src/__tests__/services/desktop2-restart-info.test.ts src/__tests__/services/process-control.test.ts src/__tests__/services/desktop-restart.test.ts src/__tests__/services/restart-relaunch-lifecycle.test.ts`

6/6 Desktop-2 tests pass (parent / marker / snapshots / kill-failed-but-port-free / still-running / prefer-v2-over-v1). Unfixed code fails stop/start for Desktop-2 (no restart info, `stopped:false` after a vanished child PID). Related restart suites: 153 passed.
