### PR TITLE
fix(2517): don't report a clear as failed when the queue verifiably holds no pending jobs

### DIFF
--- a/src/__tests__/services/queue-manager-escalation.test.ts
+++ b/src/__tests__/services/queue-manager-escalation.test.ts
@@ -29,7 +29,9 @@ const queueBehavior = vi.hoisted(() => ({
     | "gapped-then-wedged"
     | "gapped-final-wedged"
     | "target-clears-other-starts"
-    | "stops-on-interrupt",
+    | "stops-on-interrupt"
+    | "idle"
+    | "idle-with-pending",
   calls: 0,
   freeFails: false,
   clearFails: false,
@@ -121,6 +123,16 @@ vi.mock("../../comfyui/client.js", () => ({
     // /free escalation went out between the two.
     if (queueBehavior.mode === "clears-after-free" && queueBehavior.calls >= 4) {
       return { queue_running: [], queue_pending: [] };
+    }
+    // Idle at EVERY read: nothing running, nothing pending (#2517 — cancel
+    // with clear_pending against this queue, and the clear request fails).
+    if (queueBehavior.mode === "idle") {
+      return { queue_running: [], queue_pending: [] };
+    }
+    // Nothing running, but pending jobs ARE queued and the clear cannot
+    // remove them — the case where a failed clear IS a real failure.
+    if (queueBehavior.mode === "idle-with-pending") {
+      return { queue_running: [], queue_pending: [[2, "prompt-abc"]] };
     }
     return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
   },
@@ -328,6 +340,49 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
       queueBehavior.clearFails = true;
       const res = await cancelRunningJobEscalating({ clear_pending: true });
       expect(res.unverified).toBe(true);
+      expect(res.pending_cleared).toBeUndefined();
+      expect(res.message).toMatch(/Clearing pending jobs FAILED/);
+      expect(res.message).not.toMatch(/Pending jobs were cleared/);
+    },
+  );
+
+  it(
+    "an idle queue is not told pending jobs FAILED to clear when the request fails (#2517)",
+    { timeout: 20000 },
+    async () => {
+      // Nothing running, nothing pending — and the clear REQUEST still fails.
+      // The queue the same call just read holds no pending jobs, so "they may
+      // still be queued" is a contradiction, not a caution: the goal the clear
+      // was for is verifiably settled, and the result must read as a clean
+      // no-op rather than an unsettled failure.
+      queueBehavior.mode = "idle";
+      queueBehavior.clearFails = true;
+      const res = await cancelRunningJobEscalating({ clear_pending: true });
+      expect(res.target_state).toBe("stopped");
+      expect(res.pending_clear_failed).toBeUndefined();
+      expect(res.pending_cleared).toBeUndefined();
+      expect(res.message).toMatch(/No job is running\./);
+      // The failed request is still disclosed — honestly, and in present tense.
+      expect(res.message).toMatch(/clear request failed/);
+      expect(res.message).toMatch(/no pending jobs/);
+      expect(res.message).not.toMatch(/FAILED/);
+      expect(res.message).not.toMatch(/may still be queued/);
+      expect(res.message).not.toMatch(/Pending jobs were cleared/);
+    },
+  );
+
+  it(
+    "a clear that fails with pending jobs STILL queued is still a failure (control)",
+    { timeout: 20000 },
+    async () => {
+      // The inverse, which is how the #2517 fix could overshoot: nothing is
+      // running, but the pending backlog IS there and the clear did not
+      // remove it. That remains a real failure.
+      queueBehavior.mode = "idle-with-pending";
+      queueBehavior.clearFails = true;
+      const res = await cancelRunningJobEscalating({ clear_pending: true });
+      expect(res.target_state).toBe("stopped");
+      expect(res.pending_clear_failed).toBe(true);
       expect(res.pending_cleared).toBeUndefined();
       expect(res.message).toMatch(/Clearing pending jobs FAILED/);
       expect(res.message).not.toMatch(/Pending jobs were cleared/);

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -427,9 +427,11 @@ export interface EscalatedCancelResult {
    *  - "unknown" — /queue could not be read, so neither is established.
    */
   target_state: "stopped" | "running" | "unknown";
-  /** clear_pending was asked for and the clear did not complete — the pending
-   *  jobs may still be queued. Distinct from `pending_cleared: undefined`,
-   *  which is also what "clear_pending was never requested" looks like. */
+  /** clear_pending was asked for and the clear left pending jobs possibly
+   *  still queued. Distinct from `pending_cleared: undefined`, which is also
+   *  what "clear_pending was never requested" looks like. A failed REQUEST
+   *  over a queue a live read shows holds no pending jobs is not this — the
+   *  goal the clear was for is settled (#2517). */
   pending_clear_failed?: boolean;
   pending_cleared?: number; // how many pending jobs were dropped (if clear_pending)
   running_prompt_id?: string;
@@ -463,14 +465,6 @@ export async function cancelRunningJobEscalating(opts: {
     // failed request is a confident false statement.
     pending_cleared = clearPendingFailed ? undefined : before?.pending;
   }
-  // The pending half of every verdict message, true to what actually happened.
-  const pendingNote = !opts.clear_pending
-    ? `Pending jobs were NOT cleared — pass clear_pending:true or call queue (action:"clear").`
-    : clearPendingFailed
-      ? `Clearing pending jobs FAILED — they may still be queued; check queue (action:"list").`
-      : pending_cleared != null
-        ? `Pending jobs were cleared (${pending_cleared}).`
-        : `Pending jobs were cleared.`;
 
   // Identify the job we're trying to stop so we can verify it actually clears.
   // unknown-ok: null makes targetSeenRunning false, and "interrupted" is only
@@ -483,6 +477,22 @@ export async function cancelRunningJobEscalating(opts: {
     ? !!pre?.running_jobs.some((j) => j.prompt_id === opts.prompt_id)
     : !!pre && pre.running > 0;
 
+  // A clear whose REQUEST failed is only a real failure when pending jobs may
+  // still be queued: a live read showing none settles the goal the clear was
+  // for (#2517 — an idle queue was told "clearing FAILED" its own verified
+  // empty list disproved one poll later).
+  const pendingClearFailed = clearPendingFailed && (!pre || pre.pending > 0);
+  // The pending half of every verdict message, true to what actually happened.
+  const pendingNote = !opts.clear_pending
+    ? `Pending jobs were NOT cleared — pass clear_pending:true or call queue (action:"clear").`
+    : pendingClearFailed
+      ? `Clearing pending jobs FAILED — they may still be queued; check queue (action:"list").`
+      : clearPendingFailed
+        ? `The clear request failed, but /queue now shows no pending jobs.`
+        : pending_cleared != null
+          ? `Pending jobs were cleared (${pending_cleared}).`
+          : `Pending jobs were cleared.`;
+
   if (pre && pre.running === 0 && !opts.prompt_id) {
     return {
       interrupted: false,
@@ -490,7 +500,7 @@ export async function cancelRunningJobEscalating(opts: {
       freed_vram: false,
       wedged: false,
       target_state: "stopped",
-      pending_clear_failed: clearPendingFailed || undefined,
+      pending_clear_failed: pendingClearFailed || undefined,
       pending_cleared,
       message: `No job is running.${opts.clear_pending ? ` ${pendingNote}` : ""}`,
     };
@@ -502,7 +512,7 @@ export async function cancelRunningJobEscalating(opts: {
       freed_vram: false,
       wedged: false,
       target_state: "stopped",
-      pending_clear_failed: clearPendingFailed || undefined,
+      pending_clear_failed: pendingClearFailed || undefined,
       pending_cleared,
       message:
         `${opts.prompt_id} is not running (verified via /queue) — nothing to interrupt.` +
@@ -525,7 +535,7 @@ export async function cancelRunningJobEscalating(opts: {
         wedged: false,
         unverified: true,
         target_state: "stopped",
-        pending_clear_failed: clearPendingFailed || undefined,
+        pending_clear_failed: pendingClearFailed || undefined,
         pending_cleared,
         running_prompt_id: runningId,
         message:
@@ -541,7 +551,7 @@ export async function cancelRunningJobEscalating(opts: {
       freed_vram: false,
       wedged: false,
       target_state: "stopped",
-      pending_clear_failed: clearPendingFailed || undefined,
+      pending_clear_failed: pendingClearFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,
       message: `Interrupted the running job${runningId ? ` (${runningId})` : ""}.${
@@ -656,7 +666,7 @@ export async function cancelRunningJobEscalating(opts: {
       wedged: false,
       unverified: stopVerified ? undefined : true,
       target_state: "stopped",
-      pending_clear_failed: clearPendingFailed || undefined,
+      pending_clear_failed: pendingClearFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,
       message,
@@ -683,7 +693,7 @@ export async function cancelRunningJobEscalating(opts: {
       wedged: false,
       unverified: true,
       target_state: "unknown",
-      pending_clear_failed: clearPendingFailed || undefined,
+      pending_clear_failed: pendingClearFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,
       message:
@@ -719,7 +729,7 @@ export async function cancelRunningJobEscalating(opts: {
       // is what the message below already says. Calling that "running" would
       // make the field claim the identity the prose disclaims (codex gate).
       target_state: opts.prompt_id ? "running" : "unknown",
-      pending_clear_failed: clearPendingFailed || undefined,
+      pending_clear_failed: pendingClearFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,
       message:
@@ -743,7 +753,7 @@ export async function cancelRunningJobEscalating(opts: {
     freed_vram: freedVram,
     wedged: true,
     target_state: "running",
-    pending_clear_failed: clearPendingFailed || undefined,
+    pending_clear_failed: pendingClearFailed || undefined,
     pending_cleared,
     running_prompt_id: runningId,
     message:


### PR DESCRIPTION
Calling `queue` with `action:"cancel"` and `clear_pending:true` on an idle queue could answer "No job is running. Clearing pending jobs FAILED — they may still be queued; check queue (action:list)" — while `queue action:list` and the panel both showed 0 running / 0 pending.

Root cause: `cancelRunningJobEscalating` marked the clear as failed whenever the POST /queue {clear:true} request threw, and built the "FAILED — they may still be queued" note before the live queue read that same call makes next. On an idle queue the request can fail transiently while the verified read shows nothing pending, so the two halves of the response contradicted each other — and `pending_clear_failed` made the tool layer return it as an error.

Fix: a failed clear request is only a real failure when pending jobs may actually remain. A live post-clear read showing none settles the goal the clear was for, so the message becomes "The clear request failed, but /queue now shows no pending jobs." with no `pending_clear_failed`, and the tool answers a clean success. A clear that fails with the backlog still present keeps the FAILED verdict and the error.

Verified with two new tests in queue-manager-escalation.test.ts (idle + failing clear; idle-with-pending + failing clear as a control against overshoot), the existing escalation suite (25 tests), the queue tool tests (27), and the remaining queue-manager/queue-monitor suites (63).

Fixes #2517
