### PR TITLE
fix(2500): write enclosing subgraph widget before link-driven inner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+
+### MCP
+
+#### Fixed
+- panel_set_widget writes the enclosing subgraph widget before a link-driven promoted inner (#2500)
+
 ## [0.52.162] - 2026-08-30
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
-
 ### MCP
 
 #### Fixed

--- a/src/__tests__/orchestrator/promoted-link-driven-write.test.ts
+++ b/src/__tests__/orchestrator/promoted-link-driven-write.test.ts
@@ -1,0 +1,323 @@
+// #2500 — writing a promoted widget on a saved subgraph container
+// (duration/value_2, fps/value_3) was routed to the inner PrimitiveInt. The
+// tool reported success and warned that those inner widgets are link-driven,
+// so the write would not affect rendering. The enclosing container stayed at
+// 5 seconds / 25 fps. Root query and queue serialization must receive the
+// enclosing subgraph widget.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:ltx-flf";
+const CONTAINER_ID = 42;
+const DURATION_INNER_ID = 198;
+const FPS_INNER_ID = 199;
+const WORKFLOW_UUID = "workflow-flf";
+const ROOT_GRAPH = "graph:workflow-flf-root";
+const CHILD_GRAPH = "graph:workflow-flf-container-42";
+const LINK_DRIVEN_WARNING =
+  "The write SUCCEEDED and was verified, but it will NOT change the render: " +
+  "widget value on inner node is link-driven from promoted input. " +
+  "Set the enclosing subgraph node instead.";
+
+const INNER_NODES = [
+  {
+    id: DURATION_INNER_ID,
+    type: "PrimitiveInt",
+    node_identity: `node-incarnation:test:${DURATION_INNER_ID}`,
+    widgets: { value: 5 },
+    inputs: [{ name: "value", type: "INT" }],
+  },
+  {
+    id: FPS_INNER_ID,
+    type: "PrimitiveInt",
+    node_identity: `node-incarnation:test:${FPS_INNER_ID}`,
+    widgets: { value: 25 },
+    inputs: [{ name: "value", type: "INT" }],
+  },
+];
+
+function promotedTerminal(widget: string, innerNodeId: number) {
+  return {
+    widget,
+    parent_rail: { authoritative: true, widget },
+    immediate_node_id: innerNodeId,
+    immediate_widget: "value",
+    terminal_node_id: innerNodeId,
+    terminal_node_type: "PrimitiveInt",
+    terminal_widget: "value",
+    terminal_inputs: [{ name: "value", type: "INT" }],
+    chain_depth: 0,
+  };
+}
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+function parseJson(res: ToolResult): Record<string, unknown> | null {
+  const text = textOf(res).trim();
+  const start = text.indexOf("{");
+  if (start < 0) return null;
+  try {
+    return JSON.parse(text.slice(start)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function harness() {
+  const calls: Array<Record<string, unknown>> = [];
+  const containerWidgets: Record<string, number> = { value_2: 5, value_3: 25 };
+  const innerWidgets: Record<number, number> = {
+    [DURATION_INNER_ID]: 5,
+    [FPS_INNER_ID]: 25,
+  };
+  let inSubgraph = false;
+  let currentGraphIdentity = ROOT_GRAPH;
+  const connectionIdentity = { generation: 1, tabSessionId: "browser-tab-flf" };
+  let observedPromotedScope: {
+    known: true;
+    scope: "root" | "subgraph";
+    ownerNodeId: string | null;
+    workflowUuid: string;
+    graphIdentity: string;
+  } = {
+    known: true,
+    scope: "root",
+    ownerNodeId: null,
+    workflowUuid: WORKFLOW_UUID,
+    graphIdentity: ROOT_GRAPH,
+  };
+
+  const currentViewing = () => ({
+    scope: inSubgraph ? "subgraph" : "root",
+    ...(inSubgraph ? { owner_node_id: CONTAINER_ID } : {}),
+    graph_identity: currentGraphIdentity,
+    workflow_uuid: WORKFLOW_UUID,
+  });
+
+  const rememberViewing = (value: Record<string, unknown>) => {
+    const viewing = value.viewing;
+    if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return value;
+    const identity = viewing as Record<string, unknown>;
+    if (identity.scope !== "root" && identity.scope !== "subgraph") return value;
+    observedPromotedScope = {
+      known: true,
+      scope: identity.scope,
+      ownerNodeId: identity.owner_node_id == null ? null : String(identity.owner_node_id),
+      workflowUuid: WORKFLOW_UUID,
+      graphIdentity: typeof identity.graph_identity === "string"
+        ? identity.graph_identity
+        : currentGraphIdentity,
+    };
+    return value;
+  };
+
+  const subgraphEnvelope = () =>
+    rememberViewing({
+      subgraph_of: {
+        node_id: CONTAINER_ID,
+        title: "First-Last-Frame to Video (LTX-2.3)",
+        graph_identity: CHILD_GRAPH,
+      },
+      node_count: INNER_NODES.length,
+      nodes: INNER_NODES,
+      promoted_terminals: [
+        promotedTerminal("value_2", DURATION_INNER_ID),
+        promotedTerminal("value_3", FPS_INNER_ID),
+      ],
+      viewing: currentViewing(),
+    });
+
+  const containerDetail = () =>
+    rememberViewing({
+      nodes: [
+        {
+          id: CONTAINER_ID,
+          type: "SubgraphNode",
+          is_subgraph: true,
+          node_identity: "node-incarnation:test:42",
+          widgets: { ...containerWidgets },
+        },
+      ],
+      viewing: currentViewing(),
+    });
+
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      if (cmd.cmd === "graph_set_widget") {
+        const nodeId = Number(cmd.node_id);
+        const widget = String(cmd.widget);
+        const value = cmd.value;
+        if (nodeId === CONTAINER_ID && (widget === "value_2" || widget === "value_3")) {
+          const previous = containerWidgets[widget];
+          containerWidgets[widget] = Number(value);
+          return {
+            set: { node_id: nodeId, widget, previous, value: containerWidgets[widget] },
+          };
+        }
+        if (
+          (nodeId === DURATION_INNER_ID || nodeId === FPS_INNER_ID) &&
+          widget === "value"
+        ) {
+          innerWidgets[nodeId] = Number(value);
+          return {
+            set: { node_id: nodeId, widget, previous: 5, value },
+            warning: LINK_DRIVEN_WARNING,
+          };
+        }
+        throw new Error(`unexpected graph_set_widget ${nodeId} ${widget}`);
+      }
+      if (cmd.cmd === "graph_get_subgraph") {
+        if (String(cmd.node_id) !== String(CONTAINER_ID)) {
+          throw new Error(`Node ${cmd.node_id} (OrdinaryNode) is not a subgraph`);
+        }
+        return subgraphEnvelope();
+      }
+      if (cmd.cmd === "graph_enter_subgraph") {
+        inSubgraph = true;
+        currentGraphIdentity = CHILD_GRAPH;
+        return { scope: "subgraph", node_id: cmd.node_id };
+      }
+      if (cmd.cmd === "graph_exit_subgraph") {
+        inSubgraph = false;
+        currentGraphIdentity = ROOT_GRAPH;
+        return { scope: "root" };
+      }
+      if (cmd.cmd === "graph_query") {
+        const wantId = Array.isArray(cmd.ids) && cmd.ids.length ? String(cmd.ids[0]) : null;
+        if (inSubgraph && wantId) {
+          const node = INNER_NODES.find((candidate) => String(candidate.id) === wantId);
+          if (node) {
+            return rememberViewing({
+              nodes: [{ id: node.id, type: node.type, node_identity: node.node_identity }],
+              viewing: currentViewing(),
+            });
+          }
+        }
+        return containerDetail();
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "flf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabConnectionIdentity: () => connectionIdentity,
+    promotedScopeFor: () => observedPromotedScope,
+    tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedNodeIdentityFenceCapability: () => true,
+    tabExpectedScopeGraphIdentityFenceCapability: () => true,
+    tabPromotedTerminalWitnessCapability: () => true,
+    tabPromotedParentRailFenceCapability: () => true,
+    tabReceiverResolvable: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    workflowUuidFor: () => ({ known: true, uuid: WORKFLOW_UUID }),
+  } as PanelToolCtx["bridge"];
+
+  return {
+    b,
+    calls,
+    containerWidgets,
+    innerWidgets,
+    serializeForQueue: () => ({ ...containerWidgets }),
+    viewing: () => observedPromotedScope,
+    get inSubgraph() {
+      return inSubgraph;
+    },
+  };
+}
+
+async function runSetWidget(widget: "value_2" | "value_3", value: number) {
+  const h = harness();
+  const ctx = makePanelToolCtx(h.b, TAB, new WorkflowTargetStore());
+  const setDef = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  const queryDef = buildPanelToolDefs().find((d) => d.name === "panel_query_graph");
+  if (!setDef || !queryDef) throw new Error("panel tools are not registered");
+  const written: ToolResult = await setDef.handler(
+    { node_id: CONTAINER_ID, widget, value } as never,
+    ctx,
+  );
+  const queried: ToolResult = await queryDef.handler(
+    { ids: [CONTAINER_ID], fields: "detail", limit: 1 } as never,
+    ctx,
+  );
+  return { h, written, queried };
+}
+
+describe("panel_set_widget promoted link-driven inner misroute (#2500)", () => {
+  it("writes duration/value_2 on the enclosing subgraph so root query and queue serialization receive 4", async () => {
+    const { h, written, queried } = await runSetWidget("value_2", 4);
+
+    expect(written.isError === true).toBe(false);
+    expect(textOf(written)).not.toMatch(/will NOT change the render|Set the enclosing subgraph node/);
+    expect(h.calls.map((call) => call.cmd)).not.toContain("graph_enter_subgraph");
+    expect(h.inSubgraph).toBe(false);
+    expect(h.viewing().scope).toBe("root");
+
+    const writes = h.calls.filter((call) => call.cmd === "graph_set_widget");
+    expect(writes).toEqual([
+      expect.objectContaining({ node_id: CONTAINER_ID, widget: "value_2", value: 4 }),
+    ]);
+    expect(writes.some((call) => Number(call.node_id) === DURATION_INNER_ID)).toBe(false);
+
+    expect(h.containerWidgets.value_2).toBe(4);
+    expect(h.containerWidgets.value_3).toBe(25);
+    expect(h.serializeForQueue()).toEqual({ value_2: 4, value_3: 25 });
+
+    const detail = parseJson(queried);
+    const nodes = detail?.nodes as Array<Record<string, unknown>> | undefined;
+    expect(nodes?.[0]).toMatchObject({
+      id: CONTAINER_ID,
+      widgets: { value_2: 4, value_3: 25 },
+    });
+  });
+
+  it("writes fps/value_3 on the enclosing subgraph so root query and queue serialization receive 24", async () => {
+    const { h, written, queried } = await runSetWidget("value_3", 24);
+
+    expect(written.isError === true).toBe(false);
+    expect(h.calls.map((call) => call.cmd)).not.toContain("graph_enter_subgraph");
+    expect(h.inSubgraph).toBe(false);
+
+    const writes = h.calls.filter((call) => call.cmd === "graph_set_widget");
+    expect(writes).toEqual([
+      expect.objectContaining({ node_id: CONTAINER_ID, widget: "value_3", value: 24 }),
+    ]);
+    expect(writes.some((call) => Number(call.node_id) === FPS_INNER_ID)).toBe(false);
+
+    expect(h.containerWidgets).toEqual({ value_2: 5, value_3: 24 });
+    expect(h.serializeForQueue()).toEqual({ value_2: 5, value_3: 24 });
+
+    const detail = parseJson(queried);
+    const nodes = detail?.nodes as Array<Record<string, unknown>> | undefined;
+    expect(nodes?.[0]).toMatchObject({
+      id: CONTAINER_ID,
+      widgets: { value_2: 5, value_3: 24 },
+    });
+  });
+
+  it("fails closed on the reported misroute: an inner link-driven write leaves the container at 5s/25fps", async () => {
+    const h = harness();
+    await h.b.send({
+      cmd: "graph_set_widget",
+      node_id: DURATION_INNER_ID,
+      widget: "value",
+      value: 4,
+    });
+    expect(h.innerWidgets[DURATION_INNER_ID]).toBe(4);
+    expect(h.containerWidgets.value_2).toBe(5);
+    expect(h.serializeForQueue().value_2).toBe(5);
+  });
+});

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -29,6 +29,7 @@ import {
   parseContradictoryPromotedWidgetRefusal,
   parseLinkDrivenPromotedWriteWarning,
   parseSubgraphScopeRefusal,
+  promotedInnerWidgetIsLinkDriven,
   resolveInnerPromotedTarget,
   validatePromotedSubgraphEnvelope,
 } from "../../orchestrator/promoted-widget.js";
@@ -1187,6 +1188,89 @@ describe("panel_set_widget promoted subgraph input routing (#2488)", () => {
     ]);
     expect(text).toMatch(/link-driven/);
     expect(text).toMatch(/enclosing subgraph node 78/);
+    expect(text).not.toMatch(/Applied via the validated promoted inner widget/);
+  });
+});
+
+/** #2500 — inner PrimitiveInt.value is a live input driven by the promoted
+ * duration/fps rail. Without a parent-rail witness, #2488 host-first would
+ * skip and the inner write would succeed while leaving the container at 5s. */
+const DURATION_PROMOTED_SUBGRAPH = {
+  subgraph_of: { node_id: 42, title: "First-Last-Frame to Video (LTX-2.3)" },
+  node_count: 1,
+  nodes: [
+    {
+      id: 198,
+      type: "PrimitiveInt",
+      widgets: { value: 5 },
+      inputs: [{ name: "value", type: "INT" }],
+    },
+  ],
+  promoted_terminals: [
+    {
+      widget: "value_2",
+      parent_rail: { authoritative: true, widget: "value_2" },
+      immediate_node_id: 198,
+      immediate_widget: "value",
+      terminal_node_id: 198,
+      terminal_node_type: "PrimitiveInt",
+      terminal_widget: "value",
+      terminal_inputs: [{ name: "value", type: "INT" }],
+      chain_depth: 0,
+    },
+  ],
+};
+
+describe("panel_set_widget promoted Primitive value misroute (#2500)", () => {
+  const hostDetail = {
+    text:
+      '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+      '{"id":42,"type":"SubgraphNode","is_subgraph":true}',
+  };
+
+  it("writes duration/value_2 on the enclosing subgraph when the inner value input is link-driven", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 42, widget: "value_2", value: 4 },
+      {
+        ownerNodeId: 42,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: hostDetail,
+        subgraph: DURATION_PROMOTED_SUBGRAPH,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 42, widget: "value_2", value: 4 }),
+    ]);
+    expect(calls.some((call) => Number(call.node_id) === 198)).toBe(false);
+    expect(text).toMatch(/enclosing subgraph node 42 widget "value_2"/);
+    expect(text).not.toMatch(/will NOT change the render|Set the enclosing subgraph node/);
+  });
+
+  it("does not misroute a contradictory host write onto a link-driven Primitive value inner", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 42, widget: "value_2", value: 4 },
+      {
+        ownerNodeId: 42,
+        firstWriteError:
+          `Cannot set widget on subgraph node 42: "value_2" is not a promoted widget ` +
+          `on this subgraph (promoted: value_2).`,
+        promotedTerminalWitnesses: true,
+        promotedDetail: hostDetail,
+        subgraph: DURATION_PROMOTED_SUBGRAPH,
+        innerWriteLinkDriven: true,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+    expect(
+      calls.some((call) => call.cmd === "graph_set_widget" && Number(call.node_id) === 198),
+    ).toBe(false);
     expect(text).not.toMatch(/Applied via the validated promoted inner widget/);
   });
 });
