### PR TITLE
fix(panel): fence widget writes by graph identity (#2550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
+- fence ordinary `panel_set_widget` writes against the current panel graph identity across reconnects, with an actionable rebind refusal (#2550)
 
 ## [0.52.153] - 2026-08-30
 

--- a/src/__tests__/orchestrator/panel-set-widget-graph-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-set-widget-graph-identity.test.ts
@@ -1,0 +1,186 @@
+// #2550 — panel_set_widget must not turn a scope read from one graph object
+// into a success envelope for a graph object that appeared after reconnect.
+//
+// This drives the shipped tool definition and makePanelToolCtx through the
+// production beforeDispatch seam. The command/response shapes are the live
+// panel protocol: graph_query publishes viewing.graph_identity and the panel
+// accepts expected_node_type / expected_node_identity on graph_set_widget.
+
+import { describe, expect, it } from "vitest";
+import {
+  markDispatched,
+  type TabPromotedScopeRead,
+  type TabWorkflowUuidRead,
+} from "../../services/ui-bridge.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/identity-fence.json";
+const WORKFLOW_UUID = "25500000-0000-4000-8000-000000000000";
+const NODE_ID = 7;
+const NODE_TYPE = "PrimitiveFloat";
+const NODE_IDENTITY = "node:7:original";
+
+type Mode = "stable" | "stale-before-dispatch" | "unknown-after-dispatch";
+
+function textOf(result: ToolResult): string {
+  return result.content.map((block) => (block as { text?: string }).text ?? "").join(" ");
+}
+
+function setWidgetDef() {
+  const definition = buildPanelToolDefs().find((candidate) => candidate.name === "panel_set_widget");
+  if (!definition) throw new Error("panel_set_widget is not registered");
+  return definition;
+}
+
+function makeBridge(mode: Mode): {
+  bridge: PanelToolCtx["bridge"];
+  calls: Array<Record<string, unknown>>;
+  dispatchedWrites: number;
+} {
+  const calls: Array<Record<string, unknown>> = [];
+  let graphIdentity = "graph:root-before-reconnect";
+  let currentScope: Extract<TabPromotedScopeRead, { known: true }> = {
+    known: true,
+    scope: "root",
+    ownerNodeId: null,
+    workflowUuid: WORKFLOW_UUID,
+    graphIdentity,
+  };
+  let connectionIdentity = { generation: 1, tabSessionId: "browser-tab-2550" };
+  let dispatchedWrites = 0;
+
+  const bridgeShape = {
+    send: async (
+      command: Record<string, unknown>,
+      options?: { beforeDispatch?: () => void },
+    ) => {
+      calls.push({ ...command });
+      if (command.cmd === "graph_query") {
+        return {
+          viewing: {
+            scope: "root",
+            kind: "root",
+            workflow: "identity-fence.json",
+            workflow_uuid: WORKFLOW_UUID,
+            graph_identity: graphIdentity,
+          },
+          truncated: false,
+          nodes: [
+            {
+              id: NODE_ID,
+              type: NODE_TYPE,
+              is_subgraph: false,
+              node_identity: NODE_IDENTITY,
+              widgets: { value: 0.5 },
+            },
+          ],
+          node_count: 1,
+        };
+      }
+      if (command.cmd === "graph_set_widget") {
+        if (mode === "stale-before-dispatch") {
+          // A same-workflow rebind replaces the graph object while the
+          // connection tuple remains readable. This isolates the graph fence
+          // from the separate tab/connection fence.
+          graphIdentity = "graph:root-after-reconnect";
+          currentScope = { ...currentScope, graphIdentity };
+        }
+        options?.beforeDispatch?.();
+        dispatchedWrites += 1;
+        if (mode === "unknown-after-dispatch") {
+          throw markDispatched(
+            new Error(
+              `Panel tab ${TAB} disconnected mid-command ("graph_set_widget") — ` +
+                `OUTCOME UNKNOWN: the command was already sent, so the panel may have applied it.`,
+            ),
+            true,
+          );
+        }
+        return {
+          set: {
+            node_id: command.node_id,
+            widget: command.widget,
+            previous: 0.5,
+            value: command.value,
+          },
+        };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    tabConnectionIdentity: () => connectionIdentity,
+    promotedScopeFor: () => currentScope,
+    tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedNodeIdentityFenceCapability: () => true,
+    tabExpectedScopeGraphIdentityFenceCapability: () => true,
+    tabPromotedTerminalWitnessCapability: () => true,
+    tabPromotedParentRailFenceCapability: () => true,
+    tabReceiverResolvable: () => true,
+    workflowUuidFor: (): TabWorkflowUuidRead => ({ known: true, uuid: WORKFLOW_UUID }),
+  } as Partial<PanelToolCtx["bridge"]>;
+  const bridge = bridgeShape as PanelToolCtx["bridge"];
+
+  return { bridge, calls, get dispatchedWrites() { return dispatchedWrites; } };
+}
+
+async function run(mode: Mode) {
+  const harness = makeBridge(mode);
+  const ctx = makePanelToolCtx(harness.bridge, TAB, new WorkflowTargetStore());
+  const result = await setWidgetDef().handler(
+    { node_id: NODE_ID, widget: "value", value: 0.75 } as never,
+    ctx,
+  );
+  return { ...harness, result, text: textOf(result) };
+}
+
+describe("panel_set_widget graph identity fence (#2550)", () => {
+  it("refuses a reconnect-stale graph before dispatch and names the rebind remedy", async () => {
+    const { result, text, calls, dispatchedWrites } = await run("stale-before-dispatch");
+
+    expect(result.isError).toBe(true);
+    expect(text).toMatch(/current graph identity changed/);
+    expect(text).toMatch(/No graph_set_widget was dispatched/);
+    expect(text).toMatch(/panel_set_workflow_target\(\{mode:"current"\}\)/);
+    expect(calls.filter((command) => command.cmd === "graph_set_widget")).toHaveLength(1);
+    expect(dispatchedWrites).toBe(0);
+  });
+
+  it("returns the normal success envelope when the current graph identity still matches", async () => {
+    const { result, text, calls, dispatchedWrites } = await run("stable");
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(text)).toMatchObject({
+      set: { node_id: NODE_ID, widget: "value", value: 0.75 },
+    });
+    expect(calls.filter((command) => command.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({
+        node_id: NODE_ID,
+        expected_node_type: NODE_TYPE,
+        expected_node_identity: NODE_IDENTITY,
+      }),
+    ]);
+    expect(dispatchedWrites).toBe(1);
+  });
+
+  it("preserves the post-dispatch unknown outcome instead of returning a success envelope", async () => {
+    const { result, text, dispatchedWrites } = await run("unknown-after-dispatch");
+
+    expect(result.isError).toBe(true);
+    expect(text).toMatch(/OUTCOME UNKNOWN/);
+    expect(text).toMatch(/may have applied/);
+    expect(() => JSON.parse(text)).toThrow();
+    expect(dispatchedWrites).toBe(1);
+  });
+});

--- a/src/__tests__/orchestrator/set-widget-concurrent-ack.test.ts
+++ b/src/__tests__/orchestrator/set-widget-concurrent-ack.test.ts
@@ -73,6 +73,7 @@ function connectPanel(): Promise<WebSocket> {
           enforces_workflow_stamp: true,
           enforces_workflow_stamp_at_write: true,
           enforces_expected_node_type_at_write: true,
+          enforces_expected_node_identity_at_write: true,
         }),
       );
       resolve(sock);
@@ -82,7 +83,13 @@ function connectPanel(): Promise<WebSocket> {
 }
 
 function viewing() {
-  return { scope: "root", kind: "root", workflow: "video_minimax_h3_i2v.json", workflow_uuid: WORKFLOW_UUID };
+  return {
+    scope: "root",
+    kind: "root",
+    workflow: "video_minimax_h3_i2v.json",
+    workflow_uuid: WORKFLOW_UUID,
+    graph_identity: "graph:root-2559",
+  };
 }
 
 function ordinaryNode(id: unknown) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6286,6 +6286,8 @@ type QueriedNodeScope = {
   node: "ordinary" | "container";
   nodeType: string;
   nodeIdentity?: string;
+  /** The object-keyed graph identity of the exact view that supplied the row. */
+  graphIdentity?: string;
 };
 
 /** Read the active viewing scope and node's explicit container bit before
@@ -6307,8 +6309,16 @@ function parseVerifiedQueriedNodeScope(
   }
   const viewing = payload.viewing;
   if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return null;
-  const activeView = (viewing as Record<string, unknown>).scope;
+  const viewingRecord = viewing as Record<string, unknown>;
+  const activeView = viewingRecord.scope;
   if (activeView !== "root" && activeView !== "subgraph") return null;
+  const graphIdentity = viewingRecord.graph_identity;
+  if (
+    graphIdentity !== undefined &&
+    (typeof graphIdentity !== "string" || graphIdentity.length === 0 || graphIdentity.length > 256)
+  ) {
+    return null;
+  }
 
   let row: unknown;
   if (Object.prototype.hasOwnProperty.call(payload, "nodes")) {
@@ -6340,6 +6350,7 @@ function parseVerifiedQueriedNodeScope(
     node: isSubgraph ? "container" : "ordinary",
     nodeType: identity.type,
     ...(identity.nodeIdentity !== undefined ? { nodeIdentity: identity.nodeIdentity } : {}),
+    ...(graphIdentity !== undefined ? { graphIdentity } : {}),
   };
 }
 
@@ -6780,8 +6791,14 @@ type PromotedWritePlan = {
 
 type OrdinaryWritePlan = {
   kind: "ordinary-write";
+  activeView: "root" | "subgraph";
+  graphIdentity: string;
   expectedNodeType: string;
-  expectedNodeIdentity: string;
+  expectedNodeIdentity?: string;
+  binding: {
+    tabId: string;
+    identity?: { generation: number; tabSessionId: string };
+  };
 };
 
 type PromotedExpectedScope = PromotedScopeWitness & {
@@ -7423,6 +7440,106 @@ function panelBindingDriftReason(
   return undefined;
 }
 
+/** Ordinary writes do not have an `expected_scope` field that the panel can
+ * enforce. Keep their graph identity fence on the MCP side instead, and give
+ * binding drift its own diagnosis so a failed promotion read is not blamed
+ * for a reconnect. */
+function ordinaryBindingRefusal(widget: string, reason: string): ToolResult {
+  return fail(
+    `panel_set_widget refused "${widget}" because the ordinary panel graph binding ${reason}. ` +
+      `No graph_set_widget was dispatched. Rebind the live panel with ` +
+      `panel_set_workflow_target({mode:"current"}) and retry.`,
+  );
+}
+
+function ordinaryWritePlanFromScope(
+  widget: string,
+  scope: QueriedNodeScope,
+  tabBefore: string,
+  identityBefore: { generation: number; tabSessionId: string } | undefined,
+): OrdinaryWritePlan | ToolResult {
+  if (!scope.graphIdentity) {
+    return ordinaryBindingRefusal(
+      widget,
+      "did not publish the current graph identity needed to fence this ordinary write",
+    );
+  }
+  return {
+    kind: "ordinary-write",
+    activeView: scope.activeView,
+    graphIdentity: scope.graphIdentity,
+    expectedNodeType: scope.nodeType,
+    ...(scope.nodeIdentity !== undefined ? { expectedNodeIdentity: scope.nodeIdentity } : {}),
+    binding: {
+      tabId: tabBefore,
+      ...(isUsablePanelConnectionIdentity(identityBefore) ? { identity: identityBefore } : {}),
+    },
+  };
+}
+
+function currentOrdinaryWriteFenceError(
+  ctx: PanelToolCtx,
+  plan: OrdinaryWritePlan,
+): string | null {
+  if (ctx.tabId !== plan.binding.tabId) return "the panel tab was rebound";
+
+  if (typeof ctx.panelConnectionIdentity !== "function") {
+    return "the panel connection identity became unavailable";
+  }
+  let currentIdentity: { generation: number; tabSessionId: string } | undefined;
+  try {
+    currentIdentity = ctx.panelConnectionIdentity();
+  } catch {
+    return "the panel connection identity became unreadable";
+  }
+  if (plan.binding.identity) {
+    if (!isUsablePanelConnectionIdentity(currentIdentity)) {
+      return "the panel connection identity became unavailable";
+    }
+    if (!samePanelConnectionIdentity(plan.binding.identity, currentIdentity)) {
+      return "the panel session or connection changed";
+    }
+  }
+
+  const readScope = (ctx.bridge as BridgeProbe).promotedScopeFor;
+  if (typeof readScope !== "function") {
+    return "the current graph identity became unavailable";
+  }
+  let currentScope: TabPromotedScopeRead;
+  try {
+    currentScope = readScope.call(ctx.bridge, ctx.tabId);
+  } catch {
+    return "the current graph identity became unreadable";
+  }
+  if (currentScope.known !== true) {
+    return "the current graph identity became unavailable";
+  }
+  if (
+    currentScope.scope !== plan.activeView ||
+    currentScope.graphIdentity !== plan.graphIdentity
+  ) {
+    return "the current graph identity changed";
+  }
+  return null;
+}
+
+function ordinaryWriteBeforeDispatch(
+  ctx: PanelToolCtx,
+  widget: string,
+  plan: OrdinaryWritePlan,
+): () => void {
+  return () => {
+    const error = currentOrdinaryWriteFenceError(ctx, plan);
+    if (error) {
+      throw new Error(
+        `Refusing ordinary graph_set_widget for "${widget}": ${error}. ` +
+          `No graph_set_widget was dispatched. Rebind the live panel with ` +
+          `panel_set_workflow_target({mode:"current"}) and retry.`,
+      );
+    }
+  };
+}
+
 async function preparePromotedWidgetWrite(
   ctx: PanelToolCtx,
   nodeId: unknown,
@@ -7486,8 +7603,8 @@ async function preparePromotedWidgetWrite(
     // ordinary fast path; otherwise a tab/connection rebind can make this
     // probe's ordinary classification authorize a write on the new receiver.
     const drift = panelBindingDriftReason(ctx, "after the scope probe", hasIdentityApi, identityBefore, tabBefore);
-    if (drift) return promotedWriteRefusal(widget, drift);
-    return null;
+    if (drift) return ordinaryBindingRefusal(widget, drift);
+    return ordinaryWritePlanFromScope(widget, targetScope, tabBefore, identityBefore);
   }
 
   let sub = await ctx.call(
@@ -7575,7 +7692,26 @@ async function preparePromotedWidgetWrite(
             "enforces_expected_node_identity_at_write",
           );
         }
-        return { kind: "ordinary-write", expectedNodeType, expectedNodeIdentity };
+        const ordinaryScope = targetScope;
+        if (!ordinaryScope?.graphIdentity) {
+          return ordinaryBindingRefusal(
+            widget,
+            "did not publish the current graph identity needed to fence this ordinary write",
+          );
+        }
+        return {
+          kind: "ordinary-write",
+          activeView: ordinaryScope.activeView,
+          graphIdentity: ordinaryScope.graphIdentity,
+          expectedNodeType,
+          expectedNodeIdentity,
+          binding: {
+            tabId: tabBefore,
+            ...(isUsablePanelConnectionIdentity(identityBefore)
+              ? { identity: identityBefore }
+              : {}),
+          },
+        };
       }
       return promotedSubgraphReadRefusal(
         widget,
@@ -19187,7 +19323,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               nodeId,
               widget,
               promotedRetry.expectedNodeType,
-              undefined,
+              ordinaryWriteBeforeDispatch(ctx, widget, promotedRetry),
               undefined,
               promotedRetry.expectedNodeIdentity,
             );
@@ -19434,7 +19570,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           if (!promotedWritten.isError) markPanelSchemaReady(panelSchemaKey(ctx));
           return promotedWritten;
         }
-        let first = await write(args.node_id, args.widget as string);
+        let first = await write(
+          args.node_id,
+          args.widget as string,
+          expectedNodeType,
+          ordinaryPlan
+            ? ordinaryWriteBeforeDispatch(ctx, args.widget as string, ordinaryPlan)
+            : undefined,
+          undefined,
+          expectedNodeIdentity,
+        );
         if (!first.isError) {
           markPanelSchemaReady(panelSchemaKey(ctx));
           return persistUnpromotedControlAfterGenerate(first, ctx, args.node_id);


### PR DESCRIPTION
## Summary
- fence ordinary panel_set_widget writes against the current cached panel graph identity at the final pre-dispatch boundary
- preserve promoted/subgraph owner, rail, and scope routing; report binding drift separately from unresolved promotion ambiguity
- add stale/current/unknown production-shaped regressions and document #2550

## Validation
- npm.cmd run build
- npm.cmd run lint
- focused panel_set_widget/promoted/set-widget tests: 179 passed
- relevant orchestrator + ui-bridge suite: 4,870 passed
- full Vitest stage: 715 files, 13,317 passed, 6 skipped
- node scripts/asset-counts.mjs --check after build

Closes #2550