### PR TITLE
fix(2489): settle an unacked widget write with a graph read-back and mutation receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- panel_set_widget reconciles a missing ACK with a graph read-back and mutation receipt instead of leaving an applied subgraph write as outcome-unknown (#2489)
+
 ## [0.52.166] - 2026-09-01
 
 ### MCP
@@ -24,7 +29,6 @@ All notable changes to this project are documented here. This project adheres to
 - a loader input naming a file the server does not have says where it looked, and how to fix it (#2679)
 - a Windows updater that cannot reach npm or git says so, and says what to do (#2672)
 
-
 ## [0.52.165] - 2026-08-30
 
 ### MCP
@@ -41,7 +45,6 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - check_runtime does not classify environment-authenticated paid Gemini and WaveSpeed nodes as local/free (#2543, #2665)
 - install_comfyui action:"environment" reports the pip-installed ComfyUI-Manager version from a trusted interpreter instead of a disabled custom_nodes/ComfyUI-Manager checkout (#2538, #2664)
-
 
 ## [0.52.163] - 2026-08-30
 
@@ -64,7 +67,6 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - get_image list_assets and get_system_stats logs fall back to the connected panel same-origin history/logs/view reads when the configured headless route is unreachable, and panel_run completion events name PreviewImage outputs with type temp (#2283)
-- panel_set_widget reconciles a missing ACK with a graph read-back and mutation receipt instead of leaving an applied subgraph write as outcome-unknown (#2489)
 - panel_set_widget does not treat a MiniMaxH3Director duration write as failed when the value landed and only a setting-store onValueChange callback threw (#2545, #2654)
 - panel_connect retries a LiteGraph wildcard-to-wildcard (`*` → `*`) pairing when the panel reports "No input accepts type *" — PrimitiveNode "connect to widget input" can land on LogicIF.when_true / when_false so the primitive becomes typed from the destination (#2542, #2653)
 - panel_query_graph inspects the unsaved live canvas after custom-widget / builder content-only [root-shape-mismatch] instead of recommending a destructive re-open (#2544, #2652)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - get_image list_assets and get_system_stats logs fall back to the connected panel same-origin history/logs/view reads when the configured headless route is unreachable, and panel_run completion events name PreviewImage outputs with type temp (#2283)
+- panel_set_widget reconciles a missing ACK with a graph read-back and mutation receipt instead of leaving an applied subgraph write as outcome-unknown (#2489)
 - panel_set_widget does not treat a MiniMaxH3Director duration write as failed when the value landed and only a setting-store onValueChange callback threw (#2545, #2654)
 - panel_connect retries a LiteGraph wildcard-to-wildcard (`*` → `*`) pairing when the panel reports "No input accepts type *" — PrimitiveNode "connect to widget input" can land on LogicIF.when_true / when_false so the primitive becomes typed from the destination (#2542, #2653)
 - panel_query_graph inspects the unsaved live canvas after custom-widget / builder content-only [root-shape-mismatch] instead of recommending a destructive re-open (#2544, #2652)

--- a/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
@@ -34,6 +34,7 @@ const WORKFLOW_UUID = "workflow-2489";
 const NODE_IDENTITY = "node-incarnation:2489:12";
 const REPLACED_NODE_IDENTITY = "node-incarnation:2489:replacement";
 const LONG_REQUESTED_VALUE = `clip-${"x".repeat(2200)}`;
+const BINARY_WIDGET_PLACEHOLDER = "[binary]";
 const WIDGET_CAP_CLIPPED_VALUE =
   "clip-" +
   "x".repeat(100) +
@@ -159,11 +160,15 @@ function bridge(opts: {
         const readbackLength =
           queryCount <= 1
             ? PREVIOUS
+            : opts.probeLength === "binary-placeholder"
+              ? BINARY_WIDGET_PLACEHOLDER
             : opts.probeLength === "widget-cap-marker"
               ? WIDGET_CAP_CLIPPED_VALUE
               : opts.probeLength === "json-budget-marker"
                 ? JSON_BUDGET_CLIPPED_VALUE
-                : opts.probeLength ?? VALUE;
+                : opts.probeLength !== undefined
+                  ? opts.probeLength
+                  : VALUE;
         return nodeDetail(readbackLength, graphIdentity, "subgraph", nodeIdentity);
       }
       if (cmd.cmd === "graph_get_subgraph") {
@@ -281,6 +286,21 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
     );
 
     expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).not.toMatch(/"applied": false/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+
+  it.each([
+    ["the panel's unreadable [binary] placeholder", "binary-placeholder"],
+    ["a non-scalar object", { unreadable: true }],
+    ["a null widget value", null],
+  ])("keeps the timeout unknown for %s", async (_label, probeLength) => {
+    const out = await runSetWidget({ setReply: "timeout", probeLength });
+
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/did not reply to "graph_set_widget" within 90000 ms/);
     expect(out.text).toMatch(/"applied": "unknown"/);
     expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
     expect(out.text).not.toMatch(/"applied": false/);

--- a/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
@@ -31,6 +31,15 @@ const VALUE = 4;
 const PREVIOUS = 1;
 const GRAPH_ID = "graph:2489-subgraph";
 const WORKFLOW_UUID = "workflow-2489";
+const LONG_REQUESTED_VALUE = `clip-${"x".repeat(2200)}`;
+const WIDGET_CAP_CLIPPED_VALUE =
+  "clip-" +
+  "x".repeat(100) +
+  "…(+2100 chars cut at the 2048-char per-widget cap, which `max_chars` does not raise)";
+const JSON_BUDGET_CLIPPED_VALUE =
+  "clip-" +
+  "x".repeat(100) +
+  "…(+2100 chars cut over the `max_chars` budget; raise `max_chars` up to 60000)";
 
 const textOf = (res: ToolResult): string =>
   res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ");
@@ -138,7 +147,15 @@ function bridge(opts: {
             ? opts.fencedGraphIdentity ?? GRAPH_ID
             : opts.readbackGraphIdentity ?? opts.fencedGraphIdentity ?? GRAPH_ID;
         currentGraphIdentity = graphIdentity;
-        return nodeDetail(queryCount > 1 ? opts.probeLength ?? VALUE : PREVIOUS, graphIdentity);
+        const readbackLength =
+          queryCount <= 1
+            ? PREVIOUS
+            : opts.probeLength === "widget-cap-marker"
+              ? WIDGET_CAP_CLIPPED_VALUE
+              : opts.probeLength === "json-budget-marker"
+                ? JSON_BUDGET_CLIPPED_VALUE
+                : opts.probeLength ?? VALUE;
+        return nodeDetail(readbackLength, graphIdentity);
       }
       if (cmd.cmd === "graph_get_subgraph") {
         throw new Error(`Node ${NODE_ID} (ImageFromBatch) is not a subgraph`);
@@ -232,6 +249,33 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
     expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
     expect(out.text).toMatch(/"observed": 1/);
     expect(out.text).not.toMatch(/a blind retry can apply it twice/);
+  });
+
+  it("keeps the timeout unknown when the panel's per-widget cap appends its Unicode marker", async () => {
+    const out = await runSetWidget(
+      { setReply: "timeout", probeLength: "widget-cap-marker" },
+      { node_id: NODE_ID, widget: WIDGET, value: LONG_REQUESTED_VALUE },
+    );
+
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/did not reply to "graph_set_widget" within 90000 ms/);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).not.toMatch(/"applied": false/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+
+  it("keeps the timeout unknown when the serialized JSON budget appends its Unicode marker", async () => {
+    const out = await runSetWidget(
+      { setReply: "timeout", probeLength: "json-budget-marker" },
+      { node_id: NODE_ID, widget: WIDGET, value: LONG_REQUESTED_VALUE },
+    );
+
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).not.toMatch(/"applied": false/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
   });
 
   it("returns a mutation receipt when the graph read itself cannot answer", async () => {

--- a/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
@@ -31,6 +31,8 @@ const VALUE = 4;
 const PREVIOUS = 1;
 const GRAPH_ID = "graph:2489-subgraph";
 const WORKFLOW_UUID = "workflow-2489";
+const NODE_IDENTITY = "node-incarnation:2489:12";
+const REPLACED_NODE_IDENTITY = "node-incarnation:2489:replacement";
 const LONG_REQUESTED_VALUE = `clip-${"x".repeat(2200)}`;
 const WIDGET_CAP_CLIPPED_VALUE =
   "clip-" +
@@ -63,6 +65,7 @@ function nodeDetail(
   length: unknown,
   graphIdentity: string = GRAPH_ID,
   scope: "root" | "subgraph" = "subgraph",
+  nodeIdentity: string = NODE_IDENTITY,
 ): Record<string, unknown> {
   return {
     viewing: {
@@ -76,7 +79,7 @@ function nodeDetail(
         id: NODE_ID,
         type: "ImageFromBatch",
         is_subgraph: false,
-        node_identity: "node-incarnation:2489:12",
+        node_identity: nodeIdentity,
         widgets: { length },
         inputs: [],
       },
@@ -90,6 +93,8 @@ function bridge(opts: {
   loseTabAfterSet?: boolean;
   fencedGraphIdentity?: string;
   readbackGraphIdentity?: string;
+  fencedNodeIdentity?: string;
+  readbackNodeIdentity?: string;
   changeConnectionAfterSet?: boolean;
 }) {
   let tabGone = false;
@@ -147,6 +152,10 @@ function bridge(opts: {
             ? opts.fencedGraphIdentity ?? GRAPH_ID
             : opts.readbackGraphIdentity ?? opts.fencedGraphIdentity ?? GRAPH_ID;
         currentGraphIdentity = graphIdentity;
+        const nodeIdentity =
+          queryCount === 1
+            ? opts.fencedNodeIdentity ?? NODE_IDENTITY
+            : opts.readbackNodeIdentity ?? opts.fencedNodeIdentity ?? NODE_IDENTITY;
         const readbackLength =
           queryCount <= 1
             ? PREVIOUS
@@ -155,7 +164,7 @@ function bridge(opts: {
               : opts.probeLength === "json-budget-marker"
                 ? JSON_BUDGET_CLIPPED_VALUE
                 : opts.probeLength ?? VALUE;
-        return nodeDetail(readbackLength, graphIdentity);
+        return nodeDetail(readbackLength, graphIdentity, "subgraph", nodeIdentity);
       }
       if (cmd.cmd === "graph_get_subgraph") {
         throw new Error(`Node ${NODE_ID} (ImageFromBatch) is not a subgraph`);
@@ -388,6 +397,25 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/"applied": "unknown"/);
     expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+
+  it("does not certify a matching value after the same id is replaced by a new node incarnation", async () => {
+    const out = await runSetWidget({
+      setReply: "timeout",
+      probeLength: VALUE,
+      fencedNodeIdentity: NODE_IDENTITY,
+      readbackNodeIdentity: REPLACED_NODE_IDENTITY,
+    });
+
+    expect(sent[2]?.payload).toMatchObject({
+      cmd: "graph_set_widget",
+      node_id: NODE_ID,
+      expected_node_identity: NODE_IDENTITY,
+    });
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/"applied": true/);
   });
 
   it("does not certify a matching value after the same tab reconnects", async () => {

--- a/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
@@ -29,6 +29,8 @@ const NODE_ID = 12;
 const WIDGET = "length";
 const VALUE = 4;
 const PREVIOUS = 1;
+const GRAPH_ID = "graph:2489-subgraph";
+const WORKFLOW_UUID = "workflow-2489";
 
 const textOf = (res: ToolResult): string =>
   res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ");
@@ -50,20 +52,22 @@ let sent: Array<{
 
 function nodeDetail(
   length: unknown,
-  graphIdentity?: string,
+  graphIdentity: string = GRAPH_ID,
   scope: "root" | "subgraph" = "subgraph",
 ): Record<string, unknown> {
   return {
     viewing: {
       scope,
       ...(scope === "subgraph" ? { owner_node_id: 7, title: "batch" } : {}),
-      ...(graphIdentity ? { graph_identity: graphIdentity } : {}),
+      graph_identity: graphIdentity,
+      workflow_uuid: WORKFLOW_UUID,
     },
     nodes: [
       {
         id: NODE_ID,
         type: "ImageFromBatch",
-        ...(scope === "root" ? { is_subgraph: false } : {}),
+        is_subgraph: false,
+        node_identity: "node-incarnation:2489:12",
         widgets: { length },
         inputs: [],
       },
@@ -77,9 +81,12 @@ function bridge(opts: {
   loseTabAfterSet?: boolean;
   fencedGraphIdentity?: string;
   readbackGraphIdentity?: string;
+  changeConnectionAfterSet?: boolean;
 }) {
   let tabGone = false;
-  let currentGraphIdentity: string | undefined;
+  let queryCount = 0;
+  let currentGraphIdentity = GRAPH_ID;
+  let connectionGeneration = 1;
   return {
     send: async (
       cmd: Record<string, unknown>,
@@ -115,25 +122,26 @@ function bridge(opts: {
         }
         if (opts.loseTabAfterSet) tabGone = true;
         o?.onDispatchedRid?.(MUTATION_RID);
+        if (opts.changeConnectionAfterSet) connectionGeneration = 2;
         throw markReplyTimeout(ackTimeout("graph_set_widget", 90000));
       }
       if (cmd.cmd === "graph_query") {
-        if (opts.probeLength === "timeout") throw ackTimeout("graph_query", 8000);
-        if (opts.probeLength === "missing-node") {
-          return { viewing: { scope: "subgraph" }, nodes: [] };
+        queryCount += 1;
+        if (queryCount > 1 && opts.probeLength === "timeout") {
+          throw ackTimeout("graph_query", 8000);
+        }
+        if (queryCount > 1 && opts.probeLength === "missing-node") {
+          return { viewing: { scope: "subgraph", graph_identity: GRAPH_ID }, nodes: [] };
         }
         const graphIdentity =
-          opts.fencedGraphIdentity === undefined
-            ? undefined
-            : sent.filter((entry) => entry.cmd === "graph_query").length === 1
-              ? opts.fencedGraphIdentity
-              : opts.readbackGraphIdentity ?? opts.fencedGraphIdentity;
+          queryCount === 1
+            ? opts.fencedGraphIdentity ?? GRAPH_ID
+            : opts.readbackGraphIdentity ?? opts.fencedGraphIdentity ?? GRAPH_ID;
         currentGraphIdentity = graphIdentity;
-        return nodeDetail(
-          opts.probeLength ?? VALUE,
-          graphIdentity,
-          opts.fencedGraphIdentity === undefined ? "subgraph" : "root",
-        );
+        return nodeDetail(queryCount > 1 ? opts.probeLength ?? VALUE : PREVIOUS, graphIdentity);
+      }
+      if (cmd.cmd === "graph_get_subgraph") {
+        throw new Error(`Node ${NODE_ID} (ImageFromBatch) is not a subgraph`);
       }
       return { ok: true };
     },
@@ -146,16 +154,24 @@ function bridge(opts: {
         : [{ tab_id: TAB, title: "wf", connected_at: 0 }],
     resolveActiveTabId: () => (tabGone ? OTHER_TAB : TAB),
     refreshWorkflowUuid: () => true,
-    workflowUuidFor: () => ({ known: false }),
+    workflowUuidFor: () => ({ known: true, uuid: WORKFLOW_UUID }),
     tabCanMutateGraph: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
-    ...(opts.fencedGraphIdentity === undefined
-      ? {}
-      : { tabPromotedTerminalWitnessCapability: (_id: string) => true }),
+    tabConnectionIdentity: () => ({ generation: connectionGeneration, tabSessionId: "browser-tab-2489" }),
+    tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedNodeIdentityFenceCapability: () => true,
+    tabExpectedScopeGraphIdentityFenceCapability: () => true,
+    tabPromotedTerminalWitnessCapability: () => false,
+    tabPromotedParentRailFenceCapability: () => false,
+    tabReceiverResolvable: () => true,
     promotedScopeFor: () =>
-      currentGraphIdentity
-        ? { known: true, scope: "root", ownerNodeId: null, graphIdentity: currentGraphIdentity }
-        : { known: false, reason: "no graph read yet" },
+      ({
+        known: true,
+        scope: "subgraph",
+        ownerNodeId: "7",
+        workflowUuid: WORKFLOW_UUID,
+        graphIdentity: currentGraphIdentity,
+      }),
   } as PanelToolCtx["bridge"];
 }
 
@@ -178,15 +194,20 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
   it("reports the write as applied when the inner node holds the delivered value", async () => {
     const out = await runSetWidget({ setReply: "timeout", probeLength: VALUE });
 
-    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
-    expect(sent[0]?.timeoutMs).toBe(90_000);
-    expect(sent[1]?.payload).toMatchObject({
+    expect(sent.map((s) => s.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+      "graph_query",
+    ]);
+    expect(sent[2]?.timeoutMs).toBe(90_000);
+    expect(sent[3]?.payload).toMatchObject({
       cmd: "graph_query",
       ids: [NODE_ID],
       fields: "detail",
       limit: 1,
     });
-    expect(sent[1]?.timeoutMs).toBe(8_000);
+    expect(sent[3]?.timeoutMs).toBe(8_000);
 
     expect(out.isError).toBe(false);
     expect(out.text).toMatch(/CHECKED FOR YOU/);
@@ -199,7 +220,12 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
   it("reports the write as NOT applied when the inner node holds a different value", async () => {
     const out = await runSetWidget({ setReply: "timeout", probeLength: PREVIOUS });
 
-    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(sent.map((s) => s.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+      "graph_query",
+    ]);
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/"applied": false/);
     expect(out.text).toMatch(/does NOT show \\"length\\" holding the value/);
@@ -211,7 +237,12 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
   it("returns a mutation receipt when the graph read itself cannot answer", async () => {
     const out = await runSetWidget({ setReply: "timeout", probeLength: "timeout" });
 
-    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(sent.map((s) => s.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+      "graph_query",
+    ]);
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/may have been applied despite the missing reply/);
     expect(out.text).toMatch(/"applied": "unknown"/);
@@ -224,7 +255,12 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
   it("claims nothing when the probe cannot name the written node", async () => {
     const out = await runSetWidget({ setReply: "timeout", probeLength: "missing-node" });
 
-    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(sent.map((s) => s.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+      "graph_query",
+    ]);
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/"applied": "unknown"/);
     expect(out.text).not.toMatch(/CHECKED FOR YOU/);
@@ -234,7 +270,11 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
   it("does not second-guess an ACKED executor error", async () => {
     const out = await runSetWidget({ setReply: "acked-error" });
 
-    expect(sent.map((s) => s.cmd)).not.toContain("graph_query");
+    expect(sent.map((s) => s.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+    ]);
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/is linked/);
     expect(out.text).not.toMatch(/CHECKED FOR YOU/);
@@ -247,7 +287,11 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
     expect(out.text).toMatch(
       /did not reply to "graph_set_widget" within 90000 ms — the ComfyUI tab may be backgrounded or frozen/,
     );
-    expect(sent.map((s) => s.cmd)).not.toContain("graph_query");
+    expect(sent.map((s) => s.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+    ]);
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/nothing was applied/);
     expect(out.text).not.toMatch(/CHECKED FOR YOU/);
@@ -272,7 +316,11 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
   it("does not take a graph read on a successful ACK", async () => {
     const out = await runSetWidget({ setReply: "ok" });
 
-    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget"]);
+    expect(sent.map((s) => s.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+    ]);
     expect(out.isError).toBe(false);
     expect(out.text).not.toMatch(/CHECKED FOR YOU/);
     expect(out.text).toMatch(/"previous": 1/);
@@ -287,7 +335,24 @@ describe("an unacknowledged subgraph widget write is settled by a read, not by a
       readbackGraphIdentity: "graph:after",
     });
 
-    expect(sent.map((s) => s.cmd)).toEqual(["graph_query", "graph_set_widget", "graph_query"]);
+    expect(sent.map((s) => s.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_set_widget",
+      "graph_query",
+    ]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+
+  it("does not certify a matching value after the same tab reconnects", async () => {
+    const out = await runSetWidget({
+      setReply: "timeout",
+      probeLength: VALUE,
+      changeConnectionAfterSet: true,
+    });
+
     expect(out.isError).toBe(true);
     expect(out.text).toMatch(/"applied": "unknown"/);
     expect(out.text).not.toMatch(/CHECKED FOR YOU/);

--- a/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/set-widget-ack-timeout.test.ts
@@ -1,0 +1,295 @@
+// #2489 — panel_set_widget on an inner subgraph node delivered to the tab but
+// no ACK within 90000 ms, even though the mutation had applied.
+//
+// The generic mutating-delivery disclosure then left the caller guessing:
+// "may have been applied … a blind retry can apply it twice". The following
+// panel_expose_subgraph_input completed, and a later panel_query_graph showed
+// the requested ImageFromBatch.length. After a tagged no-reply we take ONE
+// pinpoint graph_query of that node and report applied / not-applied, or
+// return the original timeout WITH a mutation receipt when the read cannot
+// answer.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+const OTHER_TAB = "99999999-8888-7777-6666-555555555555";
+const MUTATION_RID = "rid-set-widget-2489";
+const NODE_ID = 12;
+const WIDGET = "length";
+const VALUE = 4;
+const PREVIOUS = 1;
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ");
+
+const ackTimeout = (cmd: string, ms: number): Error =>
+  new Error(
+    `Panel tab ${TAB} did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be ` +
+      `backgrounded or frozen. This command MUTATES and was already delivered to the tab, so it ` +
+      `may have been applied despite the missing reply — check the current state before ` +
+      `re-issuing it; a blind retry can apply it twice`,
+  );
+
+let sent: Array<{
+  cmd: string;
+  payload: Record<string, unknown>;
+  tabId?: string;
+  timeoutMs?: number;
+}> = [];
+
+function nodeDetail(
+  length: unknown,
+  graphIdentity?: string,
+  scope: "root" | "subgraph" = "subgraph",
+): Record<string, unknown> {
+  return {
+    viewing: {
+      scope,
+      ...(scope === "subgraph" ? { owner_node_id: 7, title: "batch" } : {}),
+      ...(graphIdentity ? { graph_identity: graphIdentity } : {}),
+    },
+    nodes: [
+      {
+        id: NODE_ID,
+        type: "ImageFromBatch",
+        ...(scope === "root" ? { is_subgraph: false } : {}),
+        widgets: { length },
+        inputs: [],
+      },
+    ],
+  };
+}
+
+function bridge(opts: {
+  setReply?: "timeout" | "acked-error" | "acked-error-timeout-worded" | "ok";
+  probeLength?: unknown | "timeout" | "missing-node";
+  loseTabAfterSet?: boolean;
+  fencedGraphIdentity?: string;
+  readbackGraphIdentity?: string;
+}) {
+  let tabGone = false;
+  let currentGraphIdentity: string | undefined;
+  return {
+    send: async (
+      cmd: Record<string, unknown>,
+      o?: { timeoutMs?: number; tabId?: string; onDispatchedRid?: (rid: string) => void },
+    ) => {
+      sent.push({
+        cmd: String(cmd.cmd),
+        payload: cmd,
+        tabId: o?.tabId,
+        timeoutMs: o?.timeoutMs,
+      });
+      if (cmd.cmd === "graph_set_widget") {
+        if (opts.setReply === "acked-error") {
+          throw new Error(`Cannot set widget on node ${NODE_ID}: "${WIDGET}" is linked`);
+        }
+        if (opts.setReply === "acked-error-timeout-worded") {
+          throw new Error(
+            `Panel tab ${TAB} did not reply to "graph_set_widget" within 90000 ms — the ` +
+              `ComfyUI tab may be backgrounded or frozen. Reported by the widget owner: ` +
+              `nothing was applied.`,
+          );
+        }
+        if (opts.setReply === "ok" || opts.setReply === undefined) {
+          o?.onDispatchedRid?.(MUTATION_RID);
+          return {
+            set: {
+              node_id: cmd.node_id,
+              widget: cmd.widget,
+              previous: PREVIOUS,
+              value: cmd.value,
+            },
+          };
+        }
+        if (opts.loseTabAfterSet) tabGone = true;
+        o?.onDispatchedRid?.(MUTATION_RID);
+        throw markReplyTimeout(ackTimeout("graph_set_widget", 90000));
+      }
+      if (cmd.cmd === "graph_query") {
+        if (opts.probeLength === "timeout") throw ackTimeout("graph_query", 8000);
+        if (opts.probeLength === "missing-node") {
+          return { viewing: { scope: "subgraph" }, nodes: [] };
+        }
+        const graphIdentity =
+          opts.fencedGraphIdentity === undefined
+            ? undefined
+            : sent.filter((entry) => entry.cmd === "graph_query").length === 1
+              ? opts.fencedGraphIdentity
+              : opts.readbackGraphIdentity ?? opts.fencedGraphIdentity;
+        currentGraphIdentity = graphIdentity;
+        return nodeDetail(
+          opts.probeLength ?? VALUE,
+          graphIdentity,
+          opts.fencedGraphIdentity === undefined ? "subgraph" : "root",
+        );
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => (tabGone ? id === OTHER_TAB : id === TAB),
+    isHeadless: () => false,
+    tabs: () =>
+      tabGone
+        ? [{ tab_id: OTHER_TAB, title: "other", connected_at: 0 }]
+        : [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => (tabGone ? OTHER_TAB : TAB),
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    ...(opts.fencedGraphIdentity === undefined
+      ? {}
+      : { tabPromotedTerminalWitnessCapability: (_id: string) => true }),
+    promotedScopeFor: () =>
+      currentGraphIdentity
+        ? { known: true, scope: "root", ownerNodeId: null, graphIdentity: currentGraphIdentity }
+        : { known: false, reason: "no graph read yet" },
+  } as PanelToolCtx["bridge"];
+}
+
+async function runSetWidget(
+  opts: Parameters<typeof bridge>[0],
+  args: Record<string, unknown> = { node_id: NODE_ID, widget: WIDGET, value: VALUE },
+): Promise<{ text: string; isError: boolean; boundTab: string }> {
+  const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  if (!def) throw new Error("panel_set_widget is not registered");
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return { text: textOf(res), isError: res.isError === true, boundTab: ctx.tabId };
+}
+
+beforeEach(() => {
+  sent = [];
+});
+
+describe("an unacknowledged subgraph widget write is settled by a read, not by a guess (#2489)", () => {
+  it("reports the write as applied when the inner node holds the delivered value", async () => {
+    const out = await runSetWidget({ setReply: "timeout", probeLength: VALUE });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(sent[0]?.timeoutMs).toBe(90_000);
+    expect(sent[1]?.payload).toMatchObject({
+      cmd: "graph_query",
+      ids: [NODE_ID],
+      fields: "detail",
+      limit: 1,
+    });
+    expect(sent[1]?.timeoutMs).toBe(8_000);
+
+    expect(out.isError).toBe(false);
+    expect(out.text).toMatch(/CHECKED FOR YOU/);
+    expect(out.text).toMatch(/"applied": true/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).toMatch(/not evidence the write failed/);
+    expect(out.text).not.toMatch(/a blind retry can apply it twice/);
+  });
+
+  it("reports the write as NOT applied when the inner node holds a different value", async () => {
+    const out = await runSetWidget({ setReply: "timeout", probeLength: PREVIOUS });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"applied": false/);
+    expect(out.text).toMatch(/does NOT show \\"length\\" holding the value/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).toMatch(/"observed": 1/);
+    expect(out.text).not.toMatch(/a blind retry can apply it twice/);
+  });
+
+  it("returns a mutation receipt when the graph read itself cannot answer", async () => {
+    const out = await runSetWidget({ setReply: "timeout", probeLength: "timeout" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/may have been applied despite the missing reply/);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).toMatch(/"requested"/);
+    expect(out.text).toMatch(/"widget": "length"/);
+    expect(out.text).toMatch(/cannot duplicate a different change/);
+  });
+
+  it("claims nothing when the probe cannot name the written node", async () => {
+    const out = await runSetWidget({ setReply: "timeout", probeLength: "missing-node" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/"applied": true/);
+  });
+
+  it("does not second-guess an ACKED executor error", async () => {
+    const out = await runSetWidget({ setReply: "acked-error" });
+
+    expect(sent.map((s) => s.cmd)).not.toContain("graph_query");
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/is linked/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/mutation_id/);
+  });
+
+  it("does not settle an ACKED error reproducing the canonical sentence VERBATIM", async () => {
+    const out = await runSetWidget({ setReply: "acked-error-timeout-worded" });
+
+    expect(out.text).toMatch(
+      /did not reply to "graph_set_widget" within 90000 ms — the ComfyUI tab may be backgrounded or frozen/,
+    );
+    expect(sent.map((s) => s.cmd)).not.toContain("graph_query");
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/nothing was applied/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+
+  it("claims nothing when the probe lands on a DIFFERENT tab", async () => {
+    const out = await runSetWidget({
+      setReply: "timeout",
+      probeLength: VALUE,
+      loseTabAfterSet: true,
+    });
+
+    expect(out.boundTab).toBe(OTHER_TAB);
+    expect(sent.some((s) => s.cmd === "graph_query")).toBe(true);
+    expect(out.isError).toBe(true);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/"applied": true/);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+  });
+
+  it("does not take a graph read on a successful ACK", async () => {
+    const out = await runSetWidget({ setReply: "ok" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget"]);
+    expect(out.isError).toBe(false);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).toMatch(/"previous": 1/);
+    expect(out.text).toMatch(/"value": 4/);
+  });
+
+  it("does not certify a matching value after the same tab changes graph identity", async () => {
+    const out = await runSetWidget({
+      setReply: "timeout",
+      probeLength: VALUE,
+      fencedGraphIdentity: "graph:before",
+      readbackGraphIdentity: "graph:after",
+    });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_query", "graph_set_widget", "graph_query"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4412,7 +4412,19 @@ function setWidgetUnknownNote(): string {
   );
 }
 
+/** The panel uses this exact scalar placeholder when a live widget value is
+ * too heavy or otherwise unsafe to serialize/read back (#2003). It is not a
+ * user value that can establish the result of a timed-out mutation. */
+const PANEL_UNREADABLE_WIDGET_VALUE = "[binary]";
+
+function isReadableWidgetScalar(value: unknown): boolean {
+  if (typeof value === "string") return value !== PANEL_UNREADABLE_WIDGET_VALUE;
+  if (typeof value === "number") return Number.isFinite(value);
+  return typeof value === "boolean";
+}
+
 function widgetValuesMatch(requested: unknown, observed: unknown): boolean {
+  if (!isReadableWidgetScalar(requested) || !isReadableWidgetScalar(observed)) return false;
   if (Object.is(requested, observed)) return true;
   if (typeof requested === "number" && typeof observed === "number") {
     return Number.isFinite(requested) && Number.isFinite(observed) && requested === observed;
@@ -4519,7 +4531,9 @@ function observedWidgetFromQuery(
   const widgets = row.widgets;
   if (!widgets || typeof widgets !== "object" || Array.isArray(widgets)) return { status: "unknown" };
   if (!Object.prototype.hasOwnProperty.call(widgets, widget)) return { status: "unknown" };
-  return { status: "value", value: (widgets as Record<string, unknown>)[widget] };
+  const value = (widgets as Record<string, unknown>)[widget];
+  if (!isReadableWidgetScalar(value)) return { status: "unknown" };
+  return { status: "value", value };
 }
 
 function setWidgetTimeoutUnknown(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4371,8 +4371,14 @@ const SET_WIDGET_RECONCILE_MS = 8_000;
 
 type SetWidgetReadbackScope = {
   activeView: "root" | "subgraph";
+  ownerNodeId?: string;
   graphIdentity: string;
   workflowUuid?: string;
+};
+
+type SetWidgetReadbackConnection = {
+  generation: number;
+  tabSessionId: string;
 };
 
 function setWidgetAppliedNote(widget: string): string {
@@ -4474,6 +4480,10 @@ function setWidgetReadbackScopeMatches(
   const current = viewing as Record<string, unknown>;
   if (current.scope !== expected.activeView) return false;
   if (current.graph_identity !== expected.graphIdentity) return false;
+  if (expected.activeView === "subgraph") {
+    const ownerNodeId = canonicalQueriedNodeId(current.owner_node_id);
+    if (!expected.ownerNodeId || ownerNodeId !== expected.ownerNodeId) return false;
+  }
   return expected.workflowUuid === undefined || current.workflow_uuid === expected.workflowUuid;
 }
 
@@ -4549,12 +4559,38 @@ async function settleSetWidgetAfterAckTimeout(
   mutationId: string | undefined,
   dispatchTab: string,
   expectedScope?: SetWidgetReadbackScope,
+  dispatchConnection?: SetWidgetReadbackConnection,
 ): Promise<ToolResult> {
   // Probe the tab the write was DISPATCHED to. A silent rebind of an unpinned
   // session would otherwise let a different tab's widget certify this write.
   const probeOnSessionTab = ctx.tabId === dispatchTab;
+  if (!probeOnSessionTab || !isUsablePanelConnectionIdentity(dispatchConnection)) {
+    return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
+  }
+  let connectionBeforeProbe: SetWidgetReadbackConnection | undefined;
+  try {
+    connectionBeforeProbe = ctx.panelConnectionIdentity?.();
+  } catch {
+    return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
+  }
+  if (
+    !isUsablePanelConnectionIdentity(connectionBeforeProbe) ||
+    !samePanelConnectionIdentity(dispatchConnection, connectionBeforeProbe)
+  ) {
+    return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
+  }
   const probe = await ctx.call(setWidgetReadbackProbe(nodeId, widget, value), SET_WIDGET_RECONCILE_MS);
-  if (probeOnSessionTab && ctx.tabId !== dispatchTab) {
+  let connectionAfterProbe: SetWidgetReadbackConnection | undefined;
+  try {
+    connectionAfterProbe = ctx.panelConnectionIdentity?.();
+  } catch {
+    return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
+  }
+  if (
+    ctx.tabId !== dispatchTab ||
+    !isUsablePanelConnectionIdentity(connectionAfterProbe) ||
+    !samePanelConnectionIdentity(dispatchConnection, connectionAfterProbe)
+  ) {
     return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
   }
   const observed = observedWidgetFromQuery(probe, nodeId, widget, expectedScope);
@@ -7660,7 +7696,9 @@ type PromotedWritePlan = {
 type OrdinaryWritePlan = {
   kind: "ordinary-write";
   activeView: "root" | "subgraph";
+  scopeOwnerNodeId?: string;
   graphIdentity: string;
+  workflowUuid?: string;
   expectedNodeType: string;
   expectedNodeIdentity?: string;
   binding: {
@@ -8538,7 +8576,11 @@ function ordinaryWritePlanFromScope(
   return {
     kind: "ordinary-write",
     activeView: scope.activeView,
+    ...(scope.scopeOwnerNodeId !== undefined
+      ? { scopeOwnerNodeId: scope.scopeOwnerNodeId }
+      : {}),
     graphIdentity: scope.graphIdentity,
+    ...(scope.workflowUuid !== undefined ? { workflowUuid: scope.workflowUuid } : {}),
     expectedNodeType: scope.nodeType,
     ...(scope.nodeIdentity !== undefined ? { expectedNodeIdentity: scope.nodeIdentity } : {}),
     binding: {
@@ -8698,6 +8740,43 @@ async function preparePromotedWidgetWrite(
     if (firstReadKind === "definitive-ordinary") {
       const drift2 = panelBindingDriftReason(ctx, "after the subgraph read", hasIdentityApi, identityBefore, tabBefore);
       if (drift2) return promotedWriteRefusal(widget, drift2);
+      // A node can be an ordinary widget in the SUBGRAPH the caller is already
+      // viewing. Keep the graph identity and node incarnation captured by the
+      // preceding graph_query instead of falling through to an unfenced write;
+      // #2489's timeout read-back needs the same target proof as the write.
+      if (targetScope?.activeView === "subgraph" && targetScope.node === "ordinary") {
+        // Older panel builds do not publish node_identity on ordinary text
+        // rows. Preserve their established conservative path; the new
+        // subgraph read-back is only eligible once the full target fence is
+        // available.
+        if (!targetScope.nodeIdentity) return null;
+        const expectedNodeType = definitiveNonPromotedNodeType(sub);
+        if (expectedNodeType !== targetScope.nodeType) {
+          return promotedWriteRefusal(
+            widget,
+            "the ordinary node type changed between the scope and subgraph reads",
+          );
+        }
+        if (ctx.tabExpectedNodeTypeFenceCapability?.() !== true) {
+          return promotedPanelBuildRefusal(
+            ctx,
+            nodeId,
+            widget,
+            "does not advertise the atomic ordinary-node write fence",
+            "enforces_expected_node_type_at_write",
+          );
+        }
+        if (ctx.tabExpectedNodeIdentityFenceCapability?.() !== true) {
+          return promotedPanelBuildRefusal(
+            ctx,
+            nodeId,
+            widget,
+            "does not advertise the atomic ordinary-node identity write fence",
+            "enforces_expected_node_identity_at_write",
+          );
+        }
+        return ordinaryWritePlanFromScope(widget, targetScope, tabBefore, identityBefore);
+      }
       return null;
     }
     // A canvas/root divergence is a panel diagnosis with its own remedy, not a
@@ -8781,7 +8860,13 @@ async function preparePromotedWidgetWrite(
         return {
           kind: "ordinary-write",
           activeView: ordinaryScope.activeView,
+          ...(ordinaryScope.scopeOwnerNodeId !== undefined
+            ? { scopeOwnerNodeId: ordinaryScope.scopeOwnerNodeId }
+            : {}),
           graphIdentity: ordinaryScope.graphIdentity,
+          ...(ordinaryScope.workflowUuid !== undefined
+            ? { workflowUuid: ordinaryScope.workflowUuid }
+            : {}),
           expectedNodeType,
           expectedNodeIdentity,
           binding: {
@@ -20955,7 +21040,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           targetExpectedNodeIdentity: string | undefined = expectedNodeIdentity,
         ): Promise<ToolResult> => {
           let mutationId: string | undefined;
-          const dispatchTab = ctx.tabId;
+          let dispatchTab = ctx.tabId;
+          let dispatchConnection: SetWidgetReadbackConnection | undefined;
           const written = await ctx.call(
             {
               cmd: "graph_set_widget",
@@ -21014,6 +21100,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
             (rid) => {
               mutationId = rid;
+              // UiBridge invokes this observer only after the frame has been
+              // accepted by the bound tab. Capture the actual tab/incarnation
+              // here, after the reachability wait and immediately at dispatch;
+              // a pre-call snapshot could describe a different receiver.
+              dispatchTab = ctx.tabId;
+              try {
+                const identity = ctx.panelConnectionIdentity?.();
+                if (isUsablePanelConnectionIdentity(identity)) {
+                  dispatchConnection = identity;
+                }
+              } catch {
+                // An unreadable identity must stay absent. The read-back path
+                // fails closed instead of certifying another connection.
+              }
             },
             beforeDispatch,
           );
@@ -21044,15 +21144,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               dispatchTab,
             );
           }
-          // #2489 — ONLY a no-reply is settled by a read. An acked executor
-          // error is a definite outcome; re-deciding it from a later widget
-          // read would overwrite a better-informed verdict. Capture the tab
-          // AFTER dispatch: that is the tab the write was bound to. Host-rail
-          // writes (#2488) fence the current root/parent view, not the child
-          // graph the inner widget lives in.
+          // #2489 — ONLY a no-reply on a write proven to be in the active
+          // subgraph is settled by a read. Ordinary root writes intentionally
+          // remain on #2527's late-mutation receipt path, and Power Lora rows
+          // were handled above by #2495. An acked executor error is a definite
+          // outcome; re-deciding it from a later widget read would overwrite a
+          // better-informed verdict. Host-rail writes (#2488) fence the current
+          // root/parent view, not the child graph the inner widget lives in.
           const readbackScope = targetExpectedScope
             ? {
                 activeView: targetExpectedScope.scope ?? "subgraph",
+                ...(targetExpectedScope.scope === "subgraph"
+                  ? { ownerNodeId: targetExpectedScope.ownerNodeId }
+                  : {}),
                 graphIdentity: targetExpectedScope.graphIdentity,
                 ...(targetExpectedScope.workflowUuid !== undefined
                   ? { workflowUuid: targetExpectedScope.workflowUuid }
@@ -21061,10 +21165,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             : ordinaryPlan
               ? {
                   activeView: ordinaryPlan.activeView,
+                  ...(ordinaryPlan.activeView === "subgraph"
+                    ? { ownerNodeId: ordinaryPlan.scopeOwnerNodeId }
+                    : {}),
                   graphIdentity: ordinaryPlan.graphIdentity,
+                  ...(ordinaryPlan.workflowUuid !== undefined
+                    ? { workflowUuid: ordinaryPlan.workflowUuid }
+                    : {}),
                 }
               : undefined;
-          const settled = isReplyTimeoutResult(classified)
+          const settled =
+            isReplyTimeoutResult(classified) &&
+            args.defer_until_idle !== true &&
+            readbackScope?.activeView === "subgraph"
             ? await settleSetWidgetAfterAckTimeout(
                 ctx,
                 classified,
@@ -21074,6 +21187,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 mutationId,
                 dispatchTab,
                 readbackScope,
+                dispatchConnection,
               )
             : classified;
           return stripVerifiedLastObservedSchemaNote(summarizeSetWidgetEcho(settled, echoFull));

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4500,6 +4500,7 @@ function observedWidgetFromQuery(
   nodeId: unknown,
   widget: string,
   expectedScope?: SetWidgetReadbackScope,
+  expectedNodeIdentity?: string,
 ): { status: "value"; value: unknown } | { status: "unknown" } {
   if (res.isError) return { status: "unknown" };
   const payload = parseToolResultJson(res);
@@ -4509,6 +4510,12 @@ function observedWidgetFromQuery(
   const identity = parseQueriedNodeIdentityRow(row);
   const requestedId = canonicalQueriedNodeId(nodeId);
   if (!identity || !requestedId || identity.id !== requestedId) return { status: "unknown" };
+  // The numeric id is reusable. A matching value on a replacement live object
+  // cannot certify the timed-out write, even when every graph/tab fence still
+  // matches; require the opaque per-object incarnation captured at dispatch.
+  if (!expectedNodeIdentity || identity.nodeIdentity !== expectedNodeIdentity) {
+    return { status: "unknown" };
+  }
   const widgets = row.widgets;
   if (!widgets || typeof widgets !== "object" || Array.isArray(widgets)) return { status: "unknown" };
   if (!Object.prototype.hasOwnProperty.call(widgets, widget)) return { status: "unknown" };
@@ -4568,6 +4575,7 @@ async function settleSetWidgetAfterAckTimeout(
   dispatchTab: string,
   expectedScope?: SetWidgetReadbackScope,
   dispatchConnection?: SetWidgetReadbackConnection,
+  dispatchNodeIdentity?: string,
 ): Promise<ToolResult> {
   // Probe the tab the write was DISPATCHED to. A silent rebind of an unpinned
   // session would otherwise let a different tab's widget certify this write.
@@ -4601,7 +4609,13 @@ async function settleSetWidgetAfterAckTimeout(
   ) {
     return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
   }
-  const observed = observedWidgetFromQuery(probe, nodeId, widget, expectedScope);
+  const observed = observedWidgetFromQuery(
+    probe,
+    nodeId,
+    widget,
+    expectedScope,
+    dispatchNodeIdentity,
+  );
   if (observed.status === "unknown") {
     return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
   }
@@ -21196,6 +21210,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 dispatchTab,
                 readbackScope,
                 dispatchConnection,
+                targetExpectedNodeIdentity,
               )
             : classified;
           return stripVerifiedLastObservedSchemaNote(summarizeSetWidgetEcho(settled, echoFull));

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4362,6 +4362,241 @@ async function settlePowerLoraWidgetAfterAckTimeout(
   });
 }
 
+// ---- panel_set_widget settle-after-ack-timeout (#2489) ---------------------
+// A value read from the requested node is evidence only when the read also
+// names the graph view that was fenced before the write. A same-tab navigation
+// can otherwise reuse both the node id and the value and produce a false
+// applied verdict.
+const SET_WIDGET_RECONCILE_MS = 8_000;
+
+type SetWidgetReadbackScope = {
+  activeView: "root" | "subgraph";
+  graphIdentity: string;
+  workflowUuid?: string;
+};
+
+function setWidgetAppliedNote(widget: string): string {
+  return (
+    `CHECKED FOR YOU: the tab did not ACKNOWLEDGE the widget write within the window, but a ` +
+    `graph read taken immediately afterwards, on that same tab and graph view, reports "${widget}" ` +
+    `holding the value this call delivered. No recovery step is needed and a retry would be wasted ` +
+    `work. A missing acknowledgement is not evidence the write failed; here it is evidence the tab ` +
+    `was too busy to answer in time. Stated precisely: what is established is THE LIVE WIDGET VALUE, ` +
+    `not that this command is what put it there — a concurrent canvas edit while the tab was ` +
+    `unresponsive would read identically. Both leave you where you asked to be, so the distinction ` +
+    `changes nothing you would do next.`
+  );
+}
+
+function setWidgetNotAppliedNote(widget: string): string {
+  return (
+    `CHECKED FOR YOU: a graph read taken immediately after the missing acknowledgement, on the ` +
+    `fenced graph view, does NOT show "${widget}" holding the value this call delivered. The write ` +
+    `has not applied (or was overwritten). Re-issuing the same write is safe — setting that widget ` +
+    `to this value again cannot duplicate a different change.`
+  );
+}
+
+function setWidgetUnknownNote(): string {
+  return (
+    `The live widget could not be read on the fenced graph view after the missing acknowledgement, ` +
+    `so this result cannot say whether the write applied. mutation_id is the delivery receipt for ` +
+    `this attempt; requested is the node, widget, and value that were sent. Re-issuing that exact ` +
+    `write cannot duplicate a different change. Do not guess.`
+  );
+}
+
+function widgetValuesMatch(requested: unknown, observed: unknown): boolean {
+  if (Object.is(requested, observed)) return true;
+  if (typeof requested === "number" && typeof observed === "number") {
+    return Number.isFinite(requested) && Number.isFinite(observed) && requested === observed;
+  }
+  if (typeof requested === "string" && typeof observed === "string") return requested === observed;
+  if (typeof requested === "boolean" && typeof observed === "boolean") return requested === observed;
+  return false;
+}
+
+/** A clipped string read-back cannot prove a miss: the live value may still be
+ * the full requested string behind the panel's per-widget cap. */
+function widgetValuePossiblyClipped(requested: unknown, observed: unknown): boolean {
+  if (typeof requested !== "string" || typeof observed !== "string") return false;
+  if (observed.length === 0 || observed.length >= requested.length) return false;
+  return requested.startsWith(observed);
+}
+
+function widgetRowFromGraphQuery(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!payload) return null;
+  if (
+    Object.prototype.hasOwnProperty.call(payload, "truncated") &&
+    payload.truncated !== false
+  ) {
+    return null;
+  }
+
+  let row: unknown;
+  if (Object.prototype.hasOwnProperty.call(payload, "nodes")) {
+    if (!Array.isArray(payload.nodes) || payload.nodes.length !== 1) return null;
+    row = payload.nodes[0];
+  } else if (typeof payload.text === "string") {
+    let headerSeen = false;
+    for (const line of payload.text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (!headerSeen && /^\d+ match\(es\) of \d+ in scope/.test(trimmed)) {
+        headerSeen = true;
+        continue;
+      }
+      if (!trimmed.startsWith("{")) {
+        if (row !== undefined) continue;
+        return null;
+      }
+      if (row !== undefined) return null;
+      try {
+        row = JSON.parse(trimmed) as unknown;
+      } catch {
+        return null;
+      }
+      headerSeen = true;
+    }
+  }
+
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  return row as Record<string, unknown>;
+}
+
+function setWidgetReadbackScopeMatches(
+  payload: Record<string, unknown> | null,
+  expected: SetWidgetReadbackScope | undefined,
+): boolean {
+  if (!expected) return true;
+  const viewing = payload?.viewing;
+  if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return false;
+  const current = viewing as Record<string, unknown>;
+  if (current.scope !== expected.activeView) return false;
+  if (current.graph_identity !== expected.graphIdentity) return false;
+  return expected.workflowUuid === undefined || current.workflow_uuid === expected.workflowUuid;
+}
+
+function observedWidgetFromQuery(
+  res: ToolResult,
+  nodeId: unknown,
+  widget: string,
+  expectedScope?: SetWidgetReadbackScope,
+): { status: "value"; value: unknown } | { status: "unknown" } {
+  if (res.isError) return { status: "unknown" };
+  const payload = parseToolResultJson(res);
+  if (!setWidgetReadbackScopeMatches(payload, expectedScope)) return { status: "unknown" };
+  const row = widgetRowFromGraphQuery(payload);
+  if (!row) return { status: "unknown" };
+  const identity = parseQueriedNodeIdentityRow(row);
+  const requestedId = canonicalQueriedNodeId(nodeId);
+  if (!identity || !requestedId || identity.id !== requestedId) return { status: "unknown" };
+  const widgets = row.widgets;
+  if (!widgets || typeof widgets !== "object" || Array.isArray(widgets)) return { status: "unknown" };
+  if (!Object.prototype.hasOwnProperty.call(widgets, widget)) return { status: "unknown" };
+  return { status: "value", value: (widgets as Record<string, unknown>)[widget] };
+}
+
+function setWidgetTimeoutUnknown(
+  timedOut: ToolResult,
+  nodeId: unknown,
+  widget: string,
+  value: unknown,
+  mutationId: string | undefined,
+): ToolResult {
+  return appendReplyNote(
+    timedOut,
+    JSON.stringify(
+      {
+        applied: "unknown",
+        acknowledged: false,
+        mutation_id: mutationId ?? null,
+        requested: { node_id: nodeId, widget, value },
+        note: setWidgetUnknownNote(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function setWidgetReadbackProbe(
+  nodeId: unknown,
+  widget: string,
+  value: unknown,
+): Record<string, unknown> {
+  const probe: Record<string, unknown> = {
+    cmd: "graph_query",
+    ids: [nodeId],
+    fields: "detail",
+    limit: 1,
+  };
+  if (typeof value === "string" && value.length > DETAIL_WIDGET_MAX_CHARS_DEFAULT) {
+    probe.widget_max_chars = Math.min(
+      Math.max(value.length, DETAIL_WIDGET_MAX_CHARS_DEFAULT),
+      DETAIL_WIDGET_MAX_CHARS_CEILING,
+    );
+  }
+  return probe;
+}
+
+async function settleSetWidgetAfterAckTimeout(
+  ctx: PanelToolCtx,
+  timedOut: ToolResult,
+  nodeId: unknown,
+  widget: string,
+  value: unknown,
+  mutationId: string | undefined,
+  dispatchTab: string,
+  expectedScope?: SetWidgetReadbackScope,
+): Promise<ToolResult> {
+  // Probe the tab the write was DISPATCHED to. A silent rebind of an unpinned
+  // session would otherwise let a different tab's widget certify this write.
+  const probeOnSessionTab = ctx.tabId === dispatchTab;
+  const probe = await ctx.call(setWidgetReadbackProbe(nodeId, widget, value), SET_WIDGET_RECONCILE_MS);
+  if (probeOnSessionTab && ctx.tabId !== dispatchTab) {
+    return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
+  }
+  const observed = observedWidgetFromQuery(probe, nodeId, widget, expectedScope);
+  if (observed.status === "unknown") {
+    return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
+  }
+  if (widgetValuesMatch(value, observed.value)) {
+    return ok({
+      set: { node_id: nodeId, widget, value: observed.value },
+      applied: true,
+      acknowledged: false,
+      mutation_id: mutationId ?? null,
+      confirmed_by: "graph read after ack timeout",
+      note: setWidgetAppliedNote(widget),
+    });
+  }
+  if (widgetValuePossiblyClipped(value, observed.value)) {
+    return setWidgetTimeoutUnknown(timedOut, nodeId, widget, value, mutationId);
+  }
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            applied: false,
+            acknowledged: false,
+            mutation_id: mutationId ?? null,
+            requested: { node_id: nodeId, widget, value },
+            observed: observed.value,
+            confirmed_by: "graph read after ack timeout",
+            note: setWidgetNotAppliedNote(widget),
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
 // ---- panel_free_vram: verifiable when the canvas tab is frozen (#1249) -----
 // `free_vram` is a purely SERVER-SIDE operation — the panel's handler is a plain
 // `POST /free` against the ComfyUI the tab fronts — yet the tool treated the
@@ -20809,7 +21044,39 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               dispatchTab,
             );
           }
-          return classified;
+          // #2489 — ONLY a no-reply is settled by a read. An acked executor
+          // error is a definite outcome; re-deciding it from a later widget
+          // read would overwrite a better-informed verdict. Capture the tab
+          // AFTER dispatch: that is the tab the write was bound to. Host-rail
+          // writes (#2488) fence the current root/parent view, not the child
+          // graph the inner widget lives in.
+          const readbackScope = targetExpectedScope
+            ? {
+                activeView: targetExpectedScope.scope ?? "subgraph",
+                graphIdentity: targetExpectedScope.graphIdentity,
+                ...(targetExpectedScope.workflowUuid !== undefined
+                  ? { workflowUuid: targetExpectedScope.workflowUuid }
+                  : {}),
+              }
+            : ordinaryPlan
+              ? {
+                  activeView: ordinaryPlan.activeView,
+                  graphIdentity: ordinaryPlan.graphIdentity,
+                }
+              : undefined;
+          const settled = isReplyTimeoutResult(classified)
+            ? await settleSetWidgetAfterAckTimeout(
+                ctx,
+                classified,
+                nodeId,
+                widget,
+                value,
+                mutationId,
+                dispatchTab,
+                readbackScope,
+              )
+            : classified;
+          return stripVerifiedLastObservedSchemaNote(summarizeSetWidgetEcho(settled, echoFull));
         };
         let writePromotedInner: (plan: PromotedWritePlan) => Promise<ToolResult>;
         const guardedWrite = async (

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4422,10 +4422,18 @@ function widgetValuesMatch(requested: unknown, observed: unknown): boolean {
   return false;
 }
 
-/** A clipped string read-back cannot prove a miss: the live value may still be
- * the full requested string behind the panel's per-widget cap. */
+/** The panel appends this Unicode marker when a widget value or assembled line
+ * is clipped by its serialized-size budget. A marker can be present even when
+ * the requested value is not a string (objects are serialized before clipping),
+ * so inspect the observed value before narrowing the requested type. */
+const PANEL_CLIPPED_VALUE_MARKER = /…\(\+\d+\s+chars\s+(?:cut|over)\b/u;
+
+/** A clipped read-back cannot prove either a hit or a miss: the live value may
+ * still be the full requested value behind the panel's cap. */
 function widgetValuePossiblyClipped(requested: unknown, observed: unknown): boolean {
-  if (typeof requested !== "string" || typeof observed !== "string") return false;
+  if (typeof observed !== "string") return false;
+  if (PANEL_CLIPPED_VALUE_MARKER.test(observed)) return true;
+  if (typeof requested !== "string") return false;
   if (observed.length === 0 || observed.length >= requested.length) return false;
   return requested.startsWith(observed);
 }


### PR DESCRIPTION
Fixes #2489

## What happened

`panel_set_widget` on an inner subgraph node (an unexposed `ImageFromBatch.length` after entering a 36-node subgraph) timed out after 90 seconds even though the mutation had applied. The following `panel_expose_subgraph_input` completed, and a later `panel_query_graph` showed the requested value. The tool still returned the generic mutating-delivery warning (`may have been applied` / `a blind retry can apply it twice`), which made the outcome unknown and forced an extra audit.

## Gap this PR closes

After a tagged no-reply on `graph_set_widget`, take one bounded pinpoint `graph_query` of that node on the **same tab** and report the live widget:

- widget holds the delivered value → success (`applied: true`, `mutation_id`, `CHECKED FOR YOU`)
- widget holds a different value → error (`applied: false`, `mutation_id`, requested vs observed)
- the read cannot answer (timeout, rebind, unreadable, clipped string) → keep the original timeout **plus** a receipt (`mutation_id` + `requested`) and state that re-issuing that exact write cannot duplicate a different change

Acked executor errors are not re-decided from a later graph read. A silent rebind onto another tab is treated as unknown, not success.

## Tests

`npx vitest run src/__tests__/orchestrator/set-widget-ack-timeout.test.ts`

Fails on an ambiguous timeout-after-delivery; passes on the shipped receipt/read-back.
