### PR TITLE
fix(get_image): classify existing OBJ attachments (#2608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - retry panel_connect against the live graph when a node reported by panel_graph_outline is refused as missing (#2502)
 - panel_open_workflow no longer treats frontend-normalized node fields as a failed load after reconnect (#2501)
 - make `resolve_missing` suggest `models/clip_vision/` for missing `CLIPVisionLoader.clip_name` models while keeping ordinary CLIP loaders on `models/text_encoders/` (#2604)
+- classify an existing `application/octet-stream` OBJ returned by `get_image` as an unsupported attachment instead of a missing file (#2608)
 
 
 ## [0.52.152] - 2026-08-30

--- a/src/__tests__/tools/get-image-obj-attachment.test.ts
+++ b/src/__tests__/tools/get-image-obj-attachment.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchImage: vi.fn(),
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+// Keep the real getOutputImage and get_image handler in this test. Only the
+// /view transport and local save calls are mocked, so this covers the
+// production classification path rather than stubbing the service result.
+vi.mock("../../comfyui/client.js", async () => {
+  const actual = await vi.importActual<typeof import("../../comfyui/client.js")>("../../comfyui/client.js");
+  return {
+    ...actual,
+    fetchImage: (...args: unknown[]) => mocks.fetchImage(...args),
+  };
+});
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    mkdir: (...args: unknown[]) => mocks.mkdir(...args),
+    writeFile: (...args: unknown[]) => mocks.writeFile(...args),
+  };
+});
+
+import { registerImageManagementTools } from "../../tools/image-management.js";
+
+type ToolResult = {
+  isError?: boolean;
+  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
+};
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (toolName: string, _description: string, _schema: unknown, toolHandler: ToolHandler) => {
+      if (toolName === name) handler = toolHandler;
+    },
+  };
+  registerImageManagementTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.fetchImage.mockResolvedValue({
+    // Minimal Wavefront OBJ-shaped text: the body is present, but it is not a
+    // format get_image is allowed to save or render.
+    base64: Buffer.from("# ComfyUI OBJ output\no Cube\nv 0 0 0\nf 1 1 1\n", "utf8").toString("base64"),
+    mimeType: "application/octet-stream",
+  });
+  mocks.mkdir.mockResolvedValue(undefined);
+  mocks.writeFile.mockResolvedValue(undefined);
+});
+
+describe("get_image action:get — existing OBJ attachments (#2608)", () => {
+  it("does not mistake an existing OBJ attachment for a missing file or save it", async () => {
+    const out = await getHandler("get_image")({
+      action: "get",
+      filename: "mesh.obj",
+      type: "output",
+      save_dir: "test-fixtures/saved-obj",
+    });
+
+    expect(out.isError).toBe(true);
+    const payload = JSON.parse(out.content.map((block) => block.text ?? "").join("")) as {
+      error?: string;
+      message?: string;
+    };
+    expect(payload.error).toBe("ATTACHMENT_TYPE_UNSUPPORTED");
+    expect(payload.message).toContain("existing OBJ attachment");
+    expect(payload.message).toContain("get_image cannot save this type");
+    expect(payload.message).not.toContain("may not exist");
+    expect(mocks.fetchImage).toHaveBeenCalledWith("mesh.obj", "output", "");
+    expect(mocks.mkdir).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -1068,6 +1068,17 @@ export async function getOutputImage(
   // is the server reporting an ABSENT FILE, and calling that a content refusal sends the
   // caller to inspect a payload when the filename is the thing to look at.
   const contentRejected = jsonRefusal?.kind === "content";
+  // An OBJ is a real attachment, but it is not an image, supported media, or JSON
+  // attachment that get_image can save. ComfyUI commonly serves it as the generic
+  // octet-stream type, so do not send a successful non-empty response down the
+  // missing-file path.
+  const unsupportedObjAttachment =
+    ext === ".obj" &&
+    mime === "application/octet-stream" &&
+    result.base64.length > 0 &&
+    !isImage &&
+    !isMedia &&
+    !isJson;
 
   if ((!isImage && !isMedia && !isJson) || !imageContentOk || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
@@ -1078,7 +1089,11 @@ export async function getOutputImage(
           ? `invalid image content labeled "${result.mimeType}"`
           : `content-type "${result.mimeType}"`;
     throw new ComfyUIError(
-      contentRejected
+      unsupportedObjAttachment
+        ? `ComfyUI /view returned an existing OBJ attachment for "${filename}" (${where}), ` +
+          `but get_image cannot save this type. Nothing was saved. ` +
+          `Use ComfyUI's file browser or another raw-file download path for OBJ attachments.`
+        : contentRejected
         ? // NAME THE ACTUAL REASON (#1373). "The file may not exist" for a body that
           // arrived and was rejected on its CONTENT sends the caller to re-check a
           // filename that is perfectly correct — the wrong-cause failure this issue is
@@ -1100,7 +1115,11 @@ export async function getOutputImage(
       // having one — still read IMAGE_NOT_FOUND and went off to re-check a filename that
       // was never wrong. That is the same wrong-cause failure as the prose, one layer
       // down, and it is the layer that automation reads.
-      contentRejected ? "ATTACHMENT_CONTENT_REJECTED" : "IMAGE_NOT_FOUND",
+      unsupportedObjAttachment
+        ? "ATTACHMENT_TYPE_UNSUPPORTED"
+        : contentRejected
+          ? "ATTACHMENT_CONTENT_REJECTED"
+          : "IMAGE_NOT_FOUND",
       {
         filename,
         type,


### PR DESCRIPTION
Fixes #2608.

Summary:
- classify a non-empty .obj served as application/octet-stream as ATTACHMENT_TYPE_UNSUPPORTED instead of IMAGE_NOT_FOUND
- preserve the refusal so get_image does not write an unsupported raw attachment, while explaining that the attachment exists and naming a raw-file alternative
- add a production-shaped get_image action:get regression using the real service and handler

Validation:
- 89 focused Vitest tests passed across the OBJ regression, image-management traversal, and binary-safe tool suites
- node scripts/check-changelog.mjs passed
- npm.cmd run lint passed (TypeScript, anti-slop)
- git diff --check passed