### PR TITLE
chore: release v0.52.152

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.152] - 2026-08-30
+
 ### MCP
 
 #### Fixed
-- concurrent panel_set_widget calls each settle after frontend acknowledgement instead of hanging the combined tool call (#2559)
-- panel_set_widget does not refuse an ordinary-root write when the panel connection identity is missing after a successful scope probe (#2551)
-- persist subgraph viewing scope across panel tool calls so interior mutations do not silently fall back to root (#2553)
-- use the authenticated connected panel for headless `/object_info` reads when the configured ComfyUI route is unreachable (#2283)
+- concurrent panel_set_widget calls each settle after frontend acknowledgement instead of hanging the combined tool call (#2559, #2605)
+- panel_set_widget does not refuse an ordinary-root write when the panel connection identity is missing after a successful scope probe (#2551, #2601)
+- persist subgraph viewing scope across panel tool calls so interior mutations do not silently fall back to root (#2553, #2602)
+- use the authenticated connected panel for headless `/object_info` reads when the configured ComfyUI route is unreachable (#2283, #2566)
 
 ## [0.52.151] - 2026-08-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.151",
+  "version": "0.52.152",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.151",
+      "version": "0.52.152",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.151",
+  "version": "0.52.152",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.52.152 covering #2551 (PR #2601), #2553 (PR #2602), #2283 (PR #2566). Single MCP/Fixed changelog block.