### PR TITLE
fix(2620)-drain-empty-git-enqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- drain an empty-success Git install enqueue before using the verified local clone fallback (#2620)
+
 ## [0.52.155] - 2026-08-30
 
 ### MCP
 
 #### Fixed
 - models_show local fallback does not report an arbitrary duplicate basename as the installed model (#2504, #2614)
-
 
 ## [0.52.154] - 2026-08-30
 
@@ -24,7 +28,6 @@ All notable changes to this project are documented here. This project adheres to
 - list_local_models reads inventory through the connected panel when the headless /models route is unreachable (#2511)
 - install_custom_node action:"fix" does not report repaired when Manager's task result is not-found/error (#2490)
 - panel_load_workflow restamps extra.comfyui_mcp.workflow_path (and uuid) to the active tab so an in-place save is not refused as belonging to the source workflow (#2505)
-- drain an empty-success Git install enqueue before using the verified local clone fallback (#2620)
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 - fence ordinary `panel_set_widget` writes against the current panel graph identity across reconnects, with an actionable rebind refusal (#2550)
 - clear terminal MCP panel refresh coordination state and reclaim only bounded, stale refresh records while keeping unknown completion fail-closed (#2549)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project are documented here. This project adheres to
 - list_local_models reads inventory through the connected panel when the headless /models route is unreachable (#2511)
 - install_custom_node action:"fix" does not report repaired when Manager's task result is not-found/error (#2490)
 - panel_load_workflow restamps extra.comfyui_mcp.workflow_path (and uuid) to the active tab so an in-place save is not refused as belonging to the source workflow (#2505)
+- drain an empty-success Git install enqueue before using the verified local clone fallback (#2620)
 - fall back to ComfyUI-Manager for install_custom_node action:"list" when the local comfy-cli version is unrecognized (#2603)
 - fence ordinary `panel_set_widget` writes against the current panel graph identity across reconnects, with an actionable rebind refusal (#2550)
 - clear terminal MCP panel refresh coordination state and reclaim only bounded, stale refresh records while keeping unknown completion fail-closed (#2549)

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -867,44 +867,64 @@ describe("node-management service", () => {
       ).toBeDefined();
     });
 
-    it("fails closed when Manager accepts a git enqueue with an empty success body", async () => {
+    it("drains before falling back when Manager accepts a git enqueue with an empty success body", async () => {
       const { calls } = stubFetch({ installedBody: {}, queueOpEmpty: true });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
 
-      await expect(
-        installCustomNode({
-          id: "https://github.com/teskor-hub/comfyui-teskors-utils",
-          source: "git",
-        }),
-      ).rejects.toMatchObject({
-        details: { kind: "manager-enqueue-empty-success" },
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        source: "git",
       });
 
-      // The successful empty enqueue is ambiguous: do not start/poll it and
-      // never race a possible Manager task with a local clone.
+      expect(res.mechanism).toBe("git-clone");
+      // An empty successful body is not a pre-queue refusal. Drain the task
+      // before the exact installed-pack/disk check authorizes the clone.
       expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
-      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(false);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/manager/queue/status"))).toBe(true);
       expect(
         mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
-      ).toBeUndefined();
+      ).toBeDefined();
     });
 
-    it("fails closed when Manager accepts a git enqueue with JSON null", async () => {
+    it("drains before falling back when Manager accepts a git enqueue with JSON null", async () => {
       const { calls } = stubFetch({ installedBody: {}, queueOpNull: true });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
 
-      await expect(
-        installCustomNode({
-          id: "https://github.com/teskor-hub/comfyui-teskors-utils",
-          source: "git",
-        }),
-      ).rejects.toMatchObject({
-        details: { kind: "manager-enqueue-empty-success" },
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        source: "git",
       });
 
+      expect(res.mechanism).toBe("git-clone");
       expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
-      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(false);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/manager/queue/status"))).toBe(true);
       expect(
         mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
-      ).toBeUndefined();
+      ).toBeDefined();
     });
 
     it("fails closed when a warm dialect cache later returns an empty queue status", async () => {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -1019,10 +1019,11 @@ async function resolveLocalManifestCustomNodesBase(): Promise<string | undefined
 
 /**
  * Manager can report a successful-but-empty enqueue or an empty queue/status
- * response after a warm dialect cache. Both are deliberately tagged UNKNOWN
- * by node-management: the request may already have reached the host, so no
- * caller may reissue it or authorize a local clone. Keep that meaning intact
- * when apply_manifest assembles its structured per-item result.
+ * response after a warm dialect cache. For apply_manifest, both are
+ * deliberately tagged UNKNOWN by node-management: the request may already
+ * have reached the host, so no caller may reissue it or authorize a local
+ * clone. Keep that meaning intact when apply_manifest assembles its
+ * structured per-item result.
  */
 function isUnknownManagerInstallOutcome(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
@@ -1233,6 +1234,10 @@ async function applyManifestSections(
       ...(isGitManifestSource
         ? { localCloneFallback: "verified-only" as const }
         : {}),
+      // A budget timeout may return apply_manifest while the Manager enqueue
+      // is still unresolved. Keep an empty enqueue UNKNOWN/fail-closed here
+      // so a late completion cannot authorize a background local clone.
+      ...(isGitManifestSource ? { allowEmptyV2Enqueue: false } : {}),
       managerBase,
       targetGeneration,
       localFallbackBinding: fallbackBinding,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1517,8 +1517,10 @@ async function reclassifyAfterEmptyQueueStatus(
 }
 
 interface ManagerEnqueueOptions {
-  /** A git install may fall back to a local clone, so an empty 2xx is unsafe. */
+  /** Callers may reject an empty 2xx when they cannot safely verify afterward. */
   rejectEmptyEnqueue?: boolean;
+  /** Allow an empty v4 unified enqueue to proceed to drain/verification. */
+  allowEmptyV2Enqueue?: boolean;
 }
 
 type ManagerEnqueueResponse = Record<string, unknown> | string | null | undefined;
@@ -1531,7 +1533,11 @@ function assertManagerEnqueueResponse(
   path: string,
   base: string,
 ): void {
-  if (!options.rejectEmptyEnqueue || (response !== undefined && response !== null)) return;
+  if (
+    !options.rejectEmptyEnqueue ||
+    (response !== undefined && response !== null) ||
+    (api === "v2" && options.allowEmptyV2Enqueue)
+  ) return;
   throw new NodeManagementError(
     `ComfyUI-Manager returned a successful but empty response for the ${kind} enqueue ` +
       `on the "${api}" dialect. The task may have been submitted, so its outcome is ` +
@@ -3734,6 +3740,12 @@ export interface InstallOptions {
   /** The caller has already resolved the only safe local clone root. When set,
    *  an absent comfyuiPath means Manager-only, never a second local-root lookup. */
   localCloneFallback?: "verified-only";
+  /**
+   * Internal caller policy for an empty Manager v4 Git enqueue. Direct installs
+   * can drain and verify before cloning; budgeted apply_manifest keeps the
+   * UNKNOWN/no-background-write behavior.
+   */
+  allowEmptyV2Enqueue?: boolean;
   /** Call-scoped Manager base captured with the target generation at operation entry. */
   managerBase?: string;
   /** Monotonic ComfyUI target generation captured with managerBase. */
@@ -4070,6 +4082,10 @@ async function installCustomNodeImpl(
     // Only a PRE-QUEUE refusal diverts (see managerEnqueueRefusal): the response
     // describes the request, so nothing is running and the clone cannot race a
     // Manager task writing to the same directory. Everything else rethrows.
+    // An empty successful enqueue is not a pre-queue refusal: Manager may
+    // have accepted the task and simply omitted its acknowledgement body.
+    // Start and drain the queue first, then the exact installed-pack/disk
+    // verification below decides whether a local clone is still needed.
     let refusedBy: number | undefined;
     const enqueue = async (): Promise<unknown> =>
       await queueManagerTask(
@@ -4105,10 +4121,14 @@ async function installCustomNodeImpl(
             mode: opts.mode ?? "cache",
           },
       managerBase,
-      // This branch can authorize a local clone after Manager returns. An
-      // empty successful enqueue is ambiguous, so fail before start/status
-      // rather than treating it as a safe pre-queue refusal.
-      { rejectEmptyEnqueue: true },
+      // Manager v4 may accept the task while omitting its acknowledgement
+      // body. Direct installs can safely drain and verify before cloning;
+      // apply_manifest opts out so a late completion cannot start a local
+      // write after that budgeted call has returned UNKNOWN/pending.
+      {
+        rejectEmptyEnqueue: true,
+        allowEmptyV2Enqueue: opts.allowEmptyV2Enqueue !== false,
+      },
     );
 
     let status: unknown;


### PR DESCRIPTION
Manager v4 can return a successful empty body from the unified queue/task endpoint even when the install may have been accepted. Drain that queue first, then reuse the existing installed-pack and on-disk verification before authorizing the direct Git clone fallback.

Legacy and batch empty responses remain fail-closed, as does budgeted apply_manifest handling.

Fixes #2620
