### PR TITLE
fix: report unavailable LoadImage values in panel_get_errors (#2587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_free_vram reports VRAM after CUDA release settles (#2050)
 - panel_open_workflow treats nested opened.routing_key as unsaved-open proof instead of failing a proven tmp: open as an unconfirmed filename (#2477)
 - omit the #2437 unexpose reindex warning when the removed slot is last or the panel already reindexed (#2491)
+- panel_get_errors reports unavailable saved LoadImage values instead of reasonless stale flags (#2587)
 
 ## [0.52.150] - 2026-08-30
 

--- a/src/__tests__/orchestrator/get-errors-call-budget.test.ts
+++ b/src/__tests__/orchestrator/get-errors-call-budget.test.ts
@@ -982,3 +982,122 @@ describe("get_errors completion does not invent a found type or skip the sanitiz
     ).toBeUndefined();
   });
 });
+
+// #2587 — a completed panel scan can classify a current LoadImage as a cosmetic
+// stale outline when its saved value is no longer in the freshly refreshed combo.
+// These drive the registered panel_get_errors tool, including a subgraph viewing
+// identity, rather than calling get-errors-audit.ts in isolation.
+describe("panel_get_errors reclassifies unavailable stale LoadImage values (#2587)", () => {
+  const SUBGRAPH_VIEW = {
+    kind: "subgraph",
+    scope: "subgraph",
+    workflow: "nested.json",
+    workflow_uuid: "workflow-a",
+    owner_node_id: 42,
+    title: "Preprocess",
+  };
+
+  const panelReply = (viewing = SUBGRAPH_VIEW) => ({
+    viewing,
+    node_count: 3,
+    errored_count: 0,
+    nodes: [],
+    stale_flags: [
+      { id: 306, type: "LoadImage", widgets: { image: "front_color.png" }, red_outline: true, reasons: [] },
+      { id: 307, type: "LoadImage", widgets: { image: "front_normal.png" }, red_outline: true, reasons: [] },
+      { id: 308, type: "LoadImage", widgets: { image: "front_depth.png" }, red_outline: true, reasons: [] },
+    ],
+    last_execution_error: null,
+    node_errors: null,
+    note: CLEAN_NOTE,
+  });
+
+  it("reports absent saved values with ids and values, including a nested-subgraph view", async () => {
+    const { payload, cmds, calls } = await runGetErrors((cmd) => {
+      if (cmd.cmd === "graph_get_errors") return panelReply();
+      if (cmd.cmd === "graph_get_object_info") {
+        return {
+          ok: true,
+          object_info: {
+            LoadImage: {
+              input: { required: { image: [["front_color.png", "front_other.png"], {}] } },
+            },
+          },
+        };
+      }
+      if (cmd.cmd === "graph_query") {
+        return {
+          viewing: SUBGRAPH_VIEW,
+          matched: 3,
+          shown: 3,
+          text: [
+            { id: 306, type: "LoadImage", widgets: { image: "front_color.png" } },
+            { id: 307, type: "LoadImage", widgets: { image: "front_normal.png" } },
+            { id: 308, type: "LoadImage", widgets: { image: "front_depth.png" } },
+          ].map(JSON.stringify).join("\n"),
+        };
+      }
+      throw new Error(`unexpected follow-up ${cmd.cmd}`);
+    });
+
+    expect(cmds).toEqual(["graph_get_errors", "graph_get_object_info", "graph_query"]);
+    expect(calls.find((call) => call.cmd === "graph_query")).toMatchObject({
+      fields: "detail",
+      ids: [306, 307, 308],
+    });
+    expect(payload.audit_complete).toBe(true);
+    expect(payload.errored_count).toBe(0);
+    expect(payload.note).toBeUndefined();
+
+    const unavailable = payload.unavailable_widget_values as Array<Record<string, unknown>>;
+    expect(unavailable).toHaveLength(2);
+    expect(unavailable).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 307,
+        type: "LoadImage",
+        widget: "image",
+        value: "front_normal.png",
+        kind: "missing_asset",
+        source: "orchestrator_completion",
+      }),
+      expect.objectContaining({
+        id: 308,
+        type: "LoadImage",
+        widget: "image",
+        value: "front_depth.png",
+        kind: "missing_asset",
+        source: "orchestrator_completion",
+      }),
+    ]));
+    expect((payload.stale_flags as Array<Record<string, unknown>>)).toEqual([
+      expect.objectContaining({ id: 306, type: "LoadImage" }),
+    ]);
+  });
+
+  it("keeps the cosmetic stale classification when the follow-up reads a different workflow", async () => {
+    const { payload } = await runGetErrors((cmd) => {
+      if (cmd.cmd === "graph_get_errors") return panelReply();
+      if (cmd.cmd === "graph_get_object_info") {
+        return {
+          ok: true,
+          object_info: {
+            LoadImage: { input: { required: { image: [["front_color.png"], {}] } } },
+          },
+        };
+      }
+      if (cmd.cmd === "graph_query") {
+        return {
+          viewing: { ...SUBGRAPH_VIEW, workflow_uuid: "workflow-b" },
+          matched: 3,
+          shown: 3,
+          text: JSON.stringify({ id: 307, type: "LoadImage", widgets: { image: "front_normal.png" } }),
+        };
+      }
+      throw new Error(`unexpected follow-up ${cmd.cmd}`);
+    });
+
+    expect(payload.unavailable_widget_values).toBeUndefined();
+    expect(payload.stale_flags).toHaveLength(3);
+    expect(payload.note).toBe(CLEAN_NOTE);
+  });
+});

