### PR TITLE
fix(2505): restamp load identity to the active tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_load_workflow restamps extra.comfyui_mcp.workflow_path (and uuid) to the active tab so an in-place save is not refused as belonging to the source workflow (#2505)
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 - fence ordinary `panel_set_widget` writes against the current panel graph identity across reconnects, with an actionable rebind refusal (#2550)
 

--- a/src/__tests__/orchestrator/load-workflow-stale-path.test.ts
+++ b/src/__tests__/orchestrator/load-workflow-stale-path.test.ts
@@ -1,0 +1,196 @@
+// #2505 — panel_load_workflow loaded saved workflow B into active tab A but kept
+// extra.comfyui_mcp.workflow_path from B. A later in-place panel_save_workflow
+// (no name) was refused by the #1667 stale-canvas guard because the canvas was
+// stamped as belonging to B.
+//
+// Tests drive bindLoadedWorkflowIdentity and the shipped load/save path. Dest
+// identity is the ACTIVE tab (A), never the source file's stamp. #2503 owns tmp
+// uuid rebinding and is not re-tested here.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  bindLoadedWorkflowIdentity,
+  extraWorkflowPath,
+  extraWorkflowUuid,
+  savedPathFromTabId,
+} from "../../orchestrator/open-identity-normalization.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const SOURCE_PATH = "workflows/B.app.json";
+const DEST_PATH = "workflows/A.app.json";
+const SOURCE_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const DEST_UUID = "11111111-2222-4333-8444-555555555555";
+const TAB = `wf:tabA:${DEST_PATH}`;
+
+const SOURCE_GRAPH = {
+  last_node_id: 2,
+  nodes: [
+    { id: 1, type: "CLIPTextEncode", widgets_values: ["from B"] },
+    { id: 2, type: "SaveImage", widgets_values: ["out"] },
+  ],
+  links: [],
+  extra: { comfyui_mcp: { workflow_path: SOURCE_PATH, workflow_uuid: SOURCE_UUID } },
+};
+
+const STAMP_REFUSAL =
+  `REFUSED to save: the canvas about to overwrite "${DEST_PATH}" is stamped as belonging to ` +
+  `"${SOURCE_PATH}" (extra.comfyui_mcp.workflow_path), which is a different workflow that still ` +
+  `exists. Writing it would replace that file's content with a graph that does not belong to it.`;
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((part) => (part as { text?: string }).text ?? "").join(" ");
+
+function loadTool() {
+  const tool = buildPanelToolDefs().find((def) => def.name === "panel_load_workflow");
+  if (!tool) throw new Error("panel_load_workflow is not registered");
+  return tool;
+}
+
+function saveTool() {
+  const tool = buildPanelToolDefs().find((def) => def.name === "panel_save_workflow");
+  if (!tool) throw new Error("panel_save_workflow is not registered");
+  return tool;
+}
+
+describe("savedPathFromTabId (#2505)", () => {
+  it("extracts the saved file path from a wf: route and a legacy wf: handle", () => {
+    expect(savedPathFromTabId(TAB)).toBe(DEST_PATH);
+    expect(savedPathFromTabId(`wf:${DEST_PATH}`)).toBe(DEST_PATH);
+  });
+
+  it("does not treat tmp: or a bare uuid as a saved dest path", () => {
+    expect(savedPathFromTabId(`tmp:${DEST_UUID}`)).toBeNull();
+    expect(savedPathFromTabId(DEST_UUID)).toBeNull();
+    expect(savedPathFromTabId("")).toBeNull();
+    expect(savedPathFromTabId(null)).toBeNull();
+  });
+});
+
+describe("bindLoadedWorkflowIdentity (#2505)", () => {
+  it("replaces the source extra.workflow_path with the active dest path", () => {
+    const bound = bindLoadedWorkflowIdentity(SOURCE_GRAPH, DEST_PATH, DEST_UUID);
+    expect(bound).not.toBeNull();
+    expect(extraWorkflowPath(bound)).toBe(DEST_PATH);
+    expect(extraWorkflowPath(bound)).not.toBe(SOURCE_PATH);
+    expect(extraWorkflowUuid(bound)).toBe(DEST_UUID);
+    expect(extraWorkflowUuid(bound)).not.toBe(SOURCE_UUID);
+  });
+
+  it("does not mutate the source graph", () => {
+    const original = structuredClone(SOURCE_GRAPH);
+    bindLoadedWorkflowIdentity(SOURCE_GRAPH, DEST_PATH, DEST_UUID);
+    expect(SOURCE_GRAPH).toEqual(original);
+    expect(extraWorkflowPath(SOURCE_GRAPH)).toBe(SOURCE_PATH);
+  });
+
+  it("returns null when the stamp already names dest, or dest/graph are unusable", () => {
+    const already = bindLoadedWorkflowIdentity(
+      { ...SOURCE_GRAPH, extra: { comfyui_mcp: { workflow_path: DEST_PATH, workflow_uuid: DEST_UUID } } },
+      DEST_PATH,
+      DEST_UUID,
+    );
+    expect(already).toBeNull();
+    expect(bindLoadedWorkflowIdentity({ nodes: [] }, DEST_PATH, DEST_UUID)).not.toBeNull();
+    expect(bindLoadedWorkflowIdentity(SOURCE_GRAPH, "", DEST_UUID)).toBeNull();
+    expect(bindLoadedWorkflowIdentity(SOURCE_GRAPH, `tmp:${DEST_UUID}`)).toBeNull();
+    expect(bindLoadedWorkflowIdentity(null, DEST_PATH)).toBeNull();
+    expect(bindLoadedWorkflowIdentity("graph", DEST_PATH)).toBeNull();
+  });
+
+  it("stamps dest identity onto a graph that has no extra yet", () => {
+    const bound = bindLoadedWorkflowIdentity({ nodes: [] }, DEST_PATH, DEST_UUID);
+    expect(extraWorkflowPath(bound)).toBe(DEST_PATH);
+    expect(extraWorkflowUuid(bound)).toBe(DEST_UUID);
+  });
+});
+
+function savedTabBridge() {
+  let live: Record<string, unknown> = {
+    last_node_id: 1,
+    nodes: [{ id: 1, type: "Note", widgets_values: ["tab A"] }],
+    links: [],
+    extra: { comfyui_mcp: { workflow_path: DEST_PATH, workflow_uuid: DEST_UUID } },
+  };
+  const sent: Array<Record<string, unknown>> = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(cmd);
+      if (cmd.cmd === "graph_serialize") {
+        return { workflow: live, node_count: Array.isArray(live.nodes) ? live.nodes.length : 0 };
+      }
+      if (cmd.cmd === "graph_load") {
+        const graph = cmd.graph;
+        if (graph && typeof graph === "object" && !Array.isArray(graph)) {
+          live = graph;
+        }
+        return { loaded: true, node_count: Array.isArray(live.nodes) ? live.nodes.length : 0 };
+      }
+      if (cmd.cmd === "workflow_list") {
+        return {
+          active_confirmed: true,
+          active: {
+            path: DEST_PATH,
+            filename: "A.app.json",
+            key: `wf:${DEST_PATH}`,
+            routing_key: TAB,
+            workflow_uuid: DEST_UUID,
+          },
+        };
+      }
+      if (cmd.cmd === "workflow_save") {
+        const stamped = extraWorkflowPath(live);
+        if (stamped && stamped !== DEST_PATH) throw new Error(STAMP_REFUSAL);
+        return { saved: true, workflow: DEST_PATH };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "A.app.json", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    workflowUuidFor: () => ({ known: true, uuid: DEST_UUID }),
+    refreshWorkflowUuid: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as PanelToolCtx["bridge"];
+  return { bridge, sent, liveOf: () => live };
+}
+
+describe("panel_load_workflow restamps extra.workflow_path onto the active tab (#2505)", () => {
+  it("sends graph_load stamped as dest A, not source B", async () => {
+    const { bridge, sent } = savedTabBridge();
+    const res = await loadTool().handler(
+      { graph: structuredClone(SOURCE_GRAPH) },
+      makePanelToolCtx(bridge, TAB),
+    );
+
+    expect(res.isError).toBeFalsy();
+    const loadCmd = sent.find((cmd) => cmd.cmd === "graph_load");
+    expect(loadCmd).toBeTruthy();
+    expect(extraWorkflowPath(loadCmd?.graph)).toBe(DEST_PATH);
+    expect(extraWorkflowPath(loadCmd?.graph)).not.toBe(SOURCE_PATH);
+    expect(extraWorkflowUuid(loadCmd?.graph)).toBe(DEST_UUID);
+    expect(extraWorkflowUuid(loadCmd?.graph)).not.toBe(SOURCE_UUID);
+  });
+});
+
+describe("panel_save_workflow after load-into-A is not a stale-canvas refusal (#2505)", () => {
+  it("saves in place with no name after loading B onto A", async () => {
+    const { bridge } = savedTabBridge();
+    const ctx = makePanelToolCtx(bridge, TAB);
+
+    const loaded = await loadTool().handler({ graph: structuredClone(SOURCE_GRAPH) }, ctx);
+    expect(loaded.isError).toBeFalsy();
+
+    const saved = await saveTool().handler({}, ctx);
+    expect(saved.isError).toBeFalsy();
+    expect(textOf(saved)).toMatch(/saved/i);
+    expect(textOf(saved)).not.toMatch(/stamped as belonging to/i);
+  });
+});

--- a/src/orchestrator/open-identity-normalization.ts
+++ b/src/orchestrator/open-identity-normalization.ts
@@ -51,6 +51,22 @@ export function unsavedTmpWorkflowKey(value: unknown): string | null {
 }
 
 /**
+ * Saved-file path encoded in a panel tab id. `wf:<path>` (legacy handle) and
+ * `wf:<tabRouteId>:<path>` (current route) both name dest A. `tmp:` and bare
+ * uuids do not — those tabs have no saved identity (#2503).
+ */
+export function savedPathFromTabId(tabId: unknown): string | null {
+  if (typeof tabId !== "string" || !tabId.startsWith("wf:")) return null;
+  const rest = tabId.slice(3);
+  if (!rest) return null;
+  const sep = rest.indexOf(":");
+  const head = sep === -1 ? "" : rest.slice(0, sep);
+  const isRoute = sep > 1 && !/[/\\]/.test(head);
+  const path = isRoute ? rest.slice(sep + 1) : rest;
+  return normalizeWorkflowPath(path);
+}
+
+/**
  * #2503 — importing/loading onto a new tmp tab must not keep the source graph's
  * extra.comfyui_mcp.workflow_uuid. Replace it with the tab's assigned uuid.
  * Leaves workflow_path untouched (#2505).
@@ -70,6 +86,38 @@ export function bindImportedTmpWorkflowUuid(
   const extra = isPlainObject(next.extra) ? { ...next.extra } : {};
   const meta = isPlainObject(extra.comfyui_mcp) ? { ...extra.comfyui_mcp } : {};
   meta.workflow_uuid = destUuid;
+  extra.comfyui_mcp = meta;
+  next.extra = extra;
+  return next;
+}
+
+/**
+ * #2505 — loading a graph onto another tab must not keep the source
+ * extra.comfyui_mcp.workflow_path. Replace path (and uuid when destUuid is
+ * known) with the active dest identity so a later in-place save is not refused
+ * by the #1667 stale-canvas guard.
+ *
+ * Returns a cloned graph when a rewrite is needed; null when dest/graph are
+ * unusable or the stamp already names dest.
+ */
+export function bindLoadedWorkflowIdentity(
+  graph: unknown,
+  destPath: string,
+  destUuid?: string,
+): Record<string, unknown> | null {
+  if (!isPlainObject(graph)) return null;
+  const dest = normalizeWorkflowPath(destPath);
+  if (!dest) return null;
+  const stampedPath = normalizeWorkflowPath(extraWorkflowPath(graph));
+  const stampedUuid = extraWorkflowUuid(graph);
+  const pathNeeds = stampedPath !== dest;
+  const uuidNeeds = Boolean(destUuid) && stampedUuid !== destUuid;
+  if (!pathNeeds && !uuidNeeds) return null;
+  const next: Record<string, unknown> = structuredClone(graph);
+  const extra = isPlainObject(next.extra) ? { ...next.extra } : {};
+  const meta = isPlainObject(extra.comfyui_mcp) ? { ...extra.comfyui_mcp } : {};
+  meta.workflow_path = dest;
+  if (destUuid) meta.workflow_uuid = destUuid;
   extra.comfyui_mcp = meta;
   next.extra = extra;
   return next;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -178,11 +178,13 @@ import {
 } from "./rgthree-fast-groups-property.js";
 import {
   bindImportedTmpWorkflowUuid,
+  bindLoadedWorkflowIdentity,
   isPlainObject,
   isStampMismatchSaveRefusal,
   openLiveMatchesDestAfterReconnect,
   openLiveMatchesDestContent,
   patchOpenIdentity,
+  savedPathFromTabId,
   shouldRebindOpenIdentity,
   unsavedTmpWorkflowKey,
   workflowFromSerializeReply,
@@ -19023,12 +19025,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           const fenceBefore = currentWorkflowFence(ctx);
           // #2503 — a UI import onto this tab must not keep the source file's
           // extra.comfyui_mcp.workflow_uuid. Dest is the tab uuid already
-          // assigned (fence). workflow_path is left alone (#2505).
+          // assigned (fence).
+          // #2505 — a load onto a *saved* tab must also replace
+          // extra.comfyui_mcp.workflow_path with that tab's identity, or a later
+          // in-place save is refused by the #1667 stale-canvas guard.
           const destUuid =
             fenceBefore.known && typeof fenceBefore.uuid === "string" && fenceBefore.uuid
               ? fenceBefore.uuid
               : undefined;
-          if (destUuid) {
+          const destPath = savedPathFromTabId(tabAtDispatch);
+          if (destPath) {
+            const bound = bindLoadedWorkflowIdentity(data, destPath, destUuid);
+            if (bound) data = bound;
+          } else if (destUuid) {
             const bound = bindImportedTmpWorkflowUuid(data, destUuid);
             if (bound) data = bound;
           }


### PR DESCRIPTION
## Summary

panel_load_workflow loaded saved workflow B onto active tab A but kept extra.comfyui_mcp.workflow_path from B. A later in-place panel_save_workflow (no name) was refused by the #1667 stale-canvas guard because the canvas was stamped as belonging to B.

bindLoadedWorkflowIdentity rewrites extra.comfyui_mcp.workflow_path (and workflow_uuid when the dest fence is known) to the active wf: tab identity before graph_load. tmp tabs still go through bindImportedTmpWorkflowUuid (#2503); this is the load-into-another-tab path stamp, not tmp uuid.

## Test plan

- npx vitest run src/__tests__/orchestrator/load-workflow-stale-path.test.ts (8 passed)

Fixes #2505
