### PR TITLE
fix(2502): retry panel_connect against the live graph after a stale missing-node refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- retry panel_connect against the live graph when a node reported by panel_graph_outline is refused as missing (#2502)
 - panel_open_workflow no longer treats frontend-normalized node fields as a failed load after reconnect (#2501)
 - make `resolve_missing` suggest `models/clip_vision/` for missing `CLIPVisionLoader.clip_name` models while keeping ordinary CLIP loaders on `models/text_encoders/` (#2604)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_open_workflow no longer treats frontend-normalized node fields as a failed load after reconnect (#2501)
 - make `resolve_missing` suggest `models/clip_vision/` for missing `CLIPVisionLoader.clip_name` models while keeping ordinary CLIP loaders on `models/text_encoders/` (#2604)
 
+
 ## [0.52.152] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/services/connect-live-graph.test.ts
+++ b/src/__tests__/services/connect-live-graph.test.ts
@@ -1,0 +1,254 @@
+// #2502 — after a completed render, panel_graph_outline lists live root node
+// 127, then panel_connect from 127 to a newly added 149 is refused:
+// "No node with id 127 in the current graph". Mutation lookup was bound to a
+// stale graph object while reads already walked the live snapshot.
+//
+// Tests drive the shipped connect/lookup helpers AND the panel_connect wrap —
+// a reimplementation here would stay green if the wrap were deleted.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalConnectNodeId,
+  isMissingNodeInCurrentGraphRefusal,
+  isUsableLiveGraphBinding,
+  liveGraphHasConnectEndpoints,
+  liveGraphHasNodeId,
+  missingNodeIdInCurrentGraph,
+  parseLiveGraphBinding,
+  retryConnectAgainstLiveGraph,
+} from "../../services/connect-live-graph.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const PANEL_SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url)),
+  "utf8",
+);
+const SERVICE_SRC = readFileSync(
+  fileURLToPath(new URL("../../services/connect-live-graph.ts", import.meta.url)),
+  "utf8",
+);
+
+const REPORTER_ERROR =
+  "Error: No node with id 127 in the current graph - and it is not in any other scope either.";
+
+const INSIDE_SUBGRAPH_ERROR =
+  "No node with id 188 in the current graph. Node 188 lives INSIDE a subgraph — call panel_enter_subgraph first";
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function jsonResult(payload: unknown, isError = false): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function textResult(text: string, isError = false): ToolResult {
+  return { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}) };
+}
+
+function allText(res: { content: Array<{ type: string; text?: string }> }): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+describe("missing-node current-graph refusal (#2502)", () => {
+  it("parses the reporter's exact panel sentence", () => {
+    expect(isMissingNodeInCurrentGraphRefusal(REPORTER_ERROR)).toBe(true);
+    expect(missingNodeIdInCurrentGraph(REPORTER_ERROR)).toBe("127");
+    expect(canonicalConnectNodeId("127")).toBe("127");
+    expect(canonicalConnectNodeId(127)).toBe("127");
+  });
+
+  it("does not treat a subgraph-scope miss as a stale-identity miss", () => {
+    expect(isMissingNodeInCurrentGraphRefusal(INSIDE_SUBGRAPH_ERROR)).toBe(false);
+    expect(missingNodeIdInCurrentGraph(INSIDE_SUBGRAPH_ERROR)).toBeNull();
+  });
+});
+
+describe("live graph lookup / binding", () => {
+  it("accepts the outline-shaped live query that lists both connect endpoints", () => {
+    const payload = {
+      viewing: { scope: "root", graph_identity: "graph:depth-anything-root" },
+      truncated: false,
+      matched: 2,
+      ids: [127, 149],
+      text: "127,149",
+    };
+    expect(parseLiveGraphBinding(payload.viewing)).toEqual({
+      scope: "root",
+      graphIdentity: "graph:depth-anything-root",
+    });
+    expect(isUsableLiveGraphBinding(parseLiveGraphBinding(payload.viewing))).toBe(true);
+    expect(liveGraphHasNodeId(payload, 127)).toBe(true);
+    expect(liveGraphHasNodeId(payload, "149")).toBe(true);
+    expect(liveGraphHasConnectEndpoints(payload, 127, 149)).toBe(true);
+    expect(liveGraphHasNodeId(payload, 12)).toBe(false);
+  });
+
+  it("rejects a truncated or malformed live snapshot instead of guessing", () => {
+    expect(
+      liveGraphHasNodeId({ truncated: true, ids: [127], viewing: { scope: "root" } }, 127),
+    ).toBe(false);
+    expect(parseLiveGraphBinding({ scope: "root", graph_identity: 17 })).toBeNull();
+    expect(isUsableLiveGraphBinding({ scope: "other" })).toBe(false);
+    expect(parseLiveGraphBinding({ kind: "root" })).toBeNull();
+  });
+});
+
+describe("retryConnectAgainstLiveGraph", () => {
+  it("forwards a successful connect with no extra query", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryConnectAgainstLiveGraph(
+      { from_node_id: 1, from_output: "IMAGE", to_node_id: 2, to_input: "image" },
+      async (cmd) => {
+        calls.push(cmd);
+        return jsonResult({ connected: true });
+      },
+    );
+    expect(calls).toEqual([
+      {
+        cmd: "graph_connect",
+        from_node_id: 1,
+        from_output: "IMAGE",
+        to_node_id: 2,
+        to_input: "image",
+        auto_match: undefined,
+      },
+    ]);
+    expect(res.isError).toBeUndefined();
+  });
+
+  it("THE REPORTED CASE: outline-live node 127 is retried after a stale connect miss", async () => {
+    let mutationGraph: "stale" | "live" = "stale";
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryConnectAgainstLiveGraph(
+      { from_node_id: 127, from_output: "IMAGE", to_node_id: 149, to_input: "image" },
+      async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_connect") {
+          if (mutationGraph === "stale") {
+            return textResult(REPORTER_ERROR, true);
+          }
+          return jsonResult({
+            connected: { from: 127, to: 149, from_output: "IMAGE", to_input: "image" },
+          });
+        }
+        if (cmd.cmd === "graph_query") {
+          mutationGraph = "live";
+          return jsonResult({
+            viewing: { scope: "root", graph_identity: "graph:depth-anything-root" },
+            truncated: false,
+            matched: 2,
+            ids: [127, 149],
+            text: "127,149",
+          });
+        }
+        return textResult(`unexpected ${String(cmd.cmd)}`, true);
+      },
+    );
+
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_connect", "graph_query", "graph_connect"]);
+    expect(calls[1]).toMatchObject({
+      cmd: "graph_query",
+      ids: [127, 149],
+      fields: "ids",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content[0]!.text!)).toMatchObject({
+      connected: { from: 127, to: 149 },
+    });
+    expect(allText(res)).toMatch(/#2502/);
+    expect(allText(res)).toMatch(/panel_graph_outline/);
+  });
+
+  it("leaves a genuine missing node alone", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryConnectAgainstLiveGraph(
+      { from_node_id: 127, to_node_id: 149 },
+      async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_connect") return textResult(REPORTER_ERROR, true);
+        return jsonResult({
+          viewing: { scope: "root" },
+          truncated: false,
+          matched: 1,
+          ids: [149],
+          text: "149",
+        });
+      },
+    );
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_connect", "graph_query"]);
+    expect(res.isError).toBe(true);
+    expect(allText(res)).toBe(REPORTER_ERROR);
+  });
+
+  it("does not retry a subgraph-scope miss", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryConnectAgainstLiveGraph(
+      { from_node_id: 188, to_node_id: 1 },
+      async (cmd) => {
+        calls.push(cmd);
+        return textResult(INSIDE_SUBGRAPH_ERROR, true);
+      },
+    );
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_connect"]);
+    expect(res.isError).toBe(true);
+  });
+});
+
+describe("panel_connect ships the live-graph lookup (#2502)", () => {
+  it("handlers dispatch through retryConnectAgainstLiveGraph", () => {
+    expect(PANEL_SRC).toMatch(/retryConnectAgainstLiveGraph\(/);
+    expect(PANEL_SRC).toMatch(/"panel_connect"/);
+    expect(SERVICE_SRC).toMatch(/cmd: "graph_connect"/);
+    expect(SERVICE_SRC).toMatch(/cmd: "graph_query"/);
+  });
+
+  it("THE REPORTED CASE through the registered panel_connect handler", async () => {
+    let mutationGraph: "stale" | "live" = "stale";
+    const calls: Record<string, unknown>[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_connect") {
+          if (mutationGraph === "stale") {
+            return textResult(REPORTER_ERROR, true);
+          }
+          return jsonResult({ connected: true });
+        }
+        if (cmd.cmd === "graph_query") {
+          mutationGraph = "live";
+          return jsonResult({
+            viewing: { scope: "root", graph_identity: "graph:depth-anything-root" },
+            truncated: false,
+            ids: [127, 149],
+            text: "127,149",
+          });
+        }
+        return textResult(`unexpected ${String(cmd.cmd)}`, true);
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "wf:2502-reported",
+    };
+
+    const res = await defByName("panel_connect").handler(
+      { from_node_id: 127, from_output: "IMAGE", to_node_id: 149, to_input: "image" },
+      ctx,
+    );
+    expect(res.isError).toBeUndefined();
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_connect", "graph_query", "graph_connect"]);
+    expect(allText(res)).toMatch(/#2502/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -84,6 +84,7 @@ import {
   laterSlotsFromUnexposePayload,
   unexposeHostLinkShiftNote,
 } from "../services/unexpose-host-link-shift.js";
+import { retryConnectAgainstLiveGraph } from "../services/connect-live-graph.js";
 import { retryExposeSubgraphInput } from "../services/expose-ae-wildcard.js";
 import {
   callAndRememberViewing,
@@ -18938,14 +18939,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         input: slotRef.optional().describe("Alias for to_input."),
       },
       async (args: A, ctx) =>
-        ctx.call({
-          cmd: "graph_connect",
-          from_node_id: args.from_node_id,
-          from_output: args.from_output ?? args.from_slot_name ?? args.from_slot ?? args.output,
-          to_node_id: args.to_node_id,
-          to_input: args.to_input ?? args.to_slot_name ?? args.to_slot ?? args.input,
-          auto_match: args.auto_match,
-        }),
+        retryConnectAgainstLiveGraph(
+          {
+            from_node_id: args.from_node_id,
+            from_output: args.from_output ?? args.from_slot_name ?? args.from_slot ?? args.output,
+            to_node_id: args.to_node_id,
+            to_input: args.to_input ?? args.to_slot_name ?? args.to_slot ?? args.input,
+            auto_match: args.auto_match,
+          },
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+        ),
     ),
     def(
       "panel_disconnect",

--- a/src/services/connect-live-graph.ts
+++ b/src/services/connect-live-graph.ts
@@ -50,12 +50,12 @@ function toolText(res: ToolResultLike): string {
   return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
 }
 
-function parseJsonPayload(res: ToolResultLike): unknown {
+function parseJsonPayload(res: ToolResultLike): Record<string, unknown> | null {
   if (res.isError) return null;
   const text = res.content.find((c) => c.type === "text")?.text;
   if (typeof text !== "string") return null;
   try {
-    return JSON.parse(text) as unknown;
+    return asRecord(JSON.parse(text));
   } catch {
     return null;
   }

--- a/src/services/connect-live-graph.ts
+++ b/src/services/connect-live-graph.ts
@@ -1,0 +1,261 @@
+/**
+ * #2502 — `panel_connect` can refuse a node that the immediately preceding
+ * `panel_graph_outline` listed on the same live root graph.
+ *
+ * After a completed canvas render the mutation executor can still be bound to a
+ * stale graph object while reads (`graph_outline` / `graph_query`) already walk
+ * the live snapshot. The panel then reports "No node with id N in the current
+ * graph" even though the identity string and root scope match the outline.
+ *
+ * Re-resolve the live graph (the same query surface outline uses) before treating
+ * that refusal as final, and retry the connect once when both endpoints are
+ * present. A node that truly is absent, or that lives in another subgraph, is
+ * left alone.
+ */
+
+import { NODE_ID_PATTERN, normalizeNodeId } from "../orchestrator/node-id.js";
+
+const MISSING_NODE_RE = /No node with id (\S+) in the current graph/i;
+const INSIDE_SUBGRAPH_RE = /lives INSIDE a subgraph/i;
+
+export type LiveGraphBinding = {
+  scope: "root" | "subgraph";
+  graphIdentity?: string;
+};
+
+export type ConnectArgs = {
+  from_node_id: unknown;
+  from_output?: unknown;
+  to_node_id: unknown;
+  to_input?: unknown;
+  auto_match?: unknown;
+};
+
+export type ToolResultLike = {
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+};
+
+export type GraphCall<T extends ToolResultLike> = (
+  cmd: Record<string, unknown>,
+  timeoutMs?: number,
+) => Promise<T>;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function toolText(res: ToolResultLike): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+function parseJsonPayload(res: ToolResultLike): unknown {
+  if (res.isError) return null;
+  const text = res.content.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export function canonicalConnectNodeId(value: unknown): string | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? String(value) : null;
+  }
+  if (typeof value !== "string" || value.length === 0) return null;
+  if (!NODE_ID_PATTERN.test(value)) return null;
+  return String(normalizeNodeId(value));
+}
+
+export function sameConnectNodeId(left: unknown, right: unknown): boolean {
+  const a = canonicalConnectNodeId(left);
+  const b = canonicalConnectNodeId(right);
+  return a !== null && a === b;
+}
+
+/** True when the panel refused a node as missing from the current graph, and
+ *  did not locate it inside another subgraph. */
+export function isMissingNodeInCurrentGraphRefusal(text: string): boolean {
+  return MISSING_NODE_RE.test(text) && !INSIDE_SUBGRAPH_RE.test(text);
+}
+
+export function missingNodeIdInCurrentGraph(text: string): string | null {
+  if (!isMissingNodeInCurrentGraphRefusal(text)) return null;
+  const match = MISSING_NODE_RE.exec(text);
+  const raw = match?.[1];
+  return raw ? canonicalConnectNodeId(raw) : null;
+}
+
+export function isUsableLiveGraphBinding(value: unknown): value is LiveGraphBinding {
+  const rec = asRecord(value);
+  if (!rec) return false;
+  if (rec.scope !== "root" && rec.scope !== "subgraph") return false;
+  if (rec.graphIdentity !== undefined) {
+    return (
+      typeof rec.graphIdentity === "string" &&
+      rec.graphIdentity.length > 0 &&
+      rec.graphIdentity.length <= 256
+    );
+  }
+  return true;
+}
+
+export function parseLiveGraphBinding(value: unknown): LiveGraphBinding | null {
+  const rec = asRecord(value);
+  if (!rec) return null;
+  if (rec.scope !== "root" && rec.scope !== "subgraph") return null;
+  const graphIdentity = rec.graph_identity;
+  if (
+    graphIdentity !== undefined &&
+    (typeof graphIdentity !== "string" || graphIdentity.length === 0 || graphIdentity.length > 256)
+  ) {
+    return null;
+  }
+  const binding: LiveGraphBinding = { scope: rec.scope };
+  if (typeof graphIdentity === "string") binding.graphIdentity = graphIdentity;
+  return isUsableLiveGraphBinding(binding) ? binding : null;
+}
+
+function collectLiveNodeIds(payload: unknown): Set<string> | null {
+  const rec = asRecord(payload);
+  if (!rec) return null;
+  if (Object.prototype.hasOwnProperty.call(rec, "truncated") && rec.truncated !== false) {
+    return null;
+  }
+
+  const ids = new Set<string>();
+  const add = (value: unknown): void => {
+    const id = canonicalConnectNodeId(value);
+    if (id) ids.add(id);
+  };
+
+  if (Array.isArray(rec.nodes)) {
+    for (const entry of rec.nodes) {
+      const node = asRecord(entry);
+      if (node) add(node.id);
+      else add(entry);
+    }
+  }
+  if (Array.isArray(rec.ids)) {
+    for (const entry of rec.ids) add(entry);
+  }
+  if (typeof rec.text === "string") {
+    for (const line of rec.text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (/^\d+ match\(es\) of \d+ in scope/.test(trimmed)) continue;
+      const compact = trimmed.match(/^#(\S+)\s+\S+/);
+      if (compact) {
+        add(compact[1]);
+        continue;
+      }
+      for (const part of trimmed.split(/[,\s]+/)) add(part);
+    }
+  }
+  return ids;
+}
+
+/** True when the live graph_query (same snapshot outline uses) lists `nodeId`. */
+export function liveGraphHasNodeId(payload: unknown, nodeId: unknown): boolean {
+  const want = canonicalConnectNodeId(nodeId);
+  if (!want) return false;
+  const ids = collectLiveNodeIds(payload);
+  return ids !== null && ids.has(want);
+}
+
+export function liveGraphHasConnectEndpoints(
+  payload: unknown,
+  fromNodeId: unknown,
+  toNodeId: unknown,
+): boolean {
+  return liveGraphHasNodeId(payload, fromNodeId) && liveGraphHasNodeId(payload, toNodeId);
+}
+
+function connectCommand(args: ConnectArgs): Record<string, unknown> {
+  return {
+    cmd: "graph_connect",
+    from_node_id: args.from_node_id,
+    from_output: args.from_output,
+    to_node_id: args.to_node_id,
+    to_input: args.to_input,
+    auto_match: args.auto_match,
+  };
+}
+
+function uniqueEndpointIds(fromNodeId: unknown, toNodeId: unknown): Array<number | string> {
+  const ids: Array<number | string> = [];
+  const seen = new Set<string>();
+  for (const value of [fromNodeId, toNodeId]) {
+    const canonical = canonicalConnectNodeId(value);
+    if (!canonical || seen.has(canonical)) continue;
+    seen.add(canonical);
+    const wire =
+      typeof value === "number" || typeof value === "string" ? normalizeNodeId(value) : canonical;
+    ids.push(wire);
+  }
+  return ids;
+}
+
+function withNote<T extends ToolResultLike>(res: T, note: string | null): T {
+  if (!note) return res;
+  return { ...res, content: [...res.content, { type: "text", text: note }] };
+}
+
+function retriedNote(missingId: string): string {
+  return (
+    `Re-resolved node ${missingId} on the live graph (same binding as panel_graph_outline) ` +
+    `and retried panel_connect (artokun/comfyui-mcp#2502).`
+  );
+}
+
+/**
+ * Dispatch graph_connect. On a current-graph missing-node refusal, look the
+ * endpoints up on the live graph_query snapshot and retry once when both exist.
+ */
+export async function retryConnectAgainstLiveGraph<T extends ToolResultLike>(
+  args: ConnectArgs,
+  call: GraphCall<T>,
+  timeoutMs?: number,
+): Promise<T> {
+  const cmd = connectCommand(args);
+  const first = await call(cmd, timeoutMs);
+  if (!first.isError) return first;
+
+  const text = toolText(first);
+  const missingId = missingNodeIdInCurrentGraph(text);
+  if (!missingId) return first;
+  if (
+    !sameConnectNodeId(missingId, args.from_node_id) &&
+    !sameConnectNodeId(missingId, args.to_node_id)
+  ) {
+    return first;
+  }
+
+  const endpointIds = uniqueEndpointIds(args.from_node_id, args.to_node_id);
+  if (endpointIds.length === 0) return first;
+
+  const live = await call(
+    {
+      cmd: "graph_query",
+      ids: endpointIds,
+      fields: "ids",
+      limit: endpointIds.length,
+      max_chars: 4000,
+    },
+    8000,
+  );
+  const payload = parseJsonPayload(live);
+  const rec = asRecord(payload);
+  if (!rec) return first;
+  if (rec.viewing !== undefined && !parseLiveGraphBinding(rec.viewing)) return first;
+  if (!liveGraphHasConnectEndpoints(payload, args.from_node_id, args.to_node_id)) {
+    return first;
+  }
+
+  const retry = await call(cmd, timeoutMs);
+  if (!retry.isError) return withNote(retry, retriedNote(missingId));
+  return retry;
+}


### PR DESCRIPTION
Fixes #2502.

After a completed canvas render, panel_graph_outline can list a live root node (e.g. 127) that the very next panel_connect refuses as missing from the current graph, even though the same target graph and root scope were reported. Mutation node lookup was bound to a stale graph object while reads already walked the live snapshot.

## Fix
panel_connect now goes through retryConnectAgainstLiveGraph: on a current-graph missing-node refusal, it re-resolves both endpoints with graph_query (the same live binding panel_graph_outline uses) and retries the connect once when both ids are present. A genuine miss, or a node that lives inside another subgraph, is left alone.

## Tests
`npx vitest run src/__tests__/services/connect-live-graph.test.ts` — 10 passed.
