### PR TITLE
fix: class-aware missing-model hint for CLIPVisionLoader (#2604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- make `resolve_missing` suggest `models/clip_vision/` for missing `CLIPVisionLoader.clip_name` models while keeping ordinary CLIP loaders on `models/text_encoders/` (#2604)
+
 ## [0.52.152] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/tools/missing-models.test.ts
+++ b/src/__tests__/tools/missing-models.test.ts
@@ -59,6 +59,34 @@ const WORKFLOW = {
   },
 };
 
+// Production-shaped V1 /object_info combos for the core loaders. The API
+// workflow carries the class_type alongside the named input value; the shared
+// `clip_name` spelling is intentional here.
+const CLIP_LOADER_OBJECT_INFO = {
+  CLIPVisionLoader: {
+    input: { required: { clip_name: [["installed-vision.safetensors"], {}] } },
+  },
+  CLIPLoader: {
+    input: {
+      required: {
+        clip_name: [["installed-text.safetensors"], {}],
+        type: [["stable_diffusion"], {}],
+      },
+      optional: { device: [["default", "cpu"], {}] },
+    },
+  },
+  DualCLIPLoader: {
+    input: {
+      required: {
+        clip_name1: [["installed-primary.safetensors"], {}],
+        clip_name2: [["installed-secondary.safetensors"], {}],
+        type: [["flux"], {}],
+      },
+      optional: { device: [["default", "cpu"], {}] },
+    },
+  },
+};
+
 beforeEach(() => {
   providers.civitaiDown = true;
   providers.hfDown = true;
@@ -140,5 +168,45 @@ describe('action:"resolve_missing" reports unavailable custom-node LoRA combos',
     }
     expect(text).toMatch(/DonutLoRAStack · lora_name_/);
     expect(text).toMatch(/models\/loras\//);
+  });
+});
+
+// #2604 — `clip_name` is shared by the text and vision CLIP loaders, but
+// ComfyUI resolves the former from models/text_encoders and the latter from
+// models/clip_vision. Keep this assertion at the production action boundary so
+// both the API workflow shape and object-info combo parsing are covered.
+describe('action:"resolve_missing" gives CLIPVisionLoader the class-aware directory hint', () => {
+  it("uses clip_vision only for CLIPVisionLoader and keeps ordinary CLIP loaders in text_encoders", async () => {
+    objectInfo.current = structuredClone(CLIP_LOADER_OBJECT_INFO);
+    const workflow = {
+      "1": {
+        class_type: "CLIPVisionLoader",
+        inputs: { clip_name: "dino_v3_vit_h.safetensors" },
+      },
+      "2": {
+        class_type: "CLIPLoader",
+        inputs: { clip_name: "clip_l.safetensors", type: "stable_diffusion" },
+      },
+      "3": {
+        class_type: "DualCLIPLoader",
+        inputs: {
+          clip_name1: "clip_g.safetensors",
+          clip_name2: "t5xxl_fp16.safetensors",
+          type: "flux",
+        },
+      },
+    };
+
+    const res = await captureHandler()({ workflow });
+    const text = res.content[0]!.text as string;
+
+    expect(text).toMatch(/4 missing model/);
+    expect(text).toContain(
+      "node 1 (CLIPVisionLoader · clip_name) → installs to `models/clip_vision/`",
+    );
+    expect(text).toContain("node 2 (CLIPLoader · clip_name) → installs to `models/text_encoders/`");
+    expect(text).toContain("node 3 (DualCLIPLoader · clip_name1) → installs to `models/text_encoders/`");
+    expect(text).toContain("node 3 (DualCLIPLoader · clip_name2) → installs to `models/text_encoders/`");
+    expect(text).not.toContain("CLIPVisionLoader · clip_name) → installs to `models/text_encoders/`");
   });
 });

--- a/src/services/missing-models.ts
+++ b/src/services/missing-models.ts
@@ -47,7 +47,10 @@ const DIR_BY_WIDGET: Record<string, string> = {
 /** DonutLoRAStack / LoRA Stacker V2 / similar: `lora_name_1`, `lora_name_2`, … */
 const NUMBERED_LORA_WIDGET = /^lora_name_\d+$/i;
 
-function directoryForWidget(widget: string): string | undefined {
+function directoryForWidget(widget: string, classType: string): string | undefined {
+  // CLIPVisionLoader shares `clip_name` with text-encoder loaders, but its
+  // object-info combo is sourced from ComfyUI's `clip_vision` directory.
+  if (classType === "CLIPVisionLoader" && widget === "clip_name") return "clip_vision";
   if (Object.prototype.hasOwnProperty.call(DIR_BY_WIDGET, widget)) return DIR_BY_WIDGET[widget];
   if (NUMBERED_LORA_WIDGET.test(widget)) return DIR_BY_WIDGET.lora_name;
   return undefined;
@@ -261,7 +264,7 @@ export function findMissingModels(
         node_type: classType,
         widget,
         name: value,
-        directory: directoryForWidget(widget),
+        directory: directoryForWidget(widget, classType),
       });
     }
   }


### PR DESCRIPTION
## Summary
- route missing CLIPVisionLoader.clip_name hints to models/clip_vision/
- keep CLIPLoader and DualCLIPLoader text encoder hints on models/text_encoders/
- add production-shaped resolver-action coverage for the core loader object-info and API workflow shapes
- update CHANGELOG.md Unreleased for #2604

## Validation
- 
pm.cmd exec vitest run src/__tests__/tools/missing-models.test.ts — 5 passed
- 
pm.cmd run build — passed
- 
pm.cmd run lint — passed
- 
pm.cmd test — all non-Vitest checks passed; Vitest had 13,313 passed, 6 skipped, and one unrelated full-concurrency failure in src/__tests__/orchestrator/late-mutation-e2e.test.ts; that file passed when run in isolation
