### PR TITLE
fix(2506): get_workflow reads workspace-subfolder JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- get_workflow get/analyze reads an absolute path under the live ComfyUI workspace from disk instead of sending it to /api/userdata/workflows/ (#2506)
 - list_local_models reads inventory through the connected panel when the headless /models route is unreachable (#2511)
 - panel_load_workflow restamps extra.comfyui_mcp.workflow_path (and uuid) to the active tab so an in-place save is not refused as belonging to the source workflow (#2505)
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)

--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -29,7 +29,7 @@ Return, list, summarize or query a SAVED workflow FILE — files on disk, named 
   Options: `action:"get"`, `action:"list"`, `action:"strip"`, `action:"slice"`, `action:"from_image"`, `action:"analyze"`, `action:"query"`, `action:"prompt_director"`.
 </ParamField>
 <ParamField path="filename" type="string">
-  Workflow library name, exactly as action:"list" reports it. A workflow filed in a folder keeps its folder in the name ('VIDEO/MiniMaxH3/clip.json') and that whole string goes here. REQUIRED for action:"get" and action:"analyze"; one of the three sources for "strip", "slice" and "query".
+  Workflow library name, exactly as action:"list" reports it. A workflow filed in a folder keeps its folder in the name ('VIDEO/MiniMaxH3/clip.json') and that whole string goes here. An absolute path under the live ComfyUI workspace (e.g. a JSON in data/_downloads) is read from disk, not the user library. REQUIRED for action:"get" and action:"analyze"; one of the three sources for "strip", "slice" and "query".
 </ParamField>
 <ParamField path="format" type="enum" default="api">
   action:"get" — 'api' (default, recommended) converts to compact API format with named inputs, connection references, and _meta.mode flags for muted/bypassed nodes; 'ui' returns the raw UI format with layout positions and links arrays. action:"strip" — 'api' (default) strips to the flat resolved graph; 'raw' returns the file/graph unchanged. Each action accepts only its own two values (this field is the union of what the two tools it replaces accepted) and refuses the third rather than guessing at an alias.

--- a/src/__tests__/tools/get-workflow-workspace-subfolder.test.ts
+++ b/src/__tests__/tools/get-workflow-workspace-subfolder.test.ts
@@ -1,0 +1,194 @@
+// #2506 — get_workflow action:"analyze" (and action:"get") sent every `filename`
+// to `/api/userdata/workflows/<filename>`. An absolute path under the live
+// ComfyUI workspace (the reporter's `D:\Programas\ComfyUI\data\_downloads\*.json`)
+// is not a library key; ComfyUI answers 500 and nothing is read.
+//
+// The shipped resolver must read that file from disk when it sits inside the
+// live workspace, and must NOT treat a path outside that workspace as a disk
+// read. Library-relative names still go through userdata.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const mocks = vi.hoisted(() => ({
+  fetchApi: vi.fn(),
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  liveWorkspace: vi.fn(),
+  generateSummary: vi.fn(),
+  detectSections: vi.fn(),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  comfyApiFetch: (...args: unknown[]) => mocks.fetchApi(...args),
+  getObjectInfo: (...args: unknown[]) => mocks.getObjectInfo(...args),
+  backfillObjectInfo: (...args: unknown[]) => mocks.backfillObjectInfo(...args),
+}));
+
+vi.mock("../../services/workspace-env.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/workspace-env.js")>();
+  return {
+    ...actual,
+    resolveEffectiveComfyUIBaseLive: (...args: unknown[]) => mocks.liveWorkspace(...args),
+  };
+});
+
+vi.mock("../../services/workflow-slicer.js", () => ({ sliceWorkflow: vi.fn() }));
+vi.mock("../../services/graph-query.js", () => ({
+  queryApiGraph: vi.fn(),
+  LIMIT_CEILING: 200,
+  MAX_CHARS_CEILING: 60000,
+  MAX_CHARS_FLOOR: 500,
+}));
+vi.mock("../../services/userdata-library.js", () => ({ listWorkflowLibraryKeys: vi.fn() }));
+vi.mock("../../services/workflow-sections.js", () => ({
+  detectSections: (...args: unknown[]) => mocks.detectSections(...args),
+}));
+vi.mock("../../services/hierarchical-mermaid.js", () => ({
+  generateOverview: vi.fn(),
+  generateSectionDetail: vi.fn(),
+  listSections: vi.fn(),
+  generateSummary: (...args: unknown[]) => mocks.generateSummary(...args),
+}));
+vi.mock("../../services/mermaid-converter.js", () => ({ convertToMermaid: vi.fn() }));
+vi.mock("../../services/workflow-health.js", () => ({ analyzeGraphHealth: vi.fn() }));
+vi.mock("../../services/image-management.js", () => ({ extractWorkflowFromImage: vi.fn() }));
+vi.mock("../../tools/prompt-director.js", () => ({ promptDirectorInspectAction: vi.fn() }));
+vi.mock("../../tools/workflow-lock.js", () => ({
+  lockWorkflowAction: vi.fn(),
+  verifyWorkflowLockAction: vi.fn(),
+}));
+vi.mock("../../config.js", () => ({
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+}));
+vi.mock("../../services/frontend-virtual-types.js", () => ({
+  frontendVirtualTypesFor: () => new Set<string>(),
+}));
+
+import { registerWorkflowLibraryTools } from "../../tools/workflow-library.js";
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(): Handler {
+  let handler: Handler | undefined;
+  const server = {
+    tool: (name: string, _description: string, _shape: unknown, candidate: Handler) => {
+      if (name === "get_workflow") handler = candidate;
+    },
+  };
+  registerWorkflowLibraryTools(server as never);
+  if (!handler) throw new Error("get_workflow was not registered");
+  return handler;
+}
+
+const text = (res: Awaited<ReturnType<Handler>>) => res.content.map((c) => c.text).join(" ");
+
+const GRAPH = {
+  "1": { class_type: "SaveImage", inputs: { filename_prefix: "from-downloads" } },
+};
+
+function userdata500(): void {
+  mocks.fetchApi.mockResolvedValue({
+    ok: false,
+    status: 500,
+    statusText: "Internal Server Error",
+    json: async () => ({}),
+    text: async () => "Internal Server Error",
+  });
+}
+
+let workspace = "";
+let downloadsFile = "";
+let outsideDir = "";
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  workspace = mkdtempSync(join(tmpdir(), "cmcp-2506-ws-"));
+  outsideDir = mkdtempSync(join(tmpdir(), "cmcp-2506-out-"));
+  const downloads = join(workspace, "data", "_downloads");
+  mkdirSync(downloads, { recursive: true });
+  downloadsFile = join(downloads, "clip.json");
+  writeFileSync(downloadsFile, JSON.stringify(GRAPH));
+  mocks.liveWorkspace.mockResolvedValue(workspace);
+  mocks.getObjectInfo.mockResolvedValue({});
+  mocks.backfillObjectInfo.mockImplementation(async (info: unknown) => info);
+  mocks.detectSections.mockReturnValue({
+    sections: new Map(),
+    virtualEdges: [],
+    nodeToSection: new Map(),
+    getSetNodeIds: new Set(),
+  });
+  mocks.generateSummary.mockReturnValue("summary of workspace subfolder workflow");
+  userdata500();
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+  rmSync(outsideDir, { recursive: true, force: true });
+});
+
+describe("#2506 get_workflow reads a JSON under the live workspace", () => {
+  it('action:"analyze" reads an absolute path in data/_downloads instead of userdata 500', async () => {
+    const res = await getHandler()({ action: "analyze", filename: downloadsFile, view: "summary" });
+
+    expect(res.isError).toBeUndefined();
+    expect(text(res)).not.toMatch(/Could NOT read/);
+    expect(text(res)).not.toMatch(/nothing was read/);
+    expect(text(res)).toContain("summary of workspace subfolder workflow");
+    expect(mocks.generateSummary).toHaveBeenCalled();
+    expect(mocks.generateSummary.mock.calls[0]?.[0]).toEqual(GRAPH);
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
+  });
+
+  it('action:"get" returns the disk JSON for the same workspace-subfolder path', async () => {
+    const res = await getHandler()({ action: "get", filename: downloadsFile, format: "api" });
+
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content[0].text)).toEqual(GRAPH);
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
+  });
+
+  it("a library-relative name still uses the userdata library, not a disk guess", async () => {
+    mocks.fetchApi.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => GRAPH,
+    });
+    const res = await getHandler()({ action: "get", filename: "IMAGE/portrait.json", format: "api" });
+
+    expect(res.isError).toBeUndefined();
+    expect(mocks.fetchApi).toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/IMAGE/portrait.json")}`,
+    );
+    expect(JSON.parse(res.content[0].text)).toEqual(GRAPH);
+  });
+
+  it("an absolute path OUTSIDE the live workspace is not read from disk", async () => {
+    const outsider = join(outsideDir, "secret.json");
+    writeFileSync(outsider, JSON.stringify({ "9": { class_type: "ShouldNotLoad", inputs: {} } }));
+
+    const res = await getHandler()({ action: "analyze", filename: outsider, view: "summary" });
+
+    expect(res.isError).toBe(true);
+    expect(text(res)).toMatch(/Could NOT read/);
+    expect(text(res)).toMatch(/nothing was read/);
+    expect(mocks.generateSummary).not.toHaveBeenCalled();
+    expect(mocks.fetchApi).toHaveBeenCalled();
+  });
+
+  it("a missing file that IS under the live workspace is a not-found, not a userdata 500", async () => {
+    const missing = join(workspace, "data", "_downloads", "gone.json");
+    const res = await getHandler()({ action: "analyze", filename: missing, view: "summary" });
+
+    expect(res.isError).toBe(true);
+    expect(text(res)).toMatch(/Workflow not found/);
+    expect(text(res)).not.toMatch(/the server answered 500/);
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -121,7 +121,7 @@ async function tryReadWorkspaceWorkflow(
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new ValidationError(`Could NOT read path: ${filename} is not a workflow object.`);
   }
-  return parsed;
+  return parsed as Record<string, unknown>;
 }
 
 /** Keep every saved-workflow UI conversion on the same schema-backed path. */

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve as pathResolve } from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiWorkflow, WorkflowJSON } from "../comfyui/types.js";
 import { getObjectInfo, backfillObjectInfo, comfyApiFetch } from "../comfyui/client.js";