@@ -2903,6 +2987,71 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(1);
   });
 
+});
+
+describe("promotedInnerWidgetIsLinkDriven (#2500)", () => {
+  it("detects a PrimitiveInt whose value widget is a live input", () => {
+    expect(
+      promotedInnerWidgetIsLinkDriven(
+        {
+          id: 198,
+          type: "PrimitiveInt",
+          widgets: { value: 5 },
+          inputs: [{ name: "value", type: "INT" }],
+        },
+        "value",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects the same shape from the terminal witness when the inner row omits inputs", () => {
+    expect(
+      promotedInnerWidgetIsLinkDriven(
+        { id: 198, type: "PrimitiveInt", widgets: { value: 5 } },
+        "value",
+        {
+          nodeId: 198,
+          nodeType: "PrimitiveInt",
+          widget: "value",
+          inputs: [{ name: "value", type: "INT" }],
+          chainDepth: 0,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat an unconverted inner widget as link-driven", () => {
+    expect(
+      promotedInnerWidgetIsLinkDriven(
+        { id: 76, type: "PrimitiveStringMultiline", widgets: { quality_prompt: "old" } },
+        "quality_prompt",
+        {
+          nodeId: 76,
+          nodeType: "PrimitiveStringMultiline",
+          widget: "quality_prompt",
+          inputs: [],
+          chainDepth: 0,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat a converted ordinary-node child as this Primitive shape", () => {
+    expect(
+      promotedInnerWidgetIsLinkDriven(
+        {
+          id: 76,
+          type: "MinimaxHailuo03TextToVideoNode",
+          widgets: { "model.prompt": "" },
+          inputs: [
+            { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+            { name: "model.prompt", type: "STRING" },
+          ],
+        },
+        "model.prompt",
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("parseContradictoryPromotedWidgetRefusal", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -169,6 +169,7 @@ import {
   promotedScopeWitnessFromEnvelope,
   promotedViewingMatchesScope,
   resolveLegacyInnerPromotedTarget,
+  promotedInnerWidgetIsLinkDriven,
   resolveInnerPromotedTarget,
   validatePromotedSubgraphEnvelope,
   isInnerLinkDrivenWriteWarning,
@@ -7319,6 +7320,8 @@ type PromotedWritePlan = {
     parentRail?: PromotedParentRailWitness;
   };
   innerNodeType: string;
+  /** Inner widget is a live input driven by the promoted parent rail. */
+  innerLinkDriven: boolean;
   terminal?: PromotedTerminalWitness;
   scope: PromotedScopeWitness;
   binding: PromotedWriteBinding;
@@ -7956,8 +7959,11 @@ const PROMOTED_PRIMITIVE_INNER_TYPES = new Set([
 /** #2488 — a promoted subgraph INPUT whose inner widget is a different name
  * (frame_counts → length) or a linked primitive must be written on the host.
  * Same-name proxyWidgets promotions keep the inner write so #2314's known-bad
- * live probe still runs before any container mutation. */
+ * live probe still runs before any container mutation.
+ * #2500 — a Primitive* `value` that exists as a live input is driven by the
+ * promoted rail even when the parent-rail witness is missing; write the host. */
 function shouldWritePromotedHostFirst(plan: PromotedWritePlan): boolean {
+  if (plan.innerLinkDriven) return true;
   if (!plan.inner.parentRail) return false;
   if (plan.hostWidget.toLowerCase() !== plan.inner.widget.toLowerCase()) return true;
   return PROMOTED_PRIMITIVE_INNER_TYPES.has(plan.innerNodeType);
@@ -8634,6 +8640,7 @@ async function preparePromotedWidgetWrite(
     ...(outerNodeIdentity ? { outerNodeIdentity } : {}),
     inner,
     innerNodeType,
+    innerLinkDriven: promotedInnerWidgetIsLinkDriven(innerNode, inner.widget, inner.terminal),
     ...(inner.terminal ? { terminal: inner.terminal } : {}),
     scope,
     binding: {
@@ -20621,6 +20628,58 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             }
             const afterMappingError = currentPromotedBindingError(ctx, plan.binding);
             if (afterMappingError) return promotedWriteRefusal(args.widget as string, afterMappingError);
+
+            // #2500 — a link-driven inner Primitive (duration/value_2, fps/value_3)
+            // accepts a write and warns that rendering still reads the enclosing
+            // subgraph widget. Write that container first, at the caller's current
+            // graph, and do not enter the inner scope. This is the #1655 fallback
+            // path when the #2488 host-rail write already contradicted.
+            if (plan.innerLinkDriven) {
+              if (plan.terminal) {
+                const terminalBlocked = refuseKnownBadPromotedTerminal(plan.terminal);
+                if (terminalBlocked) return terminalBlocked;
+              }
+              const hostWidget = plan.hostWidget;
+              const hostScope = plan.outerScope;
+              const written = await write(
+                plan.outerNodeId,
+                hostWidget,
+                plan.outerNodeType,
+                () => {
+                  const error = currentPromotedBindingError(ctx, plan.binding);
+                  if (error) {
+                    throw new Error(
+                      `Refusing promoted container graph_set_widget: ${error}. No graph_set_widget was dispatched.`,
+                    );
+                  }
+                  if (hostScope) {
+                    const scopeError = currentPromotedExpectedScopeError(ctx, hostScope);
+                    if (scopeError) {
+                      throw new Error(
+                        `Refusing promoted container graph_set_widget: ${scopeError}. No graph_set_widget was dispatched.`,
+                      );
+                    }
+                  }
+                },
+                hostScope,
+                plan.outerNodeIdentity,
+              );
+              if (written.isError) {
+                return appendToolResultText(
+                  written,
+                  `\n\n(Tried the enclosing subgraph widget on node ${plan.outerNodeId} ` +
+                    `"${hostWidget}" first because the promoted inner widget is link-driven. ` +
+                    `Navigation scope was left unchanged.)`,
+                );
+              }
+              markPanelSchemaReady(panelSchemaKey(ctx));
+              const persisted = await persistUnpromotedControlAfterGenerate(
+                written,
+                ctx,
+                plan.outerNodeId,
+              );
+              return appendToolResultText(persisted, promotedHostAppliedNote(plan));
+            }
 
             const enter = await ctx.call(
               { cmd: "graph_enter_subgraph", node_id: plan.outerNodeId },

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -329,6 +329,45 @@ function resolveRailBackedInnerFromEnvelope(
   };
 }
 
+function inputName(value: unknown): string | null {
+  if (!isRecord(value) || typeof value.name !== "string" || value.name.length === 0) return null;
+  return value.name;
+}
+
+const PRIMITIVE_NODE_TYPE_RE =
+  /^Primitive(?:Int|Float|Boolean|String|StringMultiline)$/;
+
+function primitiveNodeType(innerNode: Record<string, unknown> | null | undefined, terminal?: PromotedTerminalWitness): string | null {
+  if (isRecord(innerNode) && typeof innerNode.type === "string" && innerNode.type.length > 0) {
+    return innerNode.type;
+  }
+  return terminal?.nodeType ?? null;
+}
+
+/**
+ * #2500 — a Primitive* `value` widget that exists as a live input is driven by
+ * the subgraph's promoted rail. Writing that inner widget reports success and
+ * leaves the enclosing container (the value that serializes and renders)
+ * unchanged. The enclosing subgraph widget is the write target. Converted
+ * widgets on ordinary nodes (dynamic-combo children, etc.) are not this shape.
+ */
+export function promotedInnerWidgetIsLinkDriven(
+  innerNode: Record<string, unknown> | null | undefined,
+  innerWidget: string,
+  terminal?: PromotedTerminalWitness,
+): boolean {
+  if (innerWidget.toLowerCase() !== "value") return false;
+  const nodeType = primitiveNodeType(innerNode, terminal);
+  if (!nodeType || !PRIMITIVE_NODE_TYPE_RE.test(nodeType)) return false;
+  if (isRecord(innerNode) && Array.isArray(innerNode.inputs)) {
+    for (const raw of innerNode.inputs) {
+      const name = inputName(raw);
+      if (name && name.toLowerCase() === "value") return true;
+    }
+  }
+  return terminal?.inputs.some((input) => input.name.toLowerCase() === "value") === true;
+}
+
 function innerNodeId(node: Record<string, unknown>): number | string | null {
   const id = node.id;
   return isNodeId(id) ? id : null;


### PR DESCRIPTION
## Summary
`panel_set_widget` on a saved subgraph container (duration/`value_2`, fps/`value_3`) was routed to inner PrimitiveInt nodes. Those inner `value` widgets are link-driven from the promoted rail, so the tool reported success, warned that rendering would not change, and left the enclosing container at 5s/25fps. The reply then told the caller to set the enclosing subgraph node — which is what the original call already addressed.

The orchestrator now writes the enclosing subgraph widget first at the current scope and leaves navigation unchanged. Root query and queue serialization receive the new value.

## Test plan
- `npx vitest run src/__tests__/orchestrator/promoted-link-driven-write.test.ts src/__tests__/orchestrator/promoted-widget.test.ts`
- 173 passed (3 new #2500 cases + 170 existing promoted-widget tests)

Fixes #2500