### PR TITLE
fix(2488): write promoted subgraph inputs on the host node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ All notable changes to this project are documented here. This project adheres to
 - z-image-turbo-inpainting no longer installs eight unused custom-node packs (#2484)
 - list_local_models reads inventory through the connected panel when the headless /models route is unreachable (#2511)
 - install_custom_node action:"fix" does not report repaired when Manager's task result is not-found/error (#2490)
+- panel_set_widget writes a promoted subgraph input on the enclosing host node instead of the link-driven inner widget (#2488)
 - panel_load_workflow restamps extra.comfyui_mcp.workflow_path (and uuid) to the active tab so an in-place save is not refused as belonging to the source workflow (#2505)
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 - fence ordinary `panel_set_widget` writes against the current panel graph identity across reconnects, with an actionable rebind refusal (#2550)

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -27,6 +27,7 @@ import {
   matchListedName,
   parseAmbiguousPromotedWidgetRefusal,
   parseContradictoryPromotedWidgetRefusal,
+  parseLinkDrivenPromotedWriteWarning,
   parseSubgraphScopeRefusal,
   resolveInnerPromotedTarget,
   validatePromotedSubgraphEnvelope,
@@ -150,6 +151,8 @@ function bridge(opts: {
   parentRailRelinkAfterMcpFence?: boolean;
   /** Whether the fake receiver enforces the final parent-rail witness. */
   promotedParentRailFence?: boolean;
+  /** #2488: inner graph_set_widget succeeds with the panel's link-driven warning. */
+  innerWriteLinkDriven?: boolean;
   /** Receiver navigation to another graph with the SAME owner/workflow and
    * colliding inner ids. Only graph_identity may distinguish this target. */
   receiverGraphIdentityCollisionAfterMcpFence?: boolean;
@@ -419,18 +422,32 @@ function bridge(opts: {
         ) {
           throw new Error(DYNAMIC_CHILD_CONTRADICTORY);
         }
+        const outerId = String(opts.ownerNodeId ?? 78);
         const which =
           writes === 1
             ? (opts.firstWrite ?? "contradict")
             : opts.scopeLost
               ? (opts.innerWrite ?? "ok")
-            : Number(cmd.node_id) === 76 || cmd.node_id === "76"
+            : String(cmd.node_id) !== outerId
               ? (opts.innerWrite ?? "ok")
               : (opts.remappedWrite ?? "contradict");
         if (which === "contradict") throw new Error(CONTRADICTORY);
         if (which === "fail") throw new Error("inner write rejected");
         mutations += 1;
-        return { set: { node_id: cmd.node_id, widget: cmd.widget, value: cmd.value } };
+        const applied = { set: { node_id: cmd.node_id, widget: cmd.widget, value: cmd.value } };
+        if (
+          opts.innerWriteLinkDriven &&
+          String(cmd.node_id) !== String(opts.ownerNodeId ?? 78)
+        ) {
+          return {
+            ...applied,
+            warning:
+              `The write SUCCEEDED and was verified, but it will NOT change the render: ` +
+              `widget "${String(cmd.widget)}" on inner node is link-driven. ` +
+              `Set the widget on the ENCLOSING subgraph node instead.`,
+          };
+        }
+        return applied;
       }
       if (cmd.cmd === "graph_get_subgraph") {
         subgraphReads += 1;
@@ -1026,6 +1043,122 @@ const UNet_COMBO_TEMPLATE_DETAIL = {
     '{"id":472,"type":"SubgraphNode","is_subgraph":true}',
 };
 
+/** #2488 — inner PrimitiveInt.length exposed as host frame_counts. The inner
+ * widget is link-driven; the durable store is the enclosing SubgraphNode. */
+const FRAME_COUNTS_PROMOTED_SUBGRAPH = {
+  subgraph_of: { node_id: 78, title: "Clip pack" },
+  node_count: 1,
+  nodes: [
+    {
+      id: 12,
+      type: "PrimitiveInt",
+      widgets: { length: 81 },
+      inputs: [{ name: "length", type: "INT" }],
+    },
+  ],
+  promoted_terminals: [
+    {
+      widget: "frame_counts",
+      parent_rail: { authoritative: true, widget: "frame_counts" },
+      immediate_node_id: 12,
+      immediate_widget: "length",
+      terminal_node_id: 12,
+      terminal_node_type: "PrimitiveInt",
+      terminal_widget: "length",
+      terminal_inputs: [{ name: "length", type: "INT" }],
+      chain_depth: 0,
+    },
+  ],
+};
+
+describe("panel_set_widget promoted subgraph input routing (#2488)", () => {
+  const hostDetail = {
+    text:
+      '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+      '{"id":78,"type":"SubgraphNode","is_subgraph":true}',
+  };
+
+  it.each(["frame_counts", "length"] as const)(
+    "writes the host rail first when the caller addresses the SubgraphNode as %s",
+    async (widget) => {
+      const { text, isError, calls, mutations } = await setWidget(
+        { node_id: 78, widget, value: 49 },
+        {
+          firstWrite: "ok",
+          promotedTerminalWitnesses: true,
+          promotedDetail: hostDetail,
+          subgraph: FRAME_COUNTS_PROMOTED_SUBGRAPH,
+        },
+      );
+
+      expect(isError).toBe(false);
+      expect(mutations).toBe(1);
+      expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+      expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+        expect.objectContaining({ node_id: 78, widget: "frame_counts", value: 49 }),
+      ]);
+      expect(text).toMatch(/enclosing subgraph node 78 widget "frame_counts"/);
+      expect(text).toMatch(/inner mapping node 12 "length"/);
+      expect(text).not.toMatch(/validated promoted inner widget/);
+    },
+  );
+
+  it("writes the host rail when the inner PrimitiveInt keeps the same widget name", async () => {
+    const sameName = {
+      ...FRAME_COUNTS_PROMOTED_SUBGRAPH,
+      promoted_terminals: [
+        {
+          ...FRAME_COUNTS_PROMOTED_SUBGRAPH.promoted_terminals[0],
+          widget: "length",
+          parent_rail: { authoritative: true, widget: "length" },
+        },
+      ],
+    };
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "length", value: 49 },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: hostDetail,
+        subgraph: sameName,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 78, widget: "length", value: 49 }),
+    ]);
+    expect(calls.map((call) => call.cmd)).not.toContain("graph_enter_subgraph");
+    expect(text).toMatch(/enclosing subgraph node 78 widget "length"/);
+  });
+
+  it("does not report a link-driven inner fallback as a durable write", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "frame_counts", value: 49 },
+      {
+        firstWriteError:
+          `Cannot set widget on subgraph node 78: "frame_counts" is not a promoted widget ` +
+          `on this subgraph (promoted: frame_counts).`,
+        promotedTerminalWitnesses: true,
+        promotedDetail: hostDetail,
+        subgraph: FRAME_COUNTS_PROMOTED_SUBGRAPH,
+        innerWriteLinkDriven: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 78, widget: "frame_counts", value: 49 }),
+      expect.objectContaining({ node_id: 12, widget: "length", value: 49 }),
+    ]);
+    expect(text).toMatch(/link-driven/);
+    expect(text).toMatch(/enclosing subgraph node 78/);
+    expect(text).not.toMatch(/Applied via the validated promoted inner widget/);
+  });
+});
+
 describe("panel_set_widget coordinated promoted-widget fixes (#2393, #2394)", () => {
   it("refreshes one incomplete post-template terminal witness before the guarded inner write (#2393)", async () => {
     const { isError, calls, mutations } = await setWidget(
@@ -1049,10 +1182,11 @@ describe("panel_set_widget coordinated promoted-widget fixes (#2393, #2394)", ()
 
     expect(isError).toBe(false);
     expect(mutations).toBe(1);
-    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(3);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(2);
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
-      expect.objectContaining({ node_id: 168, widget: "value", value: true }),
+      expect.objectContaining({ node_id: 170, widget: "enable_turbo_mode", value: true }),
     ]);
+    expect(calls.map((call) => call.cmd)).not.toContain("graph_enter_subgraph");
   });
 
   it("allows a missing root-level Power Lora Loader lora_N row without entering promoted mapping (#2394)", async () => {
@@ -2805,6 +2939,14 @@ describe("parseContradictoryPromotedWidgetRefusal", () => {
     expect(parseSubgraphScopeRefusal(SCOPE_REFUSAL, 189)).toBeNull();
     expect(parseSubgraphScopeRefusal("No node with id 188 in the current graph", 188)).toBeNull();
   });
+
+  it("parses the panel's link-driven inner-write warning (#2488)", () => {
+    const text =
+      `The write SUCCEEDED and was verified, but it will NOT change the render: ` +
+      `widget "length" on inner node is link-driven. Set the widget on the ENCLOSING subgraph node instead.`;
+    expect(parseLinkDrivenPromotedWriteWarning(text)).toEqual({ widget: "length" });
+    expect(parseLinkDrivenPromotedWriteWarning("inner write rejected")).toBeNull();
+  });
 });
 
 describe("resolveInnerPromotedTarget", () => {
@@ -2871,6 +3013,24 @@ describe("resolveInnerPromotedTarget", () => {
         chainDepth: 1,
       },
     });
+  });
+
+  it("maps either the displayed host alias or the inner widget name to the same promotion (#2488)", () => {
+    const viaLabel = resolveInnerPromotedTarget(FRAME_COUNTS_PROMOTED_SUBGRAPH, "frame_counts", 78);
+    const viaInner = resolveInnerPromotedTarget(FRAME_COUNTS_PROMOTED_SUBGRAPH, "length", 78);
+    expect(viaLabel).toEqual({
+      innerNodeId: 12,
+      widget: "length",
+      parentRail: { authoritative: true, widget: "frame_counts" },
+      terminal: {
+        nodeId: 12,
+        nodeType: "PrimitiveInt",
+        widget: "length",
+        inputs: [{ name: "length", type: "INT" }],
+        chainDepth: 0,
+      },
+    });
+    expect(viaInner).toEqual(viaLabel);
   });
 
   it("resolves renamed outer and immediate aliases from the terminal witness", () => {

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -359,11 +359,19 @@ function bridge(opts: {
           }
           const expected = expectedScope as Record<string, unknown>;
           const actualOwner = inSubgraph ? String(currentOwnerNodeId) : null;
+          const expectedScopeKind = expected.scope ?? "subgraph";
+          const scopeMatches =
+            expectedScopeKind === "root"
+              ? !inSubgraph &&
+                String(expected.owner_node_id) === String(opts.ownerNodeId ?? 78) &&
+                expected.graph_identity === currentGraphIdentity
+              : expectedScopeKind === "subgraph" &&
+                String(expected.owner_node_id) === actualOwner &&
+                expected.graph_identity === currentGraphIdentity;
           if (
-            expected.scope !== "subgraph" ||
-            String(expected.owner_node_id) !== actualOwner ||
+            !scopeMatches ||
             (expected.workflow_uuid !== undefined && expected.workflow_uuid !== workflowUuid) ||
-            expected.graph_identity !== currentGraphIdentity
+            (expectedScopeKind !== "root" && expected.scope !== "subgraph")
           ) {
             throw new Error("graph_set_widget promoted receiver changed before dispatch: Nothing was applied.");
           }
@@ -1131,6 +1139,30 @@ describe("panel_set_widget promoted subgraph input routing (#2488)", () => {
     ]);
     expect(calls.map((call) => call.cmd)).not.toContain("graph_enter_subgraph");
     expect(text).toMatch(/enclosing subgraph node 78 widget "length"/);
+  });
+
+  it("refuses the host write when the root graph changes after the MCP fence", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "frame_counts", value: 49 },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: hostDetail,
+        subgraph: FRAME_COUNTS_PROMOTED_SUBGRAPH,
+        receiverNavigationAfterMcpFence: true,
+        receiverGraphIdentityCollisionAfterMcpFence: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(mutations).toBe(0);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(calls.find((call) => call.cmd === "graph_set_widget")).toEqual(
+      expect.objectContaining({
+        expected_scope: expect.objectContaining({ scope: "root", graph_identity: "graph:workflow-a-root" }),
+      }),
+    );
+    expect(text).toMatch(/promoted receiver changed|Nothing was applied/);
   });
 
   it("does not report a link-driven inner fallback as a durable write", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -161,6 +161,7 @@ import {
   addressedNodeMatchesPersistRemedy,
   parseAmbiguousPromotedWidgetRefusal,
   parseContradictoryPromotedWidgetRefusal,
+  parseLinkDrivenPromotedWriteWarning,
   parseSubgraphScopeRefusal,
   parseUnpromotedControlPersistRemedy,
   promotedScopeWitnessFromEnvelope,
@@ -7152,6 +7153,10 @@ type PromotedWriteBinding = {
 type PromotedWritePlan = {
   kind: "promoted-write";
   outerNodeId: number | string;
+  /** Host/subgraph-input widget to write on the addressed SubgraphNode. */
+  hostWidget: string;
+  outerNodeType?: string;
+  outerNodeIdentity?: string;
   inner: {
     innerNodeId: number | string;
     widget: string;
@@ -7350,20 +7355,40 @@ function promotedMatchCount(payload: Record<string, unknown>, widget: string): n
  * array is also the distinction between a promoted alias and an ordinary
  * widget on the same subgraph container; do not infer that distinction from
  * the inner node's concrete widget names because aliases may be renamed. */
+function rawPromotedTerminalMatchesWidget(
+  entry: Record<string, unknown>,
+  widget: string,
+): boolean {
+  const wanted = widget.toLowerCase();
+  if (typeof entry.widget === "string" && entry.widget.toLowerCase() === wanted) return true;
+  if (typeof entry.immediate_widget === "string" && entry.immediate_widget.toLowerCase() === wanted) {
+    return true;
+  }
+  return typeof entry.terminal_widget === "string" && entry.terminal_widget.toLowerCase() === wanted;
+}
+
+function rawPromotedTerminalOwnEntries(
+  entries: Array<Record<string, unknown>>,
+  widget: string,
+): Array<Record<string, unknown>> {
+  const wanted = widget.toLowerCase();
+  const byHostAlias = entries.filter(
+    (entry) => typeof entry.widget === "string" && entry.widget.toLowerCase() === wanted,
+  );
+  if (byHostAlias.length > 0) return byHostAlias;
+  return entries.filter((entry) => rawPromotedTerminalMatchesWidget(entry, widget));
+}
+
 function promotedTerminalAliasCount(
   payload: Record<string, unknown>,
   widget: string,
 ): number | null {
   const entries = payload.promoted_terminals;
   if (!Array.isArray(entries)) return null;
-  return entries.filter(
-    (entry) =>
-      !!entry &&
-      typeof entry === "object" &&
-      !Array.isArray(entry) &&
-      typeof (entry as Record<string, unknown>).widget === "string" &&
-      ((entry as Record<string, unknown>).widget as string).toLowerCase() === widget.toLowerCase(),
-  ).length;
+  const records = entries.filter(
+    (entry) => !!entry && typeof entry === "object" && !Array.isArray(entry),
+  ) as Array<Record<string, unknown>>;
+  return rawPromotedTerminalOwnEntries(records, widget).length;
 }
 
 /** A capability-skewed receiver's witness array is not authoritative. Any
@@ -7404,7 +7429,6 @@ function promotedTerminalEvidenceError(
   if (!Object.prototype.hasOwnProperty.call(payload, "promoted_terminals")) return null;
   const entries = payload.promoted_terminals;
   if (!Array.isArray(entries)) return "the current receiver's promoted-terminal witness was unavailable";
-  const wanted = widget.toLowerCase();
   // Structural pass first: a malformed array cannot be narrowed, because the
   // requested alias may be exactly the entry that failed to parse.
   for (const entry of entries) {
@@ -7418,9 +7442,7 @@ function promotedTerminalEvidenceError(
   }
   // ONE entry for the requested alias is the only case this narrows: that entry
   // is complete evidence about this write, and it decides it.
-  const own = (entries as Array<Record<string, unknown>>).filter(
-    (entry) => (entry.widget as string).toLowerCase() === wanted,
-  );
+  const own = rawPromotedTerminalOwnEntries(entries as Array<Record<string, unknown>>, widget);
   if (own.length === 1) {
     return own[0].error ? "the promoted-terminal witness was incomplete or unresolved" : null;
   }
@@ -7684,6 +7706,43 @@ function promotedWriteRefusal(widget: string, reason: string): ToolResult {
   );
 }
 
+/** True when a successful inner write is the panel's link-driven no-op. The
+ * stored value was verified, but the enclosing subgraph input still holds the
+ * render value — reporting that as a durable write is the #2488 lie. */
+function linkDrivenPromotedInnerWarning(res: ToolResult): boolean {
+  if (res.isError) return false;
+  if (parseLinkDrivenPromotedWriteWarning(textOfToolResult(res))) return true;
+  const payload = parseToolResultJson(res);
+  return typeof payload?.warning === "string" &&
+    parseLinkDrivenPromotedWriteWarning(payload.warning) != null;
+}
+
+function promotedHostAppliedNote(plan: PromotedWritePlan): string {
+  return (
+    `\n\n(Applied on the enclosing subgraph node ${plan.outerNodeId} widget ` +
+    `"${plan.hostWidget}". The promoted inner mapping node ${plan.inner.innerNodeId} ` +
+    `"${plan.inner.widget}" is synchronized from that host rail.)`
+  );
+}
+
+const PROMOTED_PRIMITIVE_INNER_TYPES = new Set([
+  "PrimitiveInt",
+  "PrimitiveFloat",
+  "PrimitiveBoolean",
+  "PrimitiveNumber",
+  "PrimitiveString",
+]);
+
+/** #2488 — a promoted subgraph INPUT whose inner widget is a different name
+ * (frame_counts → length) or a linked primitive must be written on the host.
+ * Same-name proxyWidgets promotions keep the inner write so #2314's known-bad
+ * live probe still runs before any container mutation. */
+function shouldWritePromotedHostFirst(plan: PromotedWritePlan): boolean {
+  if (!plan.inner.parentRail) return false;
+  if (plan.hostWidget.toLowerCase() !== plan.inner.widget.toLowerCase()) return true;
+  return PROMOTED_PRIMITIVE_INNER_TYPES.has(plan.innerNodeType);
+}
+
 /**
  * panel#1859 — the same refusal, for the one cause a retry can never reach.
  *
@@ -7757,10 +7816,12 @@ function promotedPanelBuildRefusal(
 
 /**
  * #2314 — inspect a promoted target before the first write. A valid mapping is
- * not permission to write the wrapper: the plan carries the receiver identity,
- * inner node id, and inner type to an inner write whose final dispatch fence
- * checks the receiver again. A later promotion relink therefore cannot redirect
- * an apparently safe container write onto a known-bad inner.
+ * not permission to write an uninspected wrapper: the plan carries the receiver
+ * identity, inner node id, and inner type so known-bad inner widgets (Anima,
+ * DaSiWa, dynamic-combo) are refused before any mutation. #2488 then writes the
+ * inspected host rail first; the inner write is only the #1655 fallback when
+ * the host listing-vs-lookup contradicts. A later promotion relink therefore
+ * cannot redirect an apparently safe container write onto a known-bad inner.
  *
  * Only the panel's definitive "is not a subgraph" result supplies a safe
  * non-promoted classification. An unavailable, malformed, or otherwise
@@ -7990,6 +8051,9 @@ async function preparePromotedWidgetWrite(
     if (drift) return ordinaryBindingRefusal(widget, drift);
     return ordinaryWritePlanFromScope(widget, targetScope, tabBefore, identityBefore);
   }
+  const outerNodeType = targetScope?.node === "container" ? targetScope.nodeType : undefined;
+  const outerNodeIdentity =
+    targetScope?.node === "container" ? targetScope.nodeIdentity : undefined;
 
   let sub = await ctx.call(
     { cmd: "graph_get_subgraph", node_id: nodeId },
@@ -8343,6 +8407,9 @@ async function preparePromotedWidgetWrite(
   return {
     kind: "promoted-write",
     outerNodeId: nodeId as number | string,
+    hostWidget: inner.parentRail?.widget ?? widget,
+    ...(outerNodeType ? { outerNodeType } : {}),
+    ...(outerNodeIdentity ? { outerNodeIdentity } : {}),
     inner,
     innerNodeType,
     ...(inner.terminal ? { terminal: inner.terminal } : {}),
@@ -20434,6 +20501,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   `"${plan.inner.widget}" and it FAILED: ${textOfToolResult(written)})`,
               );
             }
+            if (linkDrivenPromotedInnerWarning(written)) {
+              return appendToolResultText(
+                fail(
+                  `panel_set_widget wrote widget "${plan.inner.widget}" on inner node ` +
+                    `${plan.inner.innerNodeId}, but that widget is link-driven and will NOT change ` +
+                    `the render. Set the widget on the enclosing subgraph node ` +
+                    `${plan.outerNodeId} ("${plan.hostWidget}") instead. ` +
+                    `No durable host write was applied.`,
+                ),
+                exited.isError
+                  ? ` panel_exit_subgraph then FAILED — call panel_exit_subgraph. (${textOfToolResult(exited)})`
+                  : "",
+              );
+            }
             // #2514 — the caller addressed the enclosing subgraph. The panel's
             // #1087 warning is for a DIRECT inner write to a widget that is
             // link-driven from that parent rail, and it tells the caller to
@@ -20480,7 +20561,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             return appendToolResultText(
               written,
               `\n\n(Applied via the validated promoted inner widget: node ${plan.inner.innerNodeId} ` +
-                `"${plan.inner.widget}". The container was not written.)` +
+                `"${plan.inner.widget}". The host rail "${plan.hostWidget}" on node ` +
+                `${plan.outerNodeId} was not writable.)` +
                 (exited.isError
                   ? ` panel_exit_subgraph then FAILED — call panel_exit_subgraph. (${textOfToolResult(exited)})`
                   : ""),
@@ -20501,6 +20583,79 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         };
 
         if (promotedPlan) {
+          if (shouldWritePromotedHostFirst(promotedPlan)) {
+            // #2488 — the caller already addressed the host SubgraphNode. Write
+            // that host rail first so a link-driven inner widget is not treated
+            // as the durable store. Known-bad inner widgets were refused above
+            // when the terminal witness named them.
+            const hostWidget = promotedPlan.hostWidget;
+            const hostWritten = await write(
+              promotedPlan.outerNodeId,
+              hostWidget,
+              promotedPlan.outerNodeType,
+              () => {
+                const error = currentPromotedBindingError(ctx, promotedPlan.binding);
+                if (error) {
+                  throw new Error(
+                    `Refusing promoted host graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
+                  );
+                }
+              },
+              undefined,
+              promotedPlan.outerNodeIdentity,
+            );
+            if (!hostWritten.isError) {
+              markPanelSchemaReady(panelSchemaKey(ctx));
+              const persisted = await persistUnpromotedControlAfterGenerate(
+                hostWritten,
+                ctx,
+                promotedPlan.outerNodeId,
+              );
+              return appendToolResultText(persisted, promotedHostAppliedNote(promotedPlan));
+            }
+            const hostRefusal = parseContradictoryPromotedWidgetRefusal(
+              textOfToolResult(hostWritten),
+              hostWidget,
+            );
+            if (!hostRefusal || String(hostRefusal.nodeId) !== String(promotedPlan.outerNodeId)) {
+              return hostWritten;
+            }
+            if (hostRefusal.widget !== hostWidget) {
+              const remapPlan = { ...promotedPlan, hostWidget: hostRefusal.widget };
+              const remappedHost = await write(
+                promotedPlan.outerNodeId,
+                hostRefusal.widget,
+                promotedPlan.outerNodeType,
+                () => {
+                  const error = currentPromotedBindingError(ctx, promotedPlan.binding);
+                  if (error) {
+                    throw new Error(
+                      `Refusing promoted host graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
+                    );
+                  }
+                },
+                undefined,
+                promotedPlan.outerNodeIdentity,
+              );
+              if (!remappedHost.isError) {
+                markPanelSchemaReady(panelSchemaKey(ctx));
+                const persisted = await persistUnpromotedControlAfterGenerate(
+                  remappedHost,
+                  ctx,
+                  promotedPlan.outerNodeId,
+                );
+                return appendToolResultText(persisted, promotedHostAppliedNote(remapPlan));
+              }
+              if (
+                !parseContradictoryPromotedWidgetRefusal(
+                  textOfToolResult(remappedHost),
+                  hostRefusal.widget,
+                )
+              ) {
+                return remappedHost;
+              }
+            }
+          }
           const promotedWritten = await writePromotedInner(promotedPlan);
           if (!promotedWritten.isError && parseToolResultJson(promotedWritten)?.refresh_pending !== true) {
             markPanelSchemaReady(panelSchemaKey(ctx));

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6656,6 +6656,9 @@ type QueriedNodeScope = {
   node: "ordinary" | "container";
   nodeType: string;
   nodeIdentity?: string;
+  /** Owner of the currently viewed subgraph, when the target row is nested. */
+  scopeOwnerNodeId?: string;
+  workflowUuid?: string;
   /** The object-keyed graph identity of the exact view that supplied the row. */
   graphIdentity?: string;
 };
@@ -6695,6 +6698,16 @@ function parseVerifiedQueriedNodeScope(
   ) {
     return null;
   }
+  const workflowUuid = viewingRecord.workflow_uuid;
+  if (workflowUuid !== undefined && (typeof workflowUuid !== "string" || workflowUuid.length === 0)) {
+    return null;
+  }
+  const rawScopeOwner = viewingRecord.owner_node_id;
+  const scopeOwnerNodeId =
+    rawScopeOwner === undefined || rawScopeOwner === null
+      ? undefined
+      : canonicalQueriedNodeId(rawScopeOwner);
+  if (rawScopeOwner !== undefined && rawScopeOwner !== null && !scopeOwnerNodeId) return null;
 
   let row: unknown;
   if (Object.prototype.hasOwnProperty.call(payload, "nodes")) {
@@ -6726,6 +6739,8 @@ function parseVerifiedQueriedNodeScope(
     node: isSubgraph ? "container" : "ordinary",
     nodeType: identity.type,
     ...(identity.nodeIdentity !== undefined ? { nodeIdentity: identity.nodeIdentity } : {}),
+    ...(scopeOwnerNodeId ? { scopeOwnerNodeId } : {}),
+    ...(workflowUuid !== undefined ? { workflowUuid } : {}),
     ...(graphIdentity !== undefined ? { graphIdentity } : {}),
   };
 }
@@ -7155,6 +7170,9 @@ type PromotedWritePlan = {
   outerNodeId: number | string;
   /** Host/subgraph-input widget to write on the addressed SubgraphNode. */
   hostWidget: string;
+  /** The current graph that contains the addressed host instance. This is
+   * distinct from `scope`, which names the child graph reached by entering it. */
+  outerScope?: PromotedExpectedScope;
   outerNodeType?: string;
   outerNodeIdentity?: string;
   inner: {
@@ -7182,10 +7200,36 @@ type OrdinaryWritePlan = {
 };
 
 type PromotedExpectedScope = PromotedScopeWitness & {
+  /** Root is used for a host-instance write; inner writes remain subgraph-scoped. */
+  scope?: "root" | "subgraph";
   terminal?: PromotedTerminalWitness;
   promotedWidget?: string;
   parentRail?: PromotedParentRailWitness;
 };
+
+function outerPromotedExpectedScope(
+  targetScope: QueriedNodeScope | null,
+  outerNodeId: unknown,
+): PromotedExpectedScope | null {
+  if (!targetScope?.graphIdentity) return null;
+  const outerId = canonicalQueriedNodeId(outerNodeId);
+  if (!outerId) return null;
+  if (targetScope.activeView === "root") {
+    return {
+      scope: "root",
+      ownerNodeId: outerId,
+      graphIdentity: targetScope.graphIdentity,
+      ...(targetScope.workflowUuid !== undefined ? { workflowUuid: targetScope.workflowUuid } : {}),
+    };
+  }
+  if (!targetScope.scopeOwnerNodeId) return null;
+  return {
+    scope: "subgraph",
+    ownerNodeId: targetScope.scopeOwnerNodeId,
+    graphIdentity: targetScope.graphIdentity,
+    ...(targetScope.workflowUuid !== undefined ? { workflowUuid: targetScope.workflowUuid } : {}),
+  };
+}
 
 type PromotedWritePreflight = PromotedWritePlan | OrdinaryWritePlan | ToolResult | null;
 
@@ -7658,6 +7702,45 @@ function currentPromotedScopeError(
   }
   if (observed.uuid !== expected.workflowUuid) {
     return "the receiving panel workflow changed";
+  }
+  return null;
+}
+
+/** Check the graph that contains the addressed host instance. The promoted
+ * child witness above cannot do this job: before entry its graph identity is
+ * deliberately different from the current root/parent graph. Host-first
+ * writes therefore carry their own root-or-parent scope envelope. */
+function currentPromotedExpectedScopeError(
+  ctx: PanelToolCtx,
+  expected: PromotedExpectedScope,
+): string | null {
+  const readScope = ctx.bridge.promotedScopeFor;
+  if (typeof readScope !== "function") {
+    return "the receiving panel current-view scope became unavailable";
+  }
+  let observed: TabPromotedScopeRead;
+  try {
+    observed = readScope.call(ctx.bridge, ctx.tabId);
+  } catch {
+    return "the receiving panel current-view scope became unreadable";
+  }
+  if (observed.known !== true) {
+    return "the receiving panel current-view scope became unverifiable";
+  }
+  const expectedScope = expected.scope ?? "subgraph";
+  if (expectedScope === "root") {
+    if (observed.scope !== "root" || observed.graphIdentity !== expected.graphIdentity) {
+      return "the receiving panel current root graph changed or became unverifiable";
+    }
+  } else if (
+    observed.scope !== "subgraph" ||
+    observed.ownerNodeId !== expected.ownerNodeId ||
+    observed.graphIdentity !== expected.graphIdentity
+  ) {
+    return "the receiving panel current graph/subgraph identity changed or became unverifiable";
+  }
+  if (expected.workflowUuid !== undefined && observed.workflowUuid !== expected.workflowUuid) {
+    return "the receiving panel workflow scope changed or became unverifiable";
   }
   return null;
 }
@@ -8404,10 +8487,12 @@ async function preparePromotedWidgetWrite(
     );
   }
 
+  const outerScope = outerPromotedExpectedScope(targetScope, nodeId);
   return {
     kind: "promoted-write",
     outerNodeId: nodeId as number | string,
     hostWidget: inner.parentRail?.widget ?? widget,
+    ...(outerScope ? { outerScope } : {}),
     ...(outerNodeType ? { outerNodeType } : {}),
     ...(outerNodeIdentity ? { outerNodeIdentity } : {}),
     inner,
@@ -20200,7 +20285,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               ...(targetExpectedScope
                 ? {
                     expected_scope: {
-                      scope: "subgraph",
+                      scope: targetExpectedScope.scope ?? "subgraph",
                       owner_node_id: targetExpectedScope.ownerNodeId,
                       graph_identity: targetExpectedScope.graphIdentity,
                       ...(targetExpectedScope.promotedWidget && targetExpectedScope.parentRail
@@ -20588,6 +20673,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // that host rail first so a link-driven inner widget is not treated
             // as the durable store. Known-bad inner widgets were refused above
             // when the terminal witness named them.
+            const hostScope = promotedPlan.outerScope;
+            if (!hostScope) {
+              return promotedWriteRefusal(
+                args.widget as string,
+                "the current host graph identity was unavailable for the enclosing-node write",
+              );
+            }
             const hostWidget = promotedPlan.hostWidget;
             const hostWritten = await write(
               promotedPlan.outerNodeId,
@@ -20600,8 +20692,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                     `Refusing promoted host graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
                   );
                 }
+                const scopeError = currentPromotedExpectedScopeError(ctx, hostScope);
+                if (scopeError) {
+                  throw new Error(
+                    `Refusing promoted host graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
+                  );
+                }
               },
-              undefined,
+              hostScope,
               promotedPlan.outerNodeIdentity,
             );
             if (!hostWritten.isError) {
@@ -20633,8 +20731,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                       `Refusing promoted host graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
                     );
                   }
+                  const scopeError = currentPromotedExpectedScopeError(ctx, hostScope);
+                  if (scopeError) {
+                    throw new Error(
+                      `Refusing promoted host graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
+                    );
+                  }
                 },
-                undefined,
+                hostScope,
                 promotedPlan.outerNodeIdentity,
               );
               if (!remappedHost.isError) {

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -101,6 +101,12 @@ export type AmbiguousPromotedWidgetRefusal = {
   matches: number;
 };
 
+/** Panel warning when an inner write landed on a link-driven widget. The stored
+ *  value is verified, but the enclosing subgraph input is what actually renders. */
+export type LinkDrivenPromotedWriteWarning = {
+  widget: string;
+};
+
 export type SubgraphScopeRefusal = {
   nodeId: string;
   enterPath: string[];
@@ -112,6 +118,9 @@ const CONTRADICTORY_RE =
 const AMBIGUOUS_RE =
   /(?:panel_set_widget refused "([^"]+)" on node (\S+)[\s\S]*?)?promoted widget "([^"]+)" is ambiguous\s*[—-]\s*(\d+)\s+promoted inputs? match/i;
 
+const LINK_DRIVEN_RE =
+  /will NOT change the render[\s\S]*widget "([^"]+)" on inner node is link-driven[\s\S]*ENCLOSING subgraph node/i;
+
 const SCOPED_NODE_RE = /No node with id (\S+) in the current graph[\s\S]*?lives INSIDE a subgraph/i;
 const ENTER_PATH_RE = /panel_enter_subgraph\((?:node_id=)?\s*([^)]+)\)/gi;
 
@@ -121,6 +130,21 @@ export function matchListedName(wanted: string, listed: readonly string[]): stri
   if (listed.includes(wanted)) return wanted;
   const ci = listed.filter((n) => n.toLowerCase() === wanted.toLowerCase());
   return ci.length === 1 ? ci[0] : null;
+}
+
+/**
+ * Parse the panel's link-driven inner-write warning. Null unless the write was
+ * verified AND the panel named the enclosing subgraph node as the durable target.
+ * A success that does not carry both halves is left alone — that is often a
+ * genuine inner widget, not a promoted input.
+ */
+export function parseLinkDrivenPromotedWriteWarning(
+  text: string,
+): LinkDrivenPromotedWriteWarning | null {
+  const m = LINK_DRIVEN_RE.exec(text);
+  if (!m) return null;
+  const widget = m[1];
+  return widget ? { widget } : null;
 }
 
 /**
@@ -203,6 +227,29 @@ export function parseContradictoryPromotedWidgetRefusal(
   const widget =
     requestedWidget != null ? (matchListedName(requestedWidget, listed) ?? fromError) : fromError;
   return { nodeId: m[1].replace(/[,:]$/, ""), widget, listed };
+}
+
+function terminalEntryMatchesDisplayedWidget(
+  entry: PromotedTerminalEntry,
+  displayedWidget: string,
+): boolean {
+  const wanted = displayedWidget.toLowerCase();
+  if (entry.widget.toLowerCase() === wanted) return true;
+  if (entry.immediateWidget && entry.immediateWidget.toLowerCase() === wanted) return true;
+  return entry.terminal?.widget.toLowerCase() === wanted;
+}
+
+function selectPromotedTerminalEntries(
+  entries: readonly PromotedTerminalEntry[],
+  displayedWidget: string,
+): PromotedTerminalEntry[] {
+  const wanted = displayedWidget.toLowerCase();
+  const byHostAlias = entries.filter((entry) => entry.widget.toLowerCase() === wanted);
+  // Prefer the host/displayed alias. Inner/terminal names are only consulted
+  // when no host alias matches, so a duplicated unrelated alias that happens
+  // to carry the same immediate widget cannot veto this write (#2393 vs #2488).
+  if (byHostAlias.length > 0) return byHostAlias;
+  return entries.filter((entry) => terminalEntryMatchesDisplayedWidget(entry, displayedWidget));
 }
 
 function widgetNamesOnInner(node: Record<string, unknown>): string[] {
@@ -560,9 +607,10 @@ export function resolveInnerPromotedTarget(
     // relation. Prefer it over the legacy same-name scan: renamed outer and
     // intermediate aliases are valid addresses, while the inner node summary
     // intentionally contains only the concrete widget's programmatic name.
-    const entries = promotedTerminals.filter(
-      (entry) => entry.widget.toLowerCase() === displayedWidget.toLowerCase(),
-    );
+    // #2488 — the caller may address the host with either the displayed alias
+    // (`frame_counts`) or the inner programmatic name (`length`). Both names
+    // identify the same unique promotion; uniqueness is still required.
+    const entries = selectPromotedTerminalEntries(promotedTerminals, displayedWidget);
     if (entries.length !== 1) return null;
     const entry = entries[0];
     // A complete own-entry is still the preferred mapping. An incomplete own-entry


### PR DESCRIPTION
## Summary

Fixes #2488. `panel_set_widget` on a host SubgraphNode was auto-resolving to the inner widget. For an exposed PrimitiveInt (`length` promoted as `frame_counts`) that inner widget is link-driven, so the tool reported a verified write that did not change the host or the render.

When the caller addresses the enclosing SubgraphNode, write the authoritative host rail first if the promotion is a renamed input or a linked primitive. The displayed-label and inner-name paths hit the same host widget. Keep the inner write as the #1655 fallback when the host listing-vs-lookup contradicts, and do not treat a link-driven inner success as durable.

Same-name proxyWidgets promotions still use the inner path so #2314 known-bad live probes run before any container mutation.

## Validation

- `npx vitest run src/__tests__/orchestrator/promoted-widget.test.ts src/__tests__/orchestrator/promoted-control-persist.test.ts`: 185 passed
- `npx tsc --noEmit`: exit 0
- `node scripts/check-anti-slop.mjs`: no new findings

Do not merge.