### PR TITLE
fix(2493): expose AE wildcard input from live LiteGraph slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_expose_subgraph_input retries Anything Everywhere? wildcard sockets against the live LiteGraph slot array after Convert to Subgraph (#2493)
 - panel_search_nodes and panel_list_nodes serve host Manager HTTP when the panel's browser Manager request does not complete (Failed to fetch) (#2492)
 - stage nested video as_filename values at the input root so VHS_LoadVideo can select them (#2083)
 - list_templates uses the live panel when the configured origin is unreachable (#2196)

--- a/src/__tests__/services/expose-ae-wildcard.test.ts
+++ b/src/__tests__/services/expose-ae-wildcard.test.ts
@@ -1,0 +1,396 @@
+// #2493 — panel_expose_subgraph_input misses Anything Everywhere?'s wildcard
+// after Convert to Subgraph. The panel's name lookup lists widget sockets
+// (group_regex); the live LiteGraph array still carries the frontend wildcard
+// as a display label / unique `*` slot. Tests drive the shipped resolver AND
+// the handler wrap — a reimplementation in this file would stay green if the
+// wrap were deleted.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  extraLiveWildcardIndexNote,
+  liveExposeNodeFromQuery,
+  liveNamesMatchAvailable,
+  missingAeWildcardNote,
+  missingInputSlotRefusal,
+  resolveExposeInputAgainstLiveSlots,
+  retryExposeSubgraphInput,
+  type LiveInputSlot,
+} from "../../services/expose-ae-wildcard.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const PANEL_SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url)),
+  "utf8",
+);
+const SERVICE_SRC = readFileSync(
+  fileURLToPath(new URL("../../services/expose-ae-wildcard.ts", import.meta.url)),
+  "utf8",
+);
+
+const REPORTER_ERROR =
+  'Error: No input slot named "anything" (available: group_regex)';
+
+const REPORTER_LIVE: LiveInputSlot = {
+  slot: 0,
+  name: "group_regex",
+  label: "anything",
+  localized_name: null,
+  type: "*",
+};
+
+function slot(partial: Partial<LiveInputSlot> & Pick<LiveInputSlot, "slot" | "name">): LiveInputSlot {
+  return {
+    label: null,
+    localized_name: null,
+    type: null,
+    ...partial,
+  };
+}
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function jsonResult(payload: unknown, isError = false): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function textResult(text: string, isError = false): ToolResult {
+  return { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}) };
+}
+
+function allText(res: { content: Array<{ type: string; text?: string }> }): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+describe("missingInputSlotRefusal (#2493)", () => {
+  it("parses the reporter's exact panel sentence", () => {
+    expect(missingInputSlotRefusal(REPORTER_ERROR)).toEqual({
+      requested: "anything",
+      available: ["group_regex"],
+    });
+  });
+
+  it("treats available: none as an empty list", () => {
+    expect(missingInputSlotRefusal('No input slot named "pixels" (available: none)')).toEqual({
+      requested: "pixels",
+      available: [],
+    });
+  });
+
+  it("returns null for a different refusal", () => {
+    expect(missingInputSlotRefusal("Must be inside a subgraph")).toBeNull();
+  });
+});
+
+describe("liveExposeNodeFromQuery", () => {
+  const node = {
+    id: 1310,
+    type: "Anything Everywhere?",
+    inputs: [{ slot: 0, name: "group_regex", label: "anything", type: "*" }],
+  };
+
+  it("reads a nodes[] wrapper", () => {
+    expect(liveExposeNodeFromQuery({ nodes: [node] }, 1310)).toEqual({
+      id: "1310",
+      type: "Anything Everywhere?",
+      inputs: [REPORTER_LIVE],
+    });
+  });
+
+  it("reads JSONL in text, the current panel detail shape", () => {
+    expect(liveExposeNodeFromQuery({ text: JSON.stringify(node) }, "1310")?.inputs[0]?.label).toBe(
+      "anything",
+    );
+  });
+
+  it("ignores a different node id", () => {
+    expect(liveExposeNodeFromQuery({ nodes: [node] }, 9)).toBeNull();
+  });
+});
+
+describe("resolveExposeInputAgainstLiveSlots", () => {
+  it("THE REPORTED CASE: label anything on a unique * slot named group_regex", () => {
+    expect(
+      resolveExposeInputAgainstLiveSlots({
+        requested: "anything",
+        available: ["group_regex"],
+        nodeType: "Anything Everywhere?",
+        inputs: [REPORTER_LIVE],
+      }),
+    ).toEqual({ to_input: "group_regex", via: "label", slot: 0, name: "group_regex" });
+  });
+
+  it("does not expose a STRING widget socket as the virtual bus", () => {
+    expect(
+      resolveExposeInputAgainstLiveSlots({
+        requested: "anything",
+        available: ["group_regex"],
+        nodeType: "Anything Everywhere?",
+        inputs: [slot({ slot: 0, name: "group_regex", label: "anything", type: "STRING" })],
+      }),
+    ).toBeNull();
+  });
+
+  it("maps a unique * wildcard by type when the requested name is anything", () => {
+    expect(
+      resolveExposeInputAgainstLiveSlots({
+        requested: "anything",
+        available: ["ue_in"],
+        nodeType: "Anything Everywhere",
+        inputs: [slot({ slot: 0, name: "ue_in", type: "*" })],
+      }),
+    ).toEqual({ to_input: "ue_in", via: "wildcard", slot: 0, name: "ue_in" });
+  });
+
+  it("does not guess among Anything Everywhere3's three * slots", () => {
+    expect(
+      resolveExposeInputAgainstLiveSlots({
+        requested: "anything",
+        available: ["anything", "anything2", "anything3"],
+        nodeType: "Anything Everywhere3",
+        inputs: [
+          slot({ slot: 0, name: "anything", type: "*" }),
+          slot({ slot: 1, name: "anything2", type: "*" }),
+          slot({ slot: 2, name: "anything3", type: "*" }),
+        ],
+      }),
+    ).toEqual({ to_input: "anything", via: "wildcard", slot: 0, name: "anything" });
+  });
+
+  it("refuses an index remap when live names are not the panel's available list", () => {
+    expect(
+      resolveExposeInputAgainstLiveSlots({
+        requested: "anything",
+        available: ["group_regex"],
+        nodeType: "Anything Everywhere?",
+        inputs: [
+          slot({ slot: 0, name: "anything", type: "*" }),
+          slot({ slot: 1, name: "group_regex", type: "STRING" }),
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("is case-insensitive on labels", () => {
+    expect(
+      resolveExposeInputAgainstLiveSlots({
+        requested: "Anything",
+        available: ["group_regex"],
+        nodeType: "Anything Everywhere?",
+        inputs: [slot({ slot: 0, name: "group_regex", label: "ANYTHING", type: "*" })],
+      })?.to_input,
+    ).toBe("group_regex");
+  });
+
+  it("matches localized_name when label is absent", () => {
+    expect(
+      resolveExposeInputAgainstLiveSlots({
+        requested: "anything",
+        available: ["group_regex"],
+        nodeType: "Anything Everywhere?",
+        inputs: [slot({ slot: 0, name: "group_regex", localized_name: "anything", type: "*" })],
+      })?.to_input,
+    ).toBe("group_regex");
+  });
+});
+
+describe("disclosure notes", () => {
+  it("names the live * index when the panel listed a different array", () => {
+    const note = extraLiveWildcardIndexNote("anything", ["group_regex"], {
+      id: "1310",
+      type: "Anything Everywhere?",
+      inputs: [
+        slot({ slot: 0, name: "anything", type: "*" }),
+        slot({ slot: 1, name: "group_regex", type: "STRING" }),
+      ],
+    });
+    expect(note).toMatch(/to_input:0/);
+    expect(note).toMatch(/#2493/);
+    expect(liveNamesMatchAvailable(["group_regex"], [slot({ slot: 0, name: "anything", type: "*" })])).toBe(
+      false,
+    );
+  });
+
+  it("says the wildcard is gone when live inputs are only widget sockets", () => {
+    const note = missingAeWildcardNote("anything", ["group_regex"], {
+      id: "1310",
+      type: "Anything Everywhere?",
+      inputs: [slot({ slot: 0, name: "group_regex", label: "anything", type: "STRING" })],
+    });
+    expect(note).toMatch(/no wildcard/);
+    expect(note).toMatch(/group_regex/);
+    expect(note).toMatch(/#2493/);
+  });
+
+  it("does not attach the AE note to an unrelated missing slot", () => {
+    expect(
+      missingAeWildcardNote("pixels", ["image"], {
+        id: "2",
+        type: "VAEDecode",
+        inputs: [slot({ slot: 0, name: "samples", type: "LATENT" })],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("retryExposeSubgraphInput", () => {
+  it("forwards a successful expose with no extra query", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryExposeSubgraphInput({ to_node_id: 9, to_input: "model" }, async (cmd) => {
+      calls.push(cmd);
+      return jsonResult({ exposed: { name: "model" } });
+    });
+    expect(calls).toEqual([
+      { cmd: "graph_expose_subgraph_input", to_node_id: 9, to_input: "model", name: undefined },
+    ]);
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(allText(res))).toEqual({ exposed: { name: "model" } });
+  });
+
+  it("retries the reporter's label with the addressable live name", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryExposeSubgraphInput(
+      { to_node_id: 1310, to_input: "anything", name: "bus" },
+      async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_expose_subgraph_input" && cmd.to_input === "anything") {
+          return textResult(REPORTER_ERROR, true);
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            nodes: [
+              {
+                id: 1310,
+                type: "Anything Everywhere?",
+                inputs: [{ slot: 0, name: "group_regex", label: "anything", type: "*" }],
+              },
+            ],
+          });
+        }
+        if (cmd.cmd === "graph_expose_subgraph_input" && cmd.to_input === "group_regex") {
+          return jsonResult({ exposed: { name: "bus", to: { node_id: 1310, input: "group_regex" } } });
+        }
+        return textResult("unexpected", true);
+      },
+    );
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_expose_subgraph_input",
+      "graph_query",
+      "graph_expose_subgraph_input",
+    ]);
+    expect(calls[2]).toMatchObject({
+      cmd: "graph_expose_subgraph_input",
+      to_node_id: 1310,
+      to_input: "group_regex",
+      name: "bus",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content[0]!.text!)).toMatchObject({ exposed: { name: "bus" } });
+    expect(allText(res)).toMatch(/#2493/);
+    expect(allText(res)).toMatch(/group_regex/);
+  });
+
+  it("does not retry a STRING widget socket labelled anything", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryExposeSubgraphInput({ to_node_id: 1310, to_input: "anything" }, async (cmd) => {
+      calls.push(cmd);
+      if (cmd.cmd === "graph_expose_subgraph_input") return textResult(REPORTER_ERROR, true);
+      return jsonResult({
+        nodes: [
+          {
+            id: 1310,
+            type: "Anything Everywhere?",
+            inputs: [{ slot: 0, name: "group_regex", label: "anything", type: "STRING" }],
+          },
+        ],
+      });
+    });
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_expose_subgraph_input", "graph_query"]);
+    expect(res.isError).toBe(true);
+    expect(allText(res)).toContain(REPORTER_ERROR);
+    expect(allText(res)).toMatch(/no wildcard/);
+  });
+
+  it("leaves a numeric to_input refusal alone", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryExposeSubgraphInput({ to_node_id: 1310, to_input: 0 }, async (cmd) => {
+      calls.push(cmd);
+      return textResult("input slot index 0 out of range (node has 0)", true);
+    });
+    expect(calls).toHaveLength(1);
+    expect(res.isError).toBe(true);
+    expect(allText(res)).not.toMatch(/#2493/);
+  });
+});
+
+describe("panel_expose_subgraph_input attaches the #2493 retry", () => {
+  it("the handler calls the shipped retry, not a copy", () => {
+    expect(PANEL_SRC).toMatch(/retryExposeSubgraphInput\(/);
+    expect(PANEL_SRC).toMatch(/#2493/);
+    expect(SERVICE_SRC).toMatch(/cmd: "graph_expose_subgraph_input"/);
+    expect(SERVICE_SRC).toMatch(/cmd: "graph_query"/);
+  });
+
+  it("the description names the live-slot remap", () => {
+    const def = defByName("panel_expose_subgraph_input");
+    expect(def.description).toMatch(/#2493/);
+    expect(def.description).toMatch(/Anything Everywhere\?/);
+    expect(def.description).toMatch(/live LiteGraph/);
+    expect(def.description).toMatch(/STRING widget/);
+  });
+
+  it("THE REPORTED CASE reaches the retry through the registered handler", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_expose_subgraph_input" && cmd.to_input === "anything") {
+          return textResult(REPORTER_ERROR, true);
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            nodes: [
+              {
+                id: 1310,
+                type: "Anything Everywhere?",
+                inputs: [{ slot: 0, name: "group_regex", label: "anything", type: "*" }],
+              },
+            ],
+          });
+        }
+        return jsonResult({ exposed: { name: "anything", to: { node_id: 1310, input: "group_regex" } } });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+    const res = await defByName("panel_expose_subgraph_input").handler(
+      { to_node_id: 1310, to_input: "anything" },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_expose_subgraph_input",
+      to_node_id: 1310,
+      to_input: "anything",
+    });
+    expect(calls[2]).toMatchObject({
+      cmd: "graph_expose_subgraph_input",
+      to_input: "group_regex",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(allText(res)).toMatch(/#2493/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -84,6 +84,7 @@ import {
   laterSlotsFromUnexposePayload,
   unexposeHostLinkShiftNote,
 } from "../services/unexpose-host-link-shift.js";
+import { retryExposeSubgraphInput } from "../services/expose-ae-wildcard.js";
 import {
   assertScreenshotPersistAllowed,
   decodePngBase64,
@@ -23209,21 +23210,16 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_expose_subgraph_input",
-      "Wire an interior node's INPUT to the subgraph's INPUT RAIL — i.e. expose it as a SUBGRAPH INPUT on the boundary so the PARENT graph can feed the subgraph node's new input slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). This is the correct way to wire an internal input to the subgraph's input rail: do NOT panel_connect to a guessed rail node id — call this with the interior node + the input you want exposed. Read panel_query_graph's `rails` to see the resulting boundary slots. `to_input` is an input slot NAME ('model', 'pixels') or numeric index. Optional `name` titles the new boundary input (defaults from the target slot) — but it is IGNORED when this slot is ALREADY exposed: the call then returns the existing boundary input unchanged, with `reused:true` and its ORIGINAL `name`. Check `reused` before relying on the name you asked for — there is currently NO tool that renames an existing boundary slot, so a name is only applied on FIRST exposure. Undoable with Ctrl+Z.",
+      "Wire an interior node's INPUT to the subgraph's INPUT RAIL — i.e. expose it as a SUBGRAPH INPUT on the boundary so the PARENT graph can feed the subgraph node's new input slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). This is the correct way to wire an internal input to the subgraph's input rail: do NOT panel_connect to a guessed rail node id — call this with the interior node + the input you want exposed. Read panel_query_graph's `rails` to see the resulting boundary slots. `to_input` is an input slot NAME ('model', 'pixels') or numeric index. Optional `name` titles the new boundary input (defaults from the target slot) — but it is IGNORED when this slot is ALREADY exposed: the call then returns the existing boundary input unchanged, with `reused:true` and its ORIGINAL `name`. Check `reused` before relying on the name you asked for — there is currently NO tool that renames an existing boundary slot, so a name is only applied on FIRST exposure. After Convert to Subgraph, Anything Everywhere? may keep its wildcard source as a live LiteGraph socket whose DISPLAY label is \"anything\" while the panel's name lookup only lists widget sockets such as group_regex (artokun/comfyui-mcp#2493). This tool retries against that live slot array (label / unique `*` wildcard) and will not expose a STRING widget socket as the virtual bus. Undoable with Ctrl+Z.",
       {
         to_node_id: nodeId().describe("Interior (inner) node id whose input to expose (from panel_query_graph while inside the subgraph)."),
         to_input: slotRef.describe("Input slot name (e.g. 'model', 'pixels') or numeric index on that node."),
         name: z.string().optional().describe("Optional name for the new subgraph input (boundary slot). Defaults from the target slot. IGNORED when the slot is already exposed — the reply carries reused:true and the existing name."),
       },
       async (args: A, ctx) =>
-        ctx.call(
-          {
-            cmd: "graph_expose_subgraph_input",
-            to_node_id: args.to_node_id,
-            to_input: args.to_input,
-            name: args.name,
-          },
-          15000,
+        retryExposeSubgraphInput(
+          { to_node_id: args.to_node_id, to_input: args.to_input, name: args.name },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
         ),
     ),
     def(

--- a/src/services/expose-ae-wildcard.ts
+++ b/src/services/expose-ae-wildcard.ts
@@ -1,0 +1,371 @@
+/**
+ * #2493 — `panel_expose_subgraph_input` cannot expose Anything Everywhere?'s
+ * wildcard source after Convert to Subgraph.
+ *
+ * The panel's `resolveSlot` matches input `.name` only. After conversion the
+ * live LiteGraph array still carries the frontend wildcard (type `*`, display
+ * label / localized_name "anything") while the name lookup lists widget sockets
+ * such as `group_regex`. `panel_graph_outline` shows `[renamed "anything"]`;
+ * `to_input:"anything"` is refused with `available: group_regex`.
+ *
+ * This module maps the requested name onto the LIVE slot array so the handler
+ * can retry with an address `resolveSlot` already accepts. A STRING widget
+ * socket is never chosen as a stand-in for the virtual bus. Index retry is
+ * refused when the live names and the refusal's available names disagree —
+ * those are different arrays, and guessing an index would expose the wrong slot.
+ */
+
+export const AE_WILDCARD_NODE_TYPES = new Set([
+  "Anything Everywhere",
+  "Anything Everywhere?",
+  "Anything Everywhere3",
+]);
+
+const AE_WILDCARD_NAME_RE = /^anything[23]?$/i;
+
+const MISSING_INPUT_SLOT_RE = /No input slot named "([^"]+)" \(available: ([^)]*)\)/;
+
+export type LiveInputSlot = {
+  slot: number;
+  name: string | null;
+  label: string | null;
+  localized_name: string | null;
+  type: string | null;
+};
+
+export type LiveExposeNode = {
+  id: string;
+  type: string | null;
+  inputs: LiveInputSlot[];
+};
+
+export type MissingInputSlotRefusal = {
+  requested: string;
+  available: string[];
+};
+
+export type LiveSlotRetry = {
+  to_input: string;
+  via: "label" | "wildcard";
+  slot: number;
+  name: string;
+};
+
+type ToolResultLike = {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function lower(value: string | null | undefined): string | null {
+  if (typeof value !== "string" || value === "") return null;
+  return value.toLowerCase();
+}
+
+function slotType(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+export function isAeWildcardName(name: string): boolean {
+  return AE_WILDCARD_NAME_RE.test(name);
+}
+
+export function isAeWildcardNodeType(type: string | null | undefined): boolean {
+  return typeof type === "string" && AE_WILDCARD_NODE_TYPES.has(type);
+}
+
+export function isWildcardSlotType(type: string | null | undefined): boolean {
+  return type === "*";
+}
+
+export function missingInputSlotRefusal(text: string): MissingInputSlotRefusal | null {
+  const match = MISSING_INPUT_SLOT_RE.exec(text);
+  if (!match) return null;
+  const requested = match[1];
+  const raw = match[2]?.trim() ?? "";
+  if (!requested) return null;
+  const available =
+    raw === "" || raw.toLowerCase() === "none"
+      ? []
+      : raw
+          .split(",")
+          .map((part) => part.trim())
+          .filter((part) => part !== "");
+  return { requested, available };
+}
+
+function queryNodeRecords(payload: unknown): Record<string, unknown>[] {
+  if (Array.isArray(payload)) {
+    return payload.flatMap((entry) => {
+      const rec = asRecord(entry);
+      return rec ? [rec] : [];
+    });
+  }
+  const rec = asRecord(payload);
+  if (!rec) return [];
+  if (Array.isArray(rec.nodes)) {
+    return rec.nodes.flatMap((entry) => {
+      const node = asRecord(entry);
+      return node ? [node] : [];
+    });
+  }
+  if (typeof rec.text === "string") {
+    const rows: Record<string, unknown>[] = [];
+    for (const line of rec.text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("{")) continue;
+      try {
+        const row = asRecord(JSON.parse(trimmed) as unknown);
+        if (row) rows.push(row);
+      } catch {
+        /* skip a non-JSON detail line */
+      }
+    }
+    if (rows.length) return rows;
+  }
+  if (rec.id != null && (rec.inputs !== undefined || rec.type !== undefined)) return [rec];
+  return [];
+}
+
+function liveInputFromRecord(entry: unknown, index: number): LiveInputSlot | null {
+  const rec = asRecord(entry);
+  if (!rec) return null;
+  const rawSlot = rec.slot;
+  const slot =
+    typeof rawSlot === "number" && Number.isInteger(rawSlot) && rawSlot >= 0 ? rawSlot : index;
+  return {
+    slot,
+    name: typeof rec.name === "string" && rec.name ? rec.name : null,
+    label: typeof rec.label === "string" && rec.label ? rec.label : null,
+    localized_name:
+      typeof rec.localized_name === "string" && rec.localized_name ? rec.localized_name : null,
+    type: slotType(rec.type),
+  };
+}
+
+export function liveExposeNodeFromQuery(payload: unknown, nodeId: unknown): LiveExposeNode | null {
+  if (nodeId == null) return null;
+  const wanted = String(nodeId);
+  for (const rec of queryNodeRecords(payload)) {
+    if (rec.id == null || String(rec.id) !== wanted) continue;
+    const rawInputs = rec.inputs;
+    const inputs: LiveInputSlot[] = [];
+    if (Array.isArray(rawInputs)) {
+      for (let i = 0; i < rawInputs.length; i++) {
+        const slot = liveInputFromRecord(rawInputs[i], i);
+        if (slot) inputs.push(slot);
+      }
+    }
+    return {
+      id: wanted,
+      type: typeof rec.type === "string" && rec.type ? rec.type : null,
+      inputs,
+    };
+  }
+  return null;
+}
+
+function nameSet(names: readonly string[]): Set<string> {
+  const out = new Set<string>();
+  for (const name of names) {
+    const key = lower(name);
+    if (key) out.add(key);
+  }
+  return out;
+}
+
+/** True when the refusal's available names are the live slot names — same array. */
+export function liveNamesMatchAvailable(
+  available: readonly string[],
+  inputs: readonly LiveInputSlot[],
+): boolean {
+  const avail = nameSet(available);
+  if (avail.size === 0) return false;
+  const live = nameSet(inputs.map((slot) => slot.name ?? ""));
+  if (avail.size !== live.size) return false;
+  for (const name of avail) if (!live.has(name)) return false;
+  return true;
+}
+
+function uniqueSlot(hits: LiveInputSlot[]): LiveInputSlot | null {
+  return hits.length === 1 ? (hits[0] ?? null) : null;
+}
+
+function displayKeys(slot: LiveInputSlot): string[] {
+  const keys = [slot.label, slot.localized_name];
+  return keys.flatMap((key) => {
+    const lowered = lower(key);
+    return lowered ? [lowered] : [];
+  });
+}
+
+export function resolveExposeInputAgainstLiveSlots(opts: {
+  requested: string;
+  available: readonly string[];
+  nodeType: string | null;
+  inputs: readonly LiveInputSlot[];
+}): LiveSlotRetry | null {
+  const requested = opts.requested.trim();
+  const wanted = lower(requested);
+  if (!wanted) return null;
+  if (!liveNamesMatchAvailable(opts.available, opts.inputs)) return null;
+
+  const wildcardRequest = isAeWildcardName(requested);
+  const labelHits = opts.inputs.filter((slot) => displayKeys(slot).includes(wanted));
+  const labelHit = uniqueSlot(labelHits);
+  if (labelHit && labelHit.name) {
+    if (wildcardRequest && !isWildcardSlotType(labelHit.type)) return null;
+    return { to_input: labelHit.name, via: "label", slot: labelHit.slot, name: labelHit.name };
+  }
+
+  if (!wildcardRequest) return null;
+  if (opts.nodeType != null && !isAeWildcardNodeType(opts.nodeType)) return null;
+
+  const starHits = opts.inputs.filter((slot) => isWildcardSlotType(slot.type) && slot.name);
+  const namedStar = uniqueSlot(
+    starHits.filter((slot) => lower(slot.name) === wanted || displayKeys(slot).includes(wanted)),
+  );
+  const star = namedStar ?? uniqueSlot(starHits);
+  if (!star || !star.name) return null;
+  return { to_input: star.name, via: "wildcard", slot: star.slot, name: star.name };
+}
+
+export function extraLiveWildcardIndexNote(
+  requested: string,
+  available: readonly string[],
+  node: LiveExposeNode | null,
+): string | null {
+  if (!node || !isAeWildcardName(requested)) return null;
+  if (node.type != null && !isAeWildcardNodeType(node.type)) return null;
+  if (liveNamesMatchAvailable(available, node.inputs)) return null;
+  const wanted = lower(requested);
+  if (!wanted) return null;
+  const starHits = node.inputs.filter((slot) => isWildcardSlotType(slot.type));
+  const named = starHits.filter(
+    (slot) => lower(slot.name) === wanted || displayKeys(slot).includes(wanted),
+  );
+  const hit = uniqueSlot(named.length ? named : starHits);
+  if (!hit) return null;
+  const address = hit.name ? `"${hit.name}"` : `index ${hit.slot}`;
+  return (
+    `The live LiteGraph node ${node.id} (${node.type ?? "unknown type"}) still has a wildcard \`*\` ` +
+    `input at slot ${hit.slot} (${address}), but the panel's name lookup only listed ` +
+    `${available.length ? available.map((s) => JSON.stringify(s)).join(", ") : "no names"} ` +
+    `(artokun/comfyui-mcp#2493). Retry panel_expose_subgraph_input with to_input:${hit.slot} ` +
+    `(the live index). If that is refused as out of range, Convert to Subgraph dropped the ` +
+    `frontend wildcard from the array the panel mutates — re-add Anything Everywhere? inside ` +
+    `the subgraph so the live \`anything\` socket exists.`
+  );
+}
+
+export function missingAeWildcardNote(
+  requested: string,
+  available: readonly string[],
+  node: LiveExposeNode | null,
+): string | null {
+  if (!isAeWildcardName(requested)) return null;
+  if (node?.type != null && !isAeWildcardNodeType(node.type)) return null;
+  if (node && node.inputs.some((slot) => isWildcardSlotType(slot.type))) return null;
+  const where = node
+    ? `live node ${node.id} (${node.type ?? "unknown type"})`
+    : "the interior node";
+  const listed = available.length
+    ? available.map((s) => JSON.stringify(s)).join(", ")
+    : "none";
+  return (
+    `${where} has no wildcard \`*\` input after subgraph conversion (artokun/comfyui-mcp#2493). ` +
+    `panel_graph_outline's [renamed "${requested}"] is a display label, not an addressable bus socket. ` +
+    `The panel's available slot(s) are widget sockets (${listed}), not the Anything Everywhere? source. ` +
+    `Re-add the node inside the subgraph so the live LiteGraph \`anything\` socket exists, then expose ` +
+    `that slot from panel_query_graph (name, label, or index).`
+  );
+}
+
+function toolText(res: ToolResultLike): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+function parseJsonPayload(res: ToolResultLike) {
+  if (res.isError) return null;
+  const text = res.content.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function withNote<T extends ToolResultLike>(res: T, note: string | null): T {
+  if (!note) return res;
+  return { ...res, content: [...res.content, { type: "text", text: note }] };
+}
+
+/**
+ * First try the panel's name lookup. On the #2493 missing-name refusal, query
+ * the live node and retry with the addressable live slot name when that is
+ * unique and safe. Never throws.
+ */
+export async function retryExposeSubgraphInput<T extends ToolResultLike>(
+  args: { to_node_id: unknown; to_input: unknown; name?: unknown },
+  call: (cmd: Record<string, unknown>, timeoutMs?: number) => Promise<T>,
+): Promise<T> {
+  const first = await call(
+    {
+      cmd: "graph_expose_subgraph_input",
+      to_node_id: args.to_node_id,
+      to_input: args.to_input,
+      name: args.name,
+    },
+    15000,
+  );
+  if (!first.isError) return first;
+  if (typeof args.to_input === "number") return first;
+
+  const refusal = missingInputSlotRefusal(toolText(first));
+  if (!refusal) return first;
+
+  const detail = await call(
+    { cmd: "graph_query", ids: [args.to_node_id], fields: "detail", limit: 1 },
+    8000,
+  );
+  const node = liveExposeNodeFromQuery(parseJsonPayload(detail), args.to_node_id);
+  const resolved = node
+    ? resolveExposeInputAgainstLiveSlots({
+        requested: refusal.requested,
+        available: refusal.available,
+        nodeType: node.type,
+        inputs: node.inputs,
+      })
+    : null;
+
+  if (resolved && lower(resolved.to_input) !== lower(refusal.requested)) {
+    const retry = await call(
+      {
+        cmd: "graph_expose_subgraph_input",
+        to_node_id: args.to_node_id,
+        to_input: resolved.to_input,
+        name: args.name,
+      },
+      15000,
+    );
+    if (!retry.isError) {
+      return withNote(
+        retry,
+        `Resolved to_input ${JSON.stringify(args.to_input)} to live slot ` +
+          `${JSON.stringify(resolved.to_input)} (index ${resolved.slot}, via ${resolved.via}) ` +
+          `because the panel's name lookup missed the frontend wildcard (artokun/comfyui-mcp#2493).`,
+      );
+    }
+  }
+
+  return withNote(
+    first,
+    extraLiveWildcardIndexNote(refusal.requested, refusal.available, node) ??
+      missingAeWildcardNote(refusal.requested, refusal.available, node),
+  );
+}


### PR DESCRIPTION
## Summary

After Convert to Subgraph, `panel_expose_subgraph_input(to_node_id, to_input:"anything")` refused Anything Everywhere?'s wildcard source with `No input slot named "anything" (available: group_regex)`, even though `panel_graph_outline` showed `[renamed "anything"]`. The panel's `resolveSlot` matches input `.name` only, so a live LiteGraph wildcard whose display label is `anything` was invisible next to widget sockets such as `group_regex`.

`panel_expose_subgraph_input` now retries that refusal against the live node detail:

- unique live slot whose **label** / **localized_name** is the requested name
- for AE senders, a unique `*` wildcard when the requested name is `anything` / `anything2` / `anything3`
- never a STRING widget socket as the virtual bus
- no index guess when the live names and the refusal's available list disagree (different arrays)

If the live `*` socket is gone, the original refusal is returned with a note to re-add the node inside the subgraph.

Fixes #2493

## Tests

- `src/__tests__/services/expose-ae-wildcard.test.ts` — reporter case, STRING-widget refusal, AE3 non-guess, handler wrap
- `npx vitest run src/__tests__/services/expose-ae-wildcard.test.ts src/__tests__/orchestrator/panel-tools.test.ts src/__tests__/services/unexpose-host-link-shift.test.ts` (460 passed)
- `npx tsc --noEmit`
- `node scripts/check-anti-slop.mjs`
