### PR TITLE
fix(2503): rebind imported tmp workflow uuid before bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- rebind an imported tmp tab's extra.workflow_uuid to the assigned tab identity and accept panel_open_workflow on the exact tmp: key (#2503)
 - retry panel_connect against the live graph when a node reported by panel_graph_outline is refused as missing (#2502)
 - panel_open_workflow no longer treats frontend-normalized node fields as a failed load after reconnect (#2501)
 - make `resolve_missing` suggest `models/clip_vision/` for missing `CLIPVisionLoader.clip_name` models while keeping ordinary CLIP loaders on `models/text_encoders/` (#2604)

--- a/src/__tests__/orchestrator/imported-tmp-stale-uuid.test.ts
+++ b/src/__tests__/orchestrator/imported-tmp-stale-uuid.test.ts
@@ -97,7 +97,7 @@ describe("bindImportedTmpWorkflowUuid (#2503)", () => {
 });
 
 describe("unsavedTmpWorkflowKey (#2503)", () => {
-  it("accepts the exact tmp: token list_workflows publishes, including non-RFC suffixes", () => {
+  it("accepts the exact tmp: token panel_list_workflows publishes, including non-RFC suffixes", () => {
     expect(unsavedTmpWorkflowKey(TMP_KEY)).toBe(TMP_KEY);
     expect(unsavedTmpWorkflowKey("tmp:unsaved-imported")).toBe("tmp:unsaved-imported");
     expect(unsavedTmpWorkflowKey("wf:workflows/a.json")).toBeNull();

--- a/src/__tests__/orchestrator/imported-tmp-stale-uuid.test.ts
+++ b/src/__tests__/orchestrator/imported-tmp-stale-uuid.test.ts
@@ -129,7 +129,7 @@ function tmpLoadBridge(opts?: { destUuid?: string }) {
     workflowUuidFor: () => ({ known: true, uuid: destUuid }),
     refreshWorkflowUuid: () => true,
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
-  } as unknown as PanelToolCtx["bridge"];
+  } as PanelToolCtx["bridge"];
   return { bridge, sent };
 }
 
@@ -245,7 +245,7 @@ function tmpOpenBridge(opts: {
       return true;
     },
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
-  } as unknown as PanelToolCtx["bridge"];
+  } as PanelToolCtx["bridge"];
   return { bridge, sent, stampOf: () => fence };
 }
 

--- a/src/__tests__/orchestrator/imported-tmp-stale-uuid.test.ts
+++ b/src/__tests__/orchestrator/imported-tmp-stale-uuid.test.ts
@@ -1,0 +1,307 @@
+// #2503 — opening an imported workflow JSON in a new temporary tab preserved the
+// source graph's extra.comfyui_mcp.workflow_uuid, while the panel assigned a new
+// active workflow UUID. panel_graph_outline then refused with
+// root-workflow-uuid-mismatch. Recovery via panel_open_workflow on the active
+// tmp: key also failed (unconfirmed-active-workflow after resolving the temp key).
+//
+// Tests drive bindImportedTmpWorkflowUuid and the shipped load/open paths that
+// must call it. Dest identity is the tab the panel just assigned, never the
+// source file's stamp. workflow_path is left alone (#2505).
+
+import { describe, expect, it } from "vitest";
+
+import {
+  bindImportedTmpWorkflowUuid,
+  extraWorkflowUuid,
+  unsavedTmpWorkflowKey,
+} from "../../orchestrator/open-identity-normalization.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const SOURCE_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const DEST_UUID = "11111111-2222-4333-8444-555555555555";
+const SOURCE_PATH = "workflows/source.json";
+const TMP_KEY = `tmp:${DEST_UUID}`;
+const TAB = TMP_KEY;
+
+const UI_GRAPH = {
+  last_node_id: 2,
+  nodes: [
+    { id: 1, type: "CLIPTextEncode", widgets_values: ["a portrait"] },
+    { id: 2, type: "SaveImage", widgets_values: ["out"] },
+  ],
+  links: [],
+  extra: { comfyui_mcp: { workflow_path: SOURCE_PATH, workflow_uuid: SOURCE_UUID } },
+};
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((part) => (part as { text?: string }).text ?? "").join(" ");
+
+function loadTool() {
+  const tool = buildPanelToolDefs().find((def) => def.name === "panel_load_workflow");
+  if (!tool) throw new Error("panel_load_workflow is not registered");
+  return tool;
+}
+
+function openTool() {
+  const tool = buildPanelToolDefs().find((def) => def.name === "panel_open_workflow");
+  if (!tool) throw new Error("panel_open_workflow is not registered");
+  return tool;
+}
+
+describe("bindImportedTmpWorkflowUuid (#2503)", () => {
+  it("replaces the source extra.workflow_uuid with the assigned tab uuid", () => {
+    const bound = bindImportedTmpWorkflowUuid(UI_GRAPH, DEST_UUID);
+    expect(bound).not.toBeNull();
+    expect(extraWorkflowUuid(bound)).toBe(DEST_UUID);
+    expect(bound && extraWorkflowUuid(bound)).not.toBe(SOURCE_UUID);
+  });
+
+  it("does not rewrite extra.workflow_path — that is #2505", () => {
+    const bound = bindImportedTmpWorkflowUuid(UI_GRAPH, DEST_UUID);
+    expect(bound).not.toBeNull();
+    const extra = bound?.extra;
+    expect(extra && typeof extra === "object" && !Array.isArray(extra)).toBe(true);
+    const meta =
+      extra && typeof extra === "object" && !Array.isArray(extra)
+        ? extra.comfyui_mcp
+        : undefined;
+    expect(meta && typeof meta === "object" && !Array.isArray(meta)).toBe(true);
+    if (meta && typeof meta === "object" && !Array.isArray(meta)) {
+      expect(meta.workflow_path).toBe(SOURCE_PATH);
+    }
+  });
+
+  it("does not mutate the source graph", () => {
+    const original = structuredClone(UI_GRAPH);
+    bindImportedTmpWorkflowUuid(UI_GRAPH, DEST_UUID);
+    expect(UI_GRAPH).toEqual(original);
+    expect(extraWorkflowUuid(UI_GRAPH)).toBe(SOURCE_UUID);
+  });
+
+  it("returns null when the stamp already names dest, or dest/graph are unusable", () => {
+    const already = bindImportedTmpWorkflowUuid(
+      { ...UI_GRAPH, extra: { comfyui_mcp: { workflow_uuid: DEST_UUID } } },
+      DEST_UUID,
+    );
+    expect(already).toBeNull();
+    expect(bindImportedTmpWorkflowUuid({ nodes: [] }, DEST_UUID)).toBeNull();
+    expect(bindImportedTmpWorkflowUuid(UI_GRAPH, "")).toBeNull();
+    expect(bindImportedTmpWorkflowUuid(null, DEST_UUID)).toBeNull();
+    expect(bindImportedTmpWorkflowUuid("graph", DEST_UUID)).toBeNull();
+  });
+});
+
+describe("unsavedTmpWorkflowKey (#2503)", () => {
+  it("accepts the exact tmp: token list_workflows publishes, including non-RFC suffixes", () => {
+    expect(unsavedTmpWorkflowKey(TMP_KEY)).toBe(TMP_KEY);
+    expect(unsavedTmpWorkflowKey("tmp:unsaved-imported")).toBe("tmp:unsaved-imported");
+    expect(unsavedTmpWorkflowKey("wf:workflows/a.json")).toBeNull();
+    expect(unsavedTmpWorkflowKey("workflows/a.json")).toBeNull();
+    expect(unsavedTmpWorkflowKey("tmp:")).toBeNull();
+    expect(unsavedTmpWorkflowKey("tmp: has space")).toBeNull();
+  });
+});
+
+function tmpLoadBridge(opts?: { destUuid?: string }) {
+  const destUuid = opts?.destUuid ?? DEST_UUID;
+  const sent: Array<Record<string, unknown>> = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(cmd);
+      if (cmd.cmd === "graph_serialize") {
+        return { workflow: { last_node_id: 0, nodes: [], links: [] }, node_count: 0 };
+      }
+      if (cmd.cmd === "graph_load") {
+        return { loaded: true, node_count: UI_GRAPH.nodes.length };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "Unsaved Workflow", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    workflowUuidFor: () => ({ known: true, uuid: destUuid }),
+    refreshWorkflowUuid: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge, sent };
+}
+
+describe("panel_load_workflow restamps extra.workflow_uuid onto a tmp tab (#2503)", () => {
+  it("sends graph_load with the tab uuid, not the source file's uuid", async () => {
+    const { bridge, sent } = tmpLoadBridge();
+    const res = await loadTool().handler(
+      { graph: structuredClone(UI_GRAPH) },
+      makePanelToolCtx(bridge, TAB),
+    );
+
+    expect(res.isError).toBeFalsy();
+    const loadCmd = sent.find((cmd) => cmd.cmd === "graph_load");
+    expect(loadCmd).toBeTruthy();
+    expect(extraWorkflowUuid(loadCmd?.graph)).toBe(DEST_UUID);
+    expect(extraWorkflowUuid(loadCmd?.graph)).not.toBe(SOURCE_UUID);
+    const extra =
+      loadCmd?.graph && typeof loadCmd.graph === "object" && !Array.isArray(loadCmd.graph)
+        ? loadCmd.graph.extra
+        : undefined;
+    const meta =
+      extra && typeof extra === "object" && !Array.isArray(extra) ? extra.comfyui_mcp : undefined;
+    if (meta && typeof meta === "object" && !Array.isArray(meta)) {
+      expect(meta.workflow_path).toBe(SOURCE_PATH);
+    }
+  });
+
+  it("does not invent a dest uuid when the tab has no fence", async () => {
+    const { bridge, sent } = tmpLoadBridge();
+    bridge.workflowUuidFor = () => ({ known: false });
+    const res = await loadTool().handler(
+      { graph: structuredClone(UI_GRAPH) },
+      makePanelToolCtx(bridge, TAB),
+    );
+
+    expect(res.isError).toBeFalsy();
+    const loadCmd = sent.find((cmd) => cmd.cmd === "graph_load");
+    expect(extraWorkflowUuid(loadCmd?.graph)).toBe(SOURCE_UUID);
+  });
+});
+
+function tmpOpenBridge(opts: {
+  routingKey?: string | null;
+  nestRoutingKey?: boolean;
+  openedPath?: string | null;
+  liveExtraUuid?: string;
+  destUuid?: string;
+  requestedKey?: string;
+}) {
+  const destUuid = opts.destUuid ?? DEST_UUID;
+  const requestedKey = opts.requestedKey ?? TMP_KEY;
+  const liveExtraUuid = opts.liveExtraUuid ?? SOURCE_UUID;
+  let live = {
+    ...structuredClone(UI_GRAPH),
+    extra: { comfyui_mcp: { workflow_path: SOURCE_PATH, workflow_uuid: liveExtraUuid } },
+  };
+  const sent: Array<Record<string, unknown>> = [];
+  const opened: Record<string, unknown> = {
+    path: opts.openedPath === undefined ? "workflows/Unsaved Workflow.json" : opts.openedPath,
+    filename: "Unsaved Workflow",
+  };
+  if (opts.nestRoutingKey && typeof opts.routingKey === "string") {
+    opened.routing_key = opts.routingKey;
+  }
+  const openReply: Record<string, unknown> = {
+    opened,
+    ...(opts.nestRoutingKey || opts.routingKey == null
+      ? {}
+      : { routing_key: opts.routingKey }),
+    workflow_uuid: destUuid,
+    modified: true,
+  };
+  const list = {
+    active_confirmed: true,
+    active: {
+      path: null,
+      filename: null,
+      title: "Unsaved Workflow",
+      key: requestedKey,
+      routing_key: requestedKey,
+      workflow_uuid: destUuid,
+    },
+  };
+  let fence: string | undefined = SOURCE_UUID;
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(cmd);
+      if (cmd.cmd === "workflow_open") return openReply;
+      if (cmd.cmd === "workflow_list") return list;
+      if (cmd.cmd === "graph_serialize") {
+        return { workflow: live, node_count: live.nodes.length };
+      }
+      if (cmd.cmd === "graph_load") {
+        const graph = cmd.graph;
+        if (graph && typeof graph === "object" && !Array.isArray(graph)) {
+          live = {
+            ...live,
+            extra: isRecord(graph.extra) ? graph.extra : live.extra,
+          };
+        }
+        return { loaded: true, node_count: live.nodes.length };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "Unsaved Workflow", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    workflowUuidFor: () => ({ known: Boolean(fence), uuid: fence }),
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      fence = uuid;
+      return true;
+    },
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge, sent, stampOf: () => fence };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+describe("panel_open_workflow rebinds an already-active tmp tab by exact key (#2503)", () => {
+  it("does not reject a tmp: open as an unresolved filename when opened.path looks saved and routing_key is absent", async () => {
+    const { bridge } = tmpOpenBridge({ routingKey: null, openedPath: "workflows/Unsaved Workflow.json" });
+    const res = await openTool().handler({ path: TMP_KEY }, makePanelToolCtx(bridge, TAB));
+
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).not.toMatch(/unconfirmed active workflow after resolving this filename/i);
+    expect(textOf(res)).not.toMatch(/active canvas is UNKNOWN/i);
+  });
+
+  it("restamps live extra.workflow_uuid to the assigned tab uuid", async () => {
+    const { bridge, sent, stampOf } = tmpOpenBridge({
+      routingKey: TMP_KEY,
+      openedPath: "workflows/Unsaved Workflow.json",
+    });
+    const res = await openTool().handler({ path: TMP_KEY }, makePanelToolCtx(bridge, TAB));
+
+    expect(res.isError).toBeFalsy();
+    const loadCmd = sent.find((cmd) => cmd.cmd === "graph_load");
+    expect(loadCmd).toBeTruthy();
+    expect(extraWorkflowUuid(loadCmd?.graph)).toBe(DEST_UUID);
+    expect(stampOf()).toBe(DEST_UUID);
+  });
+
+  it("rebinds a non-RFC tmp: key without filename resolution", async () => {
+    const key = "tmp:unsaved-imported";
+    const { bridge, sent } = tmpOpenBridge({
+      requestedKey: key,
+      routingKey: null,
+      openedPath: "workflows/Unsaved Workflow.json",
+    });
+    const res = await openTool().handler({ path: key }, makePanelToolCtx(bridge, key));
+
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).not.toMatch(/unconfirmed active workflow after resolving this filename/i);
+    expect(textOf(res)).not.toMatch(/active canvas is UNKNOWN/i);
+    // Fence adoption stays RFC-strict on the key (#812). The open itself must
+    // still succeed so recovery is not a filename-resolution dead end.
+    expect(sent.map((cmd) => cmd.cmd)).not.toContain("workflow_list");
+  });
+
+  it("does not restamp when extra already names the assigned tab", async () => {
+    const { bridge, sent } = tmpOpenBridge({
+      routingKey: TMP_KEY,
+      liveExtraUuid: DEST_UUID,
+    });
+    const res = await openTool().handler({ path: TMP_KEY }, makePanelToolCtx(bridge, TAB));
+
+    expect(res.isError).toBeFalsy();
+    expect(sent.map((cmd) => cmd.cmd)).not.toContain("graph_load");
+  });
+});

--- a/src/orchestrator/open-identity-normalization.ts
+++ b/src/orchestrator/open-identity-normalization.ts
@@ -42,7 +42,7 @@ export function extraWorkflowUuid(graph: unknown): string | null {
 
 /**
  * Exact unsaved routing handle (`tmp:<id>`). OPEN must accept any non-empty
- * tmp: token list_workflows publishes — not only RFC-uuid suffixes — or an
+ * tmp: token panel_list_workflows publishes — not only RFC-uuid suffixes — or an
  * already-active imported tab cannot rebind (#2503).
  */
 export function unsavedTmpWorkflowKey(value: unknown): string | null {

--- a/src/orchestrator/open-identity-normalization.ts
+++ b/src/orchestrator/open-identity-normalization.ts
@@ -33,6 +33,48 @@ export function extraWorkflowPath(graph: unknown): string | null {
   return typeof meta?.workflow_path === "string" && meta.workflow_path ? meta.workflow_path : null;
 }
 
+export function extraWorkflowUuid(graph: unknown): string | null {
+  if (!isPlainObject(graph)) return null;
+  const extra = isPlainObject(graph.extra) ? graph.extra : null;
+  const meta = extra && isPlainObject(extra.comfyui_mcp) ? extra.comfyui_mcp : null;
+  return typeof meta?.workflow_uuid === "string" && meta.workflow_uuid ? meta.workflow_uuid : null;
+}
+
+/**
+ * Exact unsaved routing handle (`tmp:<id>`). OPEN must accept any non-empty
+ * tmp: token list_workflows publishes — not only RFC-uuid suffixes — or an
+ * already-active imported tab cannot rebind (#2503).
+ */
+export function unsavedTmpWorkflowKey(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  return /^tmp:\S+$/.test(value) ? value : null;
+}
+
+/**
+ * #2503 — importing/loading onto a new tmp tab must not keep the source graph's
+ * extra.comfyui_mcp.workflow_uuid. Replace it with the tab's assigned uuid.
+ * Leaves workflow_path untouched (#2505).
+ *
+ * Returns a cloned graph when a rewrite is needed; null when dest/graph are
+ * unusable or the stamp already names dest.
+ */
+export function bindImportedTmpWorkflowUuid(
+  graph: unknown,
+  destUuid: string,
+): Record<string, unknown> | null {
+  if (!isPlainObject(graph)) return null;
+  if (typeof destUuid !== "string" || !destUuid) return null;
+  const stamped = extraWorkflowUuid(graph);
+  if (!stamped || stamped === destUuid) return null;
+  const next: Record<string, unknown> = structuredClone(graph);
+  const extra = isPlainObject(next.extra) ? { ...next.extra } : {};
+  const meta = isPlainObject(extra.comfyui_mcp) ? { ...extra.comfyui_mcp } : {};
+  meta.workflow_uuid = destUuid;
+  extra.comfyui_mcp = meta;
+  next.extra = extra;
+  return next;
+}
+
 export function extraStampDisagrees(graph: unknown, destPath: string): boolean {
   const stamped = normalizeWorkflowPath(extraWorkflowPath(graph));
   const dest = normalizeWorkflowPath(destPath);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -12147,7 +12147,7 @@ async function refreshOpenWorkflowUuid(
       : undefined;
   const openedPath = typeof openedRecord?.path === "string" ? openedRecord.path : undefined;
   // #2477 / #2503 — a tmp: request is never a filename alias. Accept any
-  // non-empty tmp: token list_workflows publishes (not only RFC-uuid suffixes),
+  // non-empty tmp: token panel_list_workflows publishes (not only RFC-uuid suffixes),
   // or an already-active imported tab is rejected as an unresolved filename.
   // Fence adoption stays RFC-strict on the key (#812): a malformed tmp: suffix
   // must not stamp the session even if the reply echoes it.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -177,12 +177,14 @@ import {
   isFastGroupsFilterProperty,
 } from "./rgthree-fast-groups-property.js";
 import {
+  bindImportedTmpWorkflowUuid,
   isPlainObject,
   isStampMismatchSaveRefusal,
   openLiveMatchesDestAfterReconnect,
   openLiveMatchesDestContent,
   patchOpenIdentity,
   shouldRebindOpenIdentity,
+  unsavedTmpWorkflowKey,
   workflowFromSerializeReply,
 } from "./open-identity-normalization.js";
 import {
@@ -9683,6 +9685,38 @@ type OpenIdentityRebind =
   | { status: "skipped" };
 
 /**
+ * #2503 — restamp extra.comfyui_mcp.workflow_uuid onto an already-active tmp
+ * tab. workflow_open of the exact tmp: key is the documented rebind; it must
+ * not require a saved filename, and it must replace a source-file uuid the
+ * imported graph still carries.
+ */
+async function tryRebindImportedTmpIdentity(
+  ctx: PanelToolCtx,
+  requestedPath: string,
+): Promise<{ status: "rebound" } | { status: "skipped" }> {
+  if (!unsavedTmpWorkflowKey(requestedPath)) return { status: "skipped" };
+  const fence = currentWorkflowFence(ctx);
+  const destUuid = fence.known && typeof fence.uuid === "string" && fence.uuid ? fence.uuid : undefined;
+  if (!destUuid) return { status: "skipped" };
+
+  let live: Record<string, unknown> | null = null;
+  try {
+    const serialized = await ctx.call({ cmd: "graph_serialize" }, 8000);
+    live = workflowFromSerializeReply(parseToolResultJson(serialized));
+  } catch {
+    return { status: "skipped" };
+  }
+  if (!live) return { status: "skipped" };
+
+  const bound = bindImportedTmpWorkflowUuid(live, destUuid);
+  if (!bound) return { status: "skipped" };
+  const loaded = await ctx.call({ cmd: "graph_load", graph: bound }, 30000);
+  if (loaded.isError) return { status: "skipped" };
+  refreshWorkflowUuid(ctx, { workflow_uuid: destUuid });
+  return { status: "rebound" };
+}
+
+/**
  * #1710 — restamp extra.comfyui_mcp onto the dest the tab is already bound to,
  * and copy dest-file promoted widgets onto any live empty slots.
  *
@@ -12112,16 +12146,20 @@ async function refreshOpenWorkflowUuid(
       ? (opened as Record<string, unknown>)
       : undefined;
   const openedPath = typeof openedRecord?.path === "string" ? openedRecord.path : undefined;
-  // #2477 — some successful workflow_open replies nest routing_key under
-  // `opened` rather than at the top level. A tmp: request is never a filename
-  // alias, so prove that identity first; otherwise the #1639 unresolved-
-  // filename path rejects a canvas the panel already bound.
-  const requestedUnsaved = canonicalUnsavedWorkflowIdentity(requestedPath);
-  if (requestedUnsaved) {
+  // #2477 / #2503 — a tmp: request is never a filename alias. Accept any
+  // non-empty tmp: token list_workflows publishes (not only RFC-uuid suffixes),
+  // or an already-active imported tab is rejected as an unresolved filename.
+  // Fence adoption stays RFC-strict on the key (#812): a malformed tmp: suffix
+  // must not stamp the session even if the reply echoes it.
+  const requestedTmp = unsavedTmpWorkflowKey(requestedPath);
+  if (requestedTmp) {
     const openedRoutingKey =
-      (typeof parsedOpen?.routing_key === "string" ? parsedOpen.routing_key : undefined) ??
-      (typeof openedRecord?.routing_key === "string" ? openedRecord.routing_key : undefined);
-    if (requestedUnsaved === openedRoutingKey) {
+      unsavedTmpWorkflowKey(parsedOpen?.routing_key) ??
+      unsavedTmpWorkflowKey(openedRecord?.routing_key);
+    const requestedUnsaved = canonicalUnsavedWorkflowIdentity(requestedPath);
+    // Absent routing_key is the already-active tmp tab: the panel applied the
+    // open but did not echo the handle. A DIFFERENT tmp: key is another tab.
+    if (requestedUnsaved && (!openedRoutingKey || requestedUnsaved === openedRoutingKey)) {
       refreshWorkflowUuid(ctx, parsedOpen) || refreshWorkflowUuid(ctx, openedRecord);
     }
     return null;
@@ -12579,6 +12617,7 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
             `if you still need it — another tab became active during or after the open.`,
         );
       }
+      await tryRebindImportedTmpIdentity(ctx, path);
     }
     return res;
   }
@@ -12812,14 +12851,15 @@ function computeIsActive(rec: OpenWorkflowRecord, activeObj: unknown): boolean |
  * Per-tab unsaved handle (`tmp:<id>`). Unsaved tabs have no path/filename; this
  * is the only unique identity they publish. Accepts any non-empty `tmp:` token
  * (not only RFC-uuid suffixes) so a panel that mints a shorter handle still
- * corroborates — `canonicalUnsavedWorkflowIdentity` stays strict for OPEN,
- * which is a caller-supplied selector.
+ * corroborates. OPEN uses the same matcher to skip filename resolution (#2503);
+ * fence adoption stays RFC-strict via `canonicalUnsavedWorkflowIdentity` (#812).
  */
 function recordTmpHandle(value: unknown): string | null {
   if (!value || typeof value !== "object") return null;
   const rec = value as { key?: unknown; routing_key?: unknown };
   for (const v of [rec.routing_key, rec.key]) {
-    if (typeof v === "string" && /^tmp:\S+$/.test(v)) return v;
+    const key = unsavedTmpWorkflowKey(v);
+    if (key) return key;
   }
   return null;
 }
@@ -18845,6 +18885,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Generous timeout — loading a large graph onto the live canvas can take a moment.
           const tabAtDispatch = ctx.tabId;
           const fenceBefore = currentWorkflowFence(ctx);
+          // #2503 — a UI import onto this tab must not keep the source file's
+          // extra.comfyui_mcp.workflow_uuid. Dest is the tab uuid already
+          // assigned (fence). workflow_path is left alone (#2505).
+          const destUuid =
+            fenceBefore.known && typeof fenceBefore.uuid === "string" && fenceBefore.uuid
+              ? fenceBefore.uuid
+              : undefined;
+          if (destUuid) {
+            const bound = bindImportedTmpWorkflowUuid(data, destUuid);
+            if (bound) data = bound;
+          }
           let graphBefore: unknown;
           if (uiWorkflowNodeCount(data) !== undefined) {
             try {


### PR DESCRIPTION
Fixes #2503

Opening an imported workflow JSON in a new temporary tab kept the source graph's `extra.comfyui_mcp.workflow_uuid` after the panel assigned a new active workflow UUID. `panel_graph_outline` then refused with `root-workflow-uuid-mismatch`. Recovery via `panel_open_workflow` on the active `tmp:` key also failed, because that handle was treated as a filename alias (`unconfirmed-active-workflow`).

`bindImportedTmpWorkflowUuid` rewrites the embedded uuid to the assigned tab identity before `graph_load`. `panel_open_workflow` of an exact `tmp:` key skips filename resolution and restamps live extra uuid when it still names the source. `extra.workflow_path` is left alone (#2505).

Native ComfyUI File > Open / drag-drop import still happens in the panel. If the panel does not rewrite `extra.comfyui_mcp.workflow_uuid` at import time, the canvas can still mismatch until MCP load/open rebinds it. This PR lands the MCP bind/rebind; the panel should still replace the embedded uuid with the new tab uuid on import.

## Test

```
npx vitest run src/__tests__/orchestrator/imported-tmp-stale-uuid.test.ts
```
