### PR TITLE
fix(panel): retry graph_outline when query_graph already reads the instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_run does not claim a /prompt left the panel when ComfyUI never logged a prompt; id-less queued_unknown fails closed as not queued (#2521)
 - panel_set_widget treats a root-scope promoted widget as the authoritative parent rail and suppresses the inner link-driven warning (#2514)
 - drain an empty-success Git install enqueue before using the verified local clone fallback (#2620)
+- panel_graph_outline retries once after save when query_graph already reads the same tab instead of refusing a transient instance mismatch (#2483)
 
 ## [0.52.155] - 2026-08-30
 

--- a/src/__tests__/orchestrator/outline-transient-instance-refuse.test.ts
+++ b/src/__tests__/orchestrator/outline-transient-instance-refuse.test.ts
@@ -1,0 +1,223 @@
+// #2483 — panel_graph_outline can refuse a saved workflow while panel_query_graph
+// already reads it.
+//
+// Immediately after a live layout edit and save-in-place, outline was refused
+// with a workflow-instance mismatch. In the same tab, query_graph returned all
+// 17 nodes. A later outline succeeded with no tab switch and no mutation. The
+// panel/orchestrator had not finished reconciling the saved workflow's
+// instance/generation, and outline failed closed on that race while the cheaper
+// query already proved the current instance.
+//
+// Outline is inert, so one retry cannot double-apply. The retry fires only when
+// the tab identity (routing id + connection generation) is unchanged AND a
+// fresh graph_query answers for the same instance. A real mismatch — query also
+// refused, tab moved, query named a different uuid — still refuses, and names
+// both expected and observed instance ids.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/saved.json";
+const OTHER_TAB = "wf:workflows/other.json";
+const STAMP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const LIVE = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+const OUTLINE = {
+  node_count: 17,
+  outline: "1 CheckpointLoaderSimple \"ckpt\"\n2 KSampler \"ks\"",
+};
+const QUERY = { count: 17, nodes: [{ id: 1 }, { id: 2 }] };
+
+const mismatch = (expected: string, observed: string): Error =>
+  new Error(
+    `workflow instance mismatch: this command was issued for workflow instance ${expected}, ` +
+      `and the active canvas reports ${observed}. Nothing was applied.`,
+  );
+
+function settled(uuid: string): Record<string, unknown> {
+  const active = { path: "workflows/saved.json", routing_key: TAB, workflow_uuid: uuid };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+}
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+type Harness = {
+  sent: string[];
+  outlineCalls: number;
+  queryCalls: number;
+  corroborated: string[];
+  generation: number;
+  tabId: string;
+  fence: string;
+  queryReply: Record<string, unknown>;
+  queryThrows: boolean;
+  outlineRetryThrows: boolean;
+  moveTabOnQuery: boolean;
+  bumpGenerationOnQuery: boolean;
+};
+
+function harness(init?: Partial<Harness>): { h: Harness; bridge: PanelToolCtx["bridge"] } {
+  const h: Harness = {
+    sent: [],
+    outlineCalls: 0,
+    queryCalls: 0,
+    corroborated: [],
+    generation: 1,
+    tabId: TAB,
+    fence: STAMP,
+    queryReply: QUERY,
+    queryThrows: false,
+    outlineRetryThrows: false,
+    moveTabOnQuery: false,
+    bumpGenerationOnQuery: false,
+    ...init,
+  };
+  const box: { ctx: PanelToolCtx | null } = { ctx: null };
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- test bridge is a partial mock of UiBridge
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+      h.sent.push(name);
+      if (name === "workflow_list") return settled(h.fence);
+      if (name === "graph_query") {
+        h.queryCalls += 1;
+        if (h.moveTabOnQuery && box.ctx) box.ctx.tabId = OTHER_TAB;
+        if (h.bumpGenerationOnQuery) h.generation += 1;
+        if (h.queryThrows) throw mismatch(STAMP, LIVE);
+        return h.queryReply;
+      }
+      if (name === "graph_outline") {
+        h.outlineCalls += 1;
+        if (h.outlineCalls === 1) throw mismatch(STAMP, LIVE);
+        if (h.outlineRetryThrows) throw mismatch(STAMP, LIVE);
+        return OUTLINE;
+      }
+      throw mismatch(STAMP, LIVE);
+    },
+    push: () => 1,
+    canReach: (id: string) => id === h.tabId,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: h.tabId, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => h.tabId,
+    workflowUuidFor: () => ({ known: true, uuid: h.fence }),
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      h.fence = uuid;
+      return true;
+    },
+    corroborateTabStamp: (_tabId: string, uuid: string) => {
+      h.corroborated.push(uuid);
+      return true;
+    },
+    tabConnectionIdentity: () => ({ generation: h.generation, tabSessionId: "browser-tab-a" }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { h, bridge, box };
+}
+
+async function callOutline(
+  bridge: PanelToolCtx["bridge"],
+  box: { ctx: PanelToolCtx | null },
+): Promise<{ text: string; res: ToolResult; ctx: PanelToolCtx }> {
+  const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+  box.ctx = ctx;
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_graph_outline");
+  if (!def) throw new Error("panel_graph_outline is not registered");
+  const res: ToolResult = await def.handler({} as never, ctx);
+  return { text: textOf(res), res, ctx };
+}
+
+describe("#2483 panel_graph_outline retries once when query_graph proves the instance", () => {
+  it("returns the outline when the first call races and query already reads this tab", async () => {
+    const { h, bridge, box } = harness();
+    const { text, res } = await callOutline(bridge, box);
+
+    expect(res.isError).toBeFalsy();
+    expect(text).toContain("CheckpointLoaderSimple");
+    expect(h.outlineCalls).toBe(2);
+    expect(h.queryCalls).toBe(1);
+    expect(h.corroborated).toEqual([STAMP]);
+    expect(h.sent.filter((c) => c === "graph_outline")).toEqual(["graph_outline", "graph_outline"]);
+    expect(h.sent).toContain("graph_query");
+  });
+
+  it("CONTROL: panel_query_graph itself is not recovered by the outline retry", async () => {
+    const { h, bridge } = harness({ queryThrows: true });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_query_graph");
+    if (!def) throw new Error("panel_query_graph is not registered");
+    const res: ToolResult = await def.handler({} as never, ctx);
+    const text = textOf(res);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/workflow instance mismatch/);
+    expect(h.outlineCalls).toBe(0);
+    // The query is the refused command; it must not spawn a second query as an
+    // outline-style retry (that retry is gated on graph_outline).
+    expect(h.queryCalls).toBe(1);
+  });
+
+  it("stays refused when query_graph is also mismatched, and names both instance ids", async () => {
+    const { h, bridge, box } = harness({ queryThrows: true });
+    const { text, res } = await callOutline(bridge, box);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/workflow instance mismatch/);
+    expect(text).toContain(`instance expected=${STAMP}`);
+    expect(text).toContain(`observed=${LIVE}`);
+    expect(h.outlineCalls).toBe(1);
+    expect(h.queryCalls).toBe(1);
+  });
+
+  it("does not retry when the tab identity moved during the query proof", async () => {
+    const { h, bridge, box } = harness({ moveTabOnQuery: true });
+    const { text, res } = await callOutline(bridge, box);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/workflow instance mismatch/);
+    expect(text).toContain(`instance expected=${STAMP}`);
+    expect(h.outlineCalls).toBe(1);
+    expect(h.queryCalls).toBe(1);
+  });
+
+  it("does not retry when the connection generation moved during the query proof", async () => {
+    const { h, bridge, box } = harness({ bumpGenerationOnQuery: true });
+    const { text, res } = await callOutline(bridge, box);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/workflow instance mismatch/);
+    expect(h.outlineCalls).toBe(1);
+    expect(h.queryCalls).toBe(1);
+  });
+
+  it("does not retry when query_graph names a different workflow instance", async () => {
+    const { h, bridge, box } = harness({
+      queryReply: { ...QUERY, workflow_uuid: LIVE },
+    });
+    const { text, res } = await callOutline(bridge, box);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/workflow instance mismatch/);
+    expect(h.outlineCalls).toBe(1);
+    expect(h.queryCalls).toBe(1);
+  });
+
+  it("names both instance ids when the outline retry still mismatches", async () => {
+    const { h, bridge, box } = harness({ outlineRetryThrows: true });
+    const { text, res } = await callOutline(bridge, box);
+
+    expect(res.isError).toBe(true);
+    expect(h.outlineCalls).toBe(2);
+    expect(h.queryCalls).toBe(1);
+    expect(text).toContain(`instance expected=${STAMP}`);
+    expect(text).toContain(`observed=${LIVE}`);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10712,6 +10712,70 @@ function responseWorkflowUuid(value: unknown): string | undefined {
   return WORKFLOW_UUID_RE.test(raw) ? raw : undefined;
 }
 
+/**
+ * #2483 — the two sides of a workflow-instance mismatch, as the panel names them.
+ *
+ * "issued for" is the stamp the command carried (expected); "active canvas reports"
+ * is what the panel compared it against (observed). Older or shorter refusals omit
+ * one or both; the caller fills those from the session fence / a live probe rather
+ * than inventing values.
+ */
+function workflowInstanceIdsFromMismatchMessage(raw: string): {
+  expected: string | null;
+  observed: string | null;
+} {
+  const expected =
+    /this command was issued for workflow instance ([0-9a-f-]{36})/i.exec(raw)?.[1] ?? null;
+  const observed =
+    /the active canvas reports ([0-9a-f-]{36})/i.exec(raw)?.[1] ?? null;
+  return { expected, observed };
+}
+
+function instanceIdsDiagnostic(expected: string | null, observed: string | null): string {
+  return `instance expected=${expected ?? "unknown"} observed=${observed ?? "unknown"}`;
+}
+
+/**
+ * A successful graph_query is proof the current instance is readable on this tab.
+ * A payload that names a DIFFERENT workflow_uuid is not — that would be reading
+ * someone else's graph. No uuid on the reply is still proof: the panel accepted
+ * the fenced query, and query is the read the reporter already saw succeed.
+ */
+function graphQueryProvesCurrentInstance(
+  payload: unknown,
+  expectedUuid: string | null,
+): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const rec = payload as Record<string, unknown>;
+  if (typeof rec.error === "string" && rec.error.length > 0) return false;
+  const uuid = responseWorkflowUuid(rec);
+  if (!uuid || !expectedUuid) return true;
+  return uuid === expectedUuid;
+}
+
+/**
+ * Tab identity for the #2483 outline retry: same routing id, and the same
+ * connection generation when the bridge exposes one. Lightweight test ctxs
+ * have no generation; for those the tab id is the identity. A generation that
+ * WAS readable at refusal and then moved (or became unreadable) is a reconnect
+ * or tab replace — not the post-save race this retry covers.
+ */
+function sameTabIdentityForOutlineRetry(
+  ctx: PanelToolCtx,
+  tabAtRefusal: string,
+  identityAtRefusal: { generation: number; tabSessionId: string } | undefined,
+): boolean {
+  if (ctx.tabId !== tabAtRefusal) return false;
+  if (!isUsablePanelConnectionIdentity(identityAtRefusal)) return true;
+  let now: { generation: number; tabSessionId: string } | undefined;
+  try {
+    now = ctx.panelConnectionIdentity?.();
+  } catch {
+    return false;
+  }
+  return isUsablePanelConnectionIdentity(now) && samePanelConnectionIdentity(identityAtRefusal, now);
+}
+
 /** Refresh only the bridge-owned command stamp, never caller data. */
 /** #1656 — tell the orchestrator that a live read confirmed the routed tab's CURRENT
  *  stamp, so a value inherited on a same-socket re-hello stops being treated as
@@ -15800,10 +15864,54 @@ export function makePanelToolCtx(
         const refusedLead = inertRead
           ? `${name} was refused before it ran — no graph data was read.`
           : `${name} was refused before it ran — nothing was applied.`;
+        // #2483 — outline can lag a post-save instance/generation flip while a
+        // fresh graph_query already reads the same tab. Retry the inert outline
+        // ONCE when tab identity is unchanged and that query proves the current
+        // instance. sendRouted, not ctx.call: a nested mismatch diagnosis on the
+        // probe would recurse into this branch. Unstamped reads keep the #1519
+        // mint path; this is the stamped (and unstated) race after save.
+        if (
+          options?.retry !== false &&
+          name === "graph_outline" &&
+          inertRead &&
+          shape !== "unstamped"
+        ) {
+          const tabAtRefusal = ctx.tabId;
+          let identityAtRefusal: { generation: number; tabSessionId: string } | undefined;
+          try {
+            identityAtRefusal = ctx.panelConnectionIdentity?.();
+          } catch {
+            identityAtRefusal = undefined;
+          }
+          const fenceAtRefusal = currentWorkflowFence(ctx);
+          const expectedUuid =
+            stamped ?? (fenceAtRefusal.known ? fenceAtRefusal.uuid ?? null : null);
+          try {
+            const proved = await sendRouted(
+              { cmd: "graph_query", fields: "ids", limit: 1 },
+              Math.min(timeoutMs ?? 8000, 8000),
+            );
+            if (
+              sameTabIdentityForOutlineRetry(ctx, tabAtRefusal, identityAtRefusal) &&
+              graphQueryProvesCurrentInstance(proved, expectedUuid)
+            ) {
+              const fenceNow = currentWorkflowFence(ctx);
+              if (fenceNow.known && fenceNow.uuid) corroborateTabStamp(ctx, fenceNow.uuid);
+              const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));
+              if (successProvesSwitchCleared(cmd.cmd)) clearSwitchHold(ctx.tabId);
+              return retried;
+            }
+          } catch {
+            // query refused, tab moved, or the outline retry still mismatched —
+            // fall through to the existing diagnosis, with both instance ids named.
+          }
+        }
         let verdict: string;
+        let liveForIds: string | null = null;
         try {
           const probe = await rebindWorkflowFence(ctx, { adopt: false });
           const live = "uuid" in probe ? probe.uuid : null;
+          liveForIds = typeof live === "string" ? live : null;
           const priorAbsent =
             "before" in probe && probe.before.known === true && !probe.before.uuid;
           const admitUnstampedRead =
@@ -15924,7 +16032,18 @@ export function makePanelToolCtx(
             `refusal stands on its own terms and the fence is unchanged. ` +
             `(${probeErr instanceof Error ? probeErr.message : String(probeErr)})`;
         }
-        return fail(`${refusedLead} ${raw}${verdict}`);
+        const fromRefusal = workflowInstanceIdsFromMismatchMessage(raw);
+        const fenceForIds = currentWorkflowFence(ctx);
+        const expectedId =
+          fromRefusal.expected ??
+          stamped ??
+          (fenceForIds.known ? fenceForIds.uuid ?? null : null);
+        const observedId = fromRefusal.observed ?? liveForIds;
+        const idsNote =
+          expectedId || observedId
+            ? `\n\n${instanceIdsDiagnostic(expectedId, observedId)}`
+            : "";
+        return fail(`${refusedLead} ${raw}${verdict}${idsNote}`);
       }
       // #1480 — NAME A REMEDY THE TAB CAN ACTUALLY ACCEPT.
       //


### PR DESCRIPTION
## Summary

Fixes #2483

- Immediately after a live layout edit and save-in-place, `panel_graph_outline` could refuse with a workflow-instance mismatch while `panel_query_graph` already read the same tab. A later outline succeeded with no tab switch and no mutation.
- Retry the inert outline once when tab identity (routing id + connection generation) is unchanged and a fresh `graph_query` proves the current instance. Do not retry if the query is also refused, the tab moved, or the query names a different workflow uuid.
- Remaining refusals include both expected and observed instance IDs for diagnosis. The fence is not moved; `corroborateTabStamp` only promotes provenance of the uuid already in force.

## Validation

- `npx vitest run src/__tests__/orchestrator/outline-transient-instance-refuse.test.ts src/__tests__/orchestrator/fenced-read-absent-stamp.test.ts src/__tests__/orchestrator/save-fence-corroborate.test.ts src/__tests__/orchestrator/carried-stamp-corroboration.test.ts src/__tests__/orchestrator/fence-mismatch-corroborates.test.ts src/__tests__/orchestrator/empty-outline-recheck.test.ts src/__tests__/orchestrator/fence-lookalike-refusals.test.ts` — 46 passed
- `npx tsc --noEmit` passed
- `git diff --check` passed

No merge or release performed.
