### PR TITLE
fix(2559): settle concurrent panel_set_widget after frontend ack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- concurrent panel_set_widget calls each settle after frontend acknowledgement instead of hanging the combined tool call (#2559)
 - panel_set_widget does not refuse an ordinary-root write when the panel connection identity is missing after a successful scope probe (#2551)
 - persist subgraph viewing scope across panel tool calls so interior mutations do not silently fall back to root (#2553)
 - use the authenticated connected panel for headless `/object_info` reads when the configured ComfyUI route is unreachable (#2283)

--- a/src/__tests__/orchestrator/set-widget-concurrent-ack.test.ts
+++ b/src/__tests__/orchestrator/set-widget-concurrent-ack.test.ts
@@ -1,0 +1,253 @@
+// #2559 — six concurrent panel_set_widget calls applied their widget mutations
+// but the combined MCP tool call never completed. The panel's WS listener is
+// async-per-message and coalesces schema work; it applies each write immediately
+// and only then ACKs. Holding the per-tab graph lane until that ACK meant the
+// sixth write could never dispatch, so the frontend never flushed the coalesced
+// replies and every waiter hung past the outer tools/call budget.
+//
+// The property under test is the SHIPPED tool: real panel_set_widget defs against
+// a real UiBridge + a mock panel that applies on receive and ACKs every
+// graph_set_widget together once six are in flight — the collision the live
+// frontend exhibits. Each call must settle (resolve or reject), not hang.
+
+import { createServer } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { UiBridge } from "../../services/ui-bridge.js";
+import { buildPanelToolDefs, makePanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const TAB = "wf:workflows/video_minimax_h3_i2v.json";
+const WORKFLOW_UUID = "11111111-1111-4111-8111-111111111111";
+const WRITES = [
+  { node_id: 1, widget: "text", value: "a" },
+  { node_id: 2, widget: "text", value: "b" },
+  { node_id: 3, widget: "text", value: "c" },
+  { node_id: 4, widget: "text", value: "d" },
+  { node_id: 5, widget: "text", value: "e" },
+  { node_id: 6, widget: "text", value: "f" },
+] as const;
+
+let bridge: UiBridge;
+let port: number;
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+async function startBridge(): Promise<void> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    port = await freePort();
+    bridge = new UiBridge(port);
+    bridge.start();
+    if (await bridge.whenReady()) {
+      bridge.setTabWorkflowUuidResolver(() => WORKFLOW_UUID);
+      return;
+    }
+    lastErr = `bind to ${port} lost a close→rebind race`;
+    await bridge.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+function connectPanel(): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sock.on("open", () => {
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: TAB,
+          title: "video_minimax_h3_i2v",
+          tab_session_id: "browser-tab-2559",
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+          enforces_expected_node_type_at_write: true,
+        }),
+      );
+      resolve(sock);
+    });
+    sock.on("error", reject);
+  });
+}
+
+function viewing() {
+  return { scope: "root", kind: "root", workflow: "video_minimax_h3_i2v.json", workflow_uuid: WORKFLOW_UUID };
+}
+
+function ordinaryNode(id: unknown) {
+  return {
+    id,
+    type: "CLIPTextEncode",
+    is_subgraph: false,
+    node_identity: `node:${String(id)}`,
+    widgets: { text: "old" },
+  };
+}
+
+function replyQuery(msg: Record<string, unknown>): Record<string, unknown> {
+  const ids = Array.isArray(msg.ids) ? msg.ids : [msg.node_id ?? 1];
+  const id = ids[0];
+  return {
+    viewing: viewing(),
+    truncated: false,
+    nodes: [ordinaryNode(id)],
+    node_count: 1,
+  };
+}
+
+function setWidgetResult(msg: Record<string, unknown>): Record<string, unknown> {
+  return {
+    set: {
+      node_id: msg.node_id,
+      widget: msg.widget,
+      previous: "old",
+      value: msg.value,
+    },
+  };
+}
+
+/** Apply every graph_set_widget immediately; ACK them only once six are in flight.
+ *  Reads/preflight commands reply at once so promotion probes cannot stall the batch. */
+function attachCoalescingPanel(sock: WebSocket): { applied: Array<Record<string, unknown>> } {
+  const applied: Array<Record<string, unknown>> = [];
+  const pendingWrites: Array<Record<string, unknown>> = [];
+  const flushWrites = () => {
+    for (const msg of pendingWrites.splice(0)) {
+      if (typeof msg.rid !== "string") continue;
+      sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: setWidgetResult(msg) }));
+    }
+  };
+  sock.on("message", (buf) => {
+    const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+    if (typeof msg.rid !== "string" || typeof msg.cmd !== "string") return;
+    if (msg.cmd === "graph_set_widget") {
+      applied.push({ node_id: msg.node_id, widget: msg.widget, value: msg.value });
+      pendingWrites.push(msg);
+      if (pendingWrites.length >= WRITES.length) flushWrites();
+      return;
+    }
+    const result =
+      msg.cmd === "graph_query"
+        ? replyQuery(msg)
+        : msg.cmd === "graph_get_subgraph"
+          ? {
+              viewing: viewing(),
+              truncated: false,
+              node_count: 1,
+              nodes: [ordinaryNode(msg.node_id ?? 1)],
+            }
+          : { ok: true };
+    sock.send(JSON.stringify({ rid: msg.rid, ok: true, result }));
+  });
+  return { applied };
+}
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} is not registered`);
+  return def;
+}
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+async function settleSoon<T>(p: Promise<T>, ms = 4000): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`did not settle within ${ms} ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+beforeEach(async () => {
+  await startBridge();
+});
+
+afterEach(async () => {
+  await bridge.stop();
+});
+
+describe("concurrent panel_set_widget settlement (#2559)", () => {
+  it("each of six concurrent writes settles after the frontend acks the coalesced batch", async () => {
+    const sock = await connectPanel();
+    const { applied } = attachCoalescingPanel(sock);
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const setWidget = defByName("panel_set_widget");
+    const results = await settleSoon(
+      Promise.all(WRITES.map((args) => setWidget.handler({ ...args } as never, ctx))),
+    );
+
+    expect(applied).toHaveLength(WRITES.length);
+    expect(results).toHaveLength(WRITES.length);
+    for (const res of results) {
+      expect(res.isError).not.toBe(true);
+      expect(textOf(res)).not.toMatch(/did not reply/);
+      expect(textOf(res)).not.toMatch(/did not settle/);
+      const payload = JSON.parse(textOf(res)) as { set?: { value?: unknown } };
+      expect(payload.set?.value).toBeDefined();
+    }
+    sock.close();
+  });
+
+  it("coalesced ACKs that reuse one rid still settle every in-flight graph_set_widget", async () => {
+    const sock = await connectPanel();
+    const pending: Array<Record<string, unknown>> = [];
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+      if (typeof msg.rid !== "string" || typeof msg.cmd !== "string") return;
+      if (msg.cmd !== "graph_set_widget") {
+        sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { ok: true } }));
+        return;
+      }
+      pending.push(msg);
+      if (pending.length < WRITES.length) return;
+      const sharedRid = pending[0]?.rid;
+      for (const frame of pending) {
+        sock.send(
+          JSON.stringify({
+            rid: sharedRid,
+            ok: true,
+            result: setWidgetResult(frame),
+          }),
+        );
+      }
+    });
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+
+    const settled = await settleSoon(
+      Promise.all(
+        WRITES.map((args) =>
+          bridge.send(
+            { cmd: "graph_set_widget", node_id: args.node_id, widget: args.widget, value: args.value },
+            { tabId: TAB, timeoutMs: 800 },
+          ),
+        ),
+      ),
+    );
+
+    expect(settled).toHaveLength(WRITES.length);
+    for (const result of settled) {
+      expect(result).toMatchObject({ set: { widget: "text" } });
+    }
+    sock.close();
+  });
+});

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1877,6 +1877,32 @@ function usesGraphCommandLane(cmd: string): boolean {
 }
 
 /**
+ * Whether the per-tab graph lane must wait for this command's ACK before
+ * dispatching the next graph frame.
+ *
+ * Reads still wait (#2069): concurrent graph frames share the panel's main
+ * thread and /object_info coalescer, and graph_get_errors is the one that
+ * then misses its reply. Targeted mutations apply on the canvas immediately
+ * and only then await schema work; holding the lane until that ACK is what
+ * stranded concurrent panel_set_widget (#2559) — the frontend applied every
+ * write, then waited for a sibling mutation the lane would not dispatch, so
+ * none of the MCP promises settled.
+ */
+function graphLaneWaitsForReply(cmd: string): boolean {
+  return GRAPH_CMD_EFFECT[cmd] !== "targeted";
+}
+
+/** True when a panel reply body is a graph_set_widget success (`set: {…}`). */
+function isSetWidgetReplyResult(result: unknown): boolean {
+  return (
+    !!result &&
+    typeof result === "object" &&
+    !Array.isArray(result) &&
+    Object.prototype.hasOwnProperty.call(result, "set")
+  );
+}
+
+/**
  * A mutation the panel acknowledged AFTER its reply timeout (#694, #1175).
  *
  * `result` is the panel's own reply body, present only when it was retained (see
@@ -2226,11 +2252,14 @@ export class UiBridge {
   private static readonly MAX_MISSED_FRAMES = 100;
   private pending = new Map<string, Pending>();
   /**
-   * #2069 — per-tab chain of `graph_*` dispatches. The panel's WS listener is
-   * async-per-message, so concurrent graph frames share the main thread and the
-   * /object_info coalescer; graph_get_errors is the one that then misses its
-   * reply window while query/outline/screenshot succeed. Timeout clocks start
-   * at dispatch (after the predecessor settles), not at enqueue.
+   * #2069 / #2559 — per-tab chain of `graph_*` dispatches. The panel's WS
+   * listener is async-per-message, so concurrent READ frames share the main
+   * thread and the /object_info coalescer; graph_get_errors is the one that
+   * then misses its reply window. Targeted mutations release the lane once
+   * the frame is on the wire: they apply immediately, and waiting for their
+   * ACK before the next dispatch deadlocks when the frontend coalesces
+   * several widget writes (#2559). Timeout clocks start at dispatch, not at
+   * enqueue.
    */
   private graphLane = new Map<string, Promise<unknown>>();
   /** ask_user card sends (rid → {ask_id, ts}): lets a reply that validates AFTER
@@ -3405,61 +3434,21 @@ export class UiBridge {
               }
             }
           }
+          // #2559 — a concurrent widget write can land its ACK under a rid the
+          // bridge is no longer waiting on (rewritten, coalesced, or already
+          // recorded as late) while a sibling graph_set_widget on THIS socket
+          // is still blocked. Deliver the result to that waiter instead of
+          // stranding the MCP tool call.
+          const fifo = this.findFifoPendingForSetWidgetReply(sock, msg);
+          if (fifo) {
+            this.askRidToId.delete(rid);
+            this.settlePendingReply(fifo.rid, fifo.pending, msg, sock);
+            return;
+          }
           this.recordLateMutation(rid, msg);
           return;
         }
-        clearTimeout(p.timer);
-        this.pending.delete(rid);
-        this.askRidToId.delete(rid);
-        if (msg.ok) {
-          // #422 — the panel DEMONSTRABLY served this command. Record it on the LIVE
-          // connection (following a same-socket tmp:→wf: migration whose reply landed
-          // after the id change), so a later re-hello advertising an undercutting
-          // version can never re-gate it as "too old". Scoped to THIS reply's socket so
-          // an unrelated tab reusing the id can never be granted the veto.
-          const served = this.liveConnForTab(p.ctx.tabId, sock);
-          served?.provenSupportedCmds.add(p.cmd);
-          this.notePromotedScope(p.ctx.tabId, msg.result);
-          this.noteSiblingSuccess(p.ctx, rid);
-          p.resolve(msg.result);
-        } else {
-          // #1529 — carry the panel's STRUCTURED refusal onto the error.
-          //
-          // `msg.error` is arbitrary text, and the retry path needs one fact it
-          // cannot get from text: did the executor run? The panel states that in a
-          // field (panel 0.14.35), and dropping it here is why the first attempt at
-          // the retry had to match wording — which was reverted as a P0, because a
-          // genuine mid-write failure can contain the same sentence and the cost of
-          // being wrong is a re-applied mutation.
-          //
-          // Validated before it is attached, so only a complete pre-executor claim
-          // travels; anything else leaves the error exactly as it was.
-          // #1560 — and record the fact that this reply EXISTS, structurally.
-          // `ctx.call` flattens every failure into `isError`, so a command the panel
-          // SERVED and refused arrives indistinguishable from one the tab never
-          // answered — and a caller that reports "the channel is not answering" then
-          // says it about a panel that is demonstrably talking. This branch is the
-          // one place that knows the difference: a reply was received.
-          const err = attachPanelAnswered(new Error(String(msg.error ?? "panel reported an error")));
-          // OWN property on the WIRE message too (review, P0). A polluted
-          // Object.prototype.refusal would otherwise give every ordinary panel
-          // error — including a genuine mid-write one carrying no refusal of its
-          // own — the authority to have a mutation re-issued.
-          const refusal = hasOwnField(msg, "refusal")
-            ? readPanelRefusal((msg as { refusal?: unknown }).refusal)
-            : null;
-          const workflowListReadiness =
-            p.cmd === "workflow_list" && hasOwnField(msg, "workflow_list_readiness")
-              ? readWorkflowListReadiness(
-                  (msg as { workflow_list_readiness?: unknown }).workflow_list_readiness,
-                )
-              : null;
-          let rejected = refusal ? attachPanelRefusal(err, refusal) : err;
-          if (workflowListReadiness) {
-            rejected = attachWorkflowListReadiness(rejected, workflowListReadiness);
-          }
-          p.reject(rejected);
-        }
+        this.settlePendingReply(rid, p, msg, sock);
         return;
       }
 
@@ -5038,14 +5027,107 @@ export class UiBridge {
     result: unknown,
     sock: BridgeSocket,
   ): void {
+    this.settlePendingReply(rid, pending, { ok: true, result }, sock);
+  }
+
+  /**
+   * #2559 — oldest in-flight graph_set_widget on this socket, used when a
+   * mutation ACK misses its rid (coalesced / rewritten) while the waiter is
+   * still blocked. Never steals a non-widget pending.
+   */
+  private findFifoPendingForSetWidgetReply(
+    sock: BridgeSocket,
+    msg: Record<string, unknown>,
+  ): { rid: string; pending: Pending } | undefined {
+    if (msg.ok === true && !isSetWidgetReplyResult(msg.result)) return undefined;
+    const set =
+      msg.ok === true && isSetWidgetReplyResult(msg.result)
+        ? (msg.result as { set: Record<string, unknown> }).set
+        : undefined;
+    let oldest: { rid: string; pending: Pending } | undefined;
+    let widgetPending = 0;
+    for (const [rid, pending] of this.pending) {
+      if (pending.sock !== sock) continue;
+      if (pending.cmd !== "graph_set_widget") {
+        if (msg.ok !== true) return undefined;
+        continue;
+      }
+      widgetPending += 1;
+      const cmd = pending.ctx.command;
+      if (
+        set &&
+        cmd.node_id != null &&
+        set.node_id != null &&
+        String(cmd.node_id) !== String(set.node_id)
+      ) {
+        continue;
+      }
+      oldest ??= { rid, pending };
+    }
+    if (msg.ok !== true && widgetPending !== 1) return undefined;
+    return oldest;
+  }
+
+  /** Resolve or reject one in-flight command from a panel `{ rid, ok, … }` reply. */
+  private settlePendingReply(
+    rid: string,
+    pending: Pending,
+    msg: Record<string, unknown>,
+    sock: BridgeSocket,
+  ): void {
     clearTimeout(pending.timer);
     this.pending.delete(rid);
     this.askRidToId.delete(rid);
-    const served = this.liveConnForTab(pending.ctx.tabId, sock);
-    served?.provenSupportedCmds.add(pending.cmd);
-    this.notePromotedScope(pending.ctx.tabId, result);
-    this.noteSiblingSuccess(pending.ctx, rid);
-    pending.resolve(result);
+    if (msg.ok) {
+      // #422 — the panel DEMONSTRABLY served this command. Record it on the LIVE
+      // connection (following a same-socket tmp:→wf: migration whose reply landed
+      // after the id change), so a later re-hello advertising an undercutting
+      // version can never re-gate it as "too old". Scoped to THIS reply's socket so
+      // an unrelated tab reusing the id can never be granted the veto.
+      const served = this.liveConnForTab(pending.ctx.tabId, sock);
+      served?.provenSupportedCmds.add(pending.cmd);
+      this.notePromotedScope(pending.ctx.tabId, msg.result);
+      this.noteSiblingSuccess(pending.ctx, rid);
+      pending.resolve(msg.result);
+      return;
+    }
+    // #1529 — carry the panel's STRUCTURED refusal onto the error.
+    //
+    // `msg.error` is arbitrary text, and the retry path needs one fact it
+    // cannot get from text: did the executor run? The panel states that in a
+    // field (panel 0.14.35), and dropping it here is why the first attempt at
+    // the retry had to match wording — which was reverted as a P0, because a
+    // genuine mid-write failure can contain the same sentence and the cost of
+    // being wrong is a re-applied mutation.
+    //
+    // Validated before it is attached, so only a complete pre-executor claim
+    // travels; anything else leaves the error exactly as it was.
+    // #1560 — and record the fact that this reply EXISTS, structurally.
+    // `ctx.call` flattens every failure into `isError`, so a command the panel
+    // SERVED and refused arrives indistinguishable from one the tab never
+    // answered — and a caller that reports "the channel is not answering" then
+    // says it about a panel that is demonstrably talking. This branch is the
+    // one place that knows the difference: a reply was received.
+    const p = pending;
+    const err = attachPanelAnswered(new Error(String(msg.error ?? "panel reported an error")));
+    // OWN property on the WIRE message too (review, P0). A polluted
+    // Object.prototype.refusal would otherwise give every ordinary panel
+    // error — including a genuine mid-write one carrying no refusal of its
+    // own — the authority to have a mutation re-issued.
+    const refusal = hasOwnField(msg, "refusal")
+      ? readPanelRefusal((msg as { refusal?: unknown }).refusal)
+      : null;
+    const workflowListReadiness =
+      p.cmd === "workflow_list" && hasOwnField(msg, "workflow_list_readiness")
+        ? readWorkflowListReadiness(
+            (msg as { workflow_list_readiness?: unknown }).workflow_list_readiness,
+          )
+        : null;
+    let rejected = refusal ? attachPanelRefusal(err, refusal) : err;
+    if (workflowListReadiness) {
+      rejected = attachWorkflowListReadiness(rejected, workflowListReadiness);
+    }
+    p.reject(rejected);
   }
 
   /** The incarnation currently holding `tabId` — the identity every structure
@@ -6031,7 +6113,7 @@ export class UiBridge {
         markDispatched(new Error(`Panel tab ${conn.tabId.slice(0, 8)} is not open`), false),
       );
     }
-    const launch = (): Promise<unknown> => {
+    const launch = (releaseLane: () => void): Promise<unknown> => {
       // Re-resolve after a graph-lane wait: the tab may have migrated while a
       // predecessor occupied the lane. Gates above already ran against `conn`.
       let live: Conn;
@@ -6159,26 +6241,53 @@ export class UiBridge {
           workflowUuid:
             this.resolveTabWorkflowUuid?.(commandStampAddress(cmd, opts.tabId, live.tabId)) ??
             undefined,
-          onDispatchedRid: opts.onDispatchedRid,
+          onDispatchedRid: (rid) => {
+            releaseLane();
+            opts.onDispatchedRid?.(rid);
+          },
         };
         this.dispatch(live, ctx);
       });
     };
     if (usesGraphCommandLane(cmd.cmd)) {
-      return this.enqueueGraphLane(conn.tabId, launch);
+      return this.enqueueGraphLane(conn.tabId, launch, graphLaneWaitsForReply(cmd.cmd));
     }
-    return launch();
+    return launch(() => {});
   }
 
   /** Serialize `graph_*` dispatches per tab so concurrent reads cannot occupy
-   *  the panel at once (#2069). Failures still release the lane. */
-  private enqueueGraphLane<T>(tabId: string, run: () => Promise<T>): Promise<T> {
+   *  the panel at once (#2069). Targeted mutations release once the frame is
+   *  written so a sibling widget write can dispatch while the first awaits its
+   *  schema ACK (#2559). Failures still release the lane. */
+  private enqueueGraphLane<T>(
+    tabId: string,
+    run: (releaseLane: () => void) => Promise<T>,
+    waitForReply: boolean,
+  ): Promise<T> {
     const prev = this.graphLane.get(tabId) ?? Promise.resolve();
-    const next = prev.then(run, run);
-    const tail: Promise<unknown> = next.then(
-      () => undefined,
-      () => undefined,
+    let releaseLane = () => {};
+    const gate = waitForReply
+      ? null
+      : new Promise<void>((resolve) => {
+          releaseLane = resolve;
+        });
+    const next = prev.then(
+      () => run(releaseLane),
+      () => run(releaseLane),
     );
+    const tail: Promise<unknown> =
+      waitForReply || !gate
+        ? next.then(
+            () => undefined,
+            () => undefined,
+          )
+        : Promise.race([
+            gate,
+            next.then(
+              () => undefined,
+              () => undefined,
+            ),
+          ]);
     this.graphLane.set(tabId, tail);
     void tail.then(() => {
       if (this.graphLane.get(tabId) === tail) this.graphLane.delete(tabId);
@@ -6412,6 +6521,12 @@ export class UiBridge {
       // key on it). Previously `{ rid, ...cmd }` let a caller cmd.rid clobber the
       // minted rid, silently breaking reply correlation for that command.
       const frame: Record<string, unknown> = { ...cmd, rid };
+      // #2559 — the panel bounds duplicate-rid waits from THIS number. Use the
+      // caller-requested timeout, not the remaining clamp: retry_of fingerprints
+      // exclude only rid/retry_of, so a shrinking remainder would make a retry
+      // look like a different command. Always overwrite after the spread (same
+      // rule as rid).
+      frame.timeout_ms = ctx.timeoutMs;
       if (ctx.workflowUuid) frame.workflow_uuid = ctx.workflowUuid;
       else delete frame.workflow_uuid;
       conn.sock.send(JSON.stringify(frame));


### PR DESCRIPTION
Fixes #2559

Six concurrent `panel_set_widget` calls could apply their canvas mutations while the combined MCP tool call never returned. Targeted graph writes were holding the per-tab graph lane until the schema ACK, so a live-canvas coalescer that applies immediately and replies only after several writes were in flight could deadlock every waiter.

This releases the graph lane once a targeted mutation is on the wire, FIFO-matches a set-widget ACK that misses its rid to the oldest in-flight write on that socket, and stamps `timeout_ms` on the frame so the panel can bound duplicate-rid waits. Concurrent `panel_set_widget` calls each settle after frontend acknowledgement.

## Test

```
npx vitest run src/__tests__/orchestrator/set-widget-concurrent-ack.test.ts src/__tests__/orchestrator/get-errors-concurrent-reads.test.ts
```