### PR TITLE
fix(2487): honor a verified pin when strip captures the live canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - panel_strip_workflow applies live capturedWidgetValues to promoted subgraph widgets instead of stale definition defaults (#2522)
-
+- panel_strip_workflow honors a verified pin when capturing the live canvas instead of refusing a stale last-advertised workflow instance (#2487)
 
 ## [0.52.156] - 2026-08-30
 

--- a/src/__tests__/orchestrator/strip-pinned-workflow-mismatch.test.ts
+++ b/src/__tests__/orchestrator/strip-pinned-workflow-mismatch.test.ts
@@ -1,0 +1,295 @@
+// #2487 — panel_strip_workflow refused a live-canvas capture after a verified
+// pin because routing state compared the session stamp against a stale
+// last-advertised workflow instance, even though enter/exit subgraph had just
+// succeeded on the pinned canvas.
+//
+// Reported shape: panel_set_workflow_target({mode:"pinned"}) answered
+// pin_verified_active:true, panel_enter_subgraph / panel_exit_subgraph worked,
+// then panel_strip_workflow({}) failed with
+//
+//   workflow instance mismatch: this command was issued for workflow instance
+//   <A>, but the tab it routed to has since reported a different active
+//   workflow (<B>). Nothing was dispatched. Re-target with
+//   panel_set_workflow_target({mode:"current"})
+//
+// That recovery RELEASES the pin. The live canvas was still the pinned
+// workflow; the advertisement was the stale side. Strip captures via
+// bridge.send, so it hit the #1656 stamp-target gate without ctx.call's
+// mismatch diagnosis. The fix re-resolves the pin against the live canvas and
+// reconciles that advertisement when the pin still names it.
+//
+// These tests measure the EFFECT — whether graph_serialize reaches the socket —
+// over a real UiBridge, not the reply's claims about itself.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: async () => {
+    throw new Error("COMFYUI_URL must not be consulted for a live-canvas strip");
+  },
+  backfillObjectInfo: async (bulk: unknown) => bulk,
+  resetClient: () => {},
+  resetObjectInfoCache: () => {},
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { UiBridge } from "../../services/ui-bridge.js";
+import { isScopeAddress } from "../../services/session-scope.js";
+import { workflowIdentityParts } from "../../orchestrator/session-store.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const LIVE = "4808c797-417c-4c33-8ab0-99cf2f6ba648";
+const STALE = "caf45251-53ad-431b-afdd-02239fdb7119";
+const TAB = "wf:route1:workflows/a.json";
+const SCOPE = "orchestrator::claude";
+const PATH = "workflows/a.json";
+const OTHER_PATH = "workflows/other.json";
+const ORIGIN = "http://127.0.0.1:8188";
+
+const AGENT_KEY_SEP = "::";
+function panelTabOf(key: string): string {
+  const i = key.lastIndexOf(AGENT_KEY_SEP);
+  return i >= 0 ? key.slice(0, i) : key;
+}
+
+const NODES = [
+  { id: 1, type: "KSampler", widgets_values: [7, 20], inputs: [], outputs: [] },
+];
+const KSAMPLER_DEF = {
+  input: { required: { seed: ["INT"], steps: ["INT"] } },
+  output: [],
+  name: "KSampler",
+};
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => ("text" in c ? (c as { text: string }).text : "")).join("\n");
+}
+
+function jsonOf(res: ToolResult): Record<string, unknown> {
+  try {
+    return JSON.parse(textOf(res)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/** Self-corroborating workflow_list: the active record also appears in the
+ *  open-workflow list flagged active, which is what pin verification and fence
+ *  corroboration both require. */
+function settled(uuid: string, path = PATH): Record<string, unknown> {
+  const filename = path.split("/").pop();
+  const active = {
+    path,
+    filename,
+    key: path,
+    // Current panels advertise wf:<route>:<path> (#640), not wf:<path>.
+    routing_key: TAB,
+    workflow_uuid: uuid,
+  };
+  return {
+    active,
+    workflows: [{ ...active, active: true }],
+    active_confirmed: true,
+  };
+}
+
+describe("panel_strip_workflow honors a verified pin over a stale advertisement (#2487)", () => {
+  let bridge: UiBridge;
+  let port: number;
+
+  const advertised = new Map<string, string>();
+  let sessionStamp: string | undefined;
+  let liveCanvas: string;
+  let livePath: string;
+  let received: Array<Record<string, unknown>>;
+
+  beforeEach(async () => {
+    advertised.clear();
+    sessionStamp = undefined;
+    liveCanvas = LIVE;
+    livePath = PATH;
+    received = [];
+    for (let attempt = 0; attempt < 6; attempt++) {
+      port = await freePort();
+      bridge = new UiBridge(port);
+      bridge.start();
+      if (await bridge.whenReady()) break;
+      await bridge.stop();
+      if (attempt === 5) throw new Error("could not bind a free bridge port");
+    }
+    bridge.setTabWorkflowUuidResolver(
+      (id) => (isScopeAddress(id) ? sessionStamp : advertised.get(panelTabOf(id))),
+      (id, uuid) => {
+        if (!bridge.canReach(id)) return { ok: false, reason: `the routed tab ${id} is gone` };
+        const panelTab = isScopeAddress(id) ? bridge.resolveSharedTabId(id) : panelTabOf(id);
+        if (!panelTab) return { ok: false, reason: `${id} does not name a panel tab` };
+        const identity = workflowIdentityParts({
+          workflowUuid: uuid,
+          origin: bridge.tabServerOrigin(id),
+        });
+        if (!identity) {
+          return { ok: false, reason: `there is no server-observed Origin for ${id}` };
+        }
+        advertised.set(panelTab, identity.uuid);
+        if (isScopeAddress(id)) sessionStamp = identity.uuid;
+        return true;
+      },
+    );
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+  });
+
+  function connectPanel(): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`, { origin: ORIGIN });
+      sock.on("open", () => {
+        sock.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: TAB,
+            title: TAB,
+            enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
+          }),
+        );
+        resolve(sock);
+      });
+      sock.on("error", reject);
+      sock.on("message", (buf) => {
+        const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+        if (!msg.rid || !msg.cmd) return;
+        received.push(msg);
+        const cmd = String(msg.cmd);
+        let result: unknown = { cmd };
+        if (cmd === "workflow_list") result = settled(liveCanvas, livePath);
+        else if (cmd === "graph_serialize") result = { workflow: { nodes: NODES, links: [] } };
+        else if (cmd === "graph_get_state") result = { nodes: NODES, links: [] };
+        else if (cmd === "graph_get_object_info") {
+          result = {
+            ok: true,
+            served_by: ORIGIN,
+            object_info: { KSampler: KSAMPLER_DEF },
+          };
+        } else if (cmd === "graph_enter_subgraph") result = { ok: true, scope: "subgraph" };
+        else if (cmd === "graph_exit_subgraph") {
+          // Production: enter AND exit succeed; the advertisement then drifts
+          // (subgraph navigation remints / re-hellos a different instance) so
+          // the NEXT fenced command is what the stamp-target gate refuses.
+          advertised.set(TAB, STALE);
+          result = { ok: true, scope: "root" };
+        }
+        sock.send(JSON.stringify({ rid: msg.rid, ok: true, result }));
+      });
+    });
+  }
+
+  function ctxFor(store: WorkflowTargetStore): PanelToolCtx {
+    return makePanelToolCtx(bridge, SCOPE, store);
+  }
+
+  async function tool(name: string, args: Record<string, unknown>, ctx: PanelToolCtx): Promise<ToolResult> {
+    const def = buildPanelToolDefs().find((d) => d.name === name);
+    if (!def) throw new Error(`${name} is not registered`);
+    return def.handler(args as never, ctx);
+  }
+
+  async function inPinnedState(): Promise<{ sock: WebSocket; ctx: PanelToolCtx; store: WorkflowTargetStore }> {
+    advertised.set(TAB, LIVE);
+    sessionStamp = LIVE;
+    const sock = await connectPanel();
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    received.length = 0;
+    const store = new WorkflowTargetStore();
+    const ctx = ctxFor(store);
+    const pin = await tool("panel_set_workflow_target", { mode: "pinned", path: PATH }, ctx);
+    expect(pin.isError, textOf(pin)).toBeFalsy();
+    expect(jsonOf(pin).pin_verified_active).toBe(true);
+    return { sock, ctx, store };
+  }
+
+  it("THE REPORTED FLOW: verified pin, enter/exit, then strip still captures", async () => {
+    const { sock, ctx } = await inPinnedState();
+
+    const entered = await tool("panel_enter_subgraph", { node_id: 12 }, ctx);
+    expect(entered.isError, textOf(entered)).toBeFalsy();
+    const exited = await tool("panel_exit_subgraph", {}, ctx);
+    expect(exited.isError, textOf(exited)).toBeFalsy();
+    expect(advertised.get(TAB)).toBe(STALE);
+    expect(sessionStamp).toBe(LIVE);
+
+    // THE GATE, measured: a fenced graph command is refused pre-dispatch
+    // against the stale advertisement, nothing reaches the socket. This is
+    // the state strip used to fail in.
+    received.length = 0;
+    const refused = await bridge.send({ cmd: "graph_serialize" }, { tabId: SCOPE }).then(
+      () => null,
+      (e) => e as Error,
+    );
+    expect(refused?.message).toContain(`issued for workflow instance ${LIVE}`);
+    expect(refused?.message).toContain(`different active workflow (${STALE})`);
+    expect(received.map((f) => f.cmd)).toEqual([]);
+
+    const strip = await tool("panel_strip_workflow", {}, ctx);
+    expect(strip.isError, textOf(strip)).toBeFalsy();
+    expect(textOf(strip)).toMatch(/Stripped to 1 nodes/);
+    expect(received.map((f) => f.cmd)).toContain("graph_serialize");
+    expect(advertised.get(TAB)).toBe(LIVE);
+    expect(sessionStamp).toBe(LIVE);
+    sock.close();
+  });
+
+  it("a pin to a DIFFERENT live canvas is not laundered into a capture", async () => {
+    // Fail closed: honoring the pin must not adopt whatever happens to be
+    // active. The live canvas is PATH; the pin names OTHER_PATH.
+    advertised.set(TAB, STALE);
+    sessionStamp = LIVE;
+    livePath = PATH;
+    const sock = await connectPanel();
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    const store = new WorkflowTargetStore();
+    store.set(SCOPE, { mode: "pinned", path: OTHER_PATH, filename: "other.json" });
+    const ctx = ctxFor(store);
+    received.length = 0;
+
+    await expect(tool("panel_strip_workflow", {}, ctx)).rejects.toThrow(
+      /Couldn't capture the live canvas/,
+    );
+    expect(received.map((f) => f.cmd)).not.toContain("graph_serialize");
+    expect(advertised.get(TAB)).toBe(STALE);
+    sock.close();
+  });
+
+  it("without a pin the mismatch still refuses — the fence is not weakened", async () => {
+    advertised.set(TAB, STALE);
+    sessionStamp = LIVE;
+    const sock = await connectPanel();
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    const ctx = ctxFor(new WorkflowTargetStore());
+    received.length = 0;
+
+    await expect(tool("panel_strip_workflow", {}, ctx)).rejects.toThrow(
+      /Couldn't capture the live canvas[\s\S]*workflow instance mismatch/,
+    );
+    expect(received.map((f) => f.cmd)).not.toContain("graph_serialize");
+    expect(advertised.get(TAB)).toBe(STALE);
+    sock.close();
+  });
+});

--- a/src/__tests__/orchestrator/strip-pinned-workflow-mismatch.test.ts
+++ b/src/__tests__/orchestrator/strip-pinned-workflow-mismatch.test.ts
@@ -277,6 +277,28 @@ describe("panel_strip_workflow honors a verified pin over a stale advertisement 
     sock.close();
   });
 
+  it("does not repair an ambiguous basename pin against another directory", async () => {
+    // A lenient/older panel may preserve the caller's bare filename as the pin.
+    // That filename is not enough to identify workflows/other/a.json when the
+    // live canvas is a same-basename workflow in another directory.
+    advertised.set(TAB, STALE);
+    sessionStamp = LIVE;
+    livePath = "workflows/other/a.json";
+    const sock = await connectPanel();
+    await waitFor(() => expect(bridge.tabs().map((t) => t.tab_id)).toContain(TAB));
+    const store = new WorkflowTargetStore();
+    store.set(SCOPE, { mode: "pinned", path: "a.json", filename: "a.json" });
+    const ctx = ctxFor(store);
+    received.length = 0;
+
+    await expect(tool("panel_strip_workflow", {}, ctx)).rejects.toThrow(
+      /Couldn't capture the live canvas[\s\S]*workflow instance mismatch/,
+    );
+    expect(received.map((f) => f.cmd)).not.toContain("graph_serialize");
+    expect(advertised.get(TAB)).toBe(STALE);
+    sock.close();
+  });
+
   it("without a pin the mismatch still refuses — the fence is not weakened", async () => {
     advertised.set(TAB, STALE);
     sessionStamp = LIVE;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -12042,6 +12042,25 @@ function pinHonorsLiveCanvas(
 }
 
 /**
+ * Automatic fence repair needs stronger identity than legacy pin resolution.
+ * `activeMatchesTarget` intentionally accepts filename/basename aliases for
+ * compatibility, but a basename cannot prove which saved workflow is live
+ * when two directories contain the same filename. Use only a canonical path
+ * or a canonical key here; otherwise leave the dispatch fence refusing.
+ */
+function exactPinnedSavedPathMatchesLive(
+  pinPath: string,
+  liveActive: Record<string, unknown> | undefined,
+): boolean {
+  const expected = canonicalSavedWorkflowPath(pinPath);
+  if (!expected || !expected.includes("/") || !liveActive) return false;
+  const observed = liveActive as { path?: unknown; key?: unknown };
+  return [observed.path, observed.key].some(
+    (value) => canonicalSavedWorkflowPath(value) === expected,
+  );
+}
+
+/**
  * The ONE remedy that is actually reachable from every wedged state below, and
  * the one the reporters found to be the only thing that worked.
  *
@@ -16505,13 +16524,12 @@ async function repairPinnedStampForLiveCanvas(ctx: PanelToolCtx): Promise<boolea
   // pinHonorsLiveCanvas is the UUID-adoption gate: it needs routing_key ===
   // wf:<path>. Current panels advertise wf:<route>:<path> (#640), which that
   // gate reads as indeterminate. Path/filename/key equality still proves the
-  // pin names this canvas; a POSITIVE "different" still refuses.
+  // pin names this canvas. A path/key match is required when the panel's
+  // routing shape is indeterminate; a bare filename is never enough.
   const live = liveActiveFromProbe(probe);
   const namesLive =
     pinHonorsLiveCanvas(pin, live) ||
-    (live != null &&
-      readOpenActiveAgainstTarget(live, pin.path) !== "different" &&
-      activeMatchesTarget(live, pin.path));
+    exactPinnedSavedPathMatchesLive(pin.path, live);
   if (!namesLive) return false;
 
   if (probe.status === "already_current") {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -16448,6 +16448,98 @@ export function makePanelToolCtx(
  * first derailed real sessions (deleted placeholder files, 404 tabs).
  */
 /**
+ * #2487 — whether the dispatch-time stamp-target gate would refuse a fenced
+ * graph command from this session.
+ *
+ * TRI-STATE on purpose. The gate compares the session stamp against the routed
+ * tab's LAST ADVERTISED identity, which is not the pin and is not the live
+ * canvas. A missing or throwing probe is an unmade observation, not "no
+ * disagreement".
+ */
+function stampTargetDisagrees(ctx: PanelToolCtx): boolean | undefined {
+  try {
+    const cap = ctx.tabGraphMutationCapability?.();
+    if (!cap) return undefined;
+    if (cap.known !== true) return undefined;
+    return cap.canMutate === false && cap.because === "target_disagreement";
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * #2487 — a pin is a PATH, not the last-active tab's advertised instance.
+ *
+ * After a verified pin, subgraph enter/exit can succeed (they go through
+ * `ctx.call`) while the next live-canvas capture — `panel_strip_workflow({})`
+ * via `bridge.send` — is refused because the routed tab still advertises a
+ * different workflow instance. The refusal names `mode:"current"`, which
+ * RELEASES the pin.
+ *
+ * Re-resolve the pin against the live canvas. If it still NAMES that canvas,
+ * reconcile a stale advertisement (#2209) or refresh a reminted instance
+ * stamp (#1913: honoring the path is not abandoning it). A pin to a
+ * DIFFERENT canvas is left alone — that refusal is the fence working.
+ *
+ * Returns whether a repair actually happened, so a caller can retry a
+ * capture that was refused for this reason and not for any other.
+ */
+async function repairPinnedStampForLiveCanvas(ctx: PanelToolCtx): Promise<boolean> {
+  let pin: { mode?: string; path?: string } | undefined;
+  try {
+    pin = ctx.workflowTarget?.get(ctx.tabId);
+  } catch {
+    return false;
+  }
+  if (pin?.mode !== "pinned" || typeof pin.path !== "string" || pin.path.length === 0) {
+    return false;
+  }
+  if (typeof ctx.call !== "function") return false;
+
+  let probe: WorkflowFenceRebind;
+  try {
+    probe = await rebindWorkflowFence(ctx, { adopt: false });
+  } catch {
+    return false;
+  }
+  // pinHonorsLiveCanvas is the UUID-adoption gate: it needs routing_key ===
+  // wf:<path>. Current panels advertise wf:<route>:<path> (#640), which that
+  // gate reads as indeterminate. Path/filename/key equality still proves the
+  // pin names this canvas; a POSITIVE "different" still refuses.
+  const live = liveActiveFromProbe(probe);
+  const namesLive =
+    pinHonorsLiveCanvas(pin, live) ||
+    (live != null &&
+      readOpenActiveAgainstTarget(live, pin.path) !== "different" &&
+      activeMatchesTarget(live, pin.path));
+  if (!namesLive) return false;
+
+  if (probe.status === "already_current") {
+    return reconcileStampTarget(ctx, probe.uuid).ok;
+  }
+  if (probe.status === "diverged") {
+    const identity = probe.active ?? { workflow_uuid: probe.uuid };
+    if (!refreshWorkflowUuid(ctx, identity)) return false;
+    const rec = reconcileStampTarget(ctx, probe.uuid);
+    return rec.ok || rec.why === "no_disagreement";
+  }
+  return false;
+}
+
+/** Live-canvas capture: the same pin injection `ctx.call` applies, over the
+ *  direct `bridge.send` this path has to use (it needs the raw graph, not a
+ *  ToolResult wrapper). */
+async function sendLiveCanvasGraphCmd(
+  ctx: PanelToolCtx,
+  cmd: "graph_serialize" | "graph_get_state",
+  timeoutMs: number,
+) {
+  const target = ctx.workflowTarget?.get(ctx.tabId);
+  const routed = target ? withWorkflowTarget({ cmd }, target) : { cmd };
+  return ctx.bridge.send(routed as { cmd: string }, { tabId: ctx.tabId, timeoutMs });
+}
+
+/**
  * Rebuild a UI-format workflow ({ nodes, links }) from the panel's back-compat
  * `graph_get_state` reply (the #384 fallback). Each summarized node carries its
  * widget values keyed BY NAME (`widgets`) and its inputs' upstream source
@@ -16655,18 +16747,26 @@ async function resolveWorkflowInput(
   let reply: unknown;
   try {
     ctx.ensureReachable?.();
-    // Route to the SAME authoritative target as ctx.call: when the session is
-    // pinned, inject the pinned workflow_path so the live-canvas capture serializes
-    // the PINNED workflow, not whatever tab is visible (codex — this direct send
-    // otherwise bypasses withWorkflowTarget and reads the wrong graph).
-    const target = ctx.workflowTarget?.get(ctx.tabId);
-    const cmd = target
-      ? withWorkflowTarget({ cmd: "graph_serialize" }, target)
-      : { cmd: "graph_serialize" };
-    reply = await ctx.bridge.send(cmd as { cmd: string }, {
-      tabId: ctx.tabId,
-      timeoutMs: 30000,
-    });
+    // #2487 — honor a verified pin BEFORE the capture is compared against the
+    // routed tab's last-advertised identity. That advertisement is unrelated
+    // active-tab state: subgraph enter/exit can leave it stale while the pin
+    // still names the live canvas. Re-resolve here rather than telling the
+    // caller to `mode:"current"`, which would release the pin. Cheap when the
+    // gate is not refusing; a missing probe is not treated as disagreement.
+    if (stampTargetDisagrees(ctx) === true) {
+      await repairPinnedStampForLiveCanvas(ctx);
+    }
+    try {
+      reply = await sendLiveCanvasGraphCmd(ctx, "graph_serialize", 30000);
+    } catch (err) {
+      // The capability probe is optional (lightweight ctxs omit it) and can
+      // miss a disagreement the send() gate still sees. One repair+retry, and
+      // only for this refusal — any other capture error keeps its own path.
+      if (!isWorkflowInstanceMismatch(err) || !(await repairPinnedStampForLiveCanvas(ctx))) {
+        throw err;
+      }
+      reply = await sendLiveCanvasGraphCmd(ctx, "graph_serialize", 30000);
+    }
   } catch (err) {
     // #384: a panel too old to register graph_serialize (added at 0.8.2) still
     // answers the back-compat `graph_get_state`. On an unsupported-command
@@ -16682,14 +16782,7 @@ async function resolveWorkflowInput(
     const msg = err instanceof Error ? err.message : String(err);
     if (allowStateFallback && isPanelCmdUnsupportedError(err, "graph_serialize")) {
       try {
-        const target = ctx.workflowTarget?.get(ctx.tabId);
-        const stateCmd = target
-          ? withWorkflowTarget({ cmd: "graph_get_state" }, target)
-          : { cmd: "graph_get_state" };
-        const stateReply = await ctx.bridge.send(stateCmd as { cmd: string }, {
-          tabId: ctx.tabId,
-          timeoutMs: 30000,
-        });
+        const stateReply = await sendLiveCanvasGraphCmd(ctx, "graph_get_state", 30000);
         const rebuilt = reconstructUiFromState(stateReply);
         if (rebuilt) return rebuilt;
       } catch {
@@ -16724,14 +16817,7 @@ async function resolveWorkflowInput(
   if (allowStateFallback && notes) {
     let stateReply: unknown;
     try {
-      const target = ctx.workflowTarget?.get(ctx.tabId);
-      const stateCmd = target
-        ? withWorkflowTarget({ cmd: "graph_get_state" }, target)
-        : { cmd: "graph_get_state" };
-      stateReply = await ctx.bridge.send(stateCmd as { cmd: string }, {
-        tabId: ctx.tabId,
-        timeoutMs: 30000,
-      });
+      stateReply = await sendLiveCanvasGraphCmd(ctx, "graph_get_state", 30000);
     } catch (err) {
       // Never fatal: strip already HAS a usable graph. Losing the cross-check
       // degrades fidelity, and that degradation is what gets reported.


### PR DESCRIPTION
Fixes #2487

## What happened

After `panel_set_workflow_target({mode:"pinned"})` reported `pin_verified_active:true` and `panel_enter_subgraph` / `panel_exit_subgraph` succeeded on that canvas, `panel_strip_workflow({})` refused with a workflow-instance mismatch against a *different* advertised instance. The pin was still the live canvas; the user had not changed tabs.

The refusal named `panel_set_workflow_target({mode:"current"})`, which would **release** the pin.

## Gap this PR closes

Live-canvas strip/flatten/slice capture via `graph_serialize` goes through `bridge.send`, not `ctx.call`, so it hits the #1656 stamp-target gate (session stamp vs the routed tab's last-advertised identity) without the mismatch diagnosis other graph commands get.

That advertisement is unrelated active-tab state. Subgraph enter/exit can leave it stale while the pin still names the live canvas.

Before (and, on mismatch, after) the capture, re-resolve the pin against the live canvas:

- if it still names that canvas, reconcile the stale advertisement (#2209) or refresh a reminted instance stamp (#1913: honoring the path is not abandoning it)
- if the pin names a **different** canvas, leave the refusal alone — that is the fence working

## Tests

`npx vitest run src/__tests__/orchestrator/strip-pinned-workflow-mismatch.test.ts`

- verified pin + enter/exit + stale advertisement → strip captures (`graph_serialize` reaches the socket)
- pin to a different live canvas is not laundered into a capture
- without a pin the mismatch still refuses
