### PR TITLE
fix(2504): do not pick an arbitrary models_show duplicate basename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- models_show local fallback does not report an arbitrary duplicate basename as the installed model (#2504)
 - get_workflow get/analyze reads an absolute path under the live ComfyUI workspace from disk instead of sending it to /api/userdata/workflows/ (#2506)
 - z-image-turbo-inpainting no longer installs eight unused custom-node packs (#2484)
 - list_local_models reads inventory through the connected panel when the headless /models route is unreachable (#2511)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- models_show local fallback does not report an arbitrary duplicate basename as the installed model (#2504)
+
 ## [0.52.154] - 2026-08-30
 
 ### MCP
 
 #### Fixed
-- models_show local fallback does not report an arbitrary duplicate basename as the installed model (#2504)
 - get_workflow get/analyze reads an absolute path under the live ComfyUI workspace from disk instead of sending it to /api/userdata/workflows/ (#2506)
 - z-image-turbo-inpainting no longer installs eight unused custom-node packs (#2484)
 - list_local_models reads inventory through the connected panel when the headless /models route is unreachable (#2511)

--- a/docs/tools/comfy-cli.mdx
+++ b/docs/tools/comfy-cli.mdx
@@ -21,7 +21,7 @@ Drive the official comfy-cli (envelope/1 JSON contract) for the selected ComfyUI
 - action:"workflow_run" — Submit an API/UI workflow file (`workflowPath` required). Asynchronous by default; set wait=true to await outputs (`timeoutSeconds`).
 - action:"transfer_upload" — Upload input files (`files` required) for local ComfyUI or Comfy Cloud; overwrite=false passes --no-overwrite.
 - action:"transfer_download" — Download completed outputs for `promptId` (required); `outDir` and `urlOnly` optional.
-- action:"models_list_folders" / "models_list_folder" / "models_search" / "models_show" — Discover model folders/files locally or in Comfy Cloud (`folder` required for list_folder, `name` for show). When comfy-cli is not installed/on PATH and the target is the connected (local) server, these read-only listings fall back to that server's own local models (via /models) — so model discovery works without the CLI.
+- action:"models_list_folders" / "models_list_folder" / "models_search" / "models_show" — Discover model folders/files locally or in Comfy Cloud (`folder` required for list_folder, `name` for show). For models_show, pass `folder`/`type` or a relative `name` path (e.g. vae/foo.safetensors) when the same basename exists in more than one folder. When comfy-cli is not installed/on PATH and the target is the connected (local) server, these read-only listings fall back to that server's own local models (via /models) — so model discovery works without the CLI.
 - action:"models_download" — Download a model `url` (required) into the workspace (`relativePath`, default models/checkpoints). A download can run for many minutes and is gated on an idle-liveness timeout, so a progressing download is never killed.
 - action:"models_remove" — Remove workspace model files (`modelNames` required; `relativePath` optional).
 - action:"skills_list" / "skills_show" / "skills_validate" / "skills_install" / "skills_status" / "skills_uninstall" — Manage the official comfy-cli bundled agent skills (comfy, fragments, debug, relay, director). validate requires `path`; install/uninstall default to dry-run unless apply=true; scope="project" requires `projectDir`.
@@ -86,16 +86,16 @@ Drive the official comfy-cli (envelope/1 JSON contract) for the selected ComfyUI
   action:"transfer_download" — print URLs instead of downloading files.
 </ParamField>
 <ParamField path="folder" type="string">
-  action:"models_list_folder" — the model folder to list. REQUIRED.
+  action:"models_list_folder" — the model folder to list (REQUIRED). action:"models_show" — optional folder to pick among duplicate basenames.
 </ParamField>
 <ParamField path="text" type="string">
   action:"models_search" — search text.
 </ParamField>
 <ParamField path="type" type="string">
-  action:"models_search" — model type filter (checkpoint, lora, vae, …).
+  action:"models_search" — model type filter (checkpoint, lora, vae, …). action:"models_show" — same filter, to pick among duplicate basenames.
 </ParamField>
 <ParamField path="name" type="string">
-  actions "models_show"/"skills_show" — the model or skill name.
+  actions "models_show"/"skills_show" — the model or skill name. For models_show a relative path (e.g. vae/qwen_image_vae.safetensors) selects among duplicate basenames.
 </ParamField>
 <ParamField path="url" type="string">
   action:"models_download" — model URL to download. REQUIRED.

--- a/src/__tests__/services/local-models-fallback.test.ts
+++ b/src/__tests__/services/local-models-fallback.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const mocks = vi.hoisted(() => ({
   listLocalModels: vi.fn(),
@@ -146,6 +149,125 @@ describe("comfy_cli models_* local fallback (#460)", () => {
       model("flux_schnell.safetensors", "checkpoints"),
     ]);
     await expect(listLocalModelsFallback({ action: "show", name: "flux" })).rejects.toThrow(/was not found/i);
+  });
+
+  // #2504 — HTTP `/models/<dir>` listings share basenames across folders (a VAE
+  // copied into loras, extra_model_paths, a misplaced download). `Array.find`
+  // returned whichever copy happened to be listed first and reported it as THE
+  // installed model. The fallback must refuse that silent pick, and must honour
+  // folder/type/relative-path as the deterministic selector.
+  describe("show duplicate basename (#2504)", () => {
+    const duplicates = [
+      model("qwen_image_vae.safetensors", "loras"),
+      model("qwen_image_vae.safetensors", "vae"),
+    ];
+
+    it("does not report the first listed duplicate as the installed model", async () => {
+      mocks.listLocalModels.mockResolvedValue(duplicates);
+      const err = await listLocalModelsFallback({
+        action: "show",
+        name: "qwen_image_vae.safetensors",
+      }).catch((e) => e as Error);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toMatch(/matches 2 local files/i);
+      expect(err.message).toMatch(/loras\/qwen_image_vae\.safetensors/);
+      expect(err.message).toMatch(/vae\/qwen_image_vae\.safetensors/);
+      expect(err.message, "must not collapse to the first listed type").not.toMatch(/^Model '.*' was not found/);
+    });
+
+    it("still refuses an arbitrary pick when the other copy is listed first", async () => {
+      mocks.listLocalModels.mockResolvedValue([...duplicates].reverse());
+      await expect(
+        listLocalModelsFallback({ action: "show", name: "qwen_image_vae.safetensors" }),
+      ).rejects.toThrow(/matches 2 local files/i);
+    });
+
+    it("picks the folder-qualified copy even when the other basename is listed first", async () => {
+      mocks.listLocalModels.mockResolvedValue(duplicates);
+      const { data } = await listLocalModelsFallback({
+        action: "show",
+        name: "qwen_image_vae.safetensors",
+        folder: "vae",
+      });
+      expect(data).toMatchObject({
+        name: "qwen_image_vae.safetensors",
+        type: "vae",
+        path: "vae/qwen_image_vae.safetensors",
+      });
+    });
+
+    it("picks the type-qualified copy (cli alias) even when the other basename is listed first", async () => {
+      mocks.listLocalModels.mockResolvedValue(duplicates);
+      const { data } = await listLocalModelsFallback({
+        action: "show",
+        name: "qwen_image_vae.safetensors",
+        type: "lora",
+      });
+      expect(data).toMatchObject({
+        name: "qwen_image_vae.safetensors",
+        type: "loras",
+        path: "loras/qwen_image_vae.safetensors",
+      });
+    });
+
+    it("picks the relative-path copy even when the other basename is listed first", async () => {
+      mocks.listLocalModels.mockResolvedValue(duplicates);
+      const { data } = await listLocalModelsFallback({
+        action: "show",
+        name: "vae/qwen_image_vae.safetensors",
+      });
+      expect(data).toMatchObject({
+        name: "qwen_image_vae.safetensors",
+        type: "vae",
+        path: "vae/qwen_image_vae.safetensors",
+      });
+    });
+
+    it("does not fall back to another folder when the hinted folder has no copy", async () => {
+      mocks.listLocalModels.mockResolvedValue(duplicates);
+      await expect(
+        listLocalModelsFallback({
+          action: "show",
+          name: "qwen_image_vae.safetensors",
+          folder: "checkpoints",
+        }),
+      ).rejects.toThrow(/was not found/i);
+    });
+  });
+
+  describe("show stats a local file (#2504)", () => {
+    let root: string | undefined;
+
+    afterEach(() => {
+      if (root) rmSync(root, { recursive: true, force: true });
+      root = undefined;
+    });
+
+    it("fills size and modified from the resolved file when COMFYUI_PATH is known", async () => {
+      root = mkdtempSync(join(tmpdir(), "comfyui-mcp-2504-"));
+      const rel = join("vae", "qwen_image_vae.safetensors");
+      mkdirSync(join(root, "models", "vae"), { recursive: true });
+      const bytes = Buffer.from("vae-weights");
+      writeFileSync(join(root, "models", rel), bytes);
+      mocks.comfyuiPath = root;
+      mocks.listLocalModels.mockResolvedValue([
+        { name: "qwen_image_vae.safetensors", path: "vae/qwen_image_vae.safetensors", size: 0, modified: "", type: "vae" },
+      ]);
+
+      const { data } = await listLocalModelsFallback({
+        action: "show",
+        name: "qwen_image_vae.safetensors",
+      });
+      expect(data).toMatchObject({
+        name: "qwen_image_vae.safetensors",
+        type: "vae",
+        path: "vae/qwen_image_vae.safetensors",
+        size: bytes.length,
+      });
+      expect(data).toEqual(
+        expect.objectContaining({ modified: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) }),
+      );
+    });
   });
 
   it("throws a clear error when neither comfy-cli nor a readable server is available", async () => {

--- a/src/services/local-models-fallback.ts
+++ b/src/services/local-models-fallback.ts
@@ -1,4 +1,6 @@
-import { listLocalModels, MODEL_SUBDIRS } from "./model-resolver.js";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { stat } from "node:fs/promises";
+import { listLocalModels, MODEL_SUBDIRS, type LocalModel } from "./model-resolver.js";
 import { getSystemStats } from "../comfyui/client.js";
 import { config } from "../config.js";
 
@@ -44,6 +46,118 @@ const TYPE_ALIASES: Record<string, string> = {
 
 function resolveModelFolder(type: string): string {
   return TYPE_ALIASES[type.toLowerCase()] ?? type;
+}
+
+function posixRel(p: string): string {
+  return p.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+/** Drop a leading `models/` so `models/vae/foo.safetensors` matches listing paths. */
+function stripModelsPrefix(rel: string): string {
+  const n = posixRel(rel);
+  return /^models\//i.test(n) ? n.slice("models/".length) : n;
+}
+
+function pathBasename(rel: string): string {
+  const parts = posixRel(rel).split("/").filter(Boolean);
+  return parts.at(-1) ?? rel;
+}
+
+function pathDirname(rel: string): string | undefined {
+  const parts = posixRel(rel).split("/").filter(Boolean);
+  return parts.length >= 2 ? parts.slice(0, -1).join("/") : undefined;
+}
+
+function modelRelPath(model: LocalModel): string {
+  if (isAbsolute(model.path)) return posixRel(`${model.type}/${model.name}`);
+  return stripModelsPrefix(model.path);
+}
+
+/**
+ * Folder the caller asked for: explicit `folder`/`type`, else the directory
+ * prefix of a relative `name` (e.g. `vae/qwen_image_vae.safetensors`).
+ */
+function showFolderHint(args: { name: string; folder?: string; type?: string }): string | undefined {
+  const fromArg = (args.folder ?? args.type)?.trim();
+  if (fromArg) return resolveModelFolder(fromArg);
+  const dir = pathDirname(stripModelsPrefix(args.name.trim()));
+  if (!dir) return undefined;
+  const head = dir.split("/")[0];
+  return head ? resolveModelFolder(head) : undefined;
+}
+
+function showArgFolderConflictsName(args: { name: string; folder?: string; type?: string }): boolean {
+  const fromArg = (args.folder ?? args.type)?.trim();
+  const nameDir = pathDirname(stripModelsPrefix(args.name.trim()));
+  const nameHead = nameDir?.split("/")[0];
+  if (!fromArg || !nameHead) return false;
+  return resolveModelFolder(fromArg).toLowerCase() !== resolveModelFolder(nameHead).toLowerCase();
+}
+
+/**
+ * Exact (case-insensitive) basename matches, optionally narrowed by folder/type
+ * or a relative path. Array order is not a selector — #2504's bug was
+ * `Array.find` reporting whichever duplicate happened to be listed first.
+ */
+function showMatches(models: LocalModel[], args: { name: string; folder?: string; type?: string }): LocalModel[] {
+  if (showArgFolderConflictsName(args)) return [];
+  const needle = stripModelsPrefix(args.name.trim());
+  const wantBase = pathBasename(needle).toLowerCase();
+  const nameDir = pathDirname(needle);
+  const folder = showFolderHint(args);
+
+  return models.filter((m) => {
+    if (pathBasename(m.name).toLowerCase() !== wantBase) return false;
+    if (folder && m.type.toLowerCase() !== folder.toLowerCase()) return false;
+    if (nameDir?.includes("/")) {
+      const wantRel = needle.toLowerCase();
+      const gotRel = modelRelPath(m).toLowerCase();
+      const gotName = posixRel(m.name).toLowerCase();
+      if (gotRel !== wantRel && !gotRel.endsWith(`/${wantRel}`) && gotName !== wantRel) return false;
+    }
+    return true;
+  });
+}
+
+function pickShowMatch(models: LocalModel[], args: { name: string; folder?: string; type?: string }): LocalModel {
+  const hits = showMatches(models, args);
+  const only = hits[0];
+  if (hits.length === 1 && only) return only;
+  if (hits.length === 0) {
+    throw new Error(`Model '${args.name}' was not found among the connected ComfyUI's local models.`);
+  }
+  const listed = [...hits]
+    .sort((a, b) => modelRelPath(a).localeCompare(modelRelPath(b)))
+    .map((m) => `  ${modelRelPath(m)}`)
+    .join("\n");
+  throw new Error(
+    `Model '${args.name}' matches ${hits.length} local files:\n${listed}\n` +
+      "Pass folder, type, or a relative path (e.g. vae/qwen_image_vae.safetensors) to select one.",
+  );
+}
+
+/** HTTP listings leave size/mtime blank; stat the file when a local path is known. */
+async function enrichShowStats(match: LocalModel): Promise<LocalModel> {
+  if (match.size > 0 && match.modified) return match;
+  let abs: string | undefined;
+  if (isAbsolute(match.path)) {
+    abs = match.path;
+  } else if (config.comfyuiPath) {
+    const modelsRoot = resolve(config.comfyuiPath, "models");
+    const target = resolve(modelsRoot, match.path);
+    const rel = relative(modelsRoot, target);
+    if (rel !== "" && !rel.startsWith("..") && !isAbsolute(rel) && target.startsWith(modelsRoot + sep)) {
+      abs = target;
+    }
+  }
+  if (!abs) return match;
+  try {
+    const info = await stat(abs);
+    if (!info.isFile()) return match;
+    return { ...match, size: info.size, modified: info.mtime.toISOString() };
+  } catch {
+    return match;
+  }
 }
 
 /** Read-only comfy_cli models_* actions that can be served without comfy-cli. */
@@ -146,15 +260,14 @@ export async function listLocalModelsFallback(args: {
     }
     case "show": {
       if (!args.name) throw new Error("name is required for show");
-      const models = await listLocalModels();
+      const showArgs = { name: args.name, folder: args.folder, type: args.type };
+      // Prefer the hinted folder so a filtered REST listing does not even see
+      // same-basename files in other categories. The matcher still filters the
+      // returned set: mocks (and unfiltered listings) can still yield duplicates.
+      const folderHint = showArgFolderConflictsName(showArgs) ? undefined : showFolderHint(showArgs);
+      const models = await listLocalModels(folderHint);
       if (models.length === 0) await assertLocalSourceAvailable();
-      const needle = args.name.toLowerCase();
-      // comfy `models show <name>` addresses a specific model by name — return
-      // the EXACT (case-insensitive) match only. A substring guess would report
-      // an arbitrary model (e.g. show "flux" picking one of several), so no
-      // exact match is a clear not-found.
-      const match = models.find((m) => m.name.toLowerCase() === needle);
-      if (!match) throw new Error(`Model '${args.name}' was not found among the connected ComfyUI's local models.`);
+      const match = await enrichShowStats(pickShowMatch(models, showArgs));
       return {
         command: `models show ${args.name}`,
         data: {

--- a/src/tools/comfy-cli.ts
+++ b/src/tools/comfy-cli.ts
@@ -68,7 +68,7 @@ export function registerComfyCliTools(server: McpServer): void {
       '- action:"workflow_run" — Submit an API/UI workflow file (`workflowPath` required). Asynchronous by default; set wait=true to await outputs (`timeoutSeconds`).\n' +
       '- action:"transfer_upload" — Upload input files (`files` required) for local ComfyUI or Comfy Cloud; overwrite=false passes --no-overwrite.\n' +
       '- action:"transfer_download" — Download completed outputs for `promptId` (required); `outDir` and `urlOnly` optional.\n' +
-      '- action:"models_list_folders" / "models_list_folder" / "models_search" / "models_show" — Discover model folders/files locally or in Comfy Cloud (`folder` required for list_folder, `name` for show). When comfy-cli is not installed/on PATH and the target is the connected (local) server, these read-only listings fall back to that server\'s own local models (via /models) — so model discovery works without the CLI.\n' +
+      '- action:"models_list_folders" / "models_list_folder" / "models_search" / "models_show" — Discover model folders/files locally or in Comfy Cloud (`folder` required for list_folder, `name` for show). For models_show, pass `folder`/`type` or a relative `name` path (e.g. vae/foo.safetensors) when the same basename exists in more than one folder. When comfy-cli is not installed/on PATH and the target is the connected (local) server, these read-only listings fall back to that server\'s own local models (via /models) — so model discovery works without the CLI.\n' +
       '- action:"models_download" — Download a model `url` (required) into the workspace (`relativePath`, default models/checkpoints). A download can run for many minutes and is gated on an idle-liveness timeout, so a progressing download is never killed.\n' +
       '- action:"models_remove" — Remove workspace model files (`modelNames` required; `relativePath` optional).\n' +
       '- action:"skills_list" / "skills_show" / "skills_validate" / "skills_install" / "skills_status" / "skills_uninstall" — Manage the official comfy-cli bundled agent skills (comfy, fragments, debug, relay, director). validate requires `path`; install/uninstall default to dry-run unless apply=true; scope="project" requires `projectDir`.',
@@ -122,10 +122,10 @@ export function registerComfyCliTools(server: McpServer): void {
       outDir: z.string().optional().describe('action:"transfer_download" — output directory.'),
       overwrite: z.boolean().optional().describe('action:"transfer_upload" — set false to pass --no-overwrite.'),
       urlOnly: z.boolean().optional().describe('action:"transfer_download" — print URLs instead of downloading files.'),
-      folder: z.string().optional().describe('action:"models_list_folder" — the model folder to list. REQUIRED.'),
+      folder: z.string().optional().describe('action:"models_list_folder" — the model folder to list (REQUIRED). action:"models_show" — optional folder to pick among duplicate basenames.'),
       text: z.string().optional().describe('action:"models_search" — search text.'),
-      type: z.string().optional().describe('action:"models_search" — model type filter (checkpoint, lora, vae, …).'),
-      name: z.string().optional().describe('actions "models_show"/"skills_show" — the model or skill name.'),
+      type: z.string().optional().describe('action:"models_search" — model type filter (checkpoint, lora, vae, …). action:"models_show" — same filter, to pick among duplicate basenames.'),
+      name: z.string().optional().describe('actions "models_show"/"skills_show" — the model or skill name. For models_show a relative path (e.g. vae/qwen_image_vae.safetensors) selects among duplicate basenames.'),
       url: z.string().url().optional().describe('action:"models_download" — model URL to download. REQUIRED.'),
       relativePath: z.string().optional().describe('actions "models_download"/"models_remove" — workspace-relative model directory (default models/checkpoints).'),
       modelNames: z.array(z.string()).optional().describe('action:"models_remove" — model filenames to remove. REQUIRED.'),


### PR DESCRIPTION
Fixes #2504

The `comfy_cli` local-models fallback for `models_show` resolved by basename with `Array.find`, so a file present in more than one folder (the reporter's case: `qwen_image_vae.safetensors` in both `loras` and `vae`) was reported as whichever copy happened to be listed first — with `size: 0` and a blank mtime.

Show now:

- accepts `folder` / `type` or a relative `name` path to pick the intended copy
- refuses an ambiguous basename instead of returning an arbitrary one
- stats the resolved file when `COMFYUI_PATH` is known so size and modified are real