### PR TITLE
fix(2495): settle an unacked Power Lora lora_N write with a graph read-back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- panel_set_widget settles a missing ACK on a Power Lora lora_N row with a graph read-back instead of reporting outcome-unknown for a row that already landed (#2495)
+
 ## [0.52.157] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/orchestrator/set-widget-power-lora-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/set-widget-power-lora-ack-timeout.test.ts
@@ -1,0 +1,262 @@
+// #2495 — panel_set_widget creating lora_1 on a freshly added Power Lora Loader
+// timed out after 90s even though the row had already been inserted. The next
+// lora_2 write and panel_query_graph both succeeded, so the caller received
+// outcome-unknown for a successful dynamic-widget mutation.
+//
+// The panel's refresh-before-validate wait lives in the other repo. This process
+// can still settle a tagged no-reply with ONE graph_query read-back and return
+// applied/refresh-pending instead of a mutating-delivery error.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+const OTHER_TAB = "99999999-8888-7777-6666-555555555555";
+const MUTATION_RID = "rid-set-widget-2495";
+const NODE_ID = 82;
+const LORA_VALUE =
+  '{"on":true,"lora":"subdir/turbo.safetensors","strength":1,"strengthTwo":null}';
+const LORA_OBJECT = {
+  on: true,
+  lora: "subdir/turbo.safetensors",
+  strength: 1,
+  strengthTwo: null,
+};
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ");
+
+const ackTimeout = (cmd: string, ms: number): Error =>
+  new Error(
+    `Panel tab ${TAB} did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be ` +
+      `backgrounded or frozen. This command MUTATES and was already delivered to the tab, so it ` +
+      `may have been applied despite the missing reply — check the current state before ` +
+      `re-issuing it; a blind retry can apply it twice`,
+  );
+
+let sent: Array<{ cmd: string; tabId?: string; widget?: unknown }> = [];
+
+function powerLoraDetail(widgets: Record<string, unknown> | undefined) {
+  return {
+    truncated: false,
+    viewing: { scope: "root" },
+    nodes: [
+      {
+        id: NODE_ID,
+        type: "Power Lora Loader (rgthree)",
+        is_subgraph: false,
+        widgets: widgets ?? {},
+        inputs: [],
+      },
+    ],
+  };
+}
+
+function bridge(opts: {
+  writeReply?: "timeout" | "acked-error" | "acked-error-timeout-worded" | "ok";
+  probeWidgets?: Record<string, unknown> | "timeout" | "missing";
+  loseTabAfterWrite?: boolean;
+}) {
+  let tabGone = false;
+  return {
+    send: async (
+      cmd: Record<string, unknown>,
+      o?: { timeoutMs?: number; tabId?: string; onDispatchedRid?: (rid: string) => void },
+    ) => {
+      sent.push({
+        cmd: String(cmd.cmd),
+        tabId: o?.tabId,
+        widget: cmd.widget,
+      });
+      if (cmd.cmd === "graph_set_widget") {
+        if (opts.writeReply === "acked-error") {
+          throw new Error('Cannot set widget "lora_1" on node 82: value is not a JSON object');
+        }
+        if (opts.writeReply === "acked-error-timeout-worded") {
+          throw new Error(
+            `Panel tab ${TAB} did not reply to "graph_set_widget" within 90000 ms — the ` +
+              `ComfyUI tab may be backgrounded or frozen. Reported by the widget writer: ` +
+              `nothing was applied.`,
+          );
+        }
+        if (opts.writeReply === "ok" || opts.writeReply === undefined) {
+          o?.onDispatchedRid?.(MUTATION_RID);
+          return {
+            set: { node_id: NODE_ID, widget: cmd.widget, previous: undefined, value: cmd.value },
+            created_widget: cmd.widget,
+          };
+        }
+        if (opts.loseTabAfterWrite) tabGone = true;
+        o?.onDispatchedRid?.(MUTATION_RID);
+        throw markReplyTimeout(ackTimeout("graph_set_widget", 90000));
+      }
+      if (cmd.cmd === "graph_query") {
+        if (opts.probeWidgets === "timeout") throw ackTimeout("graph_query", 8000);
+        if (opts.probeWidgets === "missing") return powerLoraDetail({});
+        return powerLoraDetail(opts.probeWidgets ?? { lora_1: LORA_OBJECT });
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => (tabGone ? id === OTHER_TAB : id === TAB),
+    isHeadless: () => false,
+    tabs: () =>
+      tabGone
+        ? [{ tab_id: OTHER_TAB, title: "other", connected_at: 0 }]
+        : [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => (tabGone ? OTHER_TAB : TAB),
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as PanelToolCtx["bridge"];
+}
+
+async function runSetWidget(
+  opts: Parameters<typeof bridge>[0],
+  args: Record<string, unknown> = { node_id: NODE_ID, widget: "lora_1", value: LORA_VALUE },
+): Promise<{ text: string; isError: boolean; boundTab: string; json: Record<string, unknown> | null }> {
+  const ctx = makePanelToolCtx(bridge(opts), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  if (!def) throw new Error("panel_set_widget is not registered");
+  const res: ToolResult = await def.handler(args as never, ctx);
+  const text = textOf(res);
+  let json: Record<string, unknown> | null = null;
+  try {
+    json = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    json = null;
+  }
+  return { text, isError: res.isError === true, boundTab: ctx.tabId, json };
+}
+
+beforeEach(() => {
+  sent = [];
+});
+
+describe("an unacknowledged Power Lora row write is settled by a read (#2495)", () => {
+  it("THE REPORTED CASE: times out after creating lora_1, then reports the row as applied", async () => {
+    const out = await runSetWidget({
+      writeReply: "timeout",
+      probeWidgets: { lora_1: LORA_OBJECT },
+    });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(out.isError).toBe(false);
+    expect(out.json).toMatchObject({
+      applied: true,
+      acknowledged: false,
+      refresh_pending: true,
+      created_widget: "lora_1",
+      mutation_id: MUTATION_RID,
+    });
+    expect(out.text).toMatch(/CHECKED FOR YOU/);
+    expect(out.text).toMatch(/not evidence the write failed/);
+    expect(out.text).not.toMatch(/a blind retry can apply it twice/);
+  });
+
+  it("reports the write as NOT applied when the node has no lora_1 row", async () => {
+    const out = await runSetWidget({ writeReply: "timeout", probeWidgets: "missing" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(out.isError).toBe(true);
+    expect(out.json).toMatchObject({
+      applied: false,
+      acknowledged: false,
+      mutation_id: MUTATION_RID,
+    });
+    expect(out.text).toMatch(/does NOT/);
+    expect(out.text).toMatch(/lora_1/);
+  });
+
+  it("reports the write as NOT applied when the live row does not match the request", async () => {
+    const out = await runSetWidget({
+      writeReply: "timeout",
+      probeWidgets: { lora_1: { on: true, lora: "other.safetensors", strength: 0.2 } },
+    });
+
+    expect(out.isError).toBe(true);
+    expect(out.json).toMatchObject({ applied: false, mutation_id: MUTATION_RID });
+    expect(out.text).toMatch(/does NOT/);
+  });
+
+  it("returns a mutation receipt when the settling read itself cannot answer", async () => {
+    const out = await runSetWidget({ writeReply: "timeout", probeWidgets: "timeout" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/may have been applied despite the missing reply/);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+    expect(out.text).toMatch(/Do not guess/);
+  });
+
+  it("does not second-guess an ACKED executor error", async () => {
+    const out = await runSetWidget({ writeReply: "acked-error" });
+
+    expect(sent.map((s) => s.cmd)).not.toContain("graph_query");
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/not a JSON object/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/mutation_id/);
+  });
+
+  it("does not settle an ACKED error reproducing the canonical sentence VERBATIM", async () => {
+    const out = await runSetWidget({ writeReply: "acked-error-timeout-worded" });
+
+    expect(out.text).toMatch(
+      /did not reply to "graph_set_widget" within 90000 ms — the ComfyUI tab may be backgrounded or frozen/,
+    );
+    expect(sent.map((s) => s.cmd)).not.toContain("graph_query");
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/nothing was applied/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+
+  it("claims nothing when the probe lands on a DIFFERENT tab", async () => {
+    const out = await runSetWidget({
+      writeReply: "timeout",
+      probeWidgets: { lora_1: LORA_OBJECT },
+      loseTabAfterWrite: true,
+    });
+
+    expect(out.boundTab).toBe(OTHER_TAB);
+    expect(sent.some((s) => s.cmd === "graph_query")).toBe(true);
+    expect(out.isError).toBe(true);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/"applied": true/);
+    expect(out.text).toMatch(/"applied": "unknown"/);
+    expect(out.text).toMatch(new RegExp(`"mutation_id": "${MUTATION_RID}"`));
+  });
+
+  it("does not take a graph read on a successful ACK", async () => {
+    const out = await runSetWidget({ writeReply: "ok" });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget"]);
+    expect(out.isError).toBe(false);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+    expect(out.text).not.toMatch(/refresh_pending/);
+  });
+
+  it("does not settle an ordinary non-lora widget timeout", async () => {
+    const out = await runSetWidget(
+      { writeReply: "timeout", probeWidgets: { lora_1: LORA_OBJECT } },
+      { node_id: NODE_ID, widget: "steps", value: 30 },
+    );
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/may have been applied despite the missing reply/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
+  });
+});

--- a/src/__tests__/orchestrator/set-widget-power-lora-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/set-widget-power-lora-ack-timeout.test.ts
@@ -46,14 +46,17 @@ const ackTimeout = (cmd: string, ms: number): Error =>
 
 let sent: Array<{ cmd: string; tabId?: string; widget?: unknown }> = [];
 
-function powerLoraDetail(widgets: Record<string, unknown> | undefined) {
+function powerLoraDetail(
+  widgets: Record<string, unknown> | undefined,
+  type = "Power Lora Loader (rgthree)",
+) {
   return {
     truncated: false,
     viewing: { scope: "root" },
     nodes: [
       {
         id: NODE_ID,
-        type: "Power Lora Loader (rgthree)",
+        type,
         is_subgraph: false,
         widgets: widgets ?? {},
         inputs: [],
@@ -65,6 +68,7 @@ function powerLoraDetail(widgets: Record<string, unknown> | undefined) {
 function bridge(opts: {
   writeReply?: "timeout" | "acked-error" | "acked-error-timeout-worded" | "ok";
   probeWidgets?: Record<string, unknown> | "timeout" | "missing";
+  probeType?: string;
   loseTabAfterWrite?: boolean;
 }) {
   let tabGone = false;
@@ -102,8 +106,8 @@ function bridge(opts: {
       }
       if (cmd.cmd === "graph_query") {
         if (opts.probeWidgets === "timeout") throw ackTimeout("graph_query", 8000);
-        if (opts.probeWidgets === "missing") return powerLoraDetail({});
-        return powerLoraDetail(opts.probeWidgets ?? { lora_1: LORA_OBJECT });
+        if (opts.probeWidgets === "missing") return powerLoraDetail({}, opts.probeType);
+        return powerLoraDetail(opts.probeWidgets ?? { lora_1: LORA_OBJECT }, opts.probeType);
       }
       return { ok: true };
     },
@@ -209,6 +213,20 @@ describe("an unacknowledged Power Lora row write is settled by a read (#2495)", 
     expect(out.text).toMatch(/not a JSON object/);
     expect(out.text).not.toMatch(/CHECKED FOR YOU/);
     expect(out.text).not.toMatch(/mutation_id/);
+  });
+
+  it("does not settle a same-named row on a different node type", async () => {
+    const out = await runSetWidget({
+      writeReply: "timeout",
+      probeWidgets: { lora_1: LORA_OBJECT },
+      probeType: "Some Other Loader",
+    });
+
+    expect(sent.map((s) => s.cmd)).toEqual(["graph_set_widget", "graph_query"]);
+    expect(out.isError).toBe(true);
+    expect(out.text).toMatch(/\"applied\": \"unknown\"/);
+    expect(out.text).toMatch(/Do not guess/);
+    expect(out.text).not.toMatch(/CHECKED FOR YOU/);
   });
 
   it("does not settle an ACKED error reproducing the canonical sentence VERBATIM", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4103,7 +4103,7 @@ function powerLoraValuesMatch(requested: unknown, observed: unknown): boolean {
 function powerLoraWidgetsFromProbe(
   res: ToolResult,
   nodeId: unknown,
-): Record<string, unknown> | null {
+): { type: string; widgets: Record<string, unknown> } | null {
   const payload = normalizeGraphQueryResult(res);
   if (
     Object.prototype.hasOwnProperty.call(payload, "truncated") &&
@@ -4113,13 +4113,22 @@ function powerLoraWidgetsFromProbe(
   }
   const requestedId = canonicalQueriedNodeId(nodeId);
   const detail = parseVerifiedQueriedNodeDetail(payload);
-  if (detail && requestedId && detail.id === requestedId) return detail.widgets;
+  if (
+    detail &&
+    requestedId &&
+    detail.id === requestedId &&
+    detail.widgets &&
+    /\bPower Lora Loader\b/i.test(detail.type)
+  ) {
+    return { type: detail.type, widgets: detail.widgets };
+  }
   if (!Array.isArray(payload.nodes) || payload.nodes.length !== 1) return null;
   const identity = parseQueriedNodeIdentityRow(payload.nodes[0]);
   if (!identity || !requestedId || identity.id !== requestedId) return null;
   const widgets = (payload.nodes[0] as Record<string, unknown>).widgets;
   if (!widgets || typeof widgets !== "object" || Array.isArray(widgets)) return null;
-  return widgets as Record<string, unknown>;
+  if (!/\bPower Lora Loader\b/i.test(identity.type)) return null;
+  return { type: identity.type, widgets: widgets as Record<string, unknown> };
 }
 
 async function readPowerLoraNodeFromTab(
@@ -4181,9 +4190,9 @@ async function settlePowerLoraWidgetAfterAckTimeout(
   if (probeOnSessionTab && ctx.tabId !== dispatchTab) {
     return powerLoraTimeoutUnknown(timedOut, widget, requested, mutationId);
   }
-  const widgets = powerLoraWidgetsFromProbe(probe, nodeId);
-  if (widgets === null || !Object.prototype.hasOwnProperty.call(widgets, widget)) {
-    if (probe.isError || widgets === null) {
+  const node = powerLoraWidgetsFromProbe(probe, nodeId);
+  if (node === null || !Object.prototype.hasOwnProperty.call(node.widgets, widget)) {
+    if (probe.isError || node === null) {
       return powerLoraTimeoutUnknown(timedOut, widget, requested, mutationId);
     }
     return {
@@ -4209,7 +4218,7 @@ async function settlePowerLoraWidgetAfterAckTimeout(
       ],
     };
   }
-  const observed = widgets[widget];
+  const observed = node.widgets[widget];
   if (!powerLoraValuesMatch(requested, observed)) {
     return {
       isError: true,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4027,6 +4027,227 @@ async function settleSetTodoAfterAckTimeout(
   };
 }
 
+// ---- panel_set_widget Power Lora row settle-after-ack-timeout (#2495) ------
+// Creating lora_1 on a freshly added Power Lora Loader can apply the row and
+// then wait out a frontend refresh that never ACKs inside the 90s transport
+// bound. The next lora_2 write and a graph read both succeed, so the caller
+// was handed outcome-unknown for a mutation that landed. Take ONE detail
+// graph_query on the same tab and report applied / not-applied, or return the
+// original timeout WITH a mutation receipt when the read cannot answer.
+
+const POWER_LORA_RECONCILE_MS = 8_000;
+const POWER_LORA_ROW_WIDGET = /^lora_\d+$/i;
+
+function isPowerLoraDynamicRowWidget(widget: string): boolean {
+  return POWER_LORA_ROW_WIDGET.test(widget);
+}
+
+function powerLoraAppliedNote(widget: string): string {
+  return (
+    `CHECKED FOR YOU: the tab did not ACKNOWLEDGE the "${widget}" write within the window, but a ` +
+    `graph_query taken immediately afterwards, on that same tab, reports the requested row ` +
+    `object. No recovery step is needed and a retry would be wasted work. A missing ` +
+    `acknowledgement is not evidence the write failed; here it is evidence the tab was still ` +
+    `busy with a frontend refresh after the row was already inserted. refresh_pending:true ` +
+    `means that refresh may still be running — do not wait it out, and do not treat this as a ` +
+    `schema-ready signal.`
+  );
+}
+
+function powerLoraNotAppliedNote(widget: string): string {
+  return (
+    `CHECKED FOR YOU: a graph_query taken immediately after the missing acknowledgement does NOT ` +
+    `show the requested "${widget}" row. The write has not applied (or was overwritten). ` +
+    `Re-issuing the same named row is a merge, not a second row.`
+  );
+}
+
+function powerLoraUnknownNote(widget: string): string {
+  return (
+    `The node could not be read after the missing acknowledgement, so this result cannot say ` +
+    `whether "${widget}" applied. mutation_id is the delivery receipt for this attempt; ` +
+    `requested is the value that was sent. Re-issuing that exact named row cannot create a ` +
+    `duplicate widget. Do not guess.`
+  );
+}
+
+/** JSON-parse a whole-row string so a delivered object can be compared to the live widget. */
+function coercePowerLoraWidgetValue(value: unknown) {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed || (trimmed[0] !== "{" && trimmed[0] !== "[")) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function powerLoraValuesMatch(requested: unknown, observed: unknown): boolean {
+  const want = coercePowerLoraWidgetValue(requested);
+  const got = coercePowerLoraWidgetValue(observed);
+  if (want !== null && typeof want === "object") {
+    if (got === null || typeof got !== "object") return false;
+    if (Array.isArray(want)) return JSON.stringify(want) === JSON.stringify(got);
+    if (Array.isArray(got)) return false;
+    const wantRec = want as Record<string, unknown>;
+    const gotRec = got as Record<string, unknown>;
+    for (const [key, value] of Object.entries(wantRec)) {
+      if (!powerLoraValuesMatch(value, gotRec[key])) return false;
+    }
+    return true;
+  }
+  return Object.is(want, got);
+}
+
+function powerLoraWidgetsFromProbe(
+  res: ToolResult,
+  nodeId: unknown,
+): Record<string, unknown> | null {
+  const payload = normalizeGraphQueryResult(res);
+  if (
+    Object.prototype.hasOwnProperty.call(payload, "truncated") &&
+    payload.truncated !== false
+  ) {
+    return null;
+  }
+  const requestedId = canonicalQueriedNodeId(nodeId);
+  const detail = parseVerifiedQueriedNodeDetail(payload);
+  if (detail && requestedId && detail.id === requestedId) return detail.widgets;
+  if (!Array.isArray(payload.nodes) || payload.nodes.length !== 1) return null;
+  const identity = parseQueriedNodeIdentityRow(payload.nodes[0]);
+  if (!identity || !requestedId || identity.id !== requestedId) return null;
+  const widgets = (payload.nodes[0] as Record<string, unknown>).widgets;
+  if (!widgets || typeof widgets !== "object" || Array.isArray(widgets)) return null;
+  return widgets as Record<string, unknown>;
+}
+
+async function readPowerLoraNodeFromTab(
+  ctx: PanelToolCtx,
+  tabId: string,
+  nodeId: unknown,
+): Promise<ToolResult> {
+  const cmd = {
+    cmd: "graph_query",
+    ids: [nodeId],
+    fields: "detail",
+    limit: 1,
+    max_chars: DYNAMIC_COMBO_PROBE_MAX_CHARS,
+  };
+  if (tabId === ctx.tabId) return ctx.call(cmd, POWER_LORA_RECONCILE_MS);
+  return dispatchToTab(ctx, tabId, cmd, POWER_LORA_RECONCILE_MS);
+}
+
+function powerLoraTimeoutUnknown(
+  timedOut: ToolResult,
+  widget: string,
+  requested: unknown,
+  mutationId: string | undefined,
+): ToolResult {
+  return appendReplyNote(
+    timedOut,
+    JSON.stringify(
+      {
+        applied: "unknown",
+        acknowledged: false,
+        refresh_pending: true,
+        mutation_id: mutationId ?? null,
+        widget,
+        requested,
+        note: powerLoraUnknownNote(widget),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+/**
+ * After an ack timeout on a Power Lora `lora_N` write, take ONE detail read and
+ * report whether the requested row is on the node. Returns the original timeout
+ * plus a mutation receipt when the read cannot answer — #1473's rule.
+ */
+async function settlePowerLoraWidgetAfterAckTimeout(
+  ctx: PanelToolCtx,
+  timedOut: ToolResult,
+  nodeId: unknown,
+  widget: string,
+  requested: unknown,
+  mutationId: string | undefined,
+  dispatchTab: string,
+): Promise<ToolResult> {
+  const probeOnSessionTab = ctx.tabId === dispatchTab;
+  const probe = await readPowerLoraNodeFromTab(ctx, dispatchTab, nodeId);
+  if (probeOnSessionTab && ctx.tabId !== dispatchTab) {
+    return powerLoraTimeoutUnknown(timedOut, widget, requested, mutationId);
+  }
+  const widgets = powerLoraWidgetsFromProbe(probe, nodeId);
+  if (widgets === null || !Object.prototype.hasOwnProperty.call(widgets, widget)) {
+    if (probe.isError || widgets === null) {
+      return powerLoraTimeoutUnknown(timedOut, widget, requested, mutationId);
+    }
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              applied: false,
+              acknowledged: false,
+              refresh_pending: true,
+              mutation_id: mutationId ?? null,
+              widget,
+              requested,
+              confirmed_by: "graph_query after ack timeout",
+              note: powerLoraNotAppliedNote(widget),
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+  const observed = widgets[widget];
+  if (!powerLoraValuesMatch(requested, observed)) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              applied: false,
+              acknowledged: false,
+              refresh_pending: true,
+              mutation_id: mutationId ?? null,
+              widget,
+              requested,
+              value: observed,
+              confirmed_by: "graph_query after ack timeout",
+              note: powerLoraNotAppliedNote(widget),
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+  return ok({
+    ok: true,
+    applied: true,
+    acknowledged: false,
+    refresh_pending: true,
+    mutation_id: mutationId ?? null,
+    created_widget: widget,
+    set: { node_id: nodeId, widget, value: observed },
+    confirmed_by: "graph_query after ack timeout",
+    note: powerLoraAppliedNote(widget),
+  });
+}
+
 // ---- panel_free_vram: verifiable when the canvas tab is frozen (#1249) -----
 // `free_vram` is a purely SERVER-SIDE operation — the panel's handler is a plain
 // `POST /free` against the ComfyUI the tab fronts — yet the tool treated the
@@ -19846,71 +20067,92 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           beforeDispatch?: () => void,
           targetExpectedScope?: PromotedExpectedScope,
           targetExpectedNodeIdentity: string | undefined = expectedNodeIdentity,
-        ): Promise<ToolResult> =>
-          stripVerifiedLastObservedSchemaNote(
-            summarizeSetWidgetEcho(
-              await ctx.call(
-                {
-                  cmd: "graph_set_widget",
-                  node_id: nodeId,
-                  widget,
-                  value,
-                  // The caller supplies the type proven for THIS addressed node.
-                  // The outer final fence is used for direct/re-mapped writes;
-                  // promoted recovery re-probes its inner node after entering
-                  // and supplies that node's own type.
-                  ...(targetExpectedNodeType
-                    ? { expected_node_type: targetExpectedNodeType }
-                    : {}),
-                  ...(targetExpectedNodeIdentity
-                    ? { expected_node_identity: targetExpectedNodeIdentity }
-                    : {}),
-                  ...(targetExpectedScope
-                    ? {
-                        expected_scope: {
-                          scope: "subgraph",
-                          owner_node_id: targetExpectedScope.ownerNodeId,
-                          graph_identity: targetExpectedScope.graphIdentity,
-                          ...(targetExpectedScope.promotedWidget && targetExpectedScope.parentRail
-                            ? {
-                                promoted_widget: targetExpectedScope.promotedWidget,
-                                parent_rail: {
-                                  authoritative: true,
-                                  widget: targetExpectedScope.parentRail.widget,
-                                  ...(targetExpectedScope.parentRail.widgetId !== undefined
-                                    ? { widget_id: targetExpectedScope.parentRail.widgetId }
-                                    : {}),
-                                },
-                              }
-                            : {}),
-                          ...(targetExpectedScope.workflowUuid !== undefined
-                            ? { workflow_uuid: targetExpectedScope.workflowUuid }
-                            : {}),
-                          ...(targetExpectedScope.terminal
-                            ? {
-                                terminal: {
-                                  node_id: targetExpectedScope.terminal.nodeId,
-                                  type: targetExpectedScope.terminal.nodeType,
-                                  widget: targetExpectedScope.terminal.widget,
-                                  inputs: targetExpectedScope.terminal.inputs,
-                                  chain_depth: targetExpectedScope.terminal.chainDepth,
-                                },
-                              }
-                            : {}),
-                        },
-                      }
-                    : {}),
-                  ...(args.defer_until_idle === true
-                    ? { defer_until_idle: true, expected_value: args.expected_value }
-                    : {}),
-                },
-                OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
-                undefined,
-                beforeDispatch,
-              ),
-              echoFull,
-            ),
+        ): Promise<ToolResult> => {
+          let mutationId: string | undefined;
+          const dispatchTab = ctx.tabId;
+          const written = await ctx.call(
+            {
+              cmd: "graph_set_widget",
+              node_id: nodeId,
+              widget,
+              value,
+              // The caller supplies the type proven for THIS addressed node.
+              // The outer final fence is used for direct/re-mapped writes;
+              // promoted recovery re-probes its inner node after entering
+              // and supplies that node's own type.
+              ...(targetExpectedNodeType
+                ? { expected_node_type: targetExpectedNodeType }
+                : {}),
+              ...(targetExpectedNodeIdentity
+                ? { expected_node_identity: targetExpectedNodeIdentity }
+                : {}),
+              ...(targetExpectedScope
+                ? {
+                    expected_scope: {
+                      scope: "subgraph",
+                      owner_node_id: targetExpectedScope.ownerNodeId,
+                      graph_identity: targetExpectedScope.graphIdentity,
+                      ...(targetExpectedScope.promotedWidget && targetExpectedScope.parentRail
+                        ? {
+                            promoted_widget: targetExpectedScope.promotedWidget,
+                            parent_rail: {
+                              authoritative: true,
+                              widget: targetExpectedScope.parentRail.widget,
+                              ...(targetExpectedScope.parentRail.widgetId !== undefined
+                                ? { widget_id: targetExpectedScope.parentRail.widgetId }
+                                : {}),
+                            },
+                          }
+                        : {}),
+                      ...(targetExpectedScope.workflowUuid !== undefined
+                        ? { workflow_uuid: targetExpectedScope.workflowUuid }
+                        : {}),
+                      ...(targetExpectedScope.terminal
+                        ? {
+                            terminal: {
+                              node_id: targetExpectedScope.terminal.nodeId,
+                              type: targetExpectedScope.terminal.nodeType,
+                              widget: targetExpectedScope.terminal.widget,
+                              inputs: targetExpectedScope.terminal.inputs,
+                              chain_depth: targetExpectedScope.terminal.chainDepth,
+                            },
+                          }
+                        : {}),
+                    },
+                  }
+                : {}),
+              ...(args.defer_until_idle === true
+                ? { defer_until_idle: true, expected_value: args.expected_value }
+                : {}),
+            },
+            OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+            (rid) => {
+              mutationId = rid;
+            },
+            beforeDispatch,
           );
+          const echoed = stripVerifiedLastObservedSchemaNote(
+            summarizeSetWidgetEcho(written, echoFull),
+          );
+          // #2495 — ONLY a tagged no-reply on a named Power Lora row is settled
+          // by a read. An acked executor error is a definite outcome.
+          if (
+            isReplyTimeoutResult(echoed) &&
+            isPowerLoraDynamicRowWidget(widget) &&
+            args.defer_until_idle !== true
+          ) {
+            return settlePowerLoraWidgetAfterAckTimeout(
+              ctx,
+              echoed,
+              nodeId,
+              widget,
+              value,
+              mutationId,
+              dispatchTab,
+            );
+          }
+          return echoed;
+        };
         let writePromotedInner: (plan: PromotedWritePlan) => Promise<ToolResult>;
         const guardedWrite = async (
           nodeId: unknown,
@@ -20216,7 +20458,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
 
         if (promotedPlan) {
           const promotedWritten = await writePromotedInner(promotedPlan);
-          if (!promotedWritten.isError) markPanelSchemaReady(panelSchemaKey(ctx));
+          if (!promotedWritten.isError && parseToolResultJson(promotedWritten)?.refresh_pending !== true) {
+            markPanelSchemaReady(panelSchemaKey(ctx));
+          }
           return promotedWritten;
         }
         let first = await write(
@@ -20230,7 +20474,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           expectedNodeIdentity,
         );
         if (!first.isError) {
-          markPanelSchemaReady(panelSchemaKey(ctx));
+          if (parseToolResultJson(first)?.refresh_pending !== true) {
+            markPanelSchemaReady(panelSchemaKey(ctx));
+          }
           return persistUnpromotedControlAfterGenerate(first, ctx, args.node_id);
         }
         // #2202 — stale-combo recovery may have retired the panel's last usable


### PR DESCRIPTION
## Summary

`panel_set_widget` creating `lora_1` on a freshly added Power Lora Loader timed out after 90 seconds even though the row had already been inserted. The following `lora_2` write and `panel_query_graph` both succeeded, so the caller received an outcome-unknown error for a successful dynamic-widget mutation.

The panel's refresh-before-validate wait lives in the other repo. This process can still settle a **tagged** no-reply with one `graph_query` read-back, the same way `#2481` settles an unacked `set_todo`:

- requested `lora_N` object is present → `applied: true`, `acknowledged: false`, `refresh_pending: true`, `created_widget`
- live row missing or mismatched → `applied: false`
- settling read cannot answer, or the session rebound to another tab → original timeout plus mutation receipt (`applied: "unknown"`)
- acked executor errors (including ones that quote the timeout sentence) are not settled
- ordinary non-`lora_N` widget timeouts are not settled

Re-issuing the same named row is a merge, not a duplicate widget.

Fixes #2495

## Test plan

- [x] `npx vitest run src/__tests__/orchestrator/set-widget-power-lora-ack-timeout.test.ts` (reported case + not-applied / unknown / acked-error / wrong-tab / successful ACK / non-lora controls)
- [x] `npx vitest run src/__tests__/orchestrator/set-todo-ack-timeout.test.ts src/__tests__/orchestrator/object-info-budget-mutations.test.ts src/__tests__/orchestrator/set-widget-last-observed-schema.test.ts src/__tests__/orchestrator/promoted-widget.test.ts`