--- a/src/__tests__/orchestrator/get-errors-call-budget.test.ts
+++ b/src/__tests__/orchestrator/get-errors-call-budget.test.ts
@@ -993,8 +993,7 @@ describe("panel_get_errors reclassifies unavailable stale LoadImage values (#258
     scope: "subgraph",
     workflow: "nested.json",
     workflow_uuid: "workflow-a",
-    owner_node_id: 42,
-    title: "Preprocess",
+    graph_identity: "subgraph-a",
   };
 
   const panelReply = (viewing = SUBGRAPH_VIEW) => ({
@@ -1012,7 +1011,7 @@ describe("panel_get_errors reclassifies unavailable stale LoadImage values (#258
     note: CLEAN_NOTE,
   });
 
-  it("reports absent saved values with ids and values, including a nested-subgraph view", async () => {
+  it("reports an absent enumerable root-level saved value with its id and value", async () => {
     const { payload, cmds, calls } = await runGetErrors((cmd) => {
       if (cmd.cmd === "graph_get_errors") return panelReply();
       if (cmd.cmd === "graph_get_object_info") {
@@ -1074,7 +1073,94 @@ describe("panel_get_errors reclassifies unavailable stale LoadImage values (#258
     ]);
   });
 
-  it("keeps the cosmetic stale classification when the follow-up reads a different workflow", async () => {
+  it("does not classify annotated or nested upload paths without /view evidence", async () => {
+    const panel = panelReply();
+    const pathValues = ["[input]nested/front_normal.png", "[output]front_depth.png", "temp/front_mask.png"];
+    panel.stale_flags = pathValues.map((value, i) => ({
+      id: 306 + i,
+      type: "LoadImage",
+      red_outline: true,
+      reasons: [],
+      value,
+    }));
+    const { payload } = await runGetErrors((cmd) => {
+      if (cmd.cmd === "graph_get_errors") return panel;
+      if (cmd.cmd === "graph_get_object_info") {
+        return {
+          ok: true,
+          object_info: {
+            LoadImage: {
+              input: { required: { image: [["front_color.png"], { image_upload: true }] } },
+            },
+          },
+        };
+      }
+      if (cmd.cmd === "graph_query") {
+        return {
+          viewing: SUBGRAPH_VIEW,
+          matched: pathValues.length,
+          shown: pathValues.length,
+          text: pathValues
+            .map((value, i) => JSON.stringify({ id: 306 + i, type: "LoadImage", widgets: { image: value } }))
+            .join("\n"),
+        };
+      }
+      throw new Error(`unexpected follow-up ${cmd.cmd}`);
+    });
+
+    expect(payload.unavailable_widget_values).toBeUndefined();
+    expect(payload.stale_flags).toHaveLength(pathValues.length);
+    expect(payload.note).toBe(CLEAN_NOTE);
+  });
+
+  it("keeps linked and driven LoadImage values unknown", async () => {
+    const panel = panelReply();
+    panel.stale_flags = [
+      { id: 306, type: "LoadImage", red_outline: true, reasons: [] },
+      { id: 307, type: "LoadImage", red_outline: true, reasons: [] },
+    ];
+    const { payload } = await runGetErrors((cmd) => {
+      if (cmd.cmd === "graph_get_errors") return panel;
+      if (cmd.cmd === "graph_get_object_info") {
+        return {
+          ok: true,
+          object_info: {
+            LoadImage: {
+              input: { required: { image: [["front_color.png"], { image_upload: true }] } },
+            },
+          },
+        };
+      }
+      if (cmd.cmd === "graph_query") {
+        return {
+          viewing: SUBGRAPH_VIEW,
+          matched: 2,
+          shown: 2,
+          text: [
+            {
+              id: 306,
+              type: "LoadImage",
+              widgets: { image: "front_normal.png" },
+              inputs: [{ name: "image", link: { node_id: 12, output_slot: 0 } }],
+            },
+            {
+              id: 307,
+              type: "LoadImage",
+              widgets: { image: "front_depth.png" },
+              driven_by_link: { image: { node_id: 13, output_slot: 0 } },
+            },
+          ].map(JSON.stringify).join("\n"),
+        };
+      }
+      throw new Error(`unexpected follow-up ${cmd.cmd}`);
+    });
+
+    expect(payload.unavailable_widget_values).toBeUndefined();
+    expect(payload.stale_flags).toHaveLength(2);
+    expect(payload.note).toBe(CLEAN_NOTE);
+  });
+
+  it("keeps the cosmetic stale classification when a same-workflow graph identity changes", async () => {
     const { payload } = await runGetErrors((cmd) => {
       if (cmd.cmd === "graph_get_errors") return panelReply();
       if (cmd.cmd === "graph_get_object_info") {
@@ -1087,7 +1173,7 @@ describe("panel_get_errors reclassifies unavailable stale LoadImage values (#258
       }
       if (cmd.cmd === "graph_query") {
         return {
-          viewing: { ...SUBGRAPH_VIEW, workflow_uuid: "workflow-b" },
+          viewing: { ...SUBGRAPH_VIEW, graph_identity: "subgraph-b" },
           matched: 3,
           shown: 3,
           text: JSON.stringify({ id: 307, type: "LoadImage", widgets: { image: "front_normal.png" } }),

--- a/src/orchestrator/get-errors-audit.ts
+++ b/src/orchestrator/get-errors-audit.ts
@@ -216,6 +216,17 @@ function optionsLookLikeFiles(options: string[]): boolean {
   return options.filter((s) => FILE_LIKE.test(s)).length * 2 >= options.length;
 }
 
+/**
+ * Upload combos can carry paths that the combo list deliberately cannot
+ * enumerate. The panel's /view probe is the authority for those values, so a
+ * stale outline must remain unknown until that evidence exists. Root-level
+ * names are different: those are the values the refreshed list is expected to
+ * enumerate, which is the evidence #2587 needs for the missing-value report.
+ */
+function isNonEnumerableUploadPath(value: string): boolean {
+  return /^\[(?:input|output|temp)\]/i.test(value) || /[\\/]/.test(value);
+}
+
 function rewriteTextPayload(res: GetErrorsToolResult, payload: Record<string, unknown>): GetErrorsToolResult {
   const idx = res.content.findIndex((c) => c.type === "text");
   if (idx < 0) return res;
@@ -421,12 +432,12 @@ function judgeLeftoverCombos(
  * completion scanner: only the concrete LoadImage.image combo is reclassified,
  * and only when both reads prove the current node and current view.
  *
- * Upload-input paths that are not enumerated by `/object_info` are still judged
- * here because this path exists specifically for the panel_set_widget refusal
- * reported by #2587: the panel has already presented a successfully refreshed
- * option list as authoritative for this saved value. Unreadable schema, missing
- * node detail, a linked image input, and a value that is present in the list all
- * preserve the original stale flag.
+ * Upload-input paths that are not enumerated by `/object_info` stay unknown here:
+ * only the panel's `/view`/existence evidence can distinguish a valid nested or
+ * annotated path from a missing file. A root-level value absent from the refreshed
+ * list is the #2587 case. Unreadable schema, missing node detail, a linked image
+ * input, and a value that is present in the list all preserve the original stale
+ * flag.
  */
 function judgeStaleLoadImages(
   staleFlags: UncheckedEntry[],
@@ -448,6 +459,7 @@ function judgeStaleLoadImages(
     const value = node.widgets.image;
     if (typeof value !== "string" || value === "") continue;
     if (options.includes(value)) continue;
+    if (isUploadCombo(specs.image) && isNonEnumerableUploadPath(value)) continue;
 
     unavailable.push({
       id: node.id,
@@ -606,7 +618,15 @@ function viewingIdentity(payload: Record<string, unknown> | null): ViewingIdenti
   const raw = payload?.viewing;
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
   const v = raw as ViewingIdentity;
-  const keys = ["workflow_uuid", "workflow", "kind", "scope", "owner_node_id", "title"];
+  const keys = [
+    "workflow_uuid",
+    "workflow",
+    "graph_identity",
+    "kind",
+    "scope",
+    "owner_node_id",
+    "title",
+  ];
   const identity = Object.fromEntries(keys.filter((key) => key in v).map((key) => [key, v[key]]));
   return Object.keys(identity).length > 0 ? identity : null;
 }
@@ -644,6 +664,21 @@ function sameViewingIdentity(
   // replace the per-instance UUID: the same saved path may be reopened in place.
   if ("workflow" in a || "workflow" in b) {
     if (!("workflow" in a) || !("workflow" in b) || !Object.is(a.workflow, b.workflow)) return false;
+  }
+  // Ownerless subgraphs in one workflow are still distinct graphs. A graph
+  // replacement/reconnect can also retain the workflow UUID while changing
+  // this object-keyed identity, so never let an omitted or mismatched witness
+  // retire the primary read's leftovers.
+  if ("graph_identity" in a || "graph_identity" in b) {
+    if (
+      typeof a.graph_identity !== "string" ||
+      typeof b.graph_identity !== "string" ||
+      a.graph_identity.length === 0 ||
+      b.graph_identity.length === 0 ||
+      !Object.is(a.graph_identity, b.graph_identity)
+    ) {
+      return false;
+    }
   }
   const shared = Object.keys(a).filter((key) => key in b);
   return shared.length > 0 && shared.every((key) => Object.is(a[key], b[key]));

--- a/src/orchestrator/get-errors-audit.ts
+++ b/src/orchestrator/get-errors-audit.ts
@@ -128,6 +128,16 @@ function asUncheckedList(payload: Record<string, unknown>): UncheckedEntry[] {
     : [];
 }
 
+/** Red outlines are normally cosmetic, but a stale LoadImage outline can hide a
+ * current combo value that the panel would refuse to write. Keep this separate from
+ * unchecked_nodes: a stale flag is not itself an abstention and must remain untouched
+ * unless a fresh same-view graph/schema read proves the value is unavailable. */
+function asStaleFlags(payload: Record<string, unknown>): UncheckedEntry[] {
+  return Array.isArray(payload.stale_flags)
+    ? (payload.stale_flags as UncheckedEntry[])
+    : [];
+}
+
 /** An abstention a second batched read has a chance of retiring. */
 function isRetryableUnchecked(entry: UncheckedEntry): boolean {
   return typeof entry?.reason === "string" && RETRYABLE_UNCHECKED_RE.test(entry.reason);
@@ -290,6 +300,11 @@ type ComboJudgement = {
   stillUnchecked: UncheckedEntry[];
 };
 
+type StaleLoadImageJudgement = {
+  unavailable: Array<Record<string, unknown>>;
+  reclassifiedIds: Set<string>;
+};
+
 function judgeLeftoverCombos(
   leftover: UncheckedEntry[],
   nodes: QueryNode[],
@@ -396,6 +411,57 @@ function judgeLeftoverCombos(
   }
 
   return { unavailable, stillUnchecked };
+}
+
+/**
+ * #2587 — a panel can leave a red LoadImage under `stale_flags` after its live
+ * scan has otherwise completed. A fresh whole `/object_info` plus a detail read
+ * of the same graph can turn that particular cosmetic flag into an actionable
+ * unavailable widget finding. This is deliberately narrower than the budget
+ * completion scanner: only the concrete LoadImage.image combo is reclassified,
+ * and only when both reads prove the current node and current view.
+ *
+ * Upload-input paths that are not enumerated by `/object_info` are still judged
+ * here because this path exists specifically for the panel_set_widget refusal
+ * reported by #2587: the panel has already presented a successfully refreshed
+ * option list as authoritative for this saved value. Unreadable schema, missing
+ * node detail, a linked image input, and a value that is present in the list all
+ * preserve the original stale flag.
+ */
+function judgeStaleLoadImages(
+  staleFlags: UncheckedEntry[],
+  nodes: QueryNode[],
+  objectInfo: Record<string, unknown>,
+): StaleLoadImageJudgement {
+  const byId = new Map(nodes.map((n) => [String(n.id), n]));
+  const unavailable: Array<Record<string, unknown>> = [];
+  const reclassifiedIds = new Set<string>();
+
+  for (const flag of staleFlags) {
+    if (flag?.id == null || flag.type !== "LoadImage") continue;
+    const node = byId.get(String(flag.id));
+    if (!node || node.type !== "LoadImage" || node.linkedInputs.has("image")) continue;
+    const def = Object.hasOwn(objectInfo, "LoadImage") ? objectInfo.LoadImage : undefined;
+    const specs = inputSpecsOf(def);
+    const options = comboOptions(specs.image);
+    if (!options || !Object.hasOwn(node.widgets, "image")) continue;
+    const value = node.widgets.image;
+    if (typeof value !== "string" || value === "") continue;
+    if (options.includes(value)) continue;
+
+    unavailable.push({
+      id: node.id,
+      type: "LoadImage",
+      widget: "image",
+      value,
+      option_count: options.length,
+      kind: options.length === 0 || optionsLookLikeFiles(options) ? "missing_asset" : "invalid_value",
+      source: "orchestrator_completion",
+    });
+    reclassifiedIds.add(String(flag.id));
+  }
+
+  return { unavailable, reclassifiedIds };
 }
 
 function mergeUnavailable(
@@ -584,9 +650,10 @@ function sameViewingIdentity(
 }
 
 /**
- * After a budget-exhausted graph_get_errors, finish leftover combo checks from
- * one batched object_info + bounded targeted graph_query pages, then present completeness
- * honestly. Never throws: a failed follow-up still returns the incomplete audit.
+ * After a graph_get_errors, finish retryable combo checks and stale LoadImage
+ * reclassification from one batched object_info + bounded targeted graph_query
+ * pages, then present completeness honestly. Never throws: a failed follow-up
+ * leaves the original audit untouched.
  *
  * A payload the panel already finished still goes through presentGetErrorsAudit.
  * Completeness is not consistency: `errored_count: 0` plus a translated
@@ -602,7 +669,8 @@ export async function completeGetErrorsAudit(
 ): Promise<GetErrorsToolResult> {
   const payload = parseToolResultJson(res);
   if (!payload) return res;
-  if (!isGetErrorsAuditIncomplete(payload)) {
+  const staleLoadImageFlags = asStaleFlags(payload).filter((entry) => entry?.type === "LoadImage");
+  if (!isGetErrorsAuditIncomplete(payload) && staleLoadImageFlags.length === 0) {
     return rewriteTextPayload(res, presentGetErrorsAudit(payload));
   }
 
@@ -610,15 +678,24 @@ export async function completeGetErrorsAudit(
   const leftoverIds = [
     ...new Set(leftover.map((e) => e.id).filter((id) => id != null)),
   ];
+  const staleLoadImageIds = staleLoadImageFlags
+    .map((entry) => entry.id)
+    .filter((id) => id != null);
+  const candidateIds = [
+    ...new Map(
+      [...leftoverIds, ...staleLoadImageIds]
+        .filter((id) => id != null)
+        .map((id) => [String(id), id] as const),
+    ).values(),
+  ];
 
-  if (leftoverIds.length > 0) {
+  if (candidateIds.length > 0) {
     // graph_query has no cursor/offset, and a single detail reply can be cut by
     // max_chars even when its limit is high. Page by explicit ids so every normal
     // 50-node workflow gets a complete detail read within one bounded follow-up
     // pass. A truncated page stays wholly unchecked below; it must never silently
     // retire only the rows that happened to fit in the reply.
     const deadlineAt = Date.now() + Math.max(0, timeoutMs);
-    const queryIds = leftoverIds.slice(0, LIMIT_CEILING);
     const infoRead = await followUpJson(
       ctx,
       { cmd: "graph_get_object_info" },
@@ -630,7 +707,7 @@ export async function completeGetErrorsAudit(
     const objectInfo = infoReply ? objectInfoFromReply(infoReply) : null;
     const queryReads: Array<{ ids: unknown[]; read: FollowUpRead }> = [];
     if (objectInfo && infoRead.stayedOnPrimaryTab) {
-      for (const ids of chunks(queryIds, GET_ERRORS_QUERY_PAGE_SIZE)) {
+      for (const ids of chunks(candidateIds.slice(0, LIMIT_CEILING), GET_ERRORS_QUERY_PAGE_SIZE)) {
         const read = await followUpJson(
           ctx,
           {
@@ -649,7 +726,7 @@ export async function completeGetErrorsAudit(
       }
     }
     const incompletePageIds = new Set(
-      leftoverIds.slice(LIMIT_CEILING).map((id) => String(id)),
+      candidateIds.slice(LIMIT_CEILING).map((id) => String(id)),
     );
     const nodes = queryReads.flatMap(({ ids, read }) => {
       if (queryReplyWasTruncated(read.payload)) {
@@ -666,6 +743,14 @@ export async function completeGetErrorsAudit(
     if (sameGraph && objectInfo && nodes.length > 0) {
       const judgeable = leftover.filter((entry) => !incompletePageIds.has(String(entry.id)));
       const judged = judgeLeftoverCombos(judgeable, nodes, objectInfo);
+      const judgeableStaleLoadImages = staleLoadImageFlags.filter(
+        (entry) => !incompletePageIds.has(String(entry.id)),
+      );
+      const judgedStaleLoadImages = judgeStaleLoadImages(
+        judgeableStaleLoadImages,
+        nodes,
+        objectInfo,
+      );
       // Non-retryable abstentions (the probe cap, a failed lookup, an unenumerable
       // path the panel already disclosed) stay; retryable leftovers are replaced by
       // whatever this pass still could not judge.
@@ -686,8 +771,19 @@ export async function completeGetErrorsAudit(
         delete payload.unchecked_budget_exhausted;
         delete payload.unchecked_class_limit;
       }
-      if (judged.unavailable.length) {
-        const merged = mergeUnavailable(payload.unavailable_widget_values, judged.unavailable);
+      if (judgedStaleLoadImages.reclassifiedIds.size > 0) {
+        const remainingStaleFlags = asStaleFlags(payload).filter(
+          (entry) => !judgedStaleLoadImages.reclassifiedIds.has(String(entry.id)),
+        );
+        if (remainingStaleFlags.length > 0) payload.stale_flags = remainingStaleFlags;
+        else delete payload.stale_flags;
+      }
+      const completionUnavailable = [
+        ...judged.unavailable,
+        ...judgedStaleLoadImages.unavailable,
+      ];
+      if (completionUnavailable.length) {
+        const merged = mergeUnavailable(payload.unavailable_widget_values, completionUnavailable);
         const added = merged.length - (Array.isArray(payload.unavailable_widget_values)
           ? (payload.unavailable_widget_values as unknown[]).length
           : 0);
@@ -699,10 +795,9 @@ export async function completeGetErrorsAudit(
         if (added > 0) {
           payload.unavailable_widget_values_note =
             `LIVE SCAN + ORCHESTRATOR COMPLETION: ${merged.length} widget value(s) the server ` +
-            `does not offer, ${added} of them judged after the panel's scan ran out of budget, ` +
-            `from one batched /object_info read and marked source:"orchestrator_completion". ` +
-            `Values on an UPLOAD input that the combo list cannot enumerate were NOT judged ` +
-            `here — those stay in unchecked_nodes.`;
+            `does not offer, ${added} of them judged from one fresh /object_info read and ` +
+            `same-view graph detail read; entries added here are marked ` +
+            `source:"orchestrator_completion".`;
         }
       }
       payload.audit_completed_by = "orchestrator";


### PR DESCRIPTION
## Summary
- Reclassify stale LoadImage.image entries as actionable unavailable widget/media findings when a fresh /object_info combo list omits the saved value.
- Require same-view graph detail plus schema proof, including nested-subgraph viewing identity, and preserve stale/reconnect semantics on failed or mismatched follow-ups.
- Add registered panel_get_errors regression coverage and changelog entry.

## Validation
- npm.cmd run test:vitest -- src/__tests__/orchestrator/get-errors-call-budget.test.ts
- npm.cmd run test:vitest -- src/__tests__/orchestrator/get-errors-call-budget.test.ts src/__tests__/orchestrator/get-errors-ack-budget.test.ts src/__tests__/orchestrator/get-errors-concurrent-reads.test.ts src/__tests__/orchestrator/panel-tools.test.ts
- npm.cmd run build
- npm.cmd run lint
- npm.cmd test
- node scripts/check-changelog.mjs

Closes #2587