@@ -24,6 +25,7 @@ import {
   MAX_CHARS_FLOOR,
 } from "../services/graph-query.js";
 import { listWorkflowLibraryKeys } from "../services/userdata-library.js";
+import { resolveEffectiveComfyUIBaseLive } from "../services/workspace-env.js";
 import { detectSections } from "../services/workflow-sections.js";
 import {
   generateOverview,
@@ -74,6 +76,46 @@ async function loadRawFromSource(
     );
   }
   return await res.json();
+}
+
+function isInsideRoot(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+/**
+ * #2506 — get/analyze used to send every `filename` to /api/userdata/workflows/.
+ * An absolute path under the live ComfyUI workspace (e.g. data/_downloads/*.json)
+ * is not a library key; ComfyUI 500s and nothing is read. Read those from disk.
+ * Returns undefined when this is not a workspace-file read so the caller can
+ * use the userdata library. A path that IS under the workspace but missing
+ * throws not-found rather than falling through to a userdata 500.
+ */
+async function tryReadWorkspaceWorkflow(filename: string): Promise<unknown | undefined> {
+  if (!isAbsolute(filename)) return undefined;
+  const workspace = await resolveEffectiveComfyUIBaseLive();
+  if (!workspace) return undefined;
+
+  const resolvedRoot = pathResolve(workspace);
+  const resolvedFile = pathResolve(filename);
+  if (!isInsideRoot(resolvedRoot, resolvedFile)) return undefined;
+
+  let realRoot: string;
+  try {
+    realRoot = await realpath(resolvedRoot);
+  } catch {
+    throw new ValidationError(`Workflow not found: ${filename} (404)`);
+  }
+  let realFile: string;
+  try {
+    realFile = await realpath(resolvedFile);
+  } catch {
+    throw new ValidationError(`Workflow not found: ${filename} (404)`);
+  }
+  if (!isInsideRoot(realRoot, realFile)) {
+    throw new ValidationError(`Workflow not found: ${filename} (404)`);
+  }
+  return JSON.parse(await readFile(realFile, "utf8"));
 }
 
 /** Keep every saved-workflow UI conversion on the same schema-backed path. */
@@ -186,6 +228,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         .describe(
           'Workflow library name, exactly as action:"list" reports it. A workflow filed in a folder ' +
             "keeps its folder in the name ('VIDEO/MiniMaxH3/clip.json') and that whole string goes here. " +
+            "An absolute path under the live ComfyUI workspace (e.g. a JSON in data/_downloads) is read from disk, not the user library. " +
             'REQUIRED for action:"get" and action:"analyze"; one of the three sources for "strip", "slice" and "query".',
         ),
       format: z
@@ -594,39 +637,43 @@ async function listWorkflowsAction(): Promise<TextResult> {
 
 /** `get_workflow (action:"get")` — the body of the surviving get_workflow tool. */
 async function getWorkflowAction(filename: string, format: "ui" | "api"): Promise<TextResult> {
-        const encoded = encodeURIComponent(`workflows/${filename}`);
-        const res = await comfyApiFetch(
-          `/api/userdata/${encoded}`,
-        );
+        const fromDisk = await tryReadWorkspaceWorkflow(filename);
+        let raw: unknown;
+        if (fromDisk !== undefined) {
+          raw = fromDisk;
+        } else {
+          const encoded = encodeURIComponent(`workflows/${filename}`);
+          const res = await comfyApiFetch(`/api/userdata/${encoded}`);
 
-        if (!res.ok) {
-          // The worst of the four not-found sites (#385 review finding 4): it
-          // returns a NORMAL text block, so nothing marks it as a failure at all.
-          // An agent told its workflow does not exist is one step from recreating
-          // or overwriting it, and before #385 made this reachable the user got a
-          // neutral transport error instead. Only 404 may claim absence.
-          //
-          // The non-404 case THROWS rather than returning text (round-2 review
-          // residual 1). A plain TextResult leaves `isError` unset, so the
-          // orchestrator reports `ok: true` and the Ollama/Grok/ChatGPT backends
-          // mark the call succeeded — the machine-readable flag contradicting the
-          // prose. Pre-PR a 502 threw and surfaced as `ok: false`; throwing keeps
-          // that, and the handler's own `catch` renders it identically to this
-          // block's three siblings. The 404 wording stays a return, byte for byte,
-          // because a test pins it.
-          if (res.status !== 404) {
-            throw new ValidationError(
-              `Could NOT read "${filename}": the server answered ${describeStatus(res.status, res.statusText)}. ` +
-                `That is NOT a report that the workflow is missing — nothing was read. Do not recreate it on ` +
-                `the strength of this; check the server with get_system_stats (action:"health") first.`,
-            );
+          if (!res.ok) {
+            // The worst of the four not-found sites (#385 review finding 4): it
+            // returns a NORMAL text block, so nothing marks it as a failure at all.
+            // An agent told its workflow does not exist is one step from recreating
+            // or overwriting it, and before #385 made this reachable the user got a
+            // neutral transport error instead. Only 404 may claim absence.
+            //
+            // The non-404 case THROWS rather than returning text (round-2 review
+            // residual 1). A plain TextResult leaves `isError` unset, so the
+            // orchestrator reports `ok: true` and the Ollama/Grok/ChatGPT backends
+            // mark the call succeeded — the machine-readable flag contradicting the
+            // prose. Pre-PR a 502 threw and surfaced as `ok: false`; throwing keeps
+            // that, and the handler's own `catch` renders it identically to this
+            // block's three siblings. The 404 wording stays a return, byte for byte,
+            // because a test pins it.
+            if (res.status !== 404) {
+              throw new ValidationError(
+                `Could NOT read "${filename}": the server answered ${describeStatus(res.status, res.statusText)}. ` +
+                  `That is NOT a report that the workflow is missing — nothing was read. Do not recreate it on ` +
+                  `the strength of this; check the server with get_system_stats (action:"health") first.`,
+              );
+            }
+            return {
+              content: [{ type: "text", text: `Workflow not found: ${filename} (404)` }],
+            };
           }
-          return {
-            content: [{ type: "text", text: `Workflow not found: ${filename} (404)` }],
-          };
-        }
 
-        const raw = await res.json();
+          raw = await res.json();
+        }
 
         // If API format requested and workflow is in UI format, convert
         if (format === "api" && isUiFormat(raw)) {
@@ -866,24 +913,30 @@ async function loadWorkflowApi(filename: string): Promise<{
   /** Defined only for UI input, where zero means a valid empty conversion. */
   potentiallyExecutableNodeCount?: number;
 }> {
-  const encoded = encodeURIComponent(`workflows/${filename}`);
-  const res = await comfyApiFetch(`/api/userdata/${encoded}`);
+  const fromDisk = await tryReadWorkspaceWorkflow(filename);
+  let raw: unknown;
+  if (fromDisk !== undefined) {
+    raw = fromDisk;
+  } else {
+    const encoded = encodeURIComponent(`workflows/${filename}`);
+    const res = await comfyApiFetch(`/api/userdata/${encoded}`);
 
-  if (!res.ok) {
-    // Gate the ABSENCE wording on 404, the way fetchImage does (#385 review
-    // finding 4). This branch was dead until #385 made it reachable, so it had
-    // never had to distinguish "the server says it is not there" from "an auth
-    // gate, a 502, or a proxy that does not forward /api/userdata answered".
-    // Reporting the second as the first is the #796 fold, and an agent told its
-    // workflow does not exist is one step from recreating or overwriting it.
-    throw new ValidationError(
-      res.status === 404
-        ? `Workflow not found: ${filename} (404)`
-        : `Could NOT read "${filename}": the server answered ${describeStatus(res.status, res.statusText)}. That is not a report that it is missing — nothing was read.`,
-    );
+    if (!res.ok) {
+      // Gate the ABSENCE wording on 404, the way fetchImage does (#385 review
+      // finding 4). This branch was dead until #385 made it reachable, so it had
+      // never had to distinguish "the server says it is not there" from "an auth
+      // gate, a 502, or a proxy that does not forward /api/userdata answered".
+      // Reporting the second as the first is the #796 fold, and an agent told its
+      // workflow does not exist is one step from recreating or overwriting it.
+      throw new ValidationError(
+        res.status === 404
+          ? `Workflow not found: ${filename} (404)`
+          : `Could NOT read "${filename}": the server answered ${describeStatus(res.status, res.statusText)}. That is not a report that it is missing — nothing was read.`,
+      );
+    }
+
+    raw = await res.json();
   }
-
-  const raw = await res.json();
 
   if (isUiFormat(raw)) {
     const converted = await convertUiWorkflow(raw);

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -91,7 +91,9 @@ function isInsideRoot(root: string, candidate: string): boolean {
  * use the userdata library. A path that IS under the workspace but missing
  * throws not-found rather than falling through to a userdata 500.
  */
-async function tryReadWorkspaceWorkflow(filename: string): Promise<unknown | undefined> {
+async function tryReadWorkspaceWorkflow(
+  filename: string,
+): Promise<Record<string, unknown> | undefined> {
   if (!isAbsolute(filename)) return undefined;
   const workspace = await resolveEffectiveComfyUIBaseLive();
   if (!workspace) return undefined;
@@ -115,7 +117,11 @@ async function tryReadWorkspaceWorkflow(filename: string): Promise<unknown | und
   if (!isInsideRoot(realRoot, realFile)) {
     throw new ValidationError(`Workflow not found: ${filename} (404)`);
   }
-  return JSON.parse(await readFile(realFile, "utf8"));
+  const parsed: unknown = JSON.parse(await readFile(realFile, "utf8"));
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ValidationError(`Could NOT read path: ${filename} is not a workflow object.`);
+  }
+  return parsed;
 }
 
 /** Keep every saved-workflow UI conversion on the same schema-backed path. */


### PR DESCRIPTION
Fixes #2506

`get_workflow` action `"analyze"` / `"get"` sent every `filename` to `/api/userdata/workflows/<filename>`. An absolute path under the live ComfyUI workspace (the reporter's `D:\Programas\ComfyUI\data\_downloads\*.json`) is not a library key; ComfyUI answered 500 and nothing was read.

`tryReadWorkspaceWorkflow` reads that file from disk when the path stays inside the live workspace (realpath-contained). Library-relative names still use userdata. A path outside the workspace is not a disk read.

## Test

```
npx vitest run src/__tests__/tools/get-workflow-workspace-subfolder.test.ts
```
