### PR TITLE
fix(2480): list configured unet dir instead of assuming diffusion_models on REST 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- list_local_models does not treat a /models/unet 404 as proof the file is under diffusion_models (#2480)
 - panel_set_todo reconciles a missing ACK with a todo read-back and mutation receipt instead of leaving the outcome as a guess (#2481)
 - recognise ComfyUI Desktop-2 (`Comfy Desktop.exe` under `Programs/ComfyUI`, `.comfyui-desktop-2` / `.launcher/snapshots`, parent process) so `restart_comfyui action:"stop"` records a start path and does not report `stopped:false` when the server is already gone (#2482)
 

--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -36,6 +36,8 @@ const h = vi.hoisted(() => ({
    *  extra_model_paths config location IS knowable, which is what lets the
    *  "empty tree + no extra roots" refusal conclude anything at all. */
   snapshotArgv: [] as string[],
+  /** GET /object_info body. undefined → 404. */
+  objectInfo: undefined as unknown,
 }));
 
 vi.mock("../../config.js", () => ({
@@ -57,6 +59,10 @@ vi.mock("../../comfyui/client.js", () => {
   // fine to close over — it is `vi.hoisted`.
   const listingFetch = async (path: string) => {
     h.fetchCalls.push(path);
+    if (path === "/object_info" || path === "/object_info/") {
+      if (h.objectInfo === undefined) return { ok: false, status: 404, json: async () => null };
+      return { ok: true, status: 200, json: async () => h.objectInfo };
+    }
     const category = path.replace(/^\/models\//, "");
     const listing = h.liveListings[category];
     if (listing === undefined) return { ok: false, status: 404, json: async () => null };
@@ -150,6 +156,7 @@ beforeEach(() => {
   h.liveExtraRoots = { authoritative: false, roots: [] };
   h.modelsRootExists = true;
   h.destModelsDir = "/comfy/models";
+  h.objectInfo = undefined;
   // Absolute argv main.py: the live install root resolves, so the server's
   // extra_model_paths config location is knowable.
   h.snapshotArgv = [resolve("/live/ComfyUI/main.py")];
@@ -1262,6 +1269,47 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     h.liveListings["diffusion_models"] = ["new.gguf"];
     const res = await verifyLandedModel(gTarget, "diffusion_models", { attempts: 1, retryMs: 0 });
     expect(res.liveVisible).toBe("visible");
+  });
+
+  it("#2480: a GGUF under unet is visible via unet_gguf when /models/unet 404s", async () => {
+    const gTarget = resolve("/live/ComfyUI/models/unet/z_image_turbo-Q8_0.gguf");
+    h.modelsDirSource = "live-root";
+    h.destModelsDir = "/live/ComfyUI/models";
+    h.liveListings["unet_gguf"] = ["z_image_turbo-Q8_0.gguf"];
+    const res = await verifyLandedModel(gTarget, "unet", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("visible");
+    expect(res.verifiedPath).toBe(gTarget);
+    expect(res.note ?? "").not.toMatch(/almost certainly/);
+  });
+
+  it("#2480: a GGUF under unet is visible via UnetLoaderGGUF combo when REST 404s", async () => {
+    const gTarget = resolve("/live/ComfyUI/models/unet/z_image_turbo-Q8_0.gguf");
+    h.modelsDirSource = "live-root";
+    h.destModelsDir = "/live/ComfyUI/models";
+    h.objectInfo = {
+      UnetLoaderGGUF: {
+        input: {
+          required: {
+            unet_name: [["z_image_turbo-Q8_0.gguf"], {}],
+          },
+        },
+      },
+    };
+    const res = await verifyLandedModel(gTarget, "unet", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("visible");
+    expect(res.note).toMatch(/object_info|loader combo/i);
+    expect(res.note).not.toMatch(/almost certainly/);
+  });
+
+  it("#2480: unet REST 404 does not claim the GGUF lives under diffusion_models", async () => {
+    const gTarget = resolve("/live/ComfyUI/models/unet/z_image_turbo-Q8_0.gguf");
+    h.modelsDirSource = "live-root";
+    h.destModelsDir = "/live/ComfyUI/models";
+    const res = await verifyLandedModel(gTarget, "unet", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("unknown");
+    expect(res.note).not.toMatch(/almost certainly/);
+    expect(res.note).toMatch(/404/);
+    expect(res.note).toMatch(/configured unet|extra_model_paths|UnetLoaderGGUF/);
   });
 
   it("prescribes REFRESH, not a move, when a junctioned destination realpaths outside the live root (#369/#870)", async () => {

--- a/src/__tests__/services/list-local-models.test.ts
+++ b/src/__tests__/services/list-local-models.test.ts
@@ -53,6 +53,17 @@ vi.mock("node:fs/promises", () => ({
   utimes: vi.fn(),
 }));
 
+const extraRoots = vi.hoisted(() => ({
+  current: [] as Array<{ category: string; dir: string; group: string }>,
+}));
+vi.mock("../../services/extra-paths.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../../services/extra-paths.js")>();
+  return {
+    ...real,
+    getExtraModelRoots: async () => extraRoots.current,
+  };
+});
+
 const { config } = await import("../../config.js");
 const { listLocalModels } = await import("../../services/model-resolver.js");
 
@@ -68,6 +79,7 @@ beforeEach(() => {
   mode.remote = false;
   mode.generation = 0;
   mode.baseUrl = "http://127.0.0.1:8188";
+  extraRoots.current = [];
 });
 
 afterEach(() => {
@@ -630,5 +642,53 @@ describe("#962: weights under an UNKNOWN registered category are found", () => {
     const result = await listLocalModels("checkpoints");
     expect(result).toHaveLength(1);
     expect(queried).not.toContain("/models");
+  });
+
+  it("#2480: filtered unet 404 still surfaces unet_gguf REST listing", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) => {
+      if (path === "/models/unet") return new Response("", { status: 404 });
+      if (path === "/models/unet_gguf") {
+        return new Response(JSON.stringify(["z_image_turbo-Q8_0.gguf"]), { status: 200 });
+      }
+      return new Response("[]", { status: 200 });
+    });
+    const result = await listLocalModels("unet");
+    expect(result).toEqual([
+      {
+        name: "z_image_turbo-Q8_0.gguf",
+        path: "unet_gguf/z_image_turbo-Q8_0.gguf",
+        size: 0,
+        modified: "",
+        type: "unet_gguf",
+      },
+    ]);
+    expect(readdir).not.toHaveBeenCalled();
+  });
+
+  it("#2480: unet REST 404 still lists GGUF from extra_model_paths unet dir", async () => {
+    extraRoots.current = [
+      { category: "unet", dir: "/shared/models/unet", group: "desktop" },
+    ];
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) =>
+      path === "/models/unet" || path === "/models/unet_gguf"
+        ? new Response("", { status: 404 })
+        : new Response("[]", { status: 200 }),
+    );
+    readdir.mockImplementation(async (dir: string) => {
+      const s = String(dir).replace(/\\/g, "/");
+      return s.endsWith("/shared/models/unet") ? ["z_image_turbo-Q8_0.gguf"] : [];
+    });
+    stat.mockResolvedValue({
+      isFile: () => true,
+      size: 42,
+      mtime: new Date("2026-08-30T00:00:00Z"),
+    });
+
+    const result = await listLocalModels("unet");
+    expect(result.some((m) => m.name === "z_image_turbo-Q8_0.gguf" && m.type === "unet")).toBe(
+      true,
+    );
   });
 });

--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -51,6 +51,14 @@ vi.mock("node:fs/promises", () => ({
   utimes: vi.fn(),
 }));
 
+vi.mock("../../services/extra-paths.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../../services/extra-paths.js")>();
+  return {
+    ...real,
+    getExtraModelRoots: async () => [],
+  };
+});
+
 const { config } = await import("../../config.js");
 const { listLocalModelsWithCoverage, describeUnparsableBody } = await import(
   "../../services/model-resolver.js"
@@ -934,10 +942,14 @@ describe("#1015: a filtered 404 names the RENAME, not a broken server", () => {
     expect(text).not.toMatch(/Check the ComfyUI URL/);
   });
 
-  it("points unet → diffusion_models", () => {
+  it("does not claim unet files are almost certainly under diffusion_models (#2480)", () => {
     const text = describeEmptyModelListing("unet", { ...base, absent: ["unet"] });
-    expect(text).toContain("diffusion_models");
-    expect(text).toMatch(/LEGACY name/);
+    expect(text).not.toMatch(/almost certainly/);
+    expect(text).not.toMatch(/LEGACY name/);
+    expect(text).not.toMatch(/Ask for "diffusion_models" instead/);
+    expect(text).toMatch(/404/);
+    expect(text).toMatch(/extra_model_paths/);
+    expect(text).toMatch(/UnetLoaderGGUF|unet_gguf|list_paths/);
   });
 
   it("a NON-legacy 404 category says what to do without inventing a rename", () => {
@@ -954,5 +966,40 @@ describe("#1015: a filtered 404 names the RENAME, not a broken server", () => {
       absent: ["checkpoints", "loras"],
     });
     expect(text).toMatch(/older\s+ComfyUI, or a proxy/);
+  });
+});
+
+describe("#2480: unet REST 404 is not a diffusion_models remedy", () => {
+  it("list_local_models(model_type:unet) does not say almost certainly diffusion_models", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockResolvedValue(new Response("", { status: 404 }));
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    const handler = registeredListLocalModelsTool();
+    const result = await handler({ action: "list", model_type: "unet" });
+    const text = result.content[0]?.text ?? "";
+    expect(text).not.toMatch(/almost certainly/);
+    expect(text).not.toMatch(/LEGACY name/);
+    expect(text).not.toMatch(/Ask for "diffusion_models" instead/);
+    expect(text).toMatch(/404|does not serve a "unet"/);
+  });
+
+  it("lists a GGUF from the configured unet directory after /models/unet 404s", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) =>
+      String(path).endsWith("/unet")
+        ? new Response("", { status: 404 })
+        : new Response("[]", { status: 200 }),
+    );
+    readdir.mockImplementation(async (dir: string) => {
+      const s = String(dir).replace(/\\/g, "/");
+      return s.endsWith("/unet") ? ["z_image_turbo-Q8_0.gguf"] : [];
+    });
+    stat.mockResolvedValue({ isFile: () => true, size: 1024, mtime: new Date(0) });
+    const handler = registeredListLocalModelsTool();
+    const result = await handler({ action: "list", model_type: "unet" });
+    const text = result.content[0]?.text ?? "";
+    expect(text).toContain("z_image_turbo-Q8_0.gguf");
+    expect(text).not.toMatch(/almost certainly/);
+    expect(text).toMatch(/## unet/);
   });
 });

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -760,6 +760,15 @@ async function collectLocalModels(
         // listing can still say which categories this server does not register.
         if (res.status === 404) {
           (coverage.absent ??= []).push(dir);
+          // #2480 — a filtered unet (or clip) 404 is not "look under the rename".
+          // ComfyUI-GGUF still serves those files via unet_gguf / clip_gguf, and
+          // extra_model_paths can still register the original folder. Probe the
+          // alias view on a FILTERED call; unfiltered listing already discovers it.
+          if (modelType) {
+            for (const view of ggufViewsAliasing(dir)) {
+              if (!dirsToScan.includes(view)) dirsToScan.push(view);
+            }
+          }
           continue;
         }
         if (!res.ok) {
@@ -868,37 +877,60 @@ async function collectLocalModels(
   }
   coverage.usedFilesystem = true;
   const modelsRoot = join(config.comfyuiPath, "models");
+  // extra_model_paths can register unet (and other categories) at a directory
+  // that is NOT `{comfyuiPath}/models/<dir>` — Desktop's extra_models_config
+  // is the usual case. REST 404 must still list that configured directory (#2480).
+  let extraRoots: Awaited<ReturnType<typeof getExtraModelRoots>> = [];
+  try {
+    extraRoots = await getExtraModelRoots();
+  } catch {
+    extraRoots = [];
+  }
+  if (refuseStaleModelListing(target, coverage)) return [];
   const dedup = makeModelDeduper();
   for (const dir of dirsToScan) {
-    const dirPath = join(modelsRoot, dir);
-    let entries: string[];
-    try {
-      entries = await readdir(dirPath, { recursive: true });
-    } catch {
-      if (refuseStaleModelListing(target, coverage)) return [];
-      continue;
+    const primary = join(modelsRoot, dir);
+    const extraForDir = extraRoots
+      .filter((er) => er.category.trim().toLowerCase() === dir.toLowerCase())
+      .map((er) => er.dir);
+    const scanRoots: string[] = [];
+    const seenRoots = new Set<string>();
+    for (const dirPath of [primary, ...extraForDir]) {
+      const key = resolve(dirPath);
+      if (seenRoots.has(key)) continue;
+      seenRoots.add(key);
+      scanRoots.push(dirPath);
     }
-    if (refuseStaleModelListing(target, coverage)) return [];
-    for (const entry of entries) {
-      // Same `.gguf`-only guard as the HTTP path for `*_gguf` categories (e.g. an
-      // explicit `listLocalModels("unet_gguf")`): never list non-gguf files here.
-      if (isGgufCategory(dir) && !entry.toLowerCase().endsWith(".gguf")) continue;
-      const filePath = join(dirPath, entry);
+    for (const dirPath of scanRoots) {
+      let entries: string[];
       try {
-        const info = await stat(filePath);
-        if (refuseStaleModelListing(target, coverage)) return [];
-        if (!info.isFile()) continue;
-        if (!dedup.add(dir, entry)) continue; // same file already surfaced elsewhere
-        results.push({
-          name: entry,
-          path: filePath,
-          size: info.size,
-          modified: info.mtime.toISOString(),
-          type: dir,
-        });
+        entries = await readdir(dirPath, { recursive: true });
       } catch {
         if (refuseStaleModelListing(target, coverage)) return [];
-        // Skip files we can't stat
+        continue;
+      }
+      if (refuseStaleModelListing(target, coverage)) return [];
+      for (const entry of entries) {
+        // Same `.gguf`-only guard as the HTTP path for `*_gguf` categories (e.g. an
+        // explicit `listLocalModels("unet_gguf")`): never list non-gguf files here.
+        if (isGgufCategory(dir) && !entry.toLowerCase().endsWith(".gguf")) continue;
+        const filePath = join(dirPath, entry);
+        try {
+          const info = await stat(filePath);
+          if (refuseStaleModelListing(target, coverage)) return [];
+          if (!info.isFile()) continue;
+          if (!dedup.add(dir, entry)) continue; // same file already surfaced elsewhere
+          results.push({
+            name: entry,
+            path: filePath,
+            size: info.size,
+            modified: info.mtime.toISOString(),
+            type: dir,
+          });
+        } catch {
+          if (refuseStaleModelListing(target, coverage)) return [];
+          // Skip files we can't stat
+        }
       }
     }
   }
@@ -1127,6 +1159,72 @@ export async function liveCategoryListing(
     const json = (await res.json()) as unknown;
     if (!Array.isArray(json)) return undefined;
     return json.filter((n): n is string => typeof n === "string");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Combo option strings from a ComfyUI /object_info input spec (V1 `[[...], cfg]`
+ * or V3 `["COMBO", {options:[...]}]`). Undefined when this spec is not a
+ * single-select combo we can search.
+ */
+function comboOptionStrings(spec: unknown): string[] | undefined {
+  if (!Array.isArray(spec) || spec.length === 0) return undefined;
+  const cfgRaw = spec[1];
+  const cfg =
+    cfgRaw && typeof cfgRaw === "object" && !Array.isArray(cfgRaw)
+      ? (cfgRaw as Record<string, unknown>)
+      : null;
+  if (cfg?.multiselect) return undefined;
+  const type = spec[0];
+  if (Array.isArray(type)) return type.filter((v) => typeof v === "string");
+  if (typeof type !== "string" || !/COMBO/i.test(type) || /DYNAMIC/i.test(type)) {
+    return undefined;
+  }
+  if (!cfg) return undefined;
+  const opts = cfg.options;
+  if (!Array.isArray(opts)) return undefined;
+  const strings = opts.filter((v) => typeof v === "string");
+  return strings.length === opts.length ? strings : undefined;
+}
+
+function objectInfoHasFilename(info: unknown, filename: string): boolean {
+  if (!info || typeof info !== "object" || Array.isArray(info)) return false;
+  const defs = info as Record<string, unknown>;
+  const wanted = basename(filename.replace(/\\/g, "/"));
+  for (const def of Object.values(defs)) {
+    if (!def || typeof def !== "object" || Array.isArray(def)) continue;
+    const input = "input" in def ? def.input : undefined;
+    if (!input || typeof input !== "object" || Array.isArray(input)) continue;
+    const groups: unknown[] = [];
+    if ("required" in input) groups.push(input.required);
+    if ("optional" in input) groups.push(input.optional);
+    for (const group of groups) {
+      if (!group || typeof group !== "object" || Array.isArray(group)) continue;
+      const rec = group as Record<string, unknown>;
+      for (const spec of Object.values(rec)) {
+        const options = comboOptionStrings(spec);
+        if (!options) continue;
+        if (options.some((o) => basename(o.replace(/\\/g, "/")) === wanted)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Does any loader combo on /object_info list this filename? Used when
+ * `/models/<category>` 404s (#2480 — UnetLoaderGGUF still names GGUFs under
+ * unet even though core REST dropped that route). `undefined` = could not ask.
+ */
+async function objectInfoListsFilename(filename: string): Promise<boolean | undefined> {
+  if (!filename) return undefined;
+  try {
+    const res = await comfyApiFetch("/object_info");
+    if (!res.ok) return undefined;
+    const json: unknown = await res.json();
+    return objectInfoHasFilename(json, filename);
   } catch {
     return undefined;
   }
@@ -2013,12 +2111,14 @@ export async function verifyLandedModel(
     };
   }
 
+  const listingCats = await listingCategoriesFor(targetSubfolder, basename(targetPath));
   let sawListing = false;
   for (let i = 0; i < attempts; i++) {
-    const listing = await liveCategoryListing(category);
-    if (listing !== undefined) {
+    for (const cat of listingCats) {
+      const listing = await liveCategoryListing(cat);
+      if (listing === undefined) continue;
       sawListing = true;
-      if (listing.some((n) => normRel(n) === wanted)) {
+      if (!listing.some((n) => normRel(n) === wanted)) continue;
         // RE-CHECK membership AFTER the listing. The root check and the listing are
         // two separate observations; a ComfyUI restart onto a DIFFERENT install
         // between them would otherwise let the NEW server's own same-named model
@@ -2052,7 +2152,7 @@ export async function verifyLandedModel(
           verifiedPath,
           liveVisible: "unknown",
           note:
-            `The connected ComfyUI (${getComfyUIBaseUrl()}) lists "${wanted}" under "${category}", ` +
+            `The connected ComfyUI (${getComfyUIBaseUrl()}) lists "${wanted}" under "${cat}", ` +
             "but this destination was not named by the running server — it came from local " +
             "configuration, or was inferred from where the server's interpreter lives — so that " +
             "listing cannot be tied to the file just written to " +
@@ -2065,19 +2165,70 @@ export async function verifyLandedModel(
             ". " +
             unverifiableDestinationRemedy(),
         };
-      }
     }
     if (i < attempts - 1 && retryMs > 0) {
       await new Promise((r) => setTimeout(r, retryMs));
     }
   }
   if (!sawListing) {
+    // #2480 — /models/unet 404s on current ComfyUI even when extra_model_paths
+    // and UnetLoaderGGUF still use that folder. Ask /object_info before treating
+    // the REST miss as "could not confirm".
+    const comboListed = await objectInfoListsFilename(basename(targetPath));
+    if (comboListed === true) {
+      const still = await isUnderLiveModelRoots(resolve(targetPath), category);
+      if (still.inRoots === false) {
+        return {
+          verifiedPath,
+          verifiedAgainstRoot: still.liveRoot,
+          liveVisible: "not-visible",
+          note:
+            `The file IS on disk at ${landed}, but the connected ComfyUI ` +
+            `(${getComfyUIBaseUrl()}) changed while this was being checked and no longer ` +
+            "reads from that location — the entry it lists is its OWN file of the same name. " +
+            "Re-download now that the correct server is connected.",
+        };
+      }
+      if (!ambiguous) {
+        return {
+          verifiedPath,
+          verifiedAgainstRoot: still.liveRoot ?? membership.liveRoot,
+          liveVisible: "visible",
+          note:
+            `The connected ComfyUI (${getComfyUIBaseUrl()}) answered 404 for /models/${category}, ` +
+            `but /object_info lists "${wanted}" on a loader combo, so a custom loader can select it.`,
+        };
+      }
+      return {
+        verifiedPath,
+        liveVisible: "unknown",
+        note:
+          `The connected ComfyUI (${getComfyUIBaseUrl()}) lists "${wanted}" on a loader combo, ` +
+          "but this destination was not named by the running server — it came from local " +
+          "configuration, or was inferred from where the server's interpreter lives — so that " +
+          "listing cannot be tied to the file just written to " +
+          `${verifiedPath} — it may be the server's own copy elsewhere` +
+          (opts?.listedBefore === true
+            ? " (it already listed that name before this download)"
+            : opts?.listedBefore === undefined
+              ? " (whether it listed that name before this download could not be checked)"
+              : "") +
+          ". " +
+          unverifiableDestinationRemedy(),
+      };
+    }
     return {
       verifiedPath,
       liveVisible: "unknown",
       note:
-        `The connected ComfyUI (${getComfyUIBaseUrl()}) did not answer for the ` +
-        `"${category}" model folder, so it could not be confirmed that it reads from this location.`,
+        category.toLowerCase() === "unet"
+          ? `The file IS on disk at ${verifiedPath}. The connected ComfyUI answered 404 for ` +
+            `/models/unet, which does not prove the file is missing or that it lives under ` +
+            `diffusion_models. extra_model_paths and custom loaders (UnetLoaderGGUF) can still ` +
+            `use a configured unet directory. Check list_local_models (action:"list_paths") ` +
+            `for unet roots, or list with no model_type to see unet_gguf.`
+          : `The connected ComfyUI (${getComfyUIBaseUrl()}) did not answer for the ` +
+            `"${category}" model folder, so it could not be confirmed that it reads from this location.`,
     };
   }
   // A CORE category's listing enumerates only ComfyUI's own weight extensions

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -1571,7 +1571,10 @@ async function cancelAction(args: { id: string; tray_id?: string }): Promise<Cal
  */
 const LEGACY_CATEGORY_RENAMES: Record<string, string> = {
   clip: "text_encoders",
-  unet: "diffusion_models",
+  // unet → diffusion_models is a core rename too, but extra_model_paths and
+  // ComfyUI-GGUF UnetLoaderGGUF still use a configured unet directory (#2480).
+  // A 404 for /models/unet must NOT claim the files are almost certainly
+  // under diffusion_models.
 };
 
 export function describeEmptyModelListing(
@@ -1615,6 +1618,24 @@ export function describeEmptyModelListing(
     // Blaming "an older ComfyUI or a proxy" would send someone to check a URL
     // that is working perfectly.
     if (modelType) {
+      // #2480 — REST 404 for "unet" is a fact about the HTTP route, not about
+      // whether extra_model_paths or UnetLoaderGGUF still use a unet folder.
+      // Claiming the weights are almost certainly under diffusion_models is a
+      // definitive wrong-folder remedy.
+      if (modelType === "unet") {
+        return (
+          `The connected ComfyUI does not serve a "unet" model category over REST — it ` +
+          `answered 404 for /models/unet. That is a fact about the HTTP route, not about ` +
+          `whether a unet folder is configured.\n\n` +
+          `Core ComfyUI renamed its default unet folder to "diffusion_models", but ` +
+          `extra_model_paths can still register BOTH, and custom loaders such as ` +
+          `ComfyUI-GGUF UnetLoaderGGUF keep reading the configured unet directory even ` +
+          `when /models/unet 404s. Do not assume the file is under diffusion_models.\n\n` +
+          `Check list_local_models (action:"list_paths") for the unet paths this install ` +
+          `actually registers, or list with no model_type to surface unet_gguf when ` +
+          `ComfyUI-GGUF is installed.`
+        );
+      }
       const modern = LEGACY_CATEGORY_RENAMES[modelType];
       return (
         `The connected ComfyUI does not serve a "${modelType}" model category — it ` +


### PR DESCRIPTION
Closes artokun/comfyui-mcp#2480

## Recurrence

`download_model(action:"status")` could not confirm a completed GGUF UNet under `models/unet` because ComfyUI 404s `/models/unet`. `list_local_models(action:"list", model_type:"unet")` then claimed unet is legacy and the file is almost certainly under `diffusion_models`. That is wrong for ComfyUI-GGUF UnetLoaderGGUF: extra-model-path can register both unet and diffusion_models, and `/object_info` can still list the file.

## Gap this PR closes

- **No wrong-folder remedy on REST 404** — a filtered unet 404 no longer says the weights are almost certainly under diffusion_models.
- **List the configured unet directory** — filesystem fallback scans extra_model_paths unet roots, and a filtered unet 404 also probes `unet_gguf`.
- **Download status classification** — `verifyLandedModel` checks `unet_gguf` and UnetLoaderGGUF `/object_info` combos when `/models/unet` 404s, instead of stopping at UNCONFIRMED.

## Tests

`npx vitest run src/__tests__/services/model-listing-coverage.test.ts src/__tests__/services/list-local-models.test.ts src/__tests__/services/download-live-destination.test.ts src/__tests__/services/live-listing-gguf.test.ts src/__tests__/services/apply-manifest-gguf-listing.test.ts`

Unfixed code fails the "almost certainly" 404 path; shipped honest unet listing (configured dir / unet_gguf / loader combo) passes.
