### PR TITLE
fix(2511): relay list_local_models inventory through connected panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- list_local_models reads inventory through the connected panel when the headless /models route is unreachable (#2511)
 - panel_load_workflow restamps extra.comfyui_mcp.workflow_path (and uuid) to the active tab so an in-place save is not refused as belonging to the source workflow (#2505)
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 - fence ordinary `panel_set_widget` writes against the current panel graph identity across reconnects, with an actionable rebind refusal (#2550)

--- a/src/__tests__/services/list-local-models-panel-relay.test.ts
+++ b/src/__tests__/services/list-local-models-panel-relay.test.ts
@@ -1,0 +1,197 @@
+// #2511 — list_local_models action:list fails with EHOSTUNREACH against the
+// configured remote ComfyUI URL while the live sidebar panel is bound to that
+// same origin. Headless MCP cannot reach the host; the panel can. Inventory
+// must follow the #2283 object_info relay: authenticated panel fetch_comfyui_read
+// after a transport-layer failure, not an undetermined listing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mode = vi.hoisted(() => ({
+  remote: true,
+  generation: 0,
+  baseUrl: "https://gpu.example.internal:8188",
+}));
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: undefined as string | undefined },
+  getComfyUIBaseUrl: () => mode.baseUrl,
+  getComfyuiTargetGeneration: () => mode.generation,
+  isRemoteMode: () => mode.remote,
+}));
+
+const fetchApi = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getClient: () => ({ fetchApi }),
+  comfyApiFetch: (...a: unknown[]) => fetchApi(...a),
+}));
+
+const panelRead = vi.hoisted(() => vi.fn());
+vi.mock("../../services/panel-image-relay.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/panel-image-relay.js")>();
+  return { ...actual, requestPanelComfyUIRead: panelRead };
+});
+
+vi.mock("../../services/extra-paths.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../../services/extra-paths.js")>();
+  return { ...real, getExtraModelRoots: async () => [] };
+});
+
+const { config } = await import("../../config.js");
+const { listLocalModels, listLocalModelsWithCoverage } = await import(
+  "../../services/model-resolver.js"
+);
+const { describeEmptyModelListing, registerModelManagementTools } = await import(
+  "../../tools/model-management.js"
+);
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function registeredListLocalModelsTool(): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (_name: string, _description: string, _schema: unknown, ...rest: unknown[]) => {
+      const candidate = rest.find((arg) => typeof arg === "function");
+      if (typeof candidate === "function") handler = candidate as ToolHandler;
+    },
+  };
+  registerModelManagementTools(server as never);
+  if (!handler) throw new Error("list_local_models was not registered");
+  return handler;
+}
+
+function hostUnreachable(path: string): TypeError {
+  return new TypeError("fetch failed", {
+    cause: Object.assign(new Error(`connect EHOSTUNREACH ${mode.baseUrl} while requesting ${path}`), {
+      code: "EHOSTUNREACH",
+    }),
+  });
+}
+
+function panelBody(operation: string, payload: unknown): {
+  operation: string;
+  body: string;
+  contentType: string;
+  bytes: number;
+} {
+  const body = JSON.stringify(payload);
+  return {
+    operation,
+    body,
+    contentType: "application/json",
+    bytes: Buffer.byteLength(body, "utf8"),
+  };
+}
+
+beforeEach(() => {
+  fetchApi.mockReset();
+  panelRead.mockReset();
+  config.comfyuiPath = undefined;
+  mode.remote = true;
+  mode.generation = 0;
+  mode.baseUrl = "https://gpu.example.internal:8188";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("#2511: list_local_models relays inventory through the connected panel", () => {
+  it("returns panel-relayed checkpoints when headless /models/checkpoints is EHOSTUNREACH", async () => {
+    fetchApi.mockImplementation(async (path: string) => {
+      throw hostUnreachable(path);
+    });
+    panelRead.mockImplementation(async (operation: string) => {
+      if (operation === "models/checkpoints") {
+        return panelBody(operation, ["remote-ckpt.safetensors"]);
+      }
+      if (operation === "object_info") {
+        throw new Error("object_info must not be used as the models inventory");
+      }
+      return undefined;
+    });
+
+    const { models, coverage } = await listLocalModelsWithCoverage("checkpoints");
+
+    expect(models).toEqual([
+      {
+        name: "remote-ckpt.safetensors",
+        path: "checkpoints/remote-ckpt.safetensors",
+        size: 0,
+        modified: "",
+        type: "checkpoints",
+      },
+    ]);
+    expect(coverage.answered).toEqual(["checkpoints"]);
+    expect(coverage.noSourceAvailable).toBeUndefined();
+    expect(panelRead).toHaveBeenCalledWith("models/checkpoints");
+    expect(panelRead.mock.calls.map(([operation]) => operation)).not.toContain("object_info");
+  });
+
+  it("list_local_models action:list renders the relayed files, not an undetermined inventory", async () => {
+    fetchApi.mockImplementation(async (path: string) => {
+      throw hostUnreachable(path);
+    });
+    panelRead.mockImplementation(async (operation: string) => {
+      if (operation === "models/checkpoints") {
+        return panelBody(operation, ["remote-ckpt.safetensors"]);
+      }
+      return undefined;
+    });
+
+    const list = registeredListLocalModelsTool();
+    const res = await list({ action: "list", model_type: "checkpoints" });
+    const text = res.content.map((part) => part.text).join("\n");
+
+    expect(res.isError).toBeFalsy();
+    expect(text).toContain("remote-ckpt.safetensors");
+    expect(text).not.toMatch(/Could not determine which .+ are installed/i);
+    expect(describeEmptyModelListing("checkpoints", {
+      answered: [],
+      unanswered: [{ dir: "checkpoints", reason: "connect EHOSTUNREACH" }],
+      usedFilesystem: false,
+      noSourceAvailable: true,
+    })).toMatch(/Could not determine which checkpoints models are installed/i);
+  });
+
+  it("unfiltered listing uses the panel /models index and per-category reads", async () => {
+    fetchApi.mockImplementation(async (path: string) => {
+      throw hostUnreachable(path);
+    });
+    panelRead.mockImplementation(async (operation: string) => {
+      if (operation === "models") {
+        return panelBody(operation, ["checkpoints", "loras"]);
+      }
+      if (operation === "models/checkpoints") {
+        return panelBody(operation, ["remote-ckpt.safetensors"]);
+      }
+      if (operation === "models/loras") {
+        return panelBody(operation, ["remote-lora.safetensors"]);
+      }
+      return undefined;
+    });
+
+    const result = await listLocalModels();
+    expect(result.map((m) => ({ name: m.name, type: m.type }))).toEqual(
+      expect.arrayContaining([
+        { name: "remote-ckpt.safetensors", type: "checkpoints" },
+        { name: "remote-lora.safetensors", type: "loras" },
+      ]),
+    );
+    expect(panelRead).toHaveBeenCalledWith("models");
+    expect(panelRead).toHaveBeenCalledWith("models/checkpoints");
+    expect(panelRead).toHaveBeenCalledWith("models/loras");
+  });
+
+  it("does not use the panel for a configured-route HTTP error", async () => {
+    fetchApi.mockResolvedValue(new Response("gateway down", { status: 503 }));
+
+    const { models, coverage } = await listLocalModelsWithCoverage("checkpoints");
+
+    expect(models).toEqual([]);
+    expect(coverage.unanswered).toEqual([{ dir: "checkpoints", reason: "HTTP 503" }]);
+    expect(panelRead).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -28,6 +28,7 @@ import {
   startPanelImageRelayServer,
   verifyPanelImageRelayCapability,
   verifyPanelComfyUIReadRelayCapability,
+  isPanelComfyUIReadOperation,
   type PanelComfyUIReadRelayRequest,
   type PanelImageRelayRequest,
 } from "../../services/panel-image-relay.js";
@@ -782,6 +783,47 @@ describe("authenticated loopback panel image relay", () => {
       }
     },
   );
+
+  it("relays models/checkpoints without widening the object_info contract", async () => {
+    expect(isPanelComfyUIReadOperation("models")).toBe(true);
+    expect(isPanelComfyUIReadOperation("models/checkpoints")).toBe(true);
+    expect(isPanelComfyUIReadOperation("models/../object_info")).toBe(false);
+    expect(isPanelComfyUIReadOperation("object_info")).toBe(true);
+    const seen: Array<{ cmd: string; operation?: string }> = [];
+    const body = JSON.stringify(["remote-ckpt.safetensors"]);
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) =>
+        "operation" in value && verifyPanelComfyUIReadRelayCapability(SECRET, value)
+          ? { agentKey: "orchestrator::claude", secret: SECRET }
+          : undefined,
+      resolvePanelTab: () => "panel-tab",
+      bridge: {
+        canReach: () => true,
+        send: async (command) => {
+          seen.push(command);
+          return {
+            operation: "models/checkpoints",
+            body,
+            contentType: "application/json",
+            bytes: Buffer.byteLength(body, "utf8"),
+          };
+        },
+      },
+    });
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+      await expect(requestPanelComfyUIRead("models/checkpoints")).resolves.toEqual({
+        operation: "models/checkpoints",
+        body,
+        contentType: "application/json",
+        bytes: Buffer.byteLength(body, "utf8"),
+      });
+      expect(seen).toEqual([{ cmd: "fetch_comfyui_read", operation: "models/checkpoints" }]);
+    } finally {
+      await server.close();
+    }
+  });
 
   it("rejects an invalid viewing witness instead of widening the read contract", async () => {
     const body = JSON.stringify({ KSampler: { input: { required: {} } } });

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -10,6 +10,12 @@ import {
   isRemoteMode,
 } from "../config.js";
 import { getClient, getLogs, getSystemStats, comfyApiFetch } from "../comfyui/client.js";
+import { isComfyTransportFailure } from "../comfyui/fetch.js";
+import {
+  requestPanelComfyUIRead,
+  type PanelComfyUIReadOperation,
+  type PanelComfyUIReadSuccess,
+} from "./panel-image-relay.js";
 import { getExtraModelRoots, getLiveExtraModelRoots } from "./extra-paths.js";
 import {
   liveRootFromArgv,
@@ -390,6 +396,56 @@ function makeModelDeduper(): { add: (category: string, name: string) => boolean 
   };
 }
 
+const MODELS_TRANSPORT_CODES = new Set([
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNRESET",
+]);
+
+function isModelsTransportFailure(err: unknown): boolean {
+  if (isComfyTransportFailure(err)) return true;
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  while (current instanceof Error && !seen.has(current)) {
+    const code = "code" in current ? current.code : undefined;
+    if (typeof code === "string" && MODELS_TRANSPORT_CODES.has(code)) return true;
+    if (/\b(EHOSTUNREACH|ENETUNREACH|ECONNREFUSED)\b/.test(current.message)) return true;
+    seen.add(current);
+    current = "cause" in current ? current.cause : undefined;
+  }
+  return false;
+}
+
+function modelsReadOperationFor(path: string): PanelComfyUIReadOperation | undefined {
+  if (path === "/models") return "models";
+  const match = /^\/models\/([A-Za-z0-9][A-Za-z0-9._-]{0,63})$/.exec(path);
+  if (!match) return undefined;
+  return `models/${match[1]}`;
+}
+
+function panelModelsResponse(read: PanelComfyUIReadSuccess): Response {
+  const headers = new Headers();
+  if (read.contentType) headers.set("content-type", read.contentType);
+  return new Response(read.body, { status: 200, headers });
+}
+
+/** Headless `/models` first; on transport failure, the #2283 panel read relay. */
+async function fetchModelsRoute(path: string): Promise<Response> {
+  try {
+    return await comfyApiFetch(path);
+  } catch (err) {
+    if (!isModelsTransportFailure(err)) throw err;
+    const operation = modelsReadOperationFor(path);
+    if (!operation) throw err;
+    const relayed = await requestPanelComfyUIRead(operation);
+    if (!relayed) throw err;
+    return panelModelsResponse(relayed);
+  }
+}
+
 /**
  * Weight-file extensions. The gate that makes discovering the WHOLE registry
  * safe (#962).
@@ -423,7 +479,7 @@ async function discoverExtraCategories(
   client: ReturnType<typeof getClient>,
 ): Promise<string[]> {
   try {
-    const res = await comfyApiFetch("/models");
+    const res = await fetchModelsRoute("/models");
     if (!res.ok) return [];
     const json = (await res.json()) as unknown;
     if (!Array.isArray(json)) return [];
@@ -669,7 +725,7 @@ export async function listLocalModelsWithCoverage(
  */
 async function otherRegisteredCategories(asked: string): Promise<string[] | undefined> {
   try {
-    const res = await comfyApiFetch("/models");
+    const res = await fetchModelsRoute("/models");
     if (!res.ok) return undefined;
     const json = (await res.json()) as unknown;
     if (!Array.isArray(json)) return undefined;
@@ -733,7 +789,7 @@ async function collectLocalModels(
     const dedup = makeModelDeduper();
     for (const dir of dirsToScan) {
       try {
-        const res = await comfyApiFetch(`/models/${dir}`);
+        const res = await fetchModelsRoute(`/models/${dir}`);
         if (refuseStaleModelListing(target, coverage)) return [];
         // A non-OK status or a non-array body means we did NOT learn what this
         // category holds. Recording the reason is the whole point: continuing

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -41,11 +41,25 @@ const RELAY_ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const RELAY_CAPABILITY_RE = /^[a-f0-9]{64}$/;
 const RELAY_SECRET_RE = /^[a-f0-9]{64}$/;
 const IMAGE_TYPES = new Set<PanelImageType>(["output", "input", "temp"]);
-const READ_OPERATIONS = new Set<PanelComfyUIReadOperation>(["history", "system_stats", "logs", "object_info"]);
+const FIXED_READ_OPERATIONS = new Set<string>(["history", "system_stats", "logs", "object_info", "models"]);
+const MODELS_FOLDER_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 const MIME_RE = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}$/;
 
 export type PanelImageType = "output" | "input" | "temp";
-export type PanelComfyUIReadOperation = "history" | "system_stats" | "logs" | "object_info";
+export type PanelComfyUIReadOperation =
+  | "history"
+  | "system_stats"
+  | "logs"
+  | "object_info"
+  | "models"
+  | `models/${string}`;
+
+/** Closed allowlist: the four diagnostics reads, `/models`, or `/models/<folder>`. */
+export function isPanelComfyUIReadOperation(value: string): value is PanelComfyUIReadOperation {
+  if (FIXED_READ_OPERATIONS.has(value)) return true;
+  if (!value.startsWith("models/")) return false;
+  return MODELS_FOLDER_RE.test(value.slice("models/".length));
+}
 
 export interface PanelImageRelayRequest {
   version: typeof PANEL_IMAGE_RELAY_VERSION;
@@ -271,7 +285,7 @@ export function verifyPanelComfyUIReadRelayCapability(
   if (
     !isSafeRelaySecret(secret) ||
     !isSafeRelayCapability(request.capability) ||
-    !READ_OPERATIONS.has(request.operation)
+    !isPanelComfyUIReadOperation(request.operation)
   ) return false;
   const expected = makePanelComfyUIReadRelayCapability(secret, request);
   return timingSafeEqual(Buffer.from(request.capability, "hex"), Buffer.from(expected, "hex"));
@@ -413,11 +427,12 @@ function validateReadPayload(value: unknown): PanelComfyUIReadSuccess | undefine
   if (
     !hasOnlyKeys(record, ["operation", "body", "contentType", "bytes", "viewing"]) ||
     typeof record.operation !== "string" ||
-    !READ_OPERATIONS.has(record.operation as PanelComfyUIReadOperation) ||
+    !isPanelComfyUIReadOperation(record.operation) ||
     typeof record.body !== "string" ||
     (record.contentType !== null &&
       (typeof record.contentType !== "string" || !isSafeText(record.contentType, 128)))
   ) return undefined;
+  const operation = record.operation;
   if (hasOwn(record, "viewing")) {
     const viewing = record.viewing;
     if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return undefined;
@@ -443,13 +458,15 @@ function validateReadPayload(value: unknown): PanelComfyUIReadSuccess | undefine
     typeof bytes !== "number" ||
     !Number.isSafeInteger(bytes) ||
     bytes < 0 ||
-    bytes > readMaxBytes(record.operation as PanelComfyUIReadOperation) ||
+    bytes > readMaxBytes(operation) ||
     Buffer.byteLength(record.body, "utf8") !== bytes
   ) return undefined;
+  const contentType = record.contentType === null ? null : record.contentType;
+  if (contentType !== null && typeof contentType !== "string") return undefined;
   return {
-    operation: record.operation as PanelComfyUIReadOperation,
+    operation,
     body: record.body,
-    contentType: record.contentType as string | null,
+    contentType,
     bytes,
   };
 }
@@ -488,13 +505,13 @@ function validateReadRequest(value: unknown, requestId: string): PanelComfyUIRea
     record.requestId !== requestId ||
     !isSafeRelayCapability(capability) ||
     typeof record.operation !== "string" ||
-    !READ_OPERATIONS.has(record.operation as PanelComfyUIReadOperation) ||
+    !isPanelComfyUIReadOperation(record.operation) ||
     typeof createdAt !== "number" ||
     typeof deadlineAt !== "number" ||
     !Number.isSafeInteger(createdAt) ||
     !Number.isSafeInteger(deadlineAt) ||
     deadlineAt < createdAt ||
-    deadlineAt - createdAt > readTimeoutMs(record.operation as PanelComfyUIReadOperation)
+    deadlineAt - createdAt > readTimeoutMs(record.operation)
   ) return undefined;
   return record as unknown as PanelComfyUIReadRelayRequest;
 }
@@ -1104,7 +1121,7 @@ export async function requestPanelImage(
 export async function requestPanelComfyUIRead(
   operation: PanelComfyUIReadOperation,
 ): Promise<PanelComfyUIReadSuccess | undefined> {
-  if (!READ_OPERATIONS.has(operation)) {
+  if (!isPanelComfyUIReadOperation(operation)) {
     throw new PanelComfyUIReadRelayError("The ComfyUI read operation was refused.", "UNSAFE_OPERATION");
   }
   const endpoint = relayEndpoint();


### PR DESCRIPTION
## Summary
- `list_local_models` action:list no longer reports inventory as undetermined when headless `/models` fails with EHOSTUNREACH and a live sidebar panel is bound to that same ComfyUI origin.
- Reuses the #2283 authenticated `fetch_comfyui_read` channel: after a transport-layer failure, inventory is read as `models` / `models/<folder>` and parsed with the existing listing path.
- HTTP errors from the configured route still skip the panel (same as object_info).

## Test plan
- [x] `npx vitest run src/__tests__/services/list-local-models-panel-relay.test.ts src/__tests__/services/list-local-models.test.ts src/__tests__/services/model-listing-coverage.test.ts src/__tests__/services/panel-image-relay.test.ts src/__tests__/comfyui/panel-read-fallback.test.ts` (129 passed)
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-anti-slop.mjs`

Closes #2511
