### PR TITLE
fix(2492): host-HTTP fallback when panel Manager fetch does not complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_search_nodes and panel_list_nodes serve host Manager HTTP when the panel's browser Manager request does not complete (Failed to fetch) (#2492)
 - stage nested video as_filename values at the input root so VHS_LoadVideo can select them (#2083)
 - list_templates uses the live panel when the configured origin is unreachable (#2196)
 - panel_free_vram reports VRAM after CUDA release settles (#2050)

--- a/src/__tests__/orchestrator/panel-manager-fetch-fail.test.ts
+++ b/src/__tests__/orchestrator/panel-manager-fetch-fail.test.ts
@@ -1,0 +1,146 @@
+// #2492 — panel_search_nodes and panel_list_nodes died as a transport-only
+// "Failed to fetch" when the live H3 Desktop tab's browser Manager request
+// never completed. Graph reads still worked. Host Manager HTTP can still
+// serve the registry search / installed-pack listing; that is not a Manager
+// outage and not a missing pack.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { buildPanelToolDefs, type PanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+import {
+  HOST_HTTP_SEARCH_NOTE,
+  setFetchMappingsForTests,
+} from "../../services/manager-node-search.js";
+import {
+  HOST_HTTP_TRANSPORT_NOTE,
+  setListInstalledNodesForTests,
+} from "../../services/manager-node-list.js";
+import type { InstalledNode } from "../../services/node-management.js";
+
+afterEach(() => {
+  setFetchMappingsForTests(undefined);
+  setListInstalledNodesForTests(undefined);
+});
+
+const SEARCH_FETCH =
+  "ComfyUI-Manager request to /v2/customnode/getmappings?mode=cache did not complete: Failed to fetch.";
+const LIST_FETCH =
+  "ComfyUI-Manager request to /v2/customnode/installed?mode=default did not complete: Failed to fetch.";
+
+const CATALOGUE = {
+  "https://github.com/someone/ComfyUI-Lightning": [
+    ["LightningCompile"],
+    { title: "ComfyUI-Lightning", description: "compile speedup" },
+  ],
+};
+
+const PACKS: InstalledNode[] = [
+  {
+    module: "ComfyUI-Impact-Pack",
+    cnrId: "comfyui-impact-pack",
+    version: "8.0.0",
+    enabled: true,
+  },
+];
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function replyText(res: ToolResult): string {
+  return res.content.map((c) => (c.type === "text" ? c.text : "")).join("\n");
+}
+
+function failCtx(message: string): Pick<PanelToolCtx, "call"> {
+  return {
+    call: async () => ({
+      isError: true,
+      content: [{ type: "text", text: `Error: ${message}` }],
+    }),
+  };
+}
+
+describe("panel_search_nodes (#2492 Manager transport Failed to fetch)", () => {
+  it("still returns packs from host Manager HTTP when the panel fail()s Failed to fetch", async () => {
+    setFetchMappingsForTests(async (mode) => {
+      if (mode !== "cache") throw new Error("should not leave cache");
+      return CATALOGUE;
+    });
+    const res = await defByName("panel_search_nodes").handler(
+      { query: "ComfyUI-Lightning" },
+      failCtx(SEARCH_FETCH) as PanelToolCtx,
+    );
+    expect(res.isError).toBeUndefined();
+    const text = replyText(res);
+    expect(text).toMatch(/ComfyUI-Lightning/);
+    expect(text).toMatch(/not a Manager outage/i);
+    expect(text).not.toMatch(/does not exist|not found/i);
+    expect(text).not.toMatch(/Failed to fetch/);
+    const body = JSON.parse(text) as {
+      count: number;
+      source: string;
+      note: string;
+    };
+    expect(body.count).toBe(1);
+    expect(body.source).toBe("host_http");
+    expect(body.note).toBe(HOST_HTTP_SEARCH_NOTE);
+  });
+
+  it("names both causes when host mappings also fail, not a missing pack", async () => {
+    setFetchMappingsForTests(async () => {
+      throw new Error("Manager customnode/getmappings?mode=cache: HTTP 403");
+    });
+    const res = await defByName("panel_search_nodes").handler(
+      { query: "D2Cache" },
+      failCtx(SEARCH_FETCH) as PanelToolCtx,
+    );
+    expect(res.isError).toBeUndefined();
+    const text = replyText(res);
+    expect(text).toMatch(/did not complete/i);
+    expect(text).toMatch(/HTTP 403/);
+    expect(text).toMatch(/not a Manager outage inferred from a transport-only fetch failure/i);
+    expect(text).not.toMatch(/does not exist|not found/i);
+    const body = JSON.parse(text) as { count: number; manager_outage?: boolean };
+    expect(body.count).toBe(0);
+    expect(body.manager_outage).toBeUndefined();
+  });
+});
+
+describe("panel_list_nodes (#2492 Manager transport Failed to fetch)", () => {
+  it("still lists installed packs from host Manager HTTP when the panel fail()s Failed to fetch", async () => {
+    setListInstalledNodesForTests(async () => PACKS);
+    const res = await defByName("panel_list_nodes").handler({}, failCtx(LIST_FETCH) as PanelToolCtx);
+    expect(res.isError).toBeFalsy();
+    const text = replyText(res);
+    expect(text).not.toMatch(/Failed to fetch/);
+    expect(text).toMatch(/not a Manager outage/i);
+    expect(text).not.toMatch(/tab was not connected/i);
+    const body: unknown = JSON.parse(text);
+    expect(body).toMatchObject({
+      source: "host_http",
+      note: HOST_HTTP_TRANSPORT_NOTE,
+      installed: {
+        "ComfyUI-Impact-Pack": {
+          ver: "8.0.0",
+          cnr_id: "comfyui-impact-pack",
+          enabled: true,
+        },
+      },
+    });
+  });
+
+  it("names both causes when host installed listing also fails, not Manager down", async () => {
+    setListInstalledNodesForTests(async () => {
+      throw new Error("Manager customnode/installed: HTTP 503");
+    });
+    const res = await defByName("panel_list_nodes").handler({}, failCtx(LIST_FETCH) as PanelToolCtx);
+    expect(res.isError).toBe(true);
+    const text = replyText(res);
+    expect(text).toMatch(/reached the panel tab/i);
+    expect(text).toMatch(/HTTP 503/);
+    expect(text).toMatch(/not a Manager outage inferred from a transport-only fetch failure/i);
+    expect(text).not.toMatch(/could not be dispatched/i);
+    expect(text).not.toMatch(/Manager down/i);
+  });
+});

--- a/src/__tests__/services/manager-node-list.test.ts
+++ b/src/__tests__/services/manager-node-list.test.ts
@@ -6,12 +6,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { markDispatched } from "../../services/ui-bridge.js";
 import {
   HOST_HTTP_LIST_NOTE,
+  HOST_HTTP_TRANSPORT_NOTE,
   dualCauseListFailure,
   installedNodesToPanelMap,
   isPanelTabDispatchFailure,
   listPanelNodes,
   setListInstalledNodesForTests,
 } from "../../services/manager-node-list.js";
+import { isManagerTransportFetchFailure } from "../../services/manager-node-search.js";
 import type { InstalledNode } from "../../services/node-management.js";
 
 afterEach(() => setListInstalledNodesForTests(undefined));
@@ -26,6 +28,14 @@ const REPORTER_WRAP =
 const DISPATCH_FAIL = {
   isError: true,
   content: [{ type: "text", text: `Error: ${REPORTER_WRAP}` }],
+};
+
+const REPORTER_LIST_FETCH =
+  "ComfyUI-Manager request to /v2/customnode/installed?mode=default did not complete: Failed to fetch.";
+
+const TRANSPORT_FAIL = {
+  isError: true,
+  content: [{ type: "text", text: `Error: ${REPORTER_LIST_FETCH}` }],
 };
 
 const PACKS: InstalledNode[] = [
@@ -203,6 +213,64 @@ describe("listPanelNodes (#2459)", () => {
   });
 });
 
+describe("listPanelNodes (#2492 transport Failed to fetch)", () => {
+  it("matches the reporter installed wrap as transport, not tab loss", () => {
+    expect(isManagerTransportFetchFailure(TRANSPORT_FAIL)).toBe(true);
+    expect(isManagerTransportFetchFailure(new Error(REPORTER_LIST_FETCH))).toBe(true);
+    expect(isPanelTabDispatchFailure(TRANSPORT_FAIL)).toBe(false);
+    expect(isPanelTabDispatchFailure(new Error(REPORTER_LIST_FETCH))).toBe(false);
+  });
+
+  it("live tab + panel Manager fetch fail + live Manager HTTP → inventory, transport note", async () => {
+    const hostCalls: number[] = [];
+    const out = await listPanelNodes({
+      panelList: async () => TRANSPORT_FAIL,
+      listInstalled: async () => {
+        hostCalls.push(1);
+        return PACKS;
+      },
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(hostCalls).toHaveLength(1);
+    expect(out.value.source).toBe("host_http");
+    expect(out.value.note).toBe(HOST_HTTP_TRANSPORT_NOTE);
+    expect(out.value.note).toMatch(/not a Manager outage/i);
+    expect(out.value.note).not.toMatch(/tab was not connected/i);
+    expect(out.value.note).not.toMatch(/Manager down/i);
+    expect(out.value.installed["ComfyUI-Impact-Pack"]?.cnr_id).toBe("comfyui-impact-pack");
+  });
+
+  it("falls back when the panel throws the reporter wrap", async () => {
+    const out = await listPanelNodes({
+      panelList: async () => {
+        throw new Error(REPORTER_LIST_FETCH);
+      },
+      listInstalled: async () => PACKS,
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(out.value.note).toBe(HOST_HTTP_TRANSPORT_NOTE);
+  });
+
+  it("transport + host HTTP failure → dual cause, not Manager down, not tab loss", async () => {
+    const out = await listPanelNodes({
+      panelList: async () => TRANSPORT_FAIL,
+      listInstalled: async () => {
+        throw new Error("Manager customnode/installed: HTTP 503");
+      },
+    });
+    expect(out.via).toBe("failed");
+    if (out.via !== "failed") throw new Error("expected failed");
+    expect(out.message).toMatch(/reached the panel tab/i);
+    expect(out.message).toMatch(/did not complete/i);
+    expect(out.message).toMatch(/HTTP 503/);
+    expect(out.message).toMatch(/not a Manager outage inferred from a transport-only fetch failure/i);
+    expect(out.message).not.toMatch(/could not be dispatched/i);
+    expect(out.message).not.toMatch(/Manager down/i);
+  });
+});
+
 describe("dualCauseListFailure copy", () => {
   it("names both tab loss and the host read, not a Manager outage from tab loss", () => {
     const msg = dualCauseListFailure(
@@ -212,5 +280,17 @@ describe("dualCauseListFailure copy", () => {
     expect(msg).toMatch(/no connected tab/);
     expect(msg).toMatch(/unreadable payload/);
     expect(msg).toMatch(/not a Manager outage inferred from tab loss/);
+  });
+
+  it("names both the transport wrap and the host read, not tab loss", () => {
+    const msg = dualCauseListFailure(
+      new Error(REPORTER_LIST_FETCH),
+      new Error("unreadable payload"),
+    );
+    expect(msg).toMatch(/reached the panel tab/);
+    expect(msg).toMatch(/Failed to fetch/);
+    expect(msg).toMatch(/unreadable payload/);
+    expect(msg).toMatch(/not a Manager outage inferred from a transport-only fetch failure/);
+    expect(msg).not.toMatch(/could not be dispatched/);
   });
 });

--- a/src/__tests__/services/manager-node-search.test.ts
+++ b/src/__tests__/services/manager-node-search.test.ts
@@ -5,7 +5,10 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  HOST_HTTP_SEARCH_NOTE,
+  dualCauseSearchFailure,
   isManagerMappingsServerError,
+  isManagerTransportFetchFailure,
   managerMappingsOutageResult,
   parseNodeMappings,
   searchNodesViaMappings,
@@ -17,6 +20,9 @@ import {
 afterEach(() => setFetchMappingsForTests(undefined));
 
 const CACHE_500 = new Error("Manager customnode/getmappings?mode=cache: HTTP 500");
+
+const REPORTER_SEARCH_FETCH =
+  "ComfyUI-Manager request to /v2/customnode/getmappings?mode=cache did not complete: Failed to fetch.";
 
 const CATALOGUE = {
   "https://github.com/someone/ComfyUI-SolAttn": [
@@ -53,6 +59,72 @@ describe("isManagerMappingsServerError", () => {
     expect(isManagerMappingsServerError(new Error("Manager customnode/getmappings: HTTP 403"))).toBe(false);
     expect(isManagerMappingsServerError(new Error("Manager customnode/getmappings: HTTP 404"))).toBe(false);
     expect(isManagerMappingsServerError({ count: 0, results: [] })).toBe(false);
+  });
+});
+
+describe("isManagerTransportFetchFailure (#2492)", () => {
+  it("matches the reporter getmappings wrap, including fail() ToolResult", () => {
+    expect(isManagerTransportFetchFailure(new Error(REPORTER_SEARCH_FETCH))).toBe(true);
+    expect(
+      isManagerTransportFetchFailure({
+        isError: true,
+        content: [{ type: "text", text: `Error: ${REPORTER_SEARCH_FETCH}` }],
+      }),
+    ).toBe(true);
+  });
+
+  it("matches the reporter installed wrap and other browser transport causes", () => {
+    expect(
+      isManagerTransportFetchFailure(
+        new Error(
+          "ComfyUI-Manager request to /v2/customnode/installed?mode=default did not complete: Failed to fetch.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isManagerTransportFetchFailure(
+        new Error(
+          "ComfyUI-Manager request to /v2/customnode/getmappings?mode=cache did not complete: NetworkError when attempting to fetch resource.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isManagerTransportFetchFailure(
+        new Error(
+          "ComfyUI-Manager request to /customnode/getmappings?mode=cache did not complete: fetch failed",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat HTTP status, AbortError, bare Failed to fetch, or a mid-sentence mention as transport", () => {
+    expect(isManagerTransportFetchFailure(CACHE_500)).toBe(false);
+    expect(isManagerTransportFetchFailure(new Error("Failed to fetch"))).toBe(false);
+    expect(
+      isManagerTransportFetchFailure(
+        new Error(
+          "ComfyUI-Manager request to /v2/customnode/getmappings?mode=cache did not complete: AbortError",
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      isManagerTransportFetchFailure(
+        new Error(
+          "ComfyUI-Manager request to /v2/manager/queue/task did not complete: Failed to fetch.",
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      isManagerTransportFetchFailure(
+        new Error("Package validation failed: NetworkError in dependency metadata"),
+      ),
+    ).toBe(false);
+    expect(
+      isManagerTransportFetchFailure(
+        new Error("fetch failed for upstream registry"),
+      ),
+    ).toBe(false);
+    expect(isManagerTransportFetchFailure({ count: 1, results: [] })).toBe(false);
   });
 });
 
@@ -162,6 +234,76 @@ describe("searchPanelNodes (#1669)", () => {
   });
 });
 
+describe("searchPanelNodes (#2492 transport Failed to fetch)", () => {
+  it("live tab + panel Manager fetch fail + host mappings → packs, source host_http", async () => {
+    const out = await searchPanelNodes({
+      query: "SolAttnPatch",
+      panelSearch: async () => ({
+        isError: true,
+        content: [{ type: "text", text: `Error: ${REPORTER_SEARCH_FETCH}` }],
+      }),
+      fetchMappings: fetchByMode({ cache: CATALOGUE }),
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(out.value.source).toBe("host_http");
+    expect(out.value.note).toBe(HOST_HTTP_SEARCH_NOTE);
+    expect(out.value.note).toMatch(/not a Manager outage/i);
+    expect(out.value.note).not.toMatch(/does not exist|not found/i);
+    expect(out.value.manager_outage).toBeUndefined();
+    expect(out.value.count).toBe(1);
+    expect(out.value.results[0]?.title).toBe("SolAttn");
+  });
+
+  it("falls back when the panel throws the reporter wrap", async () => {
+    const out = await searchPanelNodes({
+      query: "impact",
+      panelSearch: async () => {
+        throw new Error(REPORTER_SEARCH_FETCH);
+      },
+      fetchMappings: fetchByMode({ cache: CATALOGUE }),
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(out.value.source).toBe("host_http");
+    expect(out.value.count).toBe(1);
+  });
+
+  it("transport + host HTTP failure → dual cause, not a missing pack, not outage-from-transport", async () => {
+    const out = await searchPanelNodes({
+      query: "ComfyUI-Lightning",
+      panelSearch: async () => {
+        throw new Error(REPORTER_SEARCH_FETCH);
+      },
+      fetchMappings: async () => {
+        throw new Error("Manager customnode/getmappings?mode=cache: HTTP 403");
+      },
+    });
+    expect(out.via).toBe("fallback");
+    if (out.via !== "fallback") throw new Error("expected fallback");
+    expect(out.value.count).toBe(0);
+    expect(out.value.results).toEqual([]);
+    expect(out.value.manager_outage).toBeUndefined();
+    expect(out.value.message).toMatch(/did not complete/i);
+    expect(out.value.message).toMatch(/HTTP 403/);
+    expect(out.value.message).toMatch(/not a Manager outage inferred from a transport-only fetch failure/i);
+    expect(out.value.message).not.toMatch(/does not exist|not found/i);
+    expect(out.value.message).not.toMatch(/Manager down/i);
+  });
+
+  it("does not host-fallback a live-tab mappings HTTP 403", async () => {
+    await expect(
+      searchPanelNodes({
+        query: "x",
+        panelSearch: async () => {
+          throw new Error("Manager customnode/getmappings?mode=cache: HTTP 403");
+        },
+        fetchMappings: fetchByMode({ cache: CATALOGUE }),
+      }),
+    ).rejects.toThrow(/HTTP 403/);
+  });
+});
+
 describe("parseNodeMappings / outage copy", () => {
   it("uses the repo-URL key as id, never the display title", () => {
     const res = parseNodeMappings(CATALOGUE, "SolAttn", 15);
@@ -181,5 +323,19 @@ describe("parseNodeMappings / outage copy", () => {
     expect(res.manager_outage).toBe(true);
     expect(res.message).toMatch(/Manager outage/);
     expect(res.message).not.toMatch(/does not exist/);
+  });
+
+  it("dual-cause transport copy names both fetches, not a missing pack", () => {
+    const res = dualCauseSearchFailure(
+      "ComfyUI-Lightning",
+      new Error(REPORTER_SEARCH_FETCH),
+      new Error("unreadable payload"),
+    );
+    expect(res.query).toBe("ComfyUI-Lightning");
+    expect(res.message).toMatch(/Failed to fetch/);
+    expect(res.message).toMatch(/unreadable payload/);
+    expect(res.message).toMatch(/not a Manager outage inferred from a transport-only fetch failure/);
+    expect(res.message).not.toMatch(/does not exist/);
+    expect(res.manager_outage).toBeUndefined();
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -23256,12 +23256,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_search_nodes",
-      "Search installable custom-node packs via the user's BUILT-IN ComfyUI Manager (the same source the Manager UI uses). Returns matching packs {id, title, description}. Use the `id` with panel_install_node. Prefer this over the headless search_custom_nodes tool — it works against the user's actual (Desktop) Manager. If Manager's cache mappings endpoint returns HTTP 5xx, this retries remote/local and still searches; a remaining 5xx is a Manager outage, not proof the pack is missing.",
+      "Search installable custom-node packs via the user's BUILT-IN ComfyUI Manager (the same source the Manager UI uses). Returns matching packs {id, title, description}. Use the `id` with panel_install_node. Prefer this over the headless search_custom_nodes tool — it works against the user's actual (Desktop) Manager. If Manager's cache mappings endpoint returns HTTP 5xx, this retries remote/local and still searches; a remaining 5xx is a Manager outage, not proof the pack is missing. If the panel tab is live but the browser Manager request does not complete (Failed to fetch), the search is served from host Manager HTTP instead of dying as a transport error — that is a panel-origin failure, not a Manager outage.",
       { query: z.string().describe("Search text, e.g. 'kjnodes', 'controlnet', 'ipadapter'."), limit: z.number().int().min(1).max(40).optional().describe("Max results to return, 1-40 (default 15). Requests above 40 are refused; the panel also clamps to 40 and discloses limit_cap.") },
       async (args: A, ctx) => {
         // #1669 — the panel asks getmappings?mode=cache and used to fail the
         // whole search on HTTP 500. Degrade: retry remote/local, or name the
         // 500 as a Manager outage (not a missing pack).
+        // #2492 — a live tab whose browser Manager fetch never completed
+        // (Failed to fetch) is the same host-HTTP search, not a transport
+        // death and not a Manager outage.
         const query = String(args.query ?? "");
         const limit = typeof args.limit === "number" ? args.limit : undefined;
         const out = await searchPanelNodes({
@@ -23279,13 +23282,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_list_nodes",
-      "List the custom-node PACKS currently installed in the user's ComfyUI (via the built-in Manager). Takes no arguments — it returns the whole installed set. Read-only. This lists packs, NOT node classes: to find out whether a specific node type is available (e.g. LTXVContextWindowsGuideAware), use comfy_cli action:\"search_nodes\", which fuzzy-searches real node classes and falls back to the connected server's live /object_info. panel_search_nodes is a third thing again — it searches INSTALLABLE packs in the registry, not what is already here. If the panel tab is gone, the listing is served from the ComfyUI host's Manager HTTP instead of failing as a dispatch error.",
+      "List the custom-node PACKS currently installed in the user's ComfyUI (via the built-in Manager). Takes no arguments — it returns the whole installed set. Read-only. This lists packs, NOT node classes: to find out whether a specific node type is available (e.g. LTXVContextWindowsGuideAware), use comfy_cli action:\"search_nodes\", which fuzzy-searches real node classes and falls back to the connected server's live /object_info. panel_search_nodes is a third thing again — it searches INSTALLABLE packs in the registry, not what is already here. If the panel tab is gone, the listing is served from the ComfyUI host's Manager HTTP instead of failing as a dispatch error. If the tab is live but the browser Manager request does not complete (Failed to fetch), the same host HTTP listing is used; that is a panel-origin transport failure, not a Manager outage.",
       {},
       async (_args, ctx) => {
         // #2459 — pack listing is a Manager / object_info server-state read.
         // Try the live tab first (Manager dialect + /object_info + #1496
         // filter). When dispatch never reaches the tab, serve the same
         // inventory from host Manager HTTP instead of dying as tab-loss.
+        // #2492 — a live tab whose browser Manager fetch never completed
+        // is the same host listing; do not call that a Manager outage.
         const out = await listPanelNodes({
           panelList: () => ctx.call({ cmd: "nodes_list" }, 20000),
         });

--- a/src/services/manager-node-list.ts
+++ b/src/services/manager-node-list.ts
@@ -1,4 +1,5 @@
 import { dispatchOutcomeOf } from "./ui-bridge.js";
+import { isManagerTransportFetchFailure } from "./manager-node-search.js";
 import { listInstalledNodes, type InstalledNode } from "./node-management.js";
 
 export type ListInstalledFn = () => Promise<InstalledNode[]>;
@@ -20,6 +21,11 @@ export interface ListedNodesHostResult {
 export const HOST_HTTP_LIST_NOTE =
   "Listed from ComfyUI-Manager HTTP because this session's panel tab was not connected. " +
   "This is the host pack inventory, not a Manager outage.";
+
+export const HOST_HTTP_TRANSPORT_NOTE =
+  "Listed from ComfyUI-Manager HTTP because the panel's browser request to Manager " +
+  "installed-packs did not complete. Live canvas reads still work; this is a " +
+  "panel-origin transport failure, not a Manager outage.";
 
 let listInstalledOverride: ListInstalledFn | undefined;
 
@@ -85,8 +91,17 @@ export function installedNodesToPanelMap(
 }
 
 export function dualCauseListFailure(tabErr: unknown, hostErr: unknown): string {
-  const tab = textFromUnknown(tabErr) || "panel tab was not connected";
   const host = textFromUnknown(hostErr) || "host Manager HTTP failed";
+  if (isManagerTransportFetchFailure(tabErr)) {
+    const panel = textFromUnknown(tabErr) || "panel Manager request did not complete";
+    return (
+      `nodes_list reached the panel tab, but the panel's ComfyUI-Manager request ` +
+      `did not complete, and the host Manager HTTP pack listing also failed. ` +
+      `Panel: ${panel} Host: ${host} ` +
+      `This is not a Manager outage inferred from a transport-only fetch failure.`
+    );
+  }
+  const tab = textFromUnknown(tabErr) || "panel tab was not connected";
   return (
     `nodes_list could not be dispatched to this session's panel tab, and the host ` +
     `Manager HTTP pack listing also failed. Tab: ${tab} Host: ${host} ` +
@@ -94,15 +109,24 @@ export function dualCauseListFailure(tabErr: unknown, hostErr: unknown): string 
   );
 }
 
+function shouldHostList(value: unknown): boolean {
+  return isPanelTabDispatchFailure(value) || isManagerTransportFetchFailure(value);
+}
+
+function hostListNote(panelErr: unknown): string {
+  return isManagerTransportFetchFailure(panelErr) ? HOST_HTTP_TRANSPORT_NOTE : HOST_HTTP_LIST_NOTE;
+}
+
 function resolveListInstalled(fn?: ListInstalledFn): ListInstalledFn {
   return fn ?? listInstalledOverride ?? listInstalledNodes;
 }
 
 /**
- * Panel `nodes_list` first. On pre-dispatch tab loss, serve the pack listing
- * from host Manager HTTP (`listInstalledNodes`) instead of dying as a
- * dispatch-only error. A live tab's Manager/object_info result is passed
- * through unchanged.
+ * Panel `nodes_list` first. On pre-dispatch tab loss, or when the live tab's
+ * Manager fetch never completed (`Failed to fetch` wrap), serve the pack
+ * listing from host Manager HTTP (`listInstalledNodes`) instead of dying as a
+ * dispatch-only or transport-only error. A live tab's Manager/object_info
+ * result is passed through unchanged.
  */
 export async function listPanelNodes<T>(opts: {
   panelList: () => Promise<T>;
@@ -112,7 +136,7 @@ export async function listPanelNodes<T>(opts: {
   | { via: "fallback"; value: ListedNodesHostResult }
   | { via: "failed"; message: string }
 > {
-  const runHost = async (tabErr: unknown) => {
+  const runHost = async (panelErr: unknown) => {
     try {
       const nodes = await resolveListInstalled(opts.listInstalled)();
       return {
@@ -120,20 +144,20 @@ export async function listPanelNodes<T>(opts: {
         value: {
           installed: installedNodesToPanelMap(nodes),
           source: "host_http" as const,
-          note: HOST_HTTP_LIST_NOTE,
+          note: hostListNote(panelErr),
         },
       };
     } catch (hostErr) {
-      return { via: "failed" as const, message: dualCauseListFailure(tabErr, hostErr) };
+      return { via: "failed" as const, message: dualCauseListFailure(panelErr, hostErr) };
     }
   };
 
   try {
     const value = await opts.panelList();
-    if (!isPanelTabDispatchFailure(value)) return { via: "panel", value };
+    if (!shouldHostList(value)) return { via: "panel", value };
     return await runHost(value);
   } catch (err) {
-    if (!isPanelTabDispatchFailure(err)) throw err;
+    if (!shouldHostList(err)) throw err;
     return await runHost(err);
   }
 }

--- a/src/services/manager-node-search.ts
+++ b/src/services/manager-node-search.ts
@@ -26,7 +26,14 @@ export interface NodeSearchResult {
   query?: string;
   reason?: string;
   message?: string;
+  source?: "host_http";
+  note?: string;
 }
+
+export const HOST_HTTP_SEARCH_NOTE =
+  "Searched via ComfyUI-Manager HTTP because the panel's browser request to " +
+  "Manager getmappings did not complete. Live canvas reads still work; this is a " +
+  "panel-origin transport failure, not a Manager outage or a missing pack.";
 
 export type FetchMappings = (mode: MappingsMode) => Promise<unknown>;
 
@@ -67,6 +74,56 @@ function extractText(value: unknown): string {
 export function isManagerMappingsServerError(value: unknown): boolean {
   const text = extractText(value);
   return /getmappings/i.test(text) && /HTTP\s*5\d\d\b/.test(text);
+}
+
+/**
+ * Panel wrap from comfyui-mcp-panel#1130 / comfyui-mcp#1472: the browser's
+ * Manager `fetch` never completed, so there is no HTTP status or body.
+ *
+ * Anchored on the wrap + a transport cause at the START of that cause.
+ * A Manager-originated rejection that merely mentions "Failed to fetch" or
+ * "NetworkError" mid-sentence is not this. AbortError is the caller's own
+ * cancellation. Mutating Manager routes (install/queue) do not inherit the
+ * read-only host-HTTP fallback this predicate gates.
+ */
+export function isManagerTransportFetchFailure(value: unknown): boolean {
+  const text = extractText(value).replace(/^(?:Error:\s*)+/i, "").trim();
+  if (!text) return false;
+  const match = /^ComfyUI-Manager request to (\S+) did not complete:\s*([\s\S]+)$/i.exec(text);
+  if (!match) return false;
+  const path = match[1] ?? "";
+  const cause = (match[2] ?? "").trim();
+  if (!/\/(?:v2\/)?customnode\/(?:getmappings|installed)(?:\?|$)/i.test(path)) return false;
+  if (/^AbortError\b/i.test(cause)) return false;
+  if (/\bHTTP\s*\d{3}\b/.test(cause)) return false;
+  return (
+    /^(?:TypeError:\s*)?Failed to fetch\b/i.test(cause) ||
+    /^fetch failed\.?$/i.test(cause) ||
+    /^NetworkError\b/i.test(cause)
+  );
+}
+
+export function dualCauseSearchFailure(
+  query: string,
+  panelErr: unknown,
+  hostErr: unknown,
+): NodeSearchResult {
+  const panel = extractText(panelErr) || "panel Manager request did not complete";
+  const host = extractText(hostErr) || "host Manager HTTP failed";
+  return {
+    supported: false,
+    count: 0,
+    results: [],
+    query: query == null ? "" : String(query),
+    reason: panel,
+    message:
+      "Node-registry search could not complete: the panel's ComfyUI-Manager request " +
+      "did not complete (Failed to fetch), and host Manager HTTP mappings also failed. " +
+      `Panel: ${panel} Host: ${host} ` +
+      "That is not a Manager outage inferred from a transport-only fetch failure, and " +
+      "not proof the pack is missing. Retry after Manager recovers, or search with " +
+      'search_custom_nodes action:"search" (queries api.comfy.org directly, not through Manager).',
+  };
 }
 
 export function catalogueSize(data: unknown): number {
@@ -215,9 +272,38 @@ export async function searchNodesViaMappings(opts: {
   };
 }
 
+async function hostSearchAfterTransport(
+  opts: {
+    query: string;
+    limit?: number;
+    fetchMappings?: FetchMappings;
+  },
+  panelErr: unknown,
+): Promise<NodeSearchResult> {
+  try {
+    const parsed = await searchNodesViaMappings(opts);
+    if (parsed.manager_outage) {
+      return {
+        ...dualCauseSearchFailure(opts.query, panelErr, parsed.reason ?? parsed.message),
+        manager_outage: true,
+      };
+    }
+    return { ...parsed, source: "host_http", note: HOST_HTTP_SEARCH_NOTE };
+  } catch (hostErr) {
+    return dualCauseSearchFailure(opts.query, panelErr, hostErr);
+  }
+}
+
+function shouldHostSearch(value: unknown): boolean {
+  return isManagerTransportFetchFailure(value) || isManagerMappingsServerError(value);
+}
+
 /**
  * Panel nodes_search first. If the panel surfaces a mappings HTTP 5xx
  * (throw or fail() ToolResult), degrade to searchNodesViaMappings.
+ * If the panel's Manager fetch never completed (`Failed to fetch` wrap),
+ * the same host-HTTP search is used — that is a panel-origin transport
+ * failure, not a Manager outage and not a missing pack.
  */
 export async function searchPanelNodes(opts: {
   panelSearch: () => Promise<unknown>;
@@ -227,10 +313,16 @@ export async function searchPanelNodes(opts: {
 }): Promise<{ via: "panel"; value: unknown } | { via: "fallback"; value: NodeSearchResult }> {
   try {
     const value = await opts.panelSearch();
-    if (!isManagerMappingsServerError(value)) return { via: "panel", value };
+    if (!shouldHostSearch(value)) return { via: "panel", value };
+    if (isManagerTransportFetchFailure(value)) {
+      return { via: "fallback", value: await hostSearchAfterTransport(opts, value) };
+    }
     return { via: "fallback", value: await searchNodesViaMappings(opts) };
   } catch (err) {
-    if (!isManagerMappingsServerError(err)) throw err;
+    if (!shouldHostSearch(err)) throw err;
+    if (isManagerTransportFetchFailure(err)) {
+      return { via: "fallback", value: await hostSearchAfterTransport(opts, err) };
+    }
     return { via: "fallback", value: await searchNodesViaMappings(opts) };
   }
 }


### PR DESCRIPTION
## Summary

On H3 ComfyUI Desktop, `panel_search_nodes` and `panel_list_nodes` died with the panel's Manager transport wrap even though live canvas graph reads still worked:

```
ComfyUI-Manager request to /v2/customnode/getmappings?mode=cache did not complete: Failed to fetch.
ComfyUI-Manager request to /v2/customnode/installed?mode=default did not complete: Failed to fetch.
```

That string is the #1472 wrap: the **browser** `fetch` never completed, so there is no HTTP status or body. It is not a Manager outage and not a missing pack. Host Manager HTTP from the MCP process can still serve the registry search and installed-pack listing.

## Fix

Extend the existing host-HTTP fallbacks:

1. **`panel_search_nodes`** (`searchPanelNodes`, next to #1669 mappings 5xx): on the transport wrap, search via host `customnode/getmappings` and return packs with `source: "host_http"` plus a note that this is a panel-origin transport failure.
2. **`panel_list_nodes`** (`listPanelNodes`, next to #2459 tab loss): on the same wrap, list via host `listInstalledNodes()` with a distinct transport note (does **not** claim the tab was disconnected).
3. If host HTTP also fails, fail with **both** facts. Transport-only `Failed to fetch` is not a Manager outage.

The detector is anchored on the wrap + a transport cause at the start of that cause. HTTP 4xx/5xx, AbortError, bare `Failed to fetch`, mutating Manager routes (install/queue), and a Manager rejection that merely mentions "Failed to fetch" mid-sentence do not match.

## Tests

- `src/__tests__/services/manager-node-search.test.ts` — reporter wrap matchers; live tab + host mappings → packs; dual-cause host failure; 403/AbortError/bare fetch/mid-sentence do not fallback
- `src/__tests__/services/manager-node-list.test.ts` — same for installed-packs
- `src/__tests__/orchestrator/panel-manager-fetch-fail.test.ts` — shipped `panel_search_nodes` / `panel_list_nodes` handlers

`npx vitest run src/__tests__/services/manager-node-search.test.ts src/__tests__/services/manager-node-list.test.ts src/__tests__/orchestrator/panel-manager-fetch-fail.test.ts src/__tests__/orchestrator/panel-search-nodes-manager-500.test.ts src/__tests__/orchestrator/list-nodes-scope-description.test.ts` — **50 passed**.

Fixes #2492
