### PR TITLE
fix(2553): persist subgraph viewing scope across panel tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- persist subgraph viewing scope across panel tool calls so interior mutations do not silently fall back to root (#2553)
+
+
 ## [0.52.151] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/orchestrator/subgraph-scope-persist.test.ts
+++ b/src/__tests__/orchestrator/subgraph-scope-persist.test.ts
@@ -1,0 +1,162 @@
+// #2553 — enter + query confirm subgraph; a later unexpose on a NEW tool call
+// must restore that scope instead of silently targeting root.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import {
+  clearRememberedViewingScope,
+  rememberedSubgraphOwner,
+} from "../../services/subgraph-viewing-scope.js";
+
+const SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url)),
+  "utf8",
+);
+
+const ROOT_ERROR =
+  "panel_unexpose_subgraph_input must be run INSIDE a subgraph - call panel_enter_subgraph first";
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function jsonResult(payload: unknown, isError = false): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function textResult(text: string, isError = false): ToolResult {
+  return {
+    content: [{ type: "text", text }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+afterEach(() => {
+  clearRememberedViewingScope();
+});
+
+describe("subgraph viewing scope across panel tool calls (#2553)", () => {
+  it("handlers dispatch through the shipped remember/restore helpers", () => {
+    expect(SRC).toMatch(/callAndRememberViewing\(/);
+    expect(SRC).toMatch(/callWithRememberedSubgraph\(/);
+    expect(SRC).toMatch(/cmd: "graph_unexpose_subgraph_input"/);
+    expect(SRC).toMatch(/cmd: "graph_enter_subgraph"/);
+  });
+
+  it("THE REPORTED CASE: enter, query confirms subgraph, later unexpose still restores it", async () => {
+    const tabId = "wf:2553-reported";
+    let canvas: "root" | "subgraph" = "root";
+    let owner: number | null = null;
+    const calls: Record<string, unknown>[] = [];
+
+    const call: PanelToolCtx["call"] = async (cmd) => {
+      calls.push(cmd);
+      if (cmd.cmd === "graph_enter_subgraph") {
+        canvas = "subgraph";
+        owner = Number(cmd.node_id);
+        return jsonResult({
+          entered: cmd.node_id,
+          viewing: { scope: "subgraph", owner_node_id: owner },
+          settled: true,
+        });
+      }
+      if (cmd.cmd === "graph_query") {
+        return jsonResult({
+          viewing:
+            canvas === "subgraph"
+              ? { scope: "subgraph", owner_node_id: owner }
+              : { scope: "root" },
+          total: 4,
+        });
+      }
+      if (cmd.cmd === "graph_unexpose_subgraph_input") {
+        if (canvas !== "subgraph") return textResult(`Error: ${ROOT_ERROR}`, true);
+        return jsonResult({
+          removed: {
+            side: "input",
+            name: cmd.name,
+            slot: 0,
+            interior_links_dropped: 0,
+            host_links_dropped: 0,
+            host_links_reindexed: true,
+          },
+        });
+      }
+      return textResult(`unexpected ${String(cmd.cmd)}`, true);
+    };
+
+    const ctxFor = (): PanelToolCtx => ({
+      call,
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId,
+    });
+
+    // Separate MCP tool calls, same bound tab.
+    await defByName("panel_enter_subgraph").handler({ node_id: 96 }, ctxFor());
+    expect(rememberedSubgraphOwner(tabId)).toBe("96");
+
+    const queried = await defByName("panel_query_graph").handler({ fields: "ids", limit: 1 }, ctxFor());
+    expect(queried.isError).toBeUndefined();
+    const queryPayload = JSON.parse(queried.content[0]?.text ?? "{}") as {
+      viewing?: { scope?: string };
+    };
+    expect(queryPayload.viewing?.scope).toBe("subgraph");
+
+    // Canvas pops back to root between calls — the reported loss.
+    canvas = "root";
+
+    const unexposed = await defByName("panel_unexpose_subgraph_input").handler(
+      { name: "model" },
+      ctxFor(),
+    );
+    expect(unexposed.isError).toBeUndefined();
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_enter_subgraph",
+      "graph_query",
+      "graph_unexpose_subgraph_input",
+      "graph_query",
+      "graph_enter_subgraph",
+      "graph_unexpose_subgraph_input",
+    ]);
+    expect(calls[4]).toMatchObject({ cmd: "graph_enter_subgraph", node_id: 96 });
+    expect(calls[5]).toMatchObject({ cmd: "graph_unexpose_subgraph_input", name: "model" });
+    const removed = JSON.parse(unexposed.content[0]?.text ?? "{}") as {
+      removed?: { name?: string };
+    };
+    expect(removed.removed?.name).toBe("model");
+    expect(unexposed.content.some((c) => c.type === "text" && c.text.includes("#2553"))).toBe(
+      true,
+    );
+  });
+
+  it("does not invent a subgraph when this session never confirmed one", async () => {
+    const tabId = "wf:2553-never-entered";
+    const calls: Record<string, unknown>[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        return textResult(`Error: ${ROOT_ERROR}`, true);
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId,
+    };
+    const res = await defByName("panel_unexpose_subgraph_input").handler({ name: "model" }, ctx);
+    expect(res.isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_unexpose_subgraph_input"]);
+    expect(res.content[0]?.text).toMatch(/INSIDE a subgraph/);
+  });
+});

--- a/src/__tests__/services/subgraph-viewing-scope.test.ts
+++ b/src/__tests__/services/subgraph-viewing-scope.test.ts
@@ -1,0 +1,184 @@
+// #2553 — last confirmed subgraph viewing survives a later mutation that
+// finds the canvas back at root.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  callAndRememberViewing,
+  callWithRememberedSubgraph,
+  clearRememberedViewingScope,
+  isOutsideSubgraphRefusal,
+  noteConfirmedViewing,
+  parseViewingScope,
+  rememberedSubgraphOwner,
+  rememberedViewingScope,
+  type ToolResultLike,
+} from "../../services/subgraph-viewing-scope.js";
+
+const TAB = "tab-2553";
+const ROOT_ERROR =
+  "panel_unexpose_subgraph_input must be run INSIDE a subgraph - call panel_enter_subgraph first";
+
+function jsonResult(payload: unknown, isError = false): ToolResultLike {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function textResult(text: string, isError = false): ToolResultLike {
+  return {
+    content: [{ type: "text", text }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+afterEach(() => {
+  clearRememberedViewingScope();
+});
+
+describe("parseViewingScope / isOutsideSubgraphRefusal", () => {
+  it("reads a subgraph owner and a root view", () => {
+    expect(
+      parseViewingScope({ scope: "subgraph", owner_node_id: 96, title: "Stage" }),
+    ).toEqual({ scope: "subgraph", ownerNodeId: "96" });
+    expect(parseViewingScope({ scope: "root" })).toEqual({
+      scope: "root",
+      ownerNodeId: null,
+    });
+    expect(parseViewingScope({ kind: "root" })).toBeNull();
+  });
+
+  it("matches the reported panel refusal and not a generic missing-node error", () => {
+    expect(isOutsideSubgraphRefusal(ROOT_ERROR)).toBe(true);
+    expect(
+      isOutsideSubgraphRefusal(
+        "graph_expose_subgraph_input must be run INSIDE a subgraph (no subgraph.addInput on the active graph)",
+      ),
+    ).toBe(true);
+    expect(
+      isOutsideSubgraphRefusal("No node with id 188 in the current graph. Node 188 lives INSIDE a subgraph"),
+    ).toBe(false);
+  });
+});
+
+describe("noteConfirmedViewing", () => {
+  it("records a query confirmation and an enter fallback owner", () => {
+    expect(
+      noteConfirmedViewing(TAB, {
+        viewing: { scope: "subgraph", owner_node_id: 96 },
+      }),
+    ).toEqual({ scope: "subgraph", ownerNodeId: "96" });
+    expect(rememberedSubgraphOwner(TAB)).toBe("96");
+
+    clearRememberedViewingScope(TAB);
+    expect(
+      noteConfirmedViewing(TAB, { entered: 12, settled: true }, { enteredNodeId: 12 }),
+    ).toEqual({ scope: "subgraph", ownerNodeId: "12" });
+  });
+
+  it("an explicit root confirmation clears the subgraph owner", () => {
+    noteConfirmedViewing(TAB, { viewing: { scope: "subgraph", owner_node_id: 96 } });
+    noteConfirmedViewing(TAB, { viewing: { scope: "root" } });
+    expect(rememberedSubgraphOwner(TAB)).toBeNull();
+    expect(rememberedViewingScope(TAB)).toEqual({ scope: "root", ownerNodeId: null });
+  });
+});
+
+describe("callWithRememberedSubgraph", () => {
+  it("re-enters the last confirmed owner after a later call finds root", async () => {
+    await callAndRememberViewing(
+      TAB,
+      { cmd: "graph_enter_subgraph", node_id: 96 },
+      async () =>
+        jsonResult({
+          entered: 96,
+          viewing: { scope: "subgraph", owner_node_id: 96 },
+          settled: true,
+        }),
+    );
+    await callAndRememberViewing(
+      TAB,
+      { cmd: "graph_query", fields: "ids", limit: 1 },
+      async () => jsonResult({ viewing: { scope: "subgraph", owner_node_id: 96 }, total: 4 }),
+    );
+
+    let canvas: "root" | "subgraph" = "root";
+    const calls: Record<string, unknown>[] = [];
+    const res = await callWithRememberedSubgraph(
+      TAB,
+      { cmd: "graph_unexpose_subgraph_input", name: "model" },
+      async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_unexpose_subgraph_input") {
+          if (canvas !== "subgraph") return textResult(`Error: ${ROOT_ERROR}`, true);
+          return jsonResult({ removed: { side: "input", name: "model" } });
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            viewing: canvas === "subgraph" ? { scope: "subgraph", owner_node_id: 96 } : { scope: "root" },
+          });
+        }
+        if (cmd.cmd === "graph_enter_subgraph") {
+          canvas = "subgraph";
+          return jsonResult({
+            entered: cmd.node_id,
+            viewing: { scope: "subgraph", owner_node_id: cmd.node_id },
+            settled: true,
+          });
+        }
+        return textResult("unexpected", true);
+      },
+      15000,
+    );
+
+    expect(res.isError).toBeUndefined();
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_unexpose_subgraph_input",
+      "graph_query",
+      "graph_enter_subgraph",
+      "graph_unexpose_subgraph_input",
+    ]);
+    expect(calls[2]).toMatchObject({ cmd: "graph_enter_subgraph", node_id: 96 });
+    expect(res.content.some((c) => c.text?.includes("artokun/comfyui-mcp#2553"))).toBe(true);
+  });
+
+  it("does not re-enter after an explicit root confirmation", async () => {
+    noteConfirmedViewing(TAB, { viewing: { scope: "subgraph", owner_node_id: 96 } });
+    await callAndRememberViewing(TAB, { cmd: "graph_exit_subgraph" }, async () =>
+      jsonResult({ viewing: { scope: "root" }, settled: true }),
+    );
+
+    const calls: Record<string, unknown>[] = [];
+    const res = await callWithRememberedSubgraph(
+      TAB,
+      { cmd: "graph_unexpose_subgraph_input", name: "model" },
+      async (cmd) => {
+        calls.push(cmd);
+        return textResult(`Error: ${ROOT_ERROR}`, true);
+      },
+    );
+    expect(res.isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_unexpose_subgraph_input"]);
+  });
+
+  it("refuses to restore a subgraph belonging to a different workflow", async () => {
+    noteConfirmedViewing(TAB, {
+      viewing: { scope: "subgraph", owner_node_id: 96, workflow_uuid: "aaa" },
+    });
+    const calls: Record<string, unknown>[] = [];
+    const res = await callWithRememberedSubgraph(
+      TAB,
+      { cmd: "graph_unexpose_subgraph_input", name: "model" },
+      async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_unexpose_subgraph_input") return textResult(`Error: ${ROOT_ERROR}`, true);
+        return jsonResult({ viewing: { scope: "root", workflow_uuid: "bbb" } });
+      },
+    );
+    expect(res.isError).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_unexpose_subgraph_input", "graph_query"]);
+    expect(calls.some((c) => c.cmd === "graph_enter_subgraph")).toBe(false);
+    expect(res.content.some((c) => c.text?.includes("aaa") && c.text.includes("bbb"))).toBe(true);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -86,6 +86,11 @@ import {
 } from "../services/unexpose-host-link-shift.js";
 import { retryExposeSubgraphInput } from "../services/expose-ae-wildcard.js";
 import {
+  callAndRememberViewing,
+  callWithRememberedSubgraph,
+  noteConfirmedViewingFromToolResult,
+} from "../services/subgraph-viewing-scope.js";
+import {
   assertScreenshotPersistAllowed,
   decodePngBase64,
   persistScreenshotPng,
@@ -17953,7 +17958,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       // announced. Nothing is shed while the whole reply fits.
       async (args: A, ctx) => {
         const widgetMaxChars = widgetMaxCharsRequest(args);
-        const panelReply = await ctx.call({
+        const panelReply = await callAndRememberViewing(
+          ctx.tabId,
+          {
             cmd: "graph_query",
             types: args.types,
             title: args.title,
@@ -17969,7 +17976,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             ...(widgetMaxChars.value === undefined
               ? {}
               : { widget_max_chars: widgetMaxChars.value }),
-          });
+          },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+        );
         return fitQueryGraphReply(
           panelReply,
           args.max_chars,
@@ -23246,14 +23255,25 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       "panel_enter_subgraph",
       "Navigate INTO a subgraph node so you can read and EDIT its inner nodes — after this, panel_query_graph / panel_graph_outline and all panel_* edit tools target the subgraph's inner graph (the user sees the canvas drill in). This is how you edit inside a subgraph (e.g. tweak a widget on an inner node). Call panel_exit_subgraph when done. Returns the new viewing scope.",
       { node_id: nodeId().describe("Subgraph node id (is_subgraph=true).") },
-      async (args: A, ctx) => ctx.call({ cmd: "graph_enter_subgraph", node_id: args.node_id }, 15000),
+      async (args: A, ctx) =>
+        callAndRememberViewing(
+          ctx.tabId,
+          { cmd: "graph_enter_subgraph", node_id: args.node_id },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+          15000,
+        ),
     ),
     def(
       "panel_exit_subgraph",
       "Leave the current subgraph and return to the root graph (undo a panel_enter_subgraph). After this, panel_* tools target the root graph again.",
       {},
       async (_args, ctx) => {
-        const res = await ctx.call({ cmd: "graph_exit_subgraph" }, 15000);
+        const res = await callAndRememberViewing(
+          ctx.tabId,
+          { cmd: "graph_exit_subgraph" },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+          15000,
+        );
         // #1468 — ONLY a no-reply is settled by a read. A genuine executor error
         // (the panel's own "could not confirm … no observation ever saw the canvas
         // there") is an ACKED reply the bridge received and relayed; it already
@@ -23261,7 +23281,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // so re-deciding it from out here would overwrite a better-informed verdict
         // with a worse-informed one.
         if (!isReplyTimeoutResult(res)) return res;
-        return settleExitSubgraphAfterAckTimeout(ctx, res);
+        const settled = await settleExitSubgraphAfterAckTimeout(ctx, res);
+        if (!settled.isError) noteConfirmedViewingFromToolResult(ctx.tabId, settled);
+        return settled;
       },
     ),
     def(
@@ -23271,7 +23293,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         rail: z.enum(["input", "output"]).describe("Which boundary rail to move."),
         pos: xy().describe("New top-left [x, y] (two numbers)."),
       },
-      async (args: A, ctx) => ctx.call({ cmd: "graph_move_rail", rail: args.rail, pos: args.pos }),
+      async (args: A, ctx) =>
+        callWithRememberedSubgraph(
+          ctx.tabId,
+          { cmd: "graph_move_rail", rail: args.rail, pos: args.pos },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+        ),
     ),
     def(
       "panel_promote_widget",
@@ -23282,7 +23309,17 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         demote: z.boolean().optional().describe("Set true to UN-promote (remove the widget from the parent node)."),
       },
       async (args: A, ctx) =>
-        ctx.call({ cmd: "graph_promote_widget", node_id: args.node_id, widget: args.widget, demote: args.demote }, 15000),
+        callWithRememberedSubgraph(
+          ctx.tabId,
+          {
+            cmd: "graph_promote_widget",
+            node_id: args.node_id,
+            widget: args.widget,
+            demote: args.demote,
+          },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+          15000,
+        ),
     ),
     def(
       "panel_expose_subgraph_output",
@@ -23293,13 +23330,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         name: z.string().optional().describe("Optional name for the new subgraph output (boundary slot). Defaults from the source slot. IGNORED when the slot is already exposed — the reply carries reused:true and the existing name."),
       },
       async (args: A, ctx) =>
-        ctx.call(
+        callWithRememberedSubgraph(
+          ctx.tabId,
           {
             cmd: "graph_expose_subgraph_output",
             from_node_id: args.from_node_id,
             from_output: args.from_output,
             name: args.name,
           },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
           15000,
         ),
     ),
@@ -23314,7 +23353,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       async (args: A, ctx) =>
         retryExposeSubgraphInput(
           { to_node_id: args.to_node_id, to_input: args.to_input, name: args.name },
-          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+          (cmd, timeoutMs) =>
+            cmd.cmd === "graph_expose_subgraph_input"
+              ? callWithRememberedSubgraph(
+                  ctx.tabId,
+                  cmd,
+                  (inner, innerTimeout) => ctx.call(inner, innerTimeout),
+                  timeoutMs,
+                )
+              : ctx.call(cmd, timeoutMs),
         ),
     ),
     def(
@@ -23324,7 +23371,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         name: z.string().describe("Boundary output slot name (e.g. 'IMAGE') exactly as panel_query_graph lists it under rails.output.accepts_inputs — NOT a rail_node_id."),
       },
       async (args: A, ctx) => {
-        const res = await ctx.call({ cmd: "graph_unexpose_subgraph_output", name: args.name }, 15000);
+        const res = await callWithRememberedSubgraph(
+          ctx.tabId,
+          { cmd: "graph_unexpose_subgraph_output", name: args.name },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+          15000,
+        );
         return withUnexposeHostLinkShiftNote(res, ctx);
       },
     ),
@@ -23335,7 +23387,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         name: z.string().describe("Boundary input slot name (e.g. 'model') exactly as panel_query_graph lists it under rails.input.provides_outputs — NOT a rail_node_id."),
       },
       async (args: A, ctx) => {
-        const res = await ctx.call({ cmd: "graph_unexpose_subgraph_input", name: args.name }, 15000);
+        const res = await callWithRememberedSubgraph(
+          ctx.tabId,
+          { cmd: "graph_unexpose_subgraph_input", name: args.name },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+          15000,
+        );
         return withUnexposeHostLinkShiftNote(res, ctx);
       },
     ),

--- a/src/services/subgraph-viewing-scope.ts
+++ b/src/services/subgraph-viewing-scope.ts
@@ -1,0 +1,272 @@
+/**
+ * #2553 — last confirmed subgraph viewing, per bound tab.
+ *
+ * `panel_enter_subgraph` / `panel_query_graph` can prove `viewing.scope=subgraph`
+ * and the very next MCP call still land on the root graph. Subgraph-interior
+ * mutations (`unexpose` / `expose` / rail / promote) then refuse with
+ * "must be run INSIDE a subgraph" even though this session already confirmed
+ * the inner scope. The panel canvas is the live view; this store is the last
+ * confirmation the session actually saw, so a later mutation can re-enter that
+ * owner instead of silently targeting root.
+ *
+ * Root after an explicit `panel_exit_subgraph` (or a query that saw root) is
+ * also remembered, so a deliberate leave is not undone.
+ */
+
+export type ConfirmedViewingScope = {
+  scope: "root" | "subgraph";
+  ownerNodeId: string | null;
+  workflowUuid?: string;
+};
+
+export type ToolResultLike = {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+};
+
+export type GraphCall<T extends ToolResultLike> = (
+  cmd: Record<string, unknown>,
+  timeoutMs?: number,
+) => Promise<T>;
+
+/** Bridge commands that the panel refuses unless the active graph IS a subgraph. */
+export const SUBGRAPH_INTERIOR_CMDS: ReadonlySet<string> = new Set([
+  "graph_unexpose_subgraph_input",
+  "graph_unexpose_subgraph_output",
+  "graph_expose_subgraph_input",
+  "graph_expose_subgraph_output",
+  "graph_move_rail",
+  "graph_promote_widget",
+]);
+
+const OUTSIDE_SUBGRAPH_RE = /(?:must be run|must run) INSIDE a subgraph/i;
+
+const rememberedByTab = new Map<string, ConfirmedViewingScope>();
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function toolText(res: ToolResultLike): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+export function parseJsonPayload(res: ToolResultLike): Record<string, unknown> | null {
+  if (res.isError) return null;
+  const text = res.content.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return asRecord(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function canonicalNodeId(value: unknown): string | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? String(value) : null;
+  }
+  if (typeof value !== "string" || value.length === 0) return null;
+  if (!/^-?\d+(?::\d+)*$/.test(value)) return null;
+  return value;
+}
+
+function wireNodeId(id: string): number | string {
+  return /^-?\d+$/.test(id) ? Number.parseInt(id, 10) : id;
+}
+
+export function parseViewingScope(value: unknown): ConfirmedViewingScope | null {
+  const rec = asRecord(value);
+  if (!rec) return null;
+  const scope = rec.scope;
+  if (scope !== "root" && scope !== "subgraph") return null;
+  const workflowUuid = rec.workflow_uuid;
+  if (
+    workflowUuid !== undefined &&
+    (typeof workflowUuid !== "string" || workflowUuid.length === 0)
+  ) {
+    return null;
+  }
+  let ownerNodeId: string | null = null;
+  if (rec.owner_node_id !== undefined && rec.owner_node_id !== null) {
+    ownerNodeId = canonicalNodeId(rec.owner_node_id);
+    if (!ownerNodeId) return null;
+  }
+  return {
+    scope,
+    ownerNodeId,
+    ...(typeof workflowUuid === "string" ? { workflowUuid } : {}),
+  };
+}
+
+export function isOutsideSubgraphRefusal(text: string): boolean {
+  return OUTSIDE_SUBGRAPH_RE.test(text);
+}
+
+export function isSubgraphInteriorCmd(cmd: unknown): boolean {
+  return typeof cmd === "string" && SUBGRAPH_INTERIOR_CMDS.has(cmd);
+}
+
+export function rememberedViewingScope(tabId: string): ConfirmedViewingScope | null {
+  return rememberedByTab.get(tabId) ?? null;
+}
+
+export function rememberedSubgraphOwner(tabId: string): string | null {
+  const rec = rememberedByTab.get(tabId);
+  return rec?.scope === "subgraph" ? rec.ownerNodeId : null;
+}
+
+export function clearRememberedViewingScope(tabId?: string): void {
+  if (tabId === undefined) {
+    rememberedByTab.clear();
+    return;
+  }
+  rememberedByTab.delete(tabId);
+}
+
+export function noteConfirmedViewing(
+  tabId: string,
+  payload: unknown,
+  extras?: { enteredNodeId?: unknown },
+): ConfirmedViewingScope | null {
+  if (!tabId) return null;
+  const rec = asRecord(payload);
+  const viewing = parseViewingScope(rec?.viewing);
+  const entered = canonicalNodeId(extras?.enteredNodeId ?? rec?.entered);
+
+  let next: ConfirmedViewingScope | null = null;
+  if (viewing?.scope === "root") {
+    next = viewing;
+  } else if (viewing?.scope === "subgraph") {
+    next = {
+      ...viewing,
+      ownerNodeId: viewing.ownerNodeId ?? entered,
+    };
+  } else if (entered) {
+    next = { scope: "subgraph", ownerNodeId: entered };
+  }
+  if (!next) return null;
+  rememberedByTab.set(tabId, next);
+  return next;
+}
+
+export function noteConfirmedViewingFromToolResult(
+  tabId: string,
+  res: ToolResultLike,
+  extras?: { enteredNodeId?: unknown },
+): ConfirmedViewingScope | null {
+  const payload = parseJsonPayload(res);
+  return payload ? noteConfirmedViewing(tabId, payload, extras) : null;
+}
+
+function withNote<T extends ToolResultLike>(res: T, note: string | null): T {
+  if (!note) return res;
+  return { ...res, content: [...res.content, { type: "text", text: note }] } as T;
+}
+
+function restoreNote(ownerNodeId: string): string {
+  return (
+    `Re-entered subgraph node ${ownerNodeId} from the last confirmed viewing scope ` +
+    `(artokun/comfyui-mcp#2553) — the canvas had returned to root between tool calls.`
+  );
+}
+
+function reenterFailedNote(ownerNodeId: string, enterText: string): string {
+  return (
+    `The canvas was at root, so this session tried to restore the last confirmed ` +
+    `subgraph (node ${ownerNodeId}) before retrying. panel_enter_subgraph failed: ` +
+    `${enterText} The original refusal stands. Call panel_enter_subgraph yourself ` +
+    `if that is still the graph you mean to edit. (artokun/comfyui-mcp#2553)`
+  );
+}
+
+function missingOwnerNote(): string {
+  return (
+    `This session last confirmed viewing.scope=subgraph, but no owner_node_id was ` +
+    `published, so the subgraph cannot be re-entered automatically. Call ` +
+    `panel_enter_subgraph with the subgraph node id. (artokun/comfyui-mcp#2553)`
+  );
+}
+
+function workflowMismatchNote(remembered: string, live: string): string {
+  return (
+    `The last confirmed subgraph scope belonged to workflow ${remembered}, but the ` +
+    `live canvas now reports ${live}. Not re-entering that subgraph. Call ` +
+    `panel_enter_subgraph if the live canvas is the one you mean. (artokun/comfyui-mcp#2553)`
+  );
+}
+
+/**
+ * Remember viewing from a successful graph reply (enter / query / exit / outline).
+ * Failures do not overwrite a prior confirmation.
+ */
+export async function callAndRememberViewing<T extends ToolResultLike>(
+  tabId: string,
+  cmd: Record<string, unknown>,
+  call: GraphCall<T>,
+  timeoutMs?: number,
+): Promise<T> {
+  const res = await call(cmd, timeoutMs);
+  if (!res.isError) {
+    noteConfirmedViewingFromToolResult(
+      tabId,
+      res,
+      cmd.cmd === "graph_enter_subgraph" ? { enteredNodeId: cmd.node_id } : undefined,
+    );
+  }
+  return res;
+}
+
+/**
+ * Dispatch a subgraph-interior mutation. On the panel's "must be run INSIDE a
+ * subgraph" refusal, re-enter the last confirmed owner for this tab (when the
+ * live canvas is at root) and retry once. A remembered root — an explicit exit
+ * or a query that saw root — is left alone.
+ */
+export async function callWithRememberedSubgraph<T extends ToolResultLike>(
+  tabId: string,
+  cmd: Record<string, unknown>,
+  call: GraphCall<T>,
+  timeoutMs?: number,
+): Promise<T> {
+  const first = await call(cmd, timeoutMs);
+  if (!first.isError || !isOutsideSubgraphRefusal(toolText(first))) return first;
+  if (!isSubgraphInteriorCmd(cmd.cmd)) return first;
+
+  const remembered = rememberedViewingScope(tabId);
+  if (!remembered || remembered.scope !== "subgraph") return first;
+  if (!remembered.ownerNodeId) return withNote(first, missingOwnerNote());
+
+  const probe = await call({ cmd: "graph_query", fields: "ids", limit: 1 }, 8000);
+  const live = parseViewingScope(parseJsonPayload(probe)?.viewing);
+  if (
+    remembered.workflowUuid &&
+    live?.workflowUuid &&
+    remembered.workflowUuid !== live.workflowUuid
+  ) {
+    return withNote(first, workflowMismatchNote(remembered.workflowUuid, live.workflowUuid));
+  }
+  if (live?.scope === "subgraph") {
+    const retried = await call(cmd, timeoutMs);
+    return retried;
+  }
+
+  const ownerNodeId = remembered.ownerNodeId;
+  const enter = await call(
+    { cmd: "graph_enter_subgraph", node_id: wireNodeId(ownerNodeId) },
+    15000,
+  );
+  if (enter.isError) {
+    return withNote(first, reenterFailedNote(ownerNodeId, toolText(enter)));
+  }
+  noteConfirmedViewingFromToolResult(tabId, enter, { enteredNodeId: ownerNodeId });
+
+  const retried = await call(cmd, timeoutMs);
+  if (!retried.isError) return withNote(retried, restoreNote(ownerNodeId));
+  return withNote(
+    retried,
+    `Re-entered subgraph node ${ownerNodeId}, but the mutation still failed: ${toolText(retried)}`,
+  );
+}


### PR DESCRIPTION
## Summary

`panel_enter_subgraph` and `panel_query_graph` could confirm `viewing.scope=subgraph`, then a later `panel_unexpose_subgraph_input` on a **new MCP tool call** (same bound tab) would hit the root graph and refuse:

`panel_unexpose_subgraph_input must be run INSIDE a subgraph - call panel_enter_subgraph first`

The canvas viewing scope is live panel state. Separate MCP calls did not keep the last confirmed inner owner, so a canvas reconcile / lost navigation between calls silently targeted root.

## Fix

- Remember the last confirmed viewing per tab from successful enter / query / exit replies.
- On the panel's "must be run INSIDE a subgraph" refusal for interior mutations (unexpose / expose / rail / promote), probe the live canvas.
- If it is at root, re-enter the remembered owner and retry the mutation once.
- An explicit `panel_exit_subgraph` (or a query that saw root) is left alone — we do not invent a subgraph.
- A remembered subgraph from a different `workflow_uuid` is not restored.

## Tests

- `src/__tests__/orchestrator/subgraph-scope-persist.test.ts` — enter, query confirms subgraph, later unexpose on a new ctx still re-enters node 96.
- `src/__tests__/services/subgraph-viewing-scope.test.ts` — restore helper, explicit-exit, workflow-uuid mismatch.

Fixes #2553
