### PR TITLE
fix(2591): suppress acknowledged completion replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
-- suppress already-acknowledged run-finished replays after panel reconnects while preserving undelivered completion recovery (#2591)
+- suppress already-acknowledged run-finished replays after panel reconnects while preserving undelivered completion recovery
 - concurrent panel_set_widget calls each settle after frontend acknowledgement instead of hanging the combined tool call (#2559, #2605)
 - panel_set_widget does not refuse an ordinary-root write when the panel connection identity is missing after a successful scope probe (#2551, #2601)
 - persist subgraph viewing scope across panel tool calls so interior mutations do not silently fall back to root (#2553, #2602)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- suppress already-acknowledged run-finished replays after panel reconnects while preserving undelivered completion recovery (#2591)
 - concurrent panel_set_widget calls each settle after frontend acknowledgement instead of hanging the combined tool call (#2559, #2605)
 - panel_set_widget does not refuse an ordinary-root write when the panel connection identity is missing after a successful scope probe (#2551, #2601)
 - persist subgraph viewing scope across panel tool calls so interior mutations do not silently fall back to root (#2553, #2602)

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -206,6 +206,7 @@ function makeHarness(backend: AgentBackend) {
           ? null
           : journal.record(tab, payload, { conversation })
         : journal.record(tab, payload, { conversation });
+    if (entry?.alreadyDelivered) journal.suppressAlreadyDelivered(entry.token);
     const acked =
       completionKey !== null &&
       promptId !== null &&
@@ -339,6 +340,86 @@ describe("#1824 production keyed completion ingress", () => {
     expect(panel.entry).toBeNull();
     expect(panel.acked).toBe(true);
     expect(journal.outstanding(tab)).toHaveLength(0);
+  });
+});
+
+describe("#2591 production completion reconnect dedupe", () => {
+  it("suppresses a burst of acknowledged legacy frames after reconnect", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager, flush, arriveProduction } = makeHarness(backend);
+    const tab = "tab-reconnect-2591";
+    const conversation = "orchestrator::claude";
+    const frame = {
+      kind: "executed",
+      prompt_id: PROMPT_A,
+      images: [{ filename: "reconnect-2591.png" }],
+    };
+
+    journal.openRun(PROMPT_A, { tabId: tab, conversation });
+    manager.send(tab, "render it");
+    await waitFor(() => backend.turns.length >= 1);
+
+    // This is the real production ordering: the panel completion is recorded
+    // and offered while the carrying user turn is still in flight.
+    arriveProduction(tab, frame, conversation);
+    backend.finishTurn();
+    await waitFor(() => backend.turns.length >= 2);
+    expect(backend.turns[1]).toContain("reconnect-2591.png");
+
+    // The completion's own turn result is the positive acknowledgement.
+    backend.finishTurn();
+    await waitFor(() => journal.outstanding(tab).length === 0);
+    const turnsAfterAck = backend.turns.length;
+
+    // A reconnect can resend the same legacy frame and trigger another journal
+    // sweep. It is already acknowledged, so none of the burst may create a turn.
+    for (let i = 0; i < 5; i += 1) {
+      const replay = arriveProduction(tab, frame, conversation);
+      expect(replay.entry?.alreadyDelivered).toBe(true);
+      flush(tab); // reconnect/agent-ready recovery sweep
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(journal.outstanding(tab)).toHaveLength(0);
+    expect(backend.turns).toHaveLength(turnsAfterAck);
+  });
+
+  it("still replays a genuinely undelivered legacy frame when an agent returns", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager, arriveProduction } = makeHarness(backend);
+    const tab = "tab-undelivered-2591";
+    const conversation = "orchestrator::claude";
+
+    journal.openRun(PROMPT_B, { tabId: tab, conversation });
+    const arrival = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: PROMPT_B, images: [{ filename: "undelivered-2591.png" }] },
+      conversation,
+    );
+    expect(arrival.entry?.alreadyDelivered).toBeUndefined();
+    expect(journal.pending(tab)).toHaveLength(1); // no live agent took it
+
+    manager.send(tab, "welcome back");
+    await waitFor(() => backend.turns.some((turn) => turn.includes("undelivered-2591.png")));
+    expect(journal.outstanding(tab)).toHaveLength(1); // hand-off, not yet an ack
+
+    backend.finishTurn();
+    await waitFor(() => journal.outstanding(tab).length === 0);
+    expect(journal.ticketFor(PROMPT_B)?.settled).toBe(true);
+  });
+});
+
+describe("#2591 production ingress wiring", () => {
+  it("consumes the journal verdict before the reconnect flush", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+    const record = source.indexOf("RunCompletions.record(event.tab_id");
+    const consume = source.indexOf("RunCompletions.suppressAlreadyDelivered(entry.token)", record);
+    const flush = source.indexOf("flushRunCompletions(event.tab_id)", record);
+
+    expect(record).toBeGreaterThan(-1);
+    expect(consume).toBeGreaterThan(record);
+    expect(source.slice(record, consume)).toContain("entry?.alreadyDelivered");
+    expect(flush).toBeGreaterThan(consume);
   });
 });
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -5588,6 +5588,15 @@ export async function runPanelOrchestrator(): Promise<void> {
           : RunCompletions.record(event.tab_id, evForTab as CompletionPayload, {
               conversation: agentKeyFor(event.tab_id),
             });
+        // #2591 — `completion_key` is unavailable on older/replayed panel
+        // frames, so the durable fence cannot identify an already-acked run.
+        // The journal has nevertheless proved the exact current ticket
+        // generation and ownership; consume that verdict before the flush can
+        // create another agent turn. Unprovable, foreign, and genuinely pending
+        // entries remain on the normal replay path.
+        if (entry?.alreadyDelivered) {
+          RunCompletions.suppressAlreadyDelivered(entry.token);
+        }
         const receiptAccepted =
           completionKey !== null &&
           typeof ev.prompt_id === "string" &&
@@ -5612,7 +5621,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         }
         logger.info(
           entry
-            ? `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}${entry.possibleRepeat ? " (flagged as a possible repeat)" : ""}`
+            ? `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}${entry.alreadyDelivered ? " (suppressed as already delivered)" : entry.possibleRepeat ? " (flagged as a possible repeat)" : ""}`
             : `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} replayed an acknowledged run completion key`,
         );
         flushRunCompletions(event.tab_id);

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -232,9 +232,12 @@ export interface JournalEntry {
    *  ack. Bounds the replay loop — see release(). */
   carriedReleases?: number;
   /** An identical completion was delivered recently, so this may be the same
-   *  frame re-sent. The scheduling fence consumes this marker before a second
-   *  agent turn; it is retained here so the journal's verdict cannot be lost. */
+   *  frame re-sent. Kept as a delivery hint for the agent-facing payload. */
   possibleRepeat?: boolean;
+  /** This identified completion belongs to the current ticket generation, and
+   *  that exact run was already acknowledged. The production ingress consumes
+   *  this stronger verdict before scheduling another agent turn. */
+  alreadyDelivered?: boolean;
   /** This entry's prompt id was queued AGAIN while it was still undelivered, so
    *  it belongs to the older run. Still delivered, but it can no longer be merged
    *  into, settle a ticket, or memoize a delivery. */
@@ -859,9 +862,9 @@ export class RunCompletionJournalImpl {
    *
    * DEDUPE, in both directions:
    *  • IDENTIFIED (matched or foreign) — collapses onto any existing undelivered
-   *    entry for the same key + prompt id, and is suppressed outright once that
-   *    (tab, run) has been acked. One run can never produce two deliveries,
-   *    however many times the panel re-sends it.
+   *    entry for the same key + prompt id. A matched completion for the current
+   *    ticket generation that was already acked is marked for the production
+   *    ingress to suppress; foreign and unprovable completions remain deliverable.
    *  • ID-LESS — there is no run identity, so it dedupes on a CONTENT
    *    fingerprint within IDLESS_DEDUPE_WINDOW_MS. That is enough to stop a
    *    re-sent frame producing two turns (the agent double-reporting, or acting
@@ -981,7 +984,7 @@ export class RunCompletionJournalImpl {
       // Both cases fall back to the standing rule: duplicate over loss, each
       // delivered on its own and labelled UNDETERMINED.
       idUnprovable = idReused || gen === 0;
-      // ALREADY-DELIVERED IS A JOURNAL VERDICT, NOT THE SCHEDULING VETO.
+      // ALREADY-DELIVERED IS A JOURNAL VERDICT FOR THE PRODUCTION INGRESS.
       //
       // This used to `return null` — suppressing the completion outright — and
       // that single decision produced defect after defect, because every proof it
@@ -991,9 +994,11 @@ export class RunCompletionJournalImpl {
       // swallowed: exactly the failure this whole file exists to prevent, and the
       // one the project's rules call worse than a duplicate.
       //
-      // The journal records it FLAGGED as a possible repeat. The orchestrator's
-      // scheduling boundary consumes that flag before creating another turn;
-      // this journal still retains the entry until that boundary handles it.
+      // The journal records it FLAGGED as a possible repeat and carries the
+      // stronger verdict separately. The production ingress consumes that
+      // verdict before creating another turn; generic journal callers still
+      // retain the duplicate-over-loss behavior for entries they cannot prove
+      // are from this exact acknowledged run.
       if (
         !idUnprovable &&
         (this.delivered.has(deliveredKey(ownerOf(key, conversation), correlation.promptId, gen)) ||
@@ -1095,6 +1100,7 @@ export class RunCompletionJournalImpl {
       // One flag, both paths: an identified run whose completion was already
       // delivered, or an id-less one whose content matches a recent delivery.
       ...(idlessRepeat || alreadyDelivered ? { possibleRepeat: true } : {}),
+      ...(alreadyDelivered ? { alreadyDelivered: true } : {}),
       // Freeze the ambiguity onto the entry — see JournalEntry.ambiguousId.
       ...(idUnprovable ? { ambiguousId: true } : {}),
       // …and the GENERATION this completion belongs to, for EVERY identified
@@ -1444,6 +1450,23 @@ export class RunCompletionJournalImpl {
       this.dropped.set(entry.key, (this.dropped.get(entry.key) ?? 0) + entry.disclose!);
     }
     this.entries.delete(token);
+  }
+
+  /**
+   * Consume a duplicate that `record()` proved belongs to an already-acked
+   * current ticket generation, before the production delivery flush can offer
+   * it to the agent again. This is intentionally separate from `suppress()`:
+   * the latter is called from inside `deliverPending()` by the durable fence and
+   * must preserve its in-flush disclosure bookkeeping.
+   */
+  suppressAlreadyDelivered(token: string): boolean {
+    const entry = this.entries.get(token);
+    if (!entry?.alreadyDelivered) return false;
+    // The prior delivery is the proof that this duplicate was consumed. Using
+    // the normal ack path also records a newly supplied completion_key when an
+    // older client first delivered the same run without one.
+    this.ack(token);
+    return true;
   }
 
   /** Move every entry AND every open run ticket from `from` onto `to` — a panel


### PR DESCRIPTION
## Summary\n- carry the journal's exact-generation already-delivered verdict into the production executed-event ingress\n- suppress legacy/no-completion_key resend bursts after the carrying agent turn is acknowledged\n- preserve replay for genuinely undelivered completions and fail-closed reused/foreign correlation\n- add production-shaped PanelAgentManager regression coverage and an Unreleased changelog entry\n\n## Validation\n- npm.cmd run build\n- npm.cmd run lint\n- npm.cmd exec vitest run src/__tests__/orchestrator/run-completion-continuation.test.ts src/__tests__/orchestrator/run-completion-race.test.ts src/__tests__/orchestrator/run-completion-idempotency.test.ts src/__tests__/orchestrator/possible-repeat-wording.test.ts\n- npm.cmd test