### PR TITLE
fix(2490): do not report a Manager not-found fix as repaired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - list_local_models reads inventory through the connected panel when the headless /models route is unreachable (#2511)
+- install_custom_node action:"fix" does not report repaired when Manager's task result is not-found/error (#2490)
 - panel_load_workflow restamps extra.comfyui_mcp.workflow_path (and uuid) to the active tab so an in-place save is not refused as belonging to the source workflow (#2505)
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 - fence ordinary `panel_set_widget` writes against the current panel graph identity across reconnects, with an actionable rebind refusal (#2550)

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -2311,6 +2311,7 @@ describe("node-management service", () => {
       const { calls } = stubFetch();
       const res = await fixCustomNode({ id: "my-pack" });
       expect(res.mechanism).toBe("manager-http");
+      expect(res.message).toMatch(/Queued \+ repaired/);
       expect(taskOf(calls, "fix").params).toMatchObject({ node_name: "my-pack" });
     });
 
@@ -2325,6 +2326,84 @@ describe("node-management service", () => {
       expect(args).toContain("all");
       expect(args).toContain("/split/data");
       expect(args).not.toContain("/split/code");
+    });
+
+    it("does not report repaired when Manager history records a not-found error (#2490)", async () => {
+      const { calls } = stubFetch({
+        managerTaskHistory: (uiId) => ({
+          history: {
+            ui_id: uiId,
+            kind: "fix",
+            result: "not found: ComfyUI-CacheDiT@",
+            status: { status_str: "error" },
+          },
+        }),
+      });
+      const err = await fixCustomNode({ id: "ComfyUI-CacheDiT" }).catch((e) => e as Error);
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect(err.message).toMatch(/not found: ComfyUI-CacheDiT@/);
+      expect(err.message).toMatch(/does not prove/);
+      expect(err.message).not.toMatch(/Queued \+ repaired/);
+      const { body } = taskOf(calls, "fix");
+      const historyCalls = calls.filter(
+        (c) => new URL(c.url).pathname === "/v2/manager/queue/history",
+      );
+      expect(historyCalls).toHaveLength(1);
+      expect(new URL(historyCalls[0].url).searchParams.get("ui_id")).toBe(body.ui_id);
+    });
+
+    it.each(["failed", "error"] as const)(
+      "surfaces a v4 per-task fix %s after queue drain (#2490)",
+      async (statusStr) => {
+        stubFetch({
+          managerTaskHistory: (uiId) => ({
+            history: {
+              ui_id: uiId,
+              kind: "fix",
+              result: `An error occurred while fixing 'ComfyUI-CacheDiT@'.`,
+              status: { status_str: statusStr },
+            },
+          }),
+        });
+        const err = await fixCustomNode({ id: "ComfyUI-CacheDiT" }).catch((e) => e as Error);
+        expect(err).toBeInstanceOf(NodeManagementError);
+        expect(err.message).toContain(`recorded the fix of "ComfyUI-CacheDiT" as ${statusStr}`);
+        expect(err.message).toMatch(/An error occurred while fixing/);
+        expect(err.message).not.toMatch(/Queued \+ repaired/);
+      },
+    );
+
+    it("does not report repaired when history result is not-found without status_str (#2490)", async () => {
+      stubFetch({
+        managerTaskHistory: (uiId) => ({
+          history: {
+            ui_id: uiId,
+            kind: "fix",
+            result: "not found: ComfyUI-CacheDiT@",
+          },
+        }),
+      });
+      const err = await fixCustomNode({ id: "ComfyUI-CacheDiT" }).catch((e) => e as Error);
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect(err.message).toMatch(/not found: ComfyUI-CacheDiT@/);
+      expect(err.message).not.toMatch(/Queued \+ repaired/);
+    });
+
+    it("still reports repaired when Manager history records success (#2490)", async () => {
+      const { calls } = stubFetch({
+        managerTaskHistory: (uiId) => ({
+          history: {
+            ui_id: uiId,
+            kind: "fix",
+            result: "success",
+            status: { status_str: "success" },
+          },
+        }),
+      });
+      const res = await fixCustomNode({ id: "my-pack" });
+      expect(res.mechanism).toBe("manager-http");
+      expect(res.message).toMatch(/Queued \+ repaired "my-pack"/);
+      expect(res.taskUiId).toBe(taskOf(calls, "fix").body.ui_id);
     });
   });
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1016,6 +1016,33 @@ function safeManagerTaskDetails(
   };
 }
 
+/**
+ * #2490 — a drained Manager queue is not a successful repair. On v4 the
+ * queue-wide counts are identical for a task that succeeded and one that
+ * errored; the per-task history record is the structured verdict.
+ *
+ * `unified_fix` fails with `not found: <id>@<ver>` and the worker logs
+ * `An error occurred while fixing '…'`. Those two strings are Manager's own
+ * proven-negative literals, so they are treated as failure even when
+ * `status_str` is omitted — inferring failure from any other prose is still
+ * refused (#1999).
+ */
+function managerTaskLooksFailed(
+  record: ManagerTaskHistoryEntry | null | undefined,
+): { status: string; excerpt: string } | undefined {
+  if (!record) return undefined;
+  const status = record.statusStr?.trim().toLowerCase();
+  const excerpt = managerTaskResultExcerpt(record.result);
+  if (status === "failed" || status === "error") {
+    return { status, excerpt };
+  }
+  const result = typeof record.result === "string" ? record.result : "";
+  if (/\bnot found\s*:/i.test(result) || /an error occurred while fixing/i.test(result)) {
+    return { status: status || "error", excerpt };
+  }
+  return undefined;
+}
+
 /** Wrap a legacy-Manager failure with the upgrade guidance (keeps details). */
 function annotateLegacyError(
   err: unknown,
@@ -4949,11 +4976,40 @@ async function fixCustomNodeImpl(opts: FixOptions): Promise<NodeOpResult> {
 
   // FixPackParams requires node_ver; "" lets Manager resolve the installed
   // version (do_fix looks the pack up by name).
-  const status = await queueManagerTask("fix", { node_name: id, node_ver: "" });
+  // Pin the target before the first await so the enqueue, drain, and per-task
+  // history lookup stay on the same Manager even if the panel retargets.
+  const base = managerBaseUrl();
+  const queued = await queueManagerTaskTracked("fix", { node_name: id, node_ver: "" }, base);
+  const status = queued.status;
+  // #2490 — a drained queue / done_count is not a repair. Manager v4 records
+  // the real verdict on the per-task history row (status_str + result); a
+  // not-found / error there used to still print "Queued + repaired".
+  let taskRecord: ManagerTaskHistoryEntry | null | undefined;
+  try {
+    taskRecord = await fetchManagerTaskHistoryEntry(queued.uiId, base);
+  } catch {
+    taskRecord = undefined;
+  }
+  const failure = managerTaskLooksFailed(taskRecord);
+  if (failure) {
+    throw new NodeManagementError(
+      `ComfyUI-Manager recorded the fix of "${id}" as ${failure.status}. ` +
+        `The queue drained, but that only proves the task finished running; it does not prove ` +
+        `the pack was repaired.` +
+        (failure.excerpt ? ` Manager result: ${failure.excerpt}` : ""),
+      {
+        queueStatus: status,
+        managerTask: taskRecord ? safeManagerTaskDetails(taskRecord, failure.excerpt) : undefined,
+        uiId: queued.uiId,
+      },
+    );
+  }
   return {
     mechanism: "manager-http",
     message: `Queued + repaired "${id}" via ComfyUI-Manager.`,
     details: status,
+    managerBase: base,
+    taskUiId: queued.uiId,
   };
 }
 

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -500,10 +500,11 @@ export function registerNodeManagementTools(server: McpServer): void {
           case "fix": {
             const id = requireId("fix", "the registry id / module name to repair, or 'all'");
             const mode = managerMode("fix"); // before the panel branch — see action:"install"
-            // `fix` has no verified equivalent (it reports success off the Manager
-            // queue, which proves nothing — #639), so a panel target is refused
-            // rather than redirected. Bulk "all" is handled by the pin guard inside
-            // the service.
+            // `fix` has no verified on-disk equivalent (a drained queue is not a
+            // repair — #639/#2490; the HTTP path now fails closed on Manager's
+            // per-task not-found/error, but still cannot prove the pack moved),
+            // so a panel target is refused rather than redirected. Bulk "all"
+            // is handled by the pin guard inside the service.
             if (targetsPanelPackExactly(id)) {
               assertPanelNotTargetedUnverifiable('install_custom_node action:"fix"', id);
             }


### PR DESCRIPTION
Fixes #2490

## Recurrence

`install_custom_node` with `action:"fix"` returned `Queued + repaired "ComfyUI-CacheDiT" via ComfyUI-Manager` after the Manager queue drained. ComfyUI's runtime log for the same operation showed `[ERROR] not found: ComfyUI-CacheDiT@` and `ERROR: An error occurred while fixing 'ComfyUI-CacheDiT@'.` A drained queue / `done_count` is not a repair: on Manager v4 those counters are identical for success and error.

## Gap this PR closes

- **Read the per-task history after drain** — `fixCustomNode` now uses `queueManagerTaskTracked` and `fetchManagerTaskHistoryEntry` instead of treating queue completion as success.
- **Fail on Manager not-found/error** — `status_str` of `failed`/`error`, or a result of `not found: …` / `An error occurred while fixing`, throws `NodeManagementError` instead of `Queued + repaired`.
- **Keep unverified drains unchanged** — missing/unreadable history (legacy 3.x) still reports repaired; a proven failure never does.

## Tests

`npx vitest run src/__tests__/services/node-management.test.ts -t "fixCustomNode"`

Unfixed code reports repaired on the CacheDiT not-found history row; this branch throws with the Manager result excerpt.
