### PR TITLE
fix(2491): omit the unexpose reindex warning when removing the final slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - list_templates uses the live panel when the configured origin is unreachable (#2196)
 - panel_free_vram reports VRAM after CUDA release settles (#2050)
 - panel_open_workflow treats nested opened.routing_key as unsaved-open proof instead of failing a proven tmp: open as an unconfirmed filename (#2477)
+- omit the #2437 unexpose reindex warning when the removed slot is last or the panel already reindexed (#2491)
 
 ## [0.52.150] - 2026-08-30
 

--- a/plugin/skills/panel-operations/SKILL.md
+++ b/plugin/skills/panel-operations/SKILL.md
@@ -62,7 +62,10 @@ current boundary slots — what is already exposed and what still needs it.
 named rail slot. Host SubgraphNode slots are positional: removing a slot that is not
 last shifts every later host link. `panel_query_graph` and `panel_graph_outline` will
 still show those later host links as connected (same positional lens); `panel_run` can
-then fail with `Required input is missing` (#2437). Do not trust that connectedness.
+then fail with `Required input is missing` (#2437). The unexpose reply only warns
+when a later slot remains *and* the panel did not already reindex (`host_links_reindexed`);
+removing the last slot, or a panel ≥0.15.120 that reports reindexed, is not that hazard.
+Do not trust that connectedness.
 Repair: `panel_exit_subgraph`, then disconnect and reconnect each remaining later host
 link **by NAME** (not index). Reconnecting by name re-resolves the index. Then re-enter
 if you still need the interior. Do not invent a reindex via `panel_disconnect` on a
@@ -383,4 +386,4 @@ restarts that process, so never claim such a change is live after a `panel_reloa
 ## Sources
 
 - **Official:** the panel and comfyui MCP tool descriptions in comfyui-mcp (this repo) — each tool named above is the authority on its own parameters.
-- **Empirical:** the panel agent system preamble these procedures were moved out of, plus the failure modes they were written for (issues #1398, #1551, #1708, #2234, #2437).
+- **Empirical:** the panel agent system preamble these procedures were moved out of, plus the failure modes they were written for (issues #1398, #1551, #1708, #2234, #2437, #2491).

--- a/src/__tests__/services/unexpose-host-link-shift.test.ts
+++ b/src/__tests__/services/unexpose-host-link-shift.test.ts
@@ -18,7 +18,11 @@ import {
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import {
+  hostLinksAlreadyReindexed,
   isLandedUnexpose,
+  laterSlotsAfterUnexpose,
+  laterSlotsFromRails,
+  laterSlotsFromUnexposePayload,
   unexposeHostLinkShiftNote,
 } from "../../services/unexpose-host-link-shift.js";
 
@@ -52,12 +56,14 @@ function jsonResult(payload: unknown, isError = false): ToolResult {
   };
 }
 
-function makeCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: Record<string, unknown>[] } {
+function makeCtx(
+  reply: ToolResult | ((cmd: Record<string, unknown>) => ToolResult),
+): { ctx: PanelToolCtx; calls: Record<string, unknown>[] } {
   const calls: Record<string, unknown>[] = [];
   const ctx: PanelToolCtx = {
     call: async (cmd) => {
       calls.push(cmd);
-      return reply;
+      return typeof reply === "function" ? reply(cmd) : reply;
     },
     confirm: async () => "yes" as const,
     bridge: {} as PanelToolCtx["bridge"],
@@ -66,13 +72,40 @@ function makeCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: Record<string, 
   return { ctx, calls };
 }
 
+/** #2491 — reporter removed value_3 at index 3 of 4, then value_2 at the new last index. */
+const LAST_SLOT_REMOVED = {
+  removed: {
+    side: "input",
+    name: "value_3",
+    type: "INT",
+    slot: 3,
+    interior_links_dropped: 1,
+    host_links_dropped: 0,
+    host_links_reindexed: true,
+  },
+};
+
+const LAST_SLOT_REMAINING_RAILS = {
+  rails: {
+    input: {
+      provides_outputs: [
+        { index: 0, name: "value" },
+        { index: 1, name: "value_1" },
+        { index: 2, name: "value_2" },
+      ],
+    },
+  },
+};
+
 function allText(res: ToolResult): string {
   return res.content.map((c) => (c.type === "text" ? c.text ?? "" : "")).join("\n");
 }
 
 describe("unexposeHostLinkShiftNote (#2437)", () => {
   it("the unexpose handlers attach the shipped note, not a copy", () => {
-    expect(SRC).toMatch(/unexposeHostLinkShiftNote\(parseToolResultJson\(res\)\)/);
+    expect(SRC).toMatch(
+      /unexposeHostLinkShiftNote\(payload, laterSlotsAfterUnexpose\(payload, remainingGraph\)\)/,
+    );
     expect(SRC).toMatch(/cmd: "graph_unexpose_subgraph_input"/);
     expect(SRC).toMatch(/cmd: "graph_unexpose_subgraph_output"/);
   });
@@ -115,6 +148,43 @@ describe("unexposeHostLinkShiftNote (#2437)", () => {
     ).toBeNull();
   });
 
+  it("#2491 is silent when the removed index is last — no later slot exists", () => {
+    expect(unexposeHostLinkShiftNote(LAST_SLOT_REMOVED)).toBeNull();
+    expect(
+      unexposeHostLinkShiftNote({
+        removed: { side: "input", name: "value_3", slot: 3, remaining_count: 3 },
+      }),
+    ).toBeNull();
+    expect(
+      unexposeHostLinkShiftNote(
+        { removed: { side: "input", name: "value_3", slot: 3 } },
+        [],
+      ),
+    ).toBeNull();
+    expect(laterSlotsFromUnexposePayload({
+      removed: { side: "input", name: "value_3", slot: 3, remaining_count: 3 },
+    })).toEqual([]);
+    expect(
+      laterSlotsFromRails(LAST_SLOT_REMAINING_RAILS.rails, "input", 3),
+    ).toEqual([]);
+    expect(
+      laterSlotsAfterUnexpose(
+        { removed: { side: "input", name: "value_3", slot: 3 } },
+        LAST_SLOT_REMAINING_RAILS,
+      ),
+    ).toEqual([]);
+  });
+
+  it("#2491 still warns when a remaining later slot exists and was not reindexed", () => {
+    const payload = {
+      removed: { side: "input", name: "value_1", slot: 1, remaining_count: 3 },
+    };
+    expect(laterSlotsFromUnexposePayload(payload)).toBeUndefined();
+    const note = unexposeHostLinkShiftNote(payload, ["value_2", "value_3"]);
+    expect(note).toMatch(/#2437/);
+    expect(note).toContain('"value_2"');
+  });
+
   it("is silent on a refusal / missing removed (nothing landed)", () => {
     expect(isLandedUnexpose({ error: "unknown slot" })).toBe(false);
     expect(unexposeHostLinkShiftNote({ error: "unknown slot" })).toBeNull();
@@ -148,9 +218,36 @@ describe("panel_unexpose_subgraph_input attaches the #2437 note", () => {
 
   it("#2473 a panel that reindexed does not get the stale remaining-piece note", async () => {
     const payload = { removed: { ...REPORTER_REMOVED.removed, host_links_reindexed: true } };
-    const { ctx } = makeCtx(jsonResult(payload));
+    const { ctx, calls } = makeCtx(jsonResult(payload));
     const res = await defByName("panel_unexpose_subgraph_input").handler({ name: "text" }, ctx);
     expect(res.isError).toBeUndefined();
+    expect(res.content).toHaveLength(1);
+    expect(allText(res)).not.toMatch(/#2437/);
+    expect(calls).toHaveLength(1);
+    expect(hostLinksAlreadyReindexed(payload)).toBe(true);
+  });
+
+  it("#2491 THE REPORTED CASE: last-slot unexpose with host_links_reindexed does not warn", async () => {
+    const { ctx, calls } = makeCtx(jsonResult(LAST_SLOT_REMOVED));
+    const res = await defByName("panel_unexpose_subgraph_input").handler({ name: "value_3" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "graph_unexpose_subgraph_input", name: "value_3" });
+    expect(calls).toHaveLength(1);
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toHaveLength(1);
+    expect(JSON.parse(res.content[0]!.text!)).toEqual(LAST_SLOT_REMOVED);
+    expect(allText(res)).not.toMatch(/#2437/);
+    expect(allText(res)).not.toMatch(/were not reindexed/);
+  });
+
+  it("#2491 last-slot on an older panel is proven by remaining rails, not warned", async () => {
+    const payload = {
+      removed: { side: "input", name: "value_3", type: "INT", slot: 3, host_links_dropped: 0 },
+    };
+    const { ctx, calls } = makeCtx((cmd) =>
+      jsonResult(cmd.cmd === "graph_query" ? LAST_SLOT_REMAINING_RAILS : payload),
+    );
+    const res = await defByName("panel_unexpose_subgraph_input").handler({ name: "value_3" }, ctx);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_unexpose_subgraph_input", "graph_query"]);
     expect(res.content).toHaveLength(1);
     expect(allText(res)).not.toMatch(/#2437/);
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -77,7 +77,13 @@ import {
   type WorkflowListReadinessRefusal,
 } from "../services/panel-workflow-readiness.js";
 import { isPreExecutorRefusal } from "../services/panel-refusal.js";
-import { unexposeHostLinkShiftNote } from "../services/unexpose-host-link-shift.js";
+import {
+  hostLinksAlreadyReindexed,
+  isLandedUnexpose,
+  laterSlotsAfterUnexpose,
+  laterSlotsFromUnexposePayload,
+  unexposeHostLinkShiftNote,
+} from "../services/unexpose-host-link-shift.js";
 import {
   assertScreenshotPersistAllowed,
   decodePngBase64,
@@ -586,11 +592,27 @@ export function appendReplyNote(res: ToolResult, note: string): ToolResult {
  * #2437 — remaining host links after unexpose are positional and not re-pointed.
  * A post-removal snapshot of `node.inputs[i].link` cannot see the bug, so this
  * attaches the a-priori repair (reconnect by name) to a landed `removed` reply.
- * Refusals and unparseable bodies are left alone.
+ * Refusals, reindexed replies (#2473), and a last-slot removal (#2491) are
+ * left alone. An unknown later list still warns — skipping on "we did not look"
+ * is how the original reporter queued a broken graph.
  */
-function withUnexposeHostLinkShiftNote(res: ToolResult): ToolResult {
+async function withUnexposeHostLinkShiftNote(
+  res: ToolResult,
+  ctx: PanelToolCtx,
+): Promise<ToolResult> {
   if (res.isError) return res;
-  const note = unexposeHostLinkShiftNote(parseToolResultJson(res));
+  const payload = parseToolResultJson(res);
+  let remainingGraph: Record<string, unknown> | null = null;
+  if (
+    isLandedUnexpose(payload) &&
+    !hostLinksAlreadyReindexed(payload) &&
+    laterSlotsFromUnexposePayload(payload) === undefined
+  ) {
+    // Cheapest graph_query still carries `rails` while inside a subgraph.
+    const probe = await ctx.call({ cmd: "graph_query", fields: "ids", limit: 1 }, 8000);
+    if (!probe.isError) remainingGraph = parseToolResultJson(probe);
+  }
+  const note = unexposeHostLinkShiftNote(payload, laterSlotsAfterUnexpose(payload, remainingGraph));
   return note ? appendReplyNote(res, note) : res;
 }
 
@@ -23206,7 +23228,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       },
       async (args: A, ctx) => {
         const res = await ctx.call({ cmd: "graph_unexpose_subgraph_output", name: args.name }, 15000);
-        return withUnexposeHostLinkShiftNote(res);
+        return withUnexposeHostLinkShiftNote(res, ctx);
       },
     ),
     def(
@@ -23217,7 +23239,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       },
       async (args: A, ctx) => {
         const res = await ctx.call({ cmd: "graph_unexpose_subgraph_input", name: args.name }, 15000);
-        return withUnexposeHostLinkShiftNote(res);
+        return withUnexposeHostLinkShiftNote(res, ctx);
       },
     ),
     def(

--- a/src/services/unexpose-host-link-shift.ts
+++ b/src/services/unexpose-host-link-shift.ts
@@ -13,7 +13,8 @@
  * from a landed `removed` object, not a detected divergence — UNLESS the panel
  * reports `removed.host_links_reindexed: true` (panel ≥0.15.120 / #1969), in
  * which case survivors were already re-pointed and the note would be a lie
- * (#2473). The repair that re-resolves the index is disconnect + reconnect
+ * (#2473), OR the removed index was last so no later slot exists to reindex
+ * (#2491). The repair that re-resolves the index is disconnect + reconnect
  * remaining later host links BY NAME. The reindex itself is panel-side and
  * must not be improvised here: panel#668 saw a SubgraphNode disconnect
  * cascade into deleting unrelated nodes.
@@ -22,17 +23,97 @@
 /** Later rail-slot names that sat AFTER the removed index (already shifted). */
 export type UnexposeLaterSlots = readonly string[] | undefined;
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
 function removedRecord(payload: unknown): Record<string, unknown> | null {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
-  const removed = (payload as Record<string, unknown>).removed;
-  if (!removed || typeof removed !== "object" || Array.isArray(removed)) return null;
-  return removed as Record<string, unknown>;
+  return asRecord(asRecord(payload)?.removed);
 }
 
 function landedSlot(removed: Record<string, unknown>): number | null {
   if (removed.side !== "input" && removed.side !== "output") return null;
   const slot = removed.slot;
   return typeof slot === "number" && Number.isInteger(slot) && slot >= 0 ? slot : null;
+}
+
+function nonNegInt(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function stringArray(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") return undefined;
+    out.push(item);
+  }
+  return out;
+}
+
+function railSide(removed: Record<string, unknown>): "input" | "output" {
+  return removed.side === "output" ? "output" : "input";
+}
+
+/**
+ * Remaining later slot names from a post-removal `rails` snapshot.
+ * After splicing index `removedSlot`, survivors that shifted sit at
+ * `index >= removedSlot`. `undefined` when that rail is not in the snapshot.
+ */
+export function laterSlotsFromRails(
+  rails: unknown,
+  side: "input" | "output",
+  removedSlot: number,
+): UnexposeLaterSlots {
+  const rail = asRecord(asRecord(rails)?.[side]);
+  if (!rail) return undefined;
+  const slots = side === "output" ? rail.accepts_inputs : rail.provides_outputs;
+  if (!Array.isArray(slots)) return undefined;
+  const later: string[] = [];
+  for (const [i, entry] of slots.entries()) {
+    const rec = asRecord(entry);
+    const index = rec ? (nonNegInt(rec.index) ?? i) : i;
+    if (index < removedSlot) continue;
+    const name = rec && typeof rec.name === "string" && rec.name ? rec.name : `(slot ${index})`;
+    later.push(name);
+  }
+  return later;
+}
+
+/**
+ * Later-slot evidence already on the unexpose payload. `[]` proves the
+ * removed index was last (#2491). `undefined` means the payload did not look.
+ */
+export function laterSlotsFromUnexposePayload(payload: unknown): UnexposeLaterSlots {
+  const removed = removedRecord(payload);
+  const slot = removed ? landedSlot(removed) : null;
+  if (removed == null || slot == null) return undefined;
+
+  const named = stringArray(removed.later_slots) ?? stringArray(removed.remaining_later_slots);
+  if (named !== undefined) return named;
+
+  const remainingCount =
+    nonNegInt(removed.remaining_count) ?? nonNegInt(removed.remaining_slot_count);
+  if (remainingCount != null && remainingCount <= slot) return [];
+
+  return laterSlotsFromRails(asRecord(payload)?.rails, railSide(removed), slot);
+}
+
+/**
+ * Combine the unexpose payload with an optional follow-up graph read that
+ * carries `rails`. Payload evidence wins; the live rails fill an UNKNOWN list.
+ */
+export function laterSlotsAfterUnexpose(
+  unexposePayload: unknown,
+  remainingGraphPayload?: unknown,
+): UnexposeLaterSlots {
+  const fromPayload = laterSlotsFromUnexposePayload(unexposePayload);
+  if (fromPayload !== undefined) return fromPayload;
+  const removed = removedRecord(unexposePayload);
+  const slot = removed ? landedSlot(removed) : null;
+  if (removed == null || slot == null) return undefined;
+  return laterSlotsFromRails(asRecord(remainingGraphPayload)?.rails, railSide(removed), slot);
 }
 
 /**
@@ -44,10 +125,17 @@ export function isLandedUnexpose(payload: unknown): boolean {
   return removed != null && landedSlot(removed) != null;
 }
 
+/** True when the panel already re-pointed survivors (#2473 / panel ≥0.15.120). */
+export function hostLinksAlreadyReindexed(payload: unknown): boolean {
+  return removedRecord(payload)?.host_links_reindexed === true;
+}
+
 /**
  * The agent-facing repair for a landed unexpose whose remaining later host
  * links were not reindexed. `null` when there is nothing to disclose:
  *  - not a landed `removed` object (refusal / unparseable);
+ *  - panel reported `removed.host_links_reindexed: true` (#2473);
+ *  - the removed index was last — no later slot exists to reindex (#2491);
  *  - caller proved there are no later slots (`laterSlotNames` is `[]`).
  *
  * An UNKNOWN later list still produces the note: the cheap positional
@@ -62,13 +150,15 @@ export function unexposeHostLinkShiftNote(
   const slot = removed ? landedSlot(removed) : null;
   if (removed == null || slot == null) return null;
   if (removed.host_links_reindexed === true) return null;
-  if (laterSlotNames && laterSlotNames.length === 0) return null;
+  const later =
+    laterSlotNames !== undefined ? laterSlotNames : laterSlotsFromUnexposePayload(payload);
+  if (later && later.length === 0) return null;
 
-  const side = removed.side === "output" ? "output" : "input";
+  const side = railSide(removed);
   const name = typeof removed.name === "string" && removed.name ? removed.name : "(unnamed)";
   const named =
-    laterSlotNames && laterSlotNames.length > 0
-      ? ` Remaining later host ${side} slots that shifted: ${laterSlotNames.map((s) => JSON.stringify(s)).join(", ")}.`
+    later && later.length > 0
+      ? ` Remaining later host ${side} slots that shifted: ${later.map((s) => JSON.stringify(s)).join(", ")}.`
       : "";
 
   return (


### PR DESCRIPTION
Fixes #2491

`panel_unexpose_subgraph_input` returned `removed.host_links_reindexed: true` and then appended the #2437 note claiming remaining later host links were not reindexed. That happened while removing the final boundary slot (index 3 of 4, then the new last slot), where no later slot exists. The warning contradicted the payload.

## Fix

- Skip the #2437 note when `removed.host_links_reindexed` is true (already-valid topology).
- Skip it when remaining rails prove the removed index was last — no later slot to repair.
- Older connected panels without the reindex flag still get the repair text for a non-last unexpose, including when the later-slot list is unknown.

## Tests

`npx vitest run src/__tests__/services/unexpose-host-link-shift.test.ts` — 18 passed.
`npx vitest run src/__tests__/orchestrator/panel-tools.test.ts` — 423 passed.
`npx tsc --noEmit` — clean.