### PR TITLE
fix: fall back for unsupported comfy-cli list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented here. This project adheres to
 - make `resolve_missing` suggest `models/clip_vision/` for missing `CLIPVisionLoader.clip_name` models while keeping ordinary CLIP loaders on `models/text_encoders/` (#2604)
 - classify an existing `application/octet-stream` OBJ returned by `get_image` as an unsupported attachment instead of a missing file (#2608)
 - suppress acknowledged completion replays after reconnect (#2591)
+- fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 
 
 ## [0.52.152] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
+
 ## [0.52.153] - 2026-08-30
 
 ### MCP
@@ -17,7 +22,6 @@ All notable changes to this project are documented here. This project adheres to
 - make `resolve_missing` suggest `models/clip_vision/` for missing `CLIPVisionLoader.clip_name` models while keeping ordinary CLIP loaders on `models/text_encoders/` (#2604)
 - classify an existing `application/octet-stream` OBJ returned by `get_image` as an unsupported attachment instead of a missing file (#2608)
 - suppress acknowledged completion replays after reconnect (#2591)
-- fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 
 
 ## [0.52.152] - 2026-08-30

--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -78,7 +78,7 @@ Install, repair, enable/disable and remove ComfyUI custom node packs on this Com
 - action:"uninstall" — Uninstall a pack (removes it). IRREVERSIBLE through this tool — for a cleanup audit prefer action:"disable", which is reversible. The pack must be one ComfyUI-Manager tracks: an id that resolves nowhere is REFUSED before anything is queued (a drained queue would otherwise read exactly like a success), and a pack that is on disk but unmanaged is named so you can remove its directory yourself. After the queue drains the installed-pack list is re-read and the pack must be GONE before anything claims 'uninstalled'. A ComfyUI restart is required to unload it fully. REFUSES the sidebar panel pack.
 - action:"disable" — Disable an installed pack WITHOUT removing it — the reversible first step of a cleanup (re-enable with action:"enable"; action:"uninstall" removes a pack outright). Uses the ComfyUI-Manager HTTP API (works against remote instances) or official comfy-cli locally, and re-reads the installed-pack list afterwards so a Manager no-op is reported as NOT disabled rather than as success. A ComfyUI restart is required for the change to take effect. REFUSES the sidebar panel pack.
 - action:"enable" — Re-enable a pack previously disabled with action:"disable". Same Manager/comfy-cli mechanics and the same post-op re-read, so a Manager no-op is reported as NOT enabled rather than as success. A ComfyUI restart is required for the change to take effect. REFUSES the sidebar panel pack.
-- action:"list" — List installed packs with their version and enabled/disabled state. Uses the ComfyUI-Manager HTTP API (works against remote instances); the cm-cli fallback returns names only. Read-only.
+- action:"list" — List installed packs with their version and enabled/disabled state. Uses the ComfyUI-Manager HTTP API (works against remote instances); useCmCli:true uses cm-cli when its installed version is supported, otherwise falls back to Manager HTTP, while the cm-cli path returns names only. Read-only.
 - action:"sync_deps" — Reconcile the Python dependencies of ALL installed packs through official `comfy node restore-dependencies`. Requires a local ComfyUI install and comfy-cli; takes no other parameters.
 
 <Tip>**In plain terms:** Everything you do to someone ELSE'S node pack once you have found it: install it, keep it working, turn it off, remove it. One tool for the whole pack lifecycle, chosen with `action`. FINDING a pack is `search_custom_nodes`; writing your own is `node_pack`.</Tip>
@@ -110,7 +110,7 @@ Install, repair, enable/disable and remove ComfyUI custom node packs on this Com
   ComfyUI-Manager channel name (default 'default').
 </ParamField>
 <ParamField path="useCmCli" type="boolean">
-  Prefer the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install — for actions "install"/"disable"/"enable"/"uninstall", an unavailable CLI falls back to Manager HTTP automatically (disclosed in the result); "update"/"reinstall"/"fix"/"list" do not fall back.
+  Prefer the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install — for actions "install"/"disable"/"enable"/"uninstall"/"list", an unavailable or unsupported CLI falls back to Manager HTTP automatically (disclosed in the result); "update"/"reinstall"/"fix" do not fall back.
 </ParamField>
 
 ### Examples

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -156,7 +156,7 @@ process.env.COMFYUI_MCP_PANEL_PIN = "off";
 
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { config } from "../../config.js";
 import {
@@ -184,6 +184,7 @@ import { applyManifest } from "../../services/manifest.js";
 import { getManifestPartialLeftover } from "../../services/manifest-partial.js";
 
 const mockedExec = vi.mocked(execFileSync);
+const mockedSpawn = vi.mocked(spawnSync);
 const mockedExists = vi.mocked(existsSync);
 let priorComfyuiPathEnv: string | undefined;
 
@@ -442,6 +443,21 @@ describe("node-management service", () => {
     // below and must then provide a call-scoped or verified live root.
     process.env.COMFYUI_PATH = "/fake/comfy";
     mockedExec.mockReset();
+    mockedSpawn.mockReset();
+    mockedSpawn.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({
+        schema: "envelope/1",
+        type: "envelope",
+        ok: true,
+        command: "version",
+        version: "1.11.1",
+        where: null,
+        data: {},
+        error: null,
+      }),
+      stderr: "",
+    } as never);
     mockedExists.mockReset();
     mockedExists.mockReturnValue(true);
     // Default: no custom_nodes fixture — the #797 disk scan delegates to the
@@ -3594,6 +3610,98 @@ describe("node-management service", () => {
   // ---- list --------------------------------------------------------------
 
   describe("listInstalledNodes", () => {
+    it("#2603 falls back to Manager HTTP when the installed comfy-cli version is unrecognized", async () => {
+      const cliPath = "/fake/comfy-cli-2603-unrecognized";
+      const priorCliPath = process.env.COMFY_CLI_PATH;
+      process.env.COMFY_CLI_PATH = cliPath;
+      mockedSpawn.mockReturnValue({
+        status: 0,
+        stdout: "comfy-cli version unavailable\n",
+        stderr: "",
+      } as never);
+      const { calls } = stubFetch({
+        installedBody: {
+          "ComfyUI-Manager": {
+            ver: "3.1",
+            cnr_id: "comfyui-manager",
+            enabled: true,
+          },
+        },
+      });
+
+      try {
+        const nodes = await listInstalledNodes({ mode: "default", useCmCli: true });
+        expect(nodes).toEqual([
+          {
+            module: "ComfyUI-Manager",
+            cnrId: "comfyui-manager",
+            version: "3.1",
+            enabled: true,
+          },
+        ]);
+        expect(mockedSpawn).toHaveBeenCalledWith(
+          cliPath,
+          ["--json", "--version"],
+          expect.objectContaining({ timeout: 10_000 }),
+        );
+        expect(mockedExec).not.toHaveBeenCalled();
+        expect(
+          calls.some((call) => call.url.includes("/v2/customnode/installed?mode=default")),
+        ).toBe(true);
+      } finally {
+        if (priorCliPath === undefined) delete process.env.COMFY_CLI_PATH;
+        else process.env.COMFY_CLI_PATH = priorCliPath;
+      }
+    });
+
+    it("does not fall back after a supported comfy-cli inventory command fails", async () => {
+      const cliPath = "/fake/comfy-cli-2603-command-error";
+      const priorCliPath = process.env.COMFY_CLI_PATH;
+      process.env.COMFY_CLI_PATH = cliPath;
+      mockedSpawn.mockReturnValue({
+        status: 0,
+        stdout: JSON.stringify({
+          schema: "envelope/1",
+          type: "envelope",
+          ok: true,
+          command: "version",
+          version: "1.11.1",
+          where: null,
+          data: {},
+          error: null,
+        }),
+        stderr: "",
+      } as never);
+      mockedExec.mockReturnValue(
+        JSON.stringify({
+          schema: "envelope/1",
+          type: "envelope",
+          ok: false,
+          command: "node show installed",
+          version: "1.11.1",
+          where: "local",
+          data: null,
+          error: {
+            code: "node_inventory_failed",
+            message: "inventory unavailable",
+          },
+        }) as never,
+      );
+      const { fetchMock } = stubFetch({
+        installedBody: { "Manager-pack": { ver: "1.0", enabled: true } },
+      });
+
+      try {
+        await expect(listInstalledNodes({ useCmCli: true })).rejects.toThrow(
+          /comfy-cli node show failed: node_inventory_failed: inventory unavailable/,
+        );
+        expect(fetchMock).not.toHaveBeenCalled();
+      } finally {
+        if (priorCliPath === undefined) delete process.env.COMFY_CLI_PATH;
+        else process.env.COMFY_CLI_PATH = priorCliPath;
+      }
+    });
+
     it("parses an object-keyed installed response", async () => {
       stubFetch({
         installedBody: {

--- a/src/__tests__/tools/node-management.test.ts
+++ b/src/__tests__/tools/node-management.test.ts
@@ -594,9 +594,9 @@ describe("install_custom_node action:\"list\" discloses what mode:\"imported\" c
     }
   });
 
-  // cm-cli `show installed` has no mode parameter, so useCmCli does not degrade
-  // `mode` — it drops it. Reporting the live on-disk list under a mode that was
-  // never sent is the same misreport wearing a second costume.
+  // A usable cm-cli `show installed` has no mode parameter, so that path does
+  // not degrade `mode` — it drops it. When the CLI is absent or unsupported,
+  // action:"list" falls back to Manager HTTP and the requested mode applies.
   it("discloses that useCmCli dropped `mode` entirely", async () => {
     mocks.listInstalledNodes.mockResolvedValueOnce(PACKS);
     const out = text(

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -36,6 +36,7 @@ import {
 import {
   assertComfyCliOk,
   getComfyCliVersion,
+  isComfyCliUsable,
   isSupportedComfyCliVersion,
   resolveComfyCliExecutable,
   runComfyCliSync,
@@ -6102,7 +6103,12 @@ async function listInstalledNodesAt(
 ): Promise<InstalledNode[]> {
   const { mode = "default" } = opts;
 
-  if (opts.useCmCli) {
+  // `list` is read-only, so an explicitly requested CLI is a preference here,
+  // not a reason to reject an otherwise useful inventory when the installed
+  // executable is absent or its version probe is unrecognized. Keep the remote
+  // branch on runCmCli so its existing no-local-CLI refusal remains intact.
+  const useCli = opts.useCmCli === true && (isRemoteMode() || isComfyCliUsable());
+  if (useCli) {
     // cm-cli `show installed` prints a formatted table — return raw lines as
     // pseudo-nodes since structured data is HTTP-only. `enabled` is left
     // undefined: the table does not report it, so claiming a value would be

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -193,7 +193,7 @@ const useCmCliSchema = z
   .boolean()
   .optional()
   .describe(
-    'Prefer the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install — for actions "install"/"disable"/"enable"/"uninstall", an unavailable CLI falls back to Manager HTTP automatically (disclosed in the result); "update"/"reinstall"/"fix"/"list" do not fall back.',
+    'Prefer the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install — for actions "install"/"disable"/"enable"/"uninstall"/"list", an unavailable or unsupported CLI falls back to Manager HTTP automatically (disclosed in the result); "update"/"reinstall"/"fix" do not fall back.',
   );
 
 const channelSchema = z
@@ -238,9 +238,11 @@ const IMPORTED_MODE_DISCLOSURE =
  *  entirely rather than degrading it. Silently returning the live on-disk list
  *  under a mode that was never sent is the same misreport in a second costume. */
 const CM_CLI_MODE_DROPPED =
-  'NOTE — `mode` was NOT applied: useCmCli:true reads `cm-cli show installed`, which has ' +
-  'no mode parameter, so this is the current on-disk pack list regardless of the mode ' +
-  'requested.';
+  'NOTE — if a usable comfy-cli handled this request, `mode` was NOT applied: `cm-cli show ' +
+  'installed` has no mode parameter, so that result is the current on-disk pack list ' +
+  'regardless of the mode requested. If comfy-cli was absent or its version was ' +
+  'unrecognized/unsupported, this read-only request fell back to Manager HTTP and `mode` ' +
+  'was applied there.';
 
 function formatInstalledNodes(nodes: InstalledNode[]): string {
   if (nodes.length === 0) return "No custom nodes installed.";
@@ -311,7 +313,7 @@ export function registerNodeManagementTools(server: McpServer): void {
       '- action:"uninstall" — Uninstall a pack (removes it). IRREVERSIBLE through this tool — for a cleanup audit prefer action:"disable", which is reversible. The pack must be one ComfyUI-Manager tracks: an id that resolves nowhere is REFUSED before anything is queued (a drained queue would otherwise read exactly like a success), and a pack that is on disk but unmanaged is named so you can remove its directory yourself. After the queue drains the installed-pack list is re-read and the pack must be GONE before anything claims \'uninstalled\'. A ComfyUI restart is required to unload it fully. REFUSES the sidebar panel pack.\n' +
       '- action:"disable" — Disable an installed pack WITHOUT removing it — the reversible first step of a cleanup (re-enable with action:"enable"; action:"uninstall" removes a pack outright). Uses the ComfyUI-Manager HTTP API (works against remote instances) or official comfy-cli locally, and re-reads the installed-pack list afterwards so a Manager no-op is reported as NOT disabled rather than as success. A ComfyUI restart is required for the change to take effect. REFUSES the sidebar panel pack.\n' +
       '- action:"enable" — Re-enable a pack previously disabled with action:"disable". Same Manager/comfy-cli mechanics and the same post-op re-read, so a Manager no-op is reported as NOT enabled rather than as success. A ComfyUI restart is required for the change to take effect. REFUSES the sidebar panel pack.\n' +
-      '- action:"list" — List installed packs with their version and enabled/disabled state. Uses the ComfyUI-Manager HTTP API (works against remote instances); the cm-cli fallback returns names only. Read-only.\n' +
+      '- action:"list" — List installed packs with their version and enabled/disabled state. Uses the ComfyUI-Manager HTTP API (works against remote instances); useCmCli:true uses cm-cli when its installed version is supported, otherwise falls back to Manager HTTP, while the cm-cli path returns names only. Read-only.\n' +
       '- action:"sync_deps" — Reconcile the Python dependencies of ALL installed packs through official `comfy node restore-dependencies`. Requires a local ComfyUI install and comfy-cli; takes no other parameters.',
     {
       action: z


### PR DESCRIPTION
Fixes #2603\n\nSummary:\n- Treat local comfy-cli availability/version probing as a preference for read-only install_custom_node action:list.\n- Fall back to ComfyUI-Manager HTTP when the executable is absent or its version is unrecognized/unsupported.\n- Preserve command-error behavior after a supported CLI is selected, and preserve remote no-local-CLI refusal.\n- Add production-shaped service regressions and document the mode disclosure.\n\nValidation:\n- npm.cmd test (full repository gate; after rebuilding ignored dist/)\n- npm.cmd run build\n- npm.cmd run lint\n- npm.cmd exec vitest run src/__tests__/services/node-management.test.ts src/__tests__/tools/node-management.test.ts