### PR TITLE
fix(2486): do not re-deliver run completions after a mid-reply interrupt

### DIFF
--- a/src/__tests__/orchestrator/run-completion-interrupt-ack.test.ts
+++ b/src/__tests__/orchestrator/run-completion-interrupt-ack.test.ts
@@ -1,0 +1,260 @@
+// #2486 — a user interrupt of a turn that has ALREADY reached the model must
+// not re-deliver that turn's run-completion.
+//
+// interrupt() used to steal the carrying tokens from the result path and hand
+// them back uncarried. onEventUndelivered then flushed immediately, so the
+// same prompt was re-injected as RE-DELIVERED on every following Stop — three
+// extra "Acknowledge the result in ONE short sentence" turns in the report.
+//
+// The proof that the model has the text is the same one #468 already uses:
+// turnProducedEvents, a stamped event on a marker-declaring backend. A Stop
+// BEFORE that proof still replays (the abandoned-turn contract). A Stop AFTER
+// it settles.
+
+import { describe, expect, it } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+import {
+  RunCompletionJournalImpl,
+  type CompletionPayload,
+} from "../../orchestrator/run-completion-journal.js";
+import { PanelAgentManager } from "../../orchestrator/panel-agent.js";
+
+const TAB = "tab-2486";
+const PID = "79cb9c62-aaaa-bbbb-cccc-ddddeeeeffff";
+const REDELIVERED = "RE-DELIVERED — this completion could not be handed to you when it arrived";
+const MATCHED = "This is the run YOU queued with panel_run";
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/**
+ * A marker-declaring backend that can hang mid-reply.
+ *
+ * `emitReply: true` (default) yields a stamped assistant event as soon as it
+ * consumes the turn — the production shape of "[Request interrupted by user]"
+ * landing while the model is generating. `emitReply: false` hangs silent, which
+ * is the pre-submission window the abandoned-turn replay must still cover.
+ */
+class MidReplyBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  /** Set after the stamped assistant event has been yielded. */
+  sawReply = false;
+  emitReply: boolean;
+  private breakTurn: (() => void) | null = null;
+  private brokenByInterrupt = false;
+
+  constructor(opts: { emitReply?: boolean } = {}) {
+    this.emitReply = opts.emitReply !== false;
+  }
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-2486" };
+    let turnSeq = 0;
+    for await (const turn of opts.channel) {
+      this.turns.push((turn as { text?: string }).text ?? "");
+      turnSeq += 1;
+      this.sawReply = false;
+      if (this.emitReply) {
+        yield { type: "assistant", text: "looking…", turn: turnSeq };
+        this.sawReply = true;
+      }
+      await new Promise<void>((resolve) => {
+        this.breakTurn = resolve;
+      });
+      this.breakTurn = null;
+      if (this.brokenByInterrupt) {
+        this.brokenByInterrupt = false;
+        yield { type: "result", ok: false, subtype: "error_during_execution", turn: turnSeq };
+      } else {
+        yield { type: "result", ok: true, subtype: "success", turn: turnSeq };
+      }
+    }
+  }
+
+  finishTurn(): void {
+    const brk = this.breakTurn;
+    this.breakTurn = null;
+    brk?.();
+  }
+
+  async interrupt(): Promise<void> {
+    this.brokenByInterrupt = true;
+    this.finishTurn();
+  }
+
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeHarness(backend: AgentBackend) {
+  const journal = new RunCompletionJournalImpl();
+  const flush = (tab: string) =>
+    journal.deliverPending(tab, (payload, token) =>
+      manager.injectEvent(tab, payload, { eventToken: token }),
+    );
+  journal.setRevoker(
+    (key, token) => manager.revokeEvent(key, token),
+    (key) => void flush(key),
+  );
+  const manager = new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+    makeBackend: () => backend,
+    onEventDelivered: (_key: string, tokens: string[]) => {
+      for (const t of tokens) journal.ack(t);
+    },
+    onEventUndelivered: (key: string, tokens: string[], opts?: { carried?: boolean }) => {
+      for (const t of tokens) journal.release(t, { carried: opts?.carried === true });
+      flush(key);
+    },
+    onAgentReady: (key: string) => flush(key),
+  } as never);
+  const arrive = (tab: string, payload: CompletionPayload) => {
+    journal.record(tab, payload);
+    flush(tab);
+  };
+  return { journal, manager, arrive };
+}
+
+describe("run-completion interrupt after the model has the text (#2486)", () => {
+  it("a mid-reply Stop settles the completion instead of re-delivering it", async () => {
+    const backend = new MidReplyBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+
+    journal.openRun(PID, { tabId: TAB });
+    manager.send(TAB, "queue the render");
+    await waitFor(() => backend.sawReply);
+    backend.finishTurn();
+
+    arrive(TAB, {
+      kind: "executed",
+      prompt_id: PID,
+      images: [{ filename: "ComfyUI_00149_.png" }],
+    });
+    await waitFor(() => backend.turns.length >= 2);
+    await waitFor(() => backend.sawReply);
+    expect(backend.turns[1]).toContain(MATCHED);
+    expect(backend.turns[1]).toContain(PID);
+    expect(journal.outstanding(TAB)).toHaveLength(1);
+
+    // The reported sequence: user interrupts the acknowledgement turn.
+    await manager.interrupt(TAB, { requeueInFlight: false });
+    expect(journal.outstanding(TAB)).toHaveLength(0);
+    expect(journal.ticketFor(PID)?.settled).toBe(true);
+
+    manager.send(TAB, "do something else");
+    await waitFor(() => backend.turns.length >= 3);
+    expect(backend.turns[2]).toContain("do something else");
+    expect(backend.turns[2]).not.toContain(REDELIVERED);
+    expect(backend.turns[2]).not.toContain(PID);
+  });
+
+  it("repeated Stops after receipt do not mint a second acknowledgement turn", async () => {
+    const backend = new MidReplyBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+
+    journal.openRun(PID, { tabId: TAB });
+    manager.send(TAB, "go");
+    await waitFor(() => backend.sawReply);
+    backend.finishTurn();
+
+    arrive(TAB, {
+      kind: "executed",
+      prompt_id: PID,
+      images: [{ filename: "ComfyUI_00149_.png" }],
+    });
+    await waitFor(() => backend.turns.length >= 2);
+    await waitFor(() => backend.sawReply);
+    expect(backend.turns[1]).toContain(PID);
+    expect(backend.turns[1]).not.toContain(REDELIVERED);
+
+    await manager.interrupt(TAB, { requeueInFlight: false });
+    manager.send(TAB, "first follow-up");
+    await waitFor(() => backend.turns.length >= 3);
+    await waitFor(() => backend.sawReply);
+
+    await manager.interrupt(TAB, { requeueInFlight: false });
+    manager.send(TAB, "second follow-up");
+    await waitFor(() => backend.turns.length >= 4);
+
+    expect(backend.turns.slice(2).every((t) => !t.includes(REDELIVERED))).toBe(true);
+    expect(backend.turns.slice(2).every((t) => !t.includes(PID))).toBe(true);
+    expect(journal.outstanding(TAB)).toHaveLength(0);
+  });
+
+  it("send-now after receipt requeues the user text, not the already-read completion", async () => {
+    const backend = new MidReplyBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+
+    journal.openRun(PID, { tabId: TAB });
+    manager.send(TAB, "keep going");
+    await waitFor(() => backend.sawReply);
+
+    arrive(TAB, {
+      kind: "executed",
+      prompt_id: PID,
+      images: [{ filename: "ComfyUI_00149_.png" }],
+    });
+    manager.send(TAB, "and then upscale it");
+    backend.finishTurn();
+    await waitFor(() => backend.turns.length >= 2);
+    await waitFor(() => backend.sawReply);
+    expect(backend.turns[1]).toContain(PID);
+    expect(backend.turns[1]).toContain("and then upscale it");
+
+    manager.send(TAB, "wait, change the seed");
+    await manager.interrupt(TAB, { requeueInFlight: true });
+    await waitFor(() => backend.turns.length >= 3);
+
+    const next = backend.turns[2];
+    expect(next).toContain("and then upscale it");
+    expect(next).toContain("wait, change the seed");
+    expect(next).not.toContain(REDELIVERED);
+    expect(next).not.toContain(PID);
+    expect(journal.outstanding(TAB)).toHaveLength(0);
+    expect(journal.ticketFor(PID)?.settled).toBe(true);
+  });
+
+  it("a Stop BEFORE the model receives the turn still replays (abandoned-turn contract)", async () => {
+    const backend = new MidReplyBackend({ emitReply: false });
+    const { journal, manager, arrive } = makeHarness(backend);
+
+    journal.openRun(PID, { tabId: TAB });
+    manager.send(TAB, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+
+    arrive(TAB, {
+      kind: "executed",
+      prompt_id: PID,
+      images: [{ filename: "kept_0001.png" }],
+    });
+    await waitFor(() => backend.turns.length >= 2);
+    expect(backend.turns[1]).toContain("kept_0001.png");
+    expect(backend.sawReply).toBe(false);
+
+    await manager.interrupt(TAB, { requeueInFlight: false });
+    await waitFor(() => backend.turns.length >= 3);
+    expect(backend.turns[2]).toContain("kept_0001.png");
+    expect(backend.turns[2]).toContain(REDELIVERED);
+    expect(journal.outstanding(TAB)).toHaveLength(1);
+    expect(journal.ticketFor(PID)?.settled).toBe(false);
+  });
+});

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -272,10 +272,11 @@ export interface ImageRef {
 /** One queued user turn (a panel message, or an injected panel event).
  *
  *  `eventTokens` carry #468's run-completion journal tokens through the queue.
- *  A completion is only ACKED once the turn that carried it ended, so an item
- *  that is queued-but-unread when the agent dies (or whose turn is abandoned by
- *  the stall watchdog) is handed BACK to the journal and replayed instead of
- *  vanishing with the agent. */
+ *  A completion is ACKED when the carrying turn ends, or when a user interrupt
+ *  lands AFTER the backend has produced an event for that turn (#2486). An item
+ *  that is queued-but-unread when the agent dies (or whose turn is abandoned
+ *  before the model received it) is handed BACK to the journal and replayed
+ *  instead of vanishing with the agent. */
 export interface QueueItem {
   text: string;
   images?: ImageRef[];
@@ -673,6 +674,19 @@ export class PanelAgent {
       this.deps.onEventUndelivered?.(this.tabId, [...tokens], opts);
     } catch (err) {
       logger.warn(`[panel-agent ${this.short()}] releasing completion tokens: ${msgOf(err)}`);
+    }
+  }
+
+  /** Settle tokens the model has already been shown (#2486). Same callback the
+   *  carrying turn's `result` uses; interrupt() steals the tokens from that
+   *  path, so without this a mid-reply Stop re-injects a completion the agent
+   *  already read. */
+  private ackEventTokens(tokens: string[] | undefined): void {
+    if (!tokens?.length) return;
+    try {
+      this.deps.onEventDelivered?.(this.tabId, [...tokens], { carrier: this.carrierId });
+    } catch (err) {
+      logger.warn(`[panel-agent ${this.short()}] acking completion tokens: ${msgOf(err)}`);
     }
   }
 
@@ -1440,25 +1454,35 @@ export class PanelAgent {
     // the user wants BOTH the interrupted message and the new one answered. A plain
     // Stop / Ctrl+C / Esc (requeueInFlight=false) must NOT re-queue, or it would
     // silently re-run the turn the user just stopped (double tool actions).
-    // #468 — the interrupted turn's run-completion tokens travel with its text.
-    // Re-queued: they ride the re-queued item and are acked when THAT turn ends.
-    // Dropped (plain Stop): hand them back so the completion is replayed rather
-    // than dying with the turn the user cancelled.
+    //
+    // #468 / #2486 — the interrupted turn's run-completion tokens.
+    // The model HAS seen them (`turnProducedEvents`): settle, and do not put
+    // `completionOnly` items back on the queue. Replaying after a mid-reply
+    // interrupt is what made the same prompt fire 3+ "Acknowledge the result"
+    // turns. The model has NOT seen them (pre-submission abort): keep the old
+    // rule — requeue so they ride the next turn, or hand them back so a plain
+    // Stop does not swallow a completion nobody read.
     const interruptedTokens = this.turnEventTokens;
     this.turnEventTokens = [];
+    const alreadyRead = this.turnProducedEvents;
     if (interrupted && opts.requeueInFlight) {
       // Front of the queue: the interrupted work is addressed before whatever the
       // user sends next (which is appended after this interrupt is handled). The
       // ORIGINAL items go back (not one merged item) — the next splice re-joins
       // them into the same text, while an injected completion stays a separate
       // `completionOnly` item that a later detach can remove cleanly (#468).
-      this.queue.unshift(...interrupted.items);
+      const items = alreadyRead
+        ? interrupted.items.filter((item) => !item.completionOnly)
+        : interrupted.items;
+      this.queue.unshift(...items);
+      if (alreadyRead) this.ackEventTokens(interruptedTokens);
+    } else if (alreadyRead) {
+      this.ackEventTokens(interruptedTokens);
     } else {
-      // UNCARRIED on purpose. This is a plain Stop — a deliberate human act that
-      // does not repeat on its own, so it cannot form the automatic loop the
-      // bound exists to break; settling a completion on the user's third Stop
-      // would be a surprise, not a safeguard. (The stall watchdog and rewind DO
-      // auto-repeat, so those are carried.)
+      // UNCARRIED on purpose. This is a plain Stop before the model received
+      // the turn — a deliberate human act that does not repeat on its own, so
+      // it cannot form the automatic loop the bound exists to break. (The stall
+      // watchdog and rewind DO auto-repeat, so those are carried.)
       this.releaseEventTokens(interruptedTokens);
     }
     // Track the turn this interrupt is aborting (the one holding the gate). The
@@ -2357,8 +2381,9 @@ export class PanelAgent {
         this.inFlight = null;
         // #468 — the turn that CARRIED the run completion(s) has ended, so they
         // demonstrably reached the model's context. Ack them: the journal drops
-        // them and settles their run tickets. This is the ONLY ack point; every
-        // other exit from a turn hands the tokens back for replay.
+        // them and settles their run tickets. The other ack point is a user
+        // interrupt AFTER the backend has produced an event for this turn
+        // (#2486); every other exit from a turn hands the tokens back for replay.
         //
         // ACK GATE: only THIS turn's own result may ack. On a backend that
         // DECLARES turn markers, an UNMARKED result is a traceless straggler


### PR DESCRIPTION
## Summary

Panel run-completion events were re-injected as RE-DELIVERED after a user interrupted the acknowledgement turn. `interrupt()` stole the carrying journal tokens from the result path and released them uncarried, so `onEventUndelivered` flushed the same prompt on every following Stop.

Once the backend has produced an event for the in-flight turn (`turnProducedEvents`), settle those tokens and do not requeue `completionOnly` items. A Stop before that proof still replays — the abandoned-turn contract is unchanged.

## Tests

`src/__tests__/orchestrator/run-completion-interrupt-ack.test.ts`:

- mid-reply Stop settles instead of re-delivering
- repeated Stops do not mint another acknowledgement turn
- send-now after receipt requeues user text, not the completion
- Stop before the model receives the turn still replays

Also green: `run-completion-requeued-in-flight`, `run-completion-continuation`, `send-now-requeue`.

Fixes #2486
