### PR TITLE
fix(2494): do not error a successful open on ue_properties/widget representation diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - panel_set_widget settles a missing ACK on a Power Lora lora_N row with a graph read-back instead of reporting outcome-unknown for a row that already landed (#2495)
+- panel_open_workflow does not report a successful tab switch as an error when only frontend-owned ue_properties / widget representations differ, including a live serialize that omits nested subgraph definitions (#2494)
 
 ## [0.52.157] - 2026-08-30
 

--- a/src/__tests__/orchestrator/open-normalized-properties-widgets.test.ts
+++ b/src/__tests__/orchestrator/open-normalized-properties-widgets.test.ts
@@ -1,0 +1,337 @@
+// #2494 — panel_open_workflow switched to an already-open workflow, proved
+// identity, and then reported Error because per-node ue_properties / widget
+// representations differed after frontend configure. A later graph_outline
+// showed the same node ids/types. A successful tab switch with only
+// frontend-owned bags rewritten is not an unknown open.
+//
+// Tests drive panel_open_workflow. Dest file comes through the same userdata
+// read that handler uses; live canvas comes from graph_serialize. Matcher
+// cases pin openLiveMatchesDestAfterReconnect (the handler-used additive
+// matcher) so a later wiring change cannot pass by skipping dest-vs-live.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import {
+  openLiveMatchesDestAfterReconnect,
+  openLiveMatchesDestContent,
+} from "../../orchestrator/open-identity-normalization.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const destByKey = new Map<string, Record<string, unknown>>();
+
+vi.mock("../../services/userdata-library.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/userdata-library.js")>();
+  return {
+    ...actual,
+    userdataFetch: async (route: string) => {
+      for (const [key, graph] of destByKey) {
+        if (route.includes(encodeURIComponent(key)) || route.includes(key)) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(graph),
+          } as Response;
+        }
+      }
+      throw new Error(`no dest fixture for ${route}`);
+    },
+  };
+});
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+
+const TAB = "wf:workflows/ue.json";
+const PATH = "workflows/ue.json";
+const LIVE = "77777777-7777-4777-8777-777777777777";
+const PRIOR = "11111111-1111-4111-8111-111111111111";
+const SG_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const PROMPT = "a cinematic portrait of a woman in gold light";
+
+const UE_ONLY =
+  `workflow_open RAN and the canvas IS bound to ${PATH} — that much was proven — but the graph ` +
+  `on it does not match the state that was loaded, and every node that was loaded is on it with ` +
+  `the same id and type, and nothing extra appeared — no node was lost. What differs is per-node ` +
+  `(properties, widgets_values_named); within properties, the keys that differ are: ue_properties. ` +
+  `You are on the right workflow. You are NOT on the wrong workflow: ${PATH} IS the active one. ` +
+  `This reply carries NO fence refresh.`;
+
+const DEST_UE = {
+  widget_ue_connectable: {},
+  input_ue_unconnectable: {},
+};
+const LIVE_UE = {
+  widget_ue_connectable: {},
+  input_ue_unconnectable: {},
+  version: "7.8",
+};
+
+function destGraph(opts?: { prompt?: string; extraNode?: Record<string, unknown> }) {
+  const prompt = opts?.prompt ?? PROMPT;
+  const nodes: Array<Record<string, unknown>> = [
+    {
+      id: 1,
+      type: "CLIPTextEncode",
+      properties: { ue_properties: DEST_UE },
+      widgets_values: [prompt],
+      widgets_values_named: { text: prompt, clip: "" },
+    },
+    { id: 2, type: SG_ID, widgets_values: [] },
+    {
+      id: 3,
+      type: "SaveImage",
+      widgets_values: ["out"],
+      widgets_values_named: { filename_prefix: "out" },
+    },
+  ];
+  if (opts?.extraNode) nodes.push(opts.extraNode);
+  return {
+    nodes,
+    links: [
+      [1, 1, 0, 2, 0, "CONDITIONING"],
+      [2, 2, 0, 3, 0, "IMAGE"],
+    ],
+    extra: { comfyui_mcp: { workflow_path: PATH, workflow_uuid: LIVE } },
+    definitions: {
+      subgraphs: [
+        {
+          id: SG_ID,
+          name: "Inner",
+          nodes: [
+            {
+              id: 10,
+              type: "KSampler",
+              properties: { ue_properties: DEST_UE },
+              widgets_values: [123, "randomize", 20],
+              widgets_values_named: { seed: 123, control_after_generate: "randomize", steps: 20 },
+            },
+          ],
+          links: [],
+        },
+      ],
+    },
+  };
+}
+
+function liveGraph(opts?: { prompt?: string; omitDefinitions?: boolean }) {
+  const prompt = opts?.prompt ?? PROMPT;
+  const graph: Record<string, unknown> = {
+    nodes: [
+      {
+        id: 1,
+        type: "CLIPTextEncode",
+        size: [280, 140],
+        properties: { ue_properties: LIVE_UE, "Node name for S&R": "CLIPTextEncode" },
+        widgets_values: [prompt],
+        widgets_values_named: { text: prompt },
+      },
+      { id: 2, type: SG_ID, widgets_values: [] },
+      {
+        id: 3,
+        type: "SaveImage",
+        widgets_values: ["out", "extra-frontend-slot"],
+        widgets_values_named: { filename_prefix: "out", extra: "frontend" },
+      },
+    ],
+    links: [
+      [1, 1, 0, 2, 0, "CONDITIONING"],
+      [2, 2, 0, 3, 0, "IMAGE"],
+    ],
+    extra: { comfyui_mcp: { workflow_path: PATH, workflow_uuid: LIVE } },
+  };
+  if (!opts?.omitDefinitions) {
+    graph.definitions = {
+      subgraphs: [
+        {
+          id: SG_ID,
+          name: "Inner",
+          nodes: [
+            {
+              id: 10,
+              type: "KSampler",
+              properties: { ue_properties: LIVE_UE },
+              widgets_values: [123, "randomize", 20, 7.5],
+              widgets_values_named: {
+                seed: 123,
+                control_after_generate: "randomize",
+                steps: 20,
+                cfg: 7.5,
+              },
+            },
+          ],
+          links: [],
+        },
+      ],
+    };
+  }
+  return graph;
+}
+
+type GraphQuery = "answers" | "mismatch";
+
+function bridge(opts: { live: Record<string, unknown>; graphQuery: GraphQuery }) {
+  const calls: string[] = [];
+  let stamp: string | undefined = PRIOR;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      if (cmd.cmd === "workflow_list") {
+        const active = { path: PATH, routing_key: `wf:${PATH}`, workflow_uuid: LIVE };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      if (cmd.cmd === "workflow_open") throw new Error(UE_ONLY);
+      if (cmd.cmd === "graph_query") {
+        if (opts.graphQuery === "mismatch") {
+          throw new Error(
+            `workflow instance mismatch: issued for workflow instance ${PRIOR} but canvas is ${LIVE}`,
+          );
+        }
+        return { ids: [1, 2, 3], node_count: 3 };
+      }
+      if (cmd.cmd === "graph_serialize") {
+        return { workflow: opts.live, node_count: 3 };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "ue", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_t: string, uuid: string) => {
+      calls.push(`adopt:${uuid}`);
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: Boolean(stamp), uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as PanelToolCtx["bridge"];
+  return { b, calls, stampOf: () => stamp };
+}
+
+type QueueMonitorIdle = { state: { runningPromptId: string | null } };
+
+function setQueueIdle(): void {
+  (QueueMonitor as QueueMonitorIdle).state.runningPromptId = null;
+}
+
+beforeEach(() => {
+  destByKey.clear();
+  setQueueIdle();
+});
+
+afterEach(() => {
+  destByKey.clear();
+  setQueueIdle();
+});
+
+async function openWorkflow(opts: {
+  dest: Record<string, unknown>;
+  live: Record<string, unknown>;
+  graphQuery: GraphQuery;
+}) {
+  destByKey.set(PATH, opts.dest);
+  const { b, calls, stampOf } = bridge({ live: opts.live, graphQuery: opts.graphQuery });
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow");
+  if (!def) throw new Error("panel_open_workflow is not registered");
+  const res: ToolResult = await def.handler({ path: PATH }, ctx);
+  return {
+    text: res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" "),
+    isError: res.isError === true,
+    calls,
+    stamp: stampOf(),
+  };
+}
+
+describe("openLiveMatchesDestAfterReconnect ignores frontend-owned ue_properties / widget representations (#2494)", () => {
+  it("matches when only ue_properties and named widget bags differ", () => {
+    expect(openLiveMatchesDestAfterReconnect(liveGraph(), destGraph())).toBe(true);
+  });
+
+  it("matches dest positional widgets against a live named-only serialize", () => {
+    const dest = {
+      nodes: [{ id: 1, type: "CLIPTextEncode", widgets_values: [PROMPT] }],
+      links: [],
+    };
+    const live = {
+      nodes: [{ id: 1, type: "CLIPTextEncode", widgets_values: { text: PROMPT } }],
+      links: [],
+    };
+    expect(openLiveMatchesDestContent(live, dest)).toBe(false);
+    expect(openLiveMatchesDestAfterReconnect(live, dest)).toBe(true);
+  });
+
+  it("matches when live serialize omits nested subgraph definitions", () => {
+    expect(openLiveMatchesDestContent(liveGraph({ omitDefinitions: true }), destGraph())).toBe(false);
+    expect(openLiveMatchesDestAfterReconnect(liveGraph({ omitDefinitions: true }), destGraph())).toBe(true);
+  });
+
+  it("does not match a dest widget value the live graph does not hold", () => {
+    expect(openLiveMatchesDestAfterReconnect(liveGraph({ prompt: "other prompt" }), destGraph())).toBe(false);
+  });
+});
+
+describe("panel_open_workflow ignores ue_properties / widget representation after a tab switch (#2494)", () => {
+  it("the reporter's case: identity-proven ue_properties mismatch of an already-open graph succeeds", async () => {
+    const { text, isError, calls, stamp } = await openWorkflow({
+      dest: destGraph(),
+      live: liveGraph(),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(false);
+    expect(calls).toContain("graph_serialize");
+    expect(stamp).toBe(LIVE);
+    expect(text).toMatch(/content_normalized/);
+    expect(text).toMatch(/Opened/);
+    expect(text).not.toMatch(/Treat the canvas as UNKNOWN/);
+    expect(text).not.toMatch(/PREVIOUS workflow/);
+  });
+
+  it("the same dest is accepted when the prior fence still answers", async () => {
+    const { isError, text } = await openWorkflow({
+      dest: destGraph(),
+      live: liveGraph(),
+      graphQuery: "answers",
+    });
+
+    expect(isError).toBe(false);
+    expect(text).toMatch(/content_normalized/);
+  });
+
+  it("an omitted live subgraph definition is still dest after a successful switch", async () => {
+    const { isError, text } = await openWorkflow({
+      dest: destGraph(),
+      live: liveGraph({ omitDefinitions: true }),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(false);
+    expect(text).toMatch(/content_normalized/);
+  });
+
+  it("a dest widget value the live graph does not hold stays unknown", async () => {
+    const { isError, text } = await openWorkflow({
+      dest: destGraph(),
+      live: liveGraph({ prompt: "the SOURCE prompt still on the previous graph" }),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(true);
+    expect(text).not.toMatch(/content_normalized/);
+  });
+
+  it("a dest node missing from the live canvas stays unknown", async () => {
+    const { isError, text } = await openWorkflow({
+      dest: destGraph({ extraNode: { id: 99, type: "Note", widgets_values: ["keep"] } }),
+      live: liveGraph(),
+      graphQuery: "mismatch",
+    });
+
+    expect(isError).toBe(true);
+    expect(text).not.toMatch(/content_normalized/);
+  });
+});

--- a/src/orchestrator/open-identity-normalization.ts
+++ b/src/orchestrator/open-identity-normalization.ts
@@ -507,15 +507,18 @@ export function openLiveMatchesDestContent(live: unknown, dest: unknown): boolea
 }
 
 /**
- * #2501 — dest vs live after reconnect, once identity and node id/type/link
- * topology already agree. The panel's post-restart serialize fills
- * inputs/outputs/properties and rewrites widgets_values / widgets_values_named
- * (envelopes, extra default slots, named-vs-positional). Those frontend-derived
- * bags are not a failed load.
+ * #2501 / #2494 — dest vs live after reconnect or an already-open tab switch,
+ * once identity and node id/type/link topology already agree. The panel's
+ * serialize fills inputs/outputs/properties and rewrites widgets_values /
+ * widgets_values_named (envelopes, extra default slots, named-vs-positional,
+ * ue_properties). Those frontend-derived bags are not a failed load.
  *
  * Additive to {@link openLiveMatchesDestContent}: named-first dest bags still
- * fail that matcher when live only holds positional/envelope widgets. Fail closed
- * on a missing node, a rewired link, or a dest widget value live does not hold.
+ * fail that matcher when live only holds positional/envelope widgets. A live
+ * serialize of an already-open tab can omit nested definitions while the root
+ * node set still matches — recurse only when the inner graph is present (#2494).
+ * Fail closed on a missing node, a rewired link, or a dest widget value live
+ * does not hold.
  */
 type FrontendWidgetAtom = string | number | boolean | null;
 type FrontendWidgetValue =
@@ -632,7 +635,10 @@ export function openLiveMatchesDestAfterReconnect(live: unknown, dest: unknown):
   if (!destSgs || !liveSgs) return false;
   for (const [id, destSg] of destSgs) {
     const liveSg = liveSgs.get(id);
-    if (!liveSg) return false;
+    // Live serialize of an already-open tab can omit nested definitions while
+    // the root node set still matches. Recurse only when the inner graph is
+    // actually present to compare (#2494).
+    if (!liveSg) continue;
     if (!openLiveMatchesDestAfterReconnect(liveSg, destSg)) return false;
   }
   return true;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10490,14 +10490,14 @@ function openedNormalizedContentResult(destPath: string): ToolResult {
 }
 
 /**
- * #1846 / #2501 — the panel's identity-proven CONTENT_UNVERIFIED reply is not
- * unknown when dest's structural content is already on the canvas.
+ * #1846 / #2501 / #2494 — the panel's identity-proven CONTENT_UNVERIFIED reply
+ * is not unknown when dest's structural content is already on the canvas.
  *
  * Fail closed: dest unreadable, a missing/extra node, a rewired link, or a dest
  * widget value the live graph does not hold leaves the panel error in place.
- * After reconnect, frontend-derived per-node bags (inputs/outputs/properties/
- * widgets_values representation) are accepted once identity, node id/type, and
- * link topology match (#2501).
+ * After reconnect or an already-open tab switch, frontend-derived per-node bags
+ * (inputs/outputs/properties/widgets_values representation, ue_properties) are
+ * accepted once identity, node id/type, and link topology match (#2501, #2494).
  */
 async function tryAcceptNormalizedOpenContent(
   ctx: PanelToolCtx,


### PR DESCRIPTION
Fixes #2494

`panel_open_workflow` switched to an already-open workflow and proved identity, then returned Error because dest-vs-live still treated frontend-owned per-node bags as unknown. The panel had already shown every loaded node present with the same id and type; a later `panel_graph_outline` returned the expected graph. The keys that moved were `ue_properties` and named widget representations.

## Fix

- Prefer dest's positional `widgets_values` over `widgets_values_named`. Named bags are frontend-owned, and requiring live to hold every dest named key is what false-failed the tab switch.
- Treat number/string widget values and `{name,value,type}` envelopes as the same content.
- Recurse into subgraph definitions only when live serializes them. An already-open tab can omit nested `definitions` while the root node set still matches.
- Schema fields (`properties`, including `ue_properties`) stay ignored, as before.

A dest widget value live does not hold, a missing dest node, or a rewired link still fails closed.

## Tests

`npx vitest run src/__tests__/orchestrator/open-normalized-properties-widgets.test.ts` — 9 passed.
`npx vitest run src/__tests__/orchestrator/open-definitions-rehydrate.test.ts src/__tests__/orchestrator/open-identity-normalization.test.ts src/__tests__/orchestrator/open-reconnect-false-mismatch.test.ts src/__tests__/orchestrator/open-content-mismatch-fence.test.ts src/__tests__/orchestrator/panel-load-workflow-outcome.test.ts` — related open/load matchers still pass.
`npx tsc --noEmit` — clean.
