### PR TITLE
fix(2549): reclaim stale panel refresh state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 - fence ordinary `panel_set_widget` writes against the current panel graph identity across reconnects, with an actionable rebind refusal (#2550)
+- clear terminal MCP panel refresh coordination state and reclaim only bounded, stale refresh records while keeping unknown completion fail-closed (#2549)
 
 ## [0.52.153] - 2026-08-30
 

--- a/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
+++ b/src/__tests__/orchestrator/object-info-budget-mutations.test.ts
@@ -18,7 +18,7 @@
 // acknowledged #2202 stale-combo timeout where the panel has already
 // retired its schema snapshot.
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   __resetPanelSchemaReadinessForTest,
@@ -30,6 +30,8 @@ import {
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const TAB = "wf:workflows/a.json";
+const RECONNECT_TAB = "wf:workflows/refresh-reconnect.json";
+const STALE_TAB = "wf:workflows/refresh-stale.json";
 
 /** The reporter's exact panel_add_node refusal (issue #2007). */
 const ADD_UNAVAILABLE =
@@ -90,6 +92,20 @@ function bridge(send: (cmd: Record<string, unknown>) => Promise<unknown>) {
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
   } as unknown as PanelToolCtx["bridge"];
   return { b, calls };
+}
+
+type RefreshIdentityBridge = PanelToolCtx["bridge"] & {
+  tabConnectionGeneration: (tabId: string) => number;
+  tabIncarnation: (tabId: string) => string;
+};
+
+function setRefreshIdentity(
+  bridge: PanelToolCtx["bridge"],
+  generation: () => number,
+): void {
+  const identified = bridge as RefreshIdentityBridge;
+  identified.tabConnectionGeneration = () => generation();
+  identified.tabIncarnation = () => "same-browser-tab";
 }
 
 async function callTool(
@@ -205,6 +221,117 @@ describe("panel_add_node retries a schema-budget refusal without refresh_nodes (
 });
 
 describe("panel_set_widget shares schema refresh recovery (#2007, #2274)", () => {
+  it("clears a terminal success so the next explicit refresh starts a new request", async () => {
+    let refreshes = 0;
+    const { b, calls } = bridge(async (cmd) => {
+      if (cmd.cmd === "refresh_nodes") {
+        refreshes += 1;
+        return { refreshed: true, refresh: refreshes };
+      }
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const refreshNodes = buildPanelToolDefs().find((d) => d.name === "panel_refresh_nodes");
+    if (!refreshNodes) throw new Error("panel_refresh_nodes is not registered");
+
+    const first = await refreshNodes.handler({} as never, ctx);
+    const second = await refreshNodes.handler({} as never, ctx);
+
+    expect(first.isError).toBeFalsy();
+    expect(second.isError).toBeFalsy();
+    expect(calls).toEqual(["refresh_nodes", "refresh_nodes"]);
+  });
+
+  it("clears a terminal failure, including refresh_still_running, before a later retry", async () => {
+    let refreshes = 0;
+    const { b, calls } = bridge(async (cmd) => {
+      if (cmd.cmd === "refresh_nodes") {
+        refreshes += 1;
+        return refreshes === 1
+          ? { refreshed: false, reason: "refresh_still_running" }
+          : { refreshed: true };
+      }
+      return { ok: true };
+    });
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    const refreshNodes = buildPanelToolDefs().find((d) => d.name === "panel_refresh_nodes");
+    if (!refreshNodes) throw new Error("panel_refresh_nodes is not registered");
+
+    const first = await refreshNodes.handler({} as never, ctx);
+    const second = await refreshNodes.handler({} as never, ctx);
+
+    expect(first.isError).toBeFalsy();
+    expect(textOf(first)).toMatch(/refresh_still_running/);
+    expect(second.isError).toBeFalsy();
+    expect(JSON.parse(second.content[0].text!).refreshed).toBe(true);
+    expect(calls).toEqual(["refresh_nodes", "refresh_nodes"]);
+  });
+
+  it("keeps joining an active refresh across a reconnect generation", async () => {
+    let generation = 1;
+    let resolveRefresh!: (value: unknown) => void;
+    const refresh = new Promise((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const { b, calls } = bridge(
+      async (cmd) => (cmd.cmd === "refresh_nodes" ? refresh : { ok: true }),
+    );
+    setRefreshIdentity(b, () => generation);
+    const ctx = makePanelToolCtx(b, RECONNECT_TAB, new WorkflowTargetStore());
+    const refreshNodes = buildPanelToolDefs().find((d) => d.name === "panel_refresh_nodes");
+    if (!refreshNodes) throw new Error("panel_refresh_nodes is not registered");
+
+    const first = refreshNodes.handler({} as never, ctx);
+    await Promise.resolve();
+    generation = 2;
+    const second = refreshNodes.handler({} as never, ctx);
+    await Promise.resolve();
+
+    expect(calls).toEqual(["refresh_nodes"]);
+    resolveRefresh({ refreshed: true });
+    const results = await Promise.all([first, second]);
+    expect(results.every((result) => !result.isError)).toBe(true);
+  });
+
+  it("reclaims only an over-bound refresh with a known current generation", async () => {
+    vi.useFakeTimers();
+    try {
+      let generation = 7;
+      const resolvers: Array<(value: unknown) => void> = [];
+      const { b, calls } = bridge(async (cmd) => {
+        if (cmd.cmd !== "refresh_nodes") return { ok: true };
+        return new Promise((resolve) => resolvers.push(resolve));
+      });
+      setRefreshIdentity(b, () => generation);
+      const ctx = makePanelToolCtx(b, STALE_TAB, new WorkflowTargetStore());
+      const refreshNodes = buildPanelToolDefs().find((d) => d.name === "panel_refresh_nodes");
+      if (!refreshNodes) throw new Error("panel_refresh_nodes is not registered");
+
+      const first = refreshNodes.handler({} as never, ctx);
+      await Promise.resolve();
+      expect(calls).toEqual(["refresh_nodes"]);
+
+      vi.advanceTimersByTime(90_001);
+      generation = 8;
+      const second = refreshNodes.handler({} as never, ctx);
+      await Promise.resolve();
+      expect(calls).toEqual(["refresh_nodes", "refresh_nodes"]);
+
+      // The old request settling must not clear the replacement record.
+      resolvers[0]({ refreshed: false, reason: "refresh_still_running" });
+      await first;
+      const third = refreshNodes.handler({} as never, ctx);
+      await Promise.resolve();
+      expect(calls).toEqual(["refresh_nodes", "refresh_nodes"]);
+
+      resolvers[1]({ refreshed: true });
+      const results = await Promise.all([second, third]);
+      expect(results.every((result) => !result.isError)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("THE REPORTED CASE: share-timeout write then succeeds on the retry", async () => {
     let writes = 0;
     const { res, calls, text } = await callTool(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5487,18 +5487,68 @@ function isObjectInfoBudgetRefusal(res: ToolResult): boolean {
  * The refresh is only a coordination primitive. Callers must still require the panel's
  * explicit `refreshed:true` result before retrying a write; a timeout, malformed reply,
  * `refresh_still_running`, or any other non-authoritative result remains fail-closed.
+ * The bridge already gives this idempotent read one bounded reconnect retry, so a
+ * generation change alone does not make a still-young record stale. A record that has
+ * outlived that same bounded request window may be replaced once the current bridge
+ * generation is known and monotonic; replacing the coordinator record does not cancel
+ * or authorize the old request.
  */
+type PanelSchemaRefreshRecord = {
+  token: object;
+  promise: Promise<ToolResult>;
+  startedAt: number;
+  generation: number | undefined;
+};
+
 const panelSchemaRefreshes = new Map<
   string,
-  { token: object; promise: Promise<ToolResult> }
+  PanelSchemaRefreshRecord
 >();
+
+function panelSchemaRefreshGeneration(ctx: PanelToolCtx): number | undefined {
+  const bridge = ctx.bridge as
+    | { tabConnectionGeneration?: (tabId: string) => number | undefined }
+    | undefined;
+  if (typeof bridge?.tabConnectionGeneration !== "function") return undefined;
+  try {
+    const generation = bridge.tabConnectionGeneration(journalTabFor(ctx));
+    return typeof generation === "number" && Number.isSafeInteger(generation) && generation >= 0
+      ? generation
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function panelSchemaRefreshIsStale(
+  record: PanelSchemaRefreshRecord,
+  ctx: PanelToolCtx,
+  now = Date.now(),
+): boolean {
+  // A refresh can legitimately be parked and resumed by UiBridge after a reconnect.
+  // Do not replace it merely because the hello generation changed, or because the
+  // generation probe is unavailable. Only a record beyond the same finite request
+  // bound, with a known non-regressing current generation, is reclaimable.
+  if (now - record.startedAt < OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS) return false;
+  const currentGeneration = panelSchemaRefreshGeneration(ctx);
+  return (
+    record.generation !== undefined &&
+    currentGeneration !== undefined &&
+    currentGeneration >= record.generation
+  );
+}
 
 function sharedPanelSchemaRefresh(ctx: PanelToolCtx): Promise<ToolResult> {
   const key = panelSchemaKey(ctx);
   const existing = panelSchemaRefreshes.get(key);
-  if (existing) return existing.promise;
+  if (existing && !panelSchemaRefreshIsStale(existing, ctx)) return existing.promise;
+  // Replacing a stale record is deliberately not cancellation: the old bridge read
+  // may still settle later. Its token-guarded finally cannot remove this new record.
+  if (existing) panelSchemaRefreshes.delete(key);
 
   const token = {};
+  const startedAt = Date.now();
+  const generation = panelSchemaRefreshGeneration(ctx);
   // Yield before dispatch so the map is installed before even a synchronously-throwing
   // bridge stub can settle this promise and run its cleanup.
   const promise = (async () => {
@@ -5511,7 +5561,7 @@ function sharedPanelSchemaRefresh(ctx: PanelToolCtx): Promise<ToolResult> {
       if (panelSchemaRefreshes.get(key)?.token === token) panelSchemaRefreshes.delete(key);
     }
   })();
-  panelSchemaRefreshes.set(key, { token, promise });
+  panelSchemaRefreshes.set(key, { token, promise, startedAt, generation });
   return promise;
 }
 


### PR DESCRIPTION
## Summary
- Clear the shared panel refresh coordinator record in finally for terminal success, failure, and unknown outcomes.
- Join a still-active refresh across reconnect generation changes.
- Reclaim only records older than the bounded refresh request timeout when a monotonic bridge generation is known; old completions cannot clear replacements.
- Preserve fail-closed write retries unless the panel returns refreshed:true.

## Tests
- npm.cmd test
- npm.cmd exec vitest -- run src/__tests__/orchestrator/object-info-budget-mutations.test.ts src/__tests__/orchestrator/get-errors-ack-budget.test.ts --passWithNoTests
- npm.cmd run build
- npm.cmd run lint

Closes #2549