### PR TITLE
fix(2512): deliver cancelled-run completion at interrupt time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- deliver interrupted run-completions at interrupt time with duration from ComfyUI's execution record, not from the next prompt (#2512)
 - panel_run does not claim a /prompt left the panel when ComfyUI never logged a prompt; id-less queued_unknown fails closed as not queued (#2521)
 - panel_set_widget treats a root-scope promoted widget as the authoritative parent rail and suppresses the inner link-driven warning (#2514)
 - drain an empty-success Git install enqueue before using the verified local clone fallback (#2620)

--- a/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
+++ b/src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts
@@ -99,7 +99,8 @@ describe("#1789 — the history fallback is WIRED into the orchestrator, not mer
     // #1853 — outputs come from the shipped /history parse, not a status-only
     // pointer. A second path that invented filenames would be the over-claim.
     expect(block).toContain("resolveOutputs:");
-    expect(block).toContain("resolveHistoryCompletionImages(");
+    expect(block).toContain("resolveHistoryCompletion(");
+    expect(block).not.toContain("resolveHistoryCompletionImages(");
     // #1556 — reconnect looks the still-owed ids up in /history, not only in
     // the QueueMonitor drain that may have already missed them.
     expect(block).toContain("lookupStatus:");

--- a/src/__tests__/orchestrator/run-completion-interrupt-timing.test.ts
+++ b/src/__tests__/orchestrator/run-completion-interrupt-timing.test.ts
@@ -1,0 +1,144 @@
+// #2512 — an interrupted/cancelled prompt must emit its run-completion at
+// interrupt time, with duration/finished-at from ComfyUI's execution record,
+// not from the next "got prompt" an hour later.
+//
+// The panel defers its "Run finished … workflow completed in 79m" card until
+// the next queue activity. The orchestrator already observes the interrupt
+// (QueueMonitor) and already journals completions (RunCompletions). This file
+// drives those shipped functions: buildCompletionNotification for timing, the
+// watchdog + journal for immediate delivery.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { HistoryEntry } from "../../comfyui/client.js";
+import { buildCompletionNotification } from "../../services/job-watcher.js";
+import { extractExecutionStats } from "../../services/job-history.js";
+import {
+  createRunCompletionWatchdog,
+  parseHistoryCompletion,
+  synthesizeCompletionPayload,
+  DEFAULT_SYNTHESIS_GRACE_MS,
+} from "../../orchestrator/run-completion-watchdog.js";
+import { RunCompletions, type CompletionPayload, type RunTicket } from "../../orchestrator/run-completion-journal.js";
+
+const TAB = "tab-2512";
+const CONV = "orchestrator::claude";
+const PID = "0871d72c-2512-4c0e-9f14-cancelled-late";
+
+/** Queue at 09:33:47, interrupt at 09:54:55 (ComfyUI: Prompt executed in 00:21:08). */
+const QUEUED_AT = 1_700_000_000_000;
+const INTERRUPT_MS = 21 * 60 * 1000 + 8 * 1000;
+const INTERRUPTED_AT = QUEUED_AT + INTERRUPT_MS;
+/** Next "got prompt" — the wall clock that used to inflate duration to ~79m. */
+const NEXT_PROMPT_AT = QUEUED_AT + 79 * 60 * 1000 + 14 * 1000;
+
+beforeEach(() => RunCompletions.reset());
+afterEach(() => RunCompletions.reset());
+
+function interruptedHistory(promptId: string): HistoryEntry {
+  return {
+    prompt: {},
+    outputs: {},
+    status: {
+      status_str: "error",
+      completed: true,
+      messages: [
+        ["execution_start", { prompt_id: promptId, timestamp: QUEUED_AT }],
+        ["execution_interrupted", { prompt_id: promptId, timestamp: INTERRUPTED_AT }],
+      ],
+    },
+  };
+}
+
+function makeWatchdog(
+  clock: { t: number },
+  resolveOutputs?: (promptId: string) => Promise<ReturnType<typeof parseHistoryCompletion>>,
+) {
+  const delivered: Array<{ payload: CompletionPayload; ticket: RunTicket }> = [];
+  const wd = createRunCompletionWatchdog({
+    awaiting: (id) => RunCompletions.awaitingCompletion(id),
+    knownTicket: (id) => RunCompletions.ticketFor(id),
+    deliver: (payload, ticket) => {
+      delivered.push({ payload, ticket });
+      RunCompletions.record(ticket.tabId, payload, {
+        ...(ticket.conversation !== undefined ? { conversation: ticket.conversation } : {}),
+      });
+    },
+    now: () => clock.t,
+    ...(resolveOutputs ? { resolveOutputs } : {}),
+  });
+  return { wd, delivered };
+}
+
+describe("#2512: interrupted completion timing comes from ComfyUI, not next-prompt delivery", () => {
+  it("buildCompletionNotification uses the interrupt timestamp, not Date.now() at a later prompt", () => {
+    const entry = interruptedHistory(PID);
+    const notification = buildCompletionNotification(PID, entry, QUEUED_AT);
+
+    expect(notification.status).toBe("interrupted");
+    expect(notification.duration_ms).toBe(INTERRUPT_MS);
+    expect(Date.parse(notification.timestamp)).toBe(INTERRUPTED_AT);
+    // The inflated wall-clock (queue → next prompt) must not win.
+    expect(notification.duration_ms).toBeLessThan(NEXT_PROMPT_AT - QUEUED_AT);
+    expect(Date.parse(notification.timestamp)).toBeLessThan(NEXT_PROMPT_AT);
+  });
+
+  it("extractExecutionStats treats execution_interrupted as the terminal end event", () => {
+    const stats = extractExecutionStats(interruptedHistory(PID));
+    expect(stats?.total_duration_ms).toBe(INTERRUPT_MS);
+  });
+
+  it("parseHistoryCompletion (the shipped history parse) carries that duration into the journal payload", () => {
+    const parsed = parseHistoryCompletion(PID, interruptedHistory(PID));
+    expect(parsed.status).toBe("interrupted");
+    expect(parsed.duration_ms).toBe(INTERRUPT_MS);
+    expect(Date.parse(parsed.timestamp)).toBe(INTERRUPTED_AT);
+  });
+
+  it("the synthesised interrupt notice names ComfyUI's duration, not the next-prompt wait", () => {
+    const parsed = parseHistoryCompletion(PID, interruptedHistory(PID));
+    const payload = synthesizeCompletionPayload(
+      { promptId: PID, status: "interrupted", observedAt: INTERRUPTED_AT },
+      {
+        deliveredAt: NEXT_PROMPT_AT,
+        durationMs: parsed.duration_ms,
+        finishedAt: parsed.timestamp,
+      },
+    );
+    expect(payload.run_status).toBe("interrupted");
+    expect(payload.duration_ms).toBe(INTERRUPT_MS);
+    expect(payload.finished_at).toBe(parsed.timestamp);
+    expect(String(payload.note)).toContain("21m 8s");
+    expect(String(payload.note)).not.toMatch(/79m/);
+  });
+
+  it("watchdog journals the interrupt immediately — not after grace, not at the next prompt", async () => {
+    const clock = { t: INTERRUPTED_AT };
+    const entry = interruptedHistory(PID);
+    const { wd, delivered } = makeWatchdog(clock, async () => parseHistoryCompletion(PID, entry));
+    expect(RunCompletions.openRun(PID, { tabId: TAB, conversation: CONV })).toBe(true);
+
+    wd.observe([{ promptId: PID, status: "interrupted" }]);
+    await wd.tick();
+
+    expect(delivered).toHaveLength(1);
+    expect(wd.armedCount()).toBe(0);
+    expect(delivered[0].payload.run_status).toBe("interrupted");
+    expect(delivered[0].payload.duration_ms).toBe(INTERRUPT_MS);
+    expect(Date.parse(String(delivered[0].payload.finished_at))).toBe(INTERRUPTED_AT);
+    expect(String(delivered[0].payload.note)).toContain("INTERRUPTED");
+    expect(String(delivered[0].payload.note)).toContain("21m 8s");
+
+    const outstanding = RunCompletions.outstanding(TAB);
+    expect(outstanding).toHaveLength(1);
+    expect(outstanding[0].correlation).toEqual({ status: "matched", promptId: PID });
+    expect(outstanding[0].payload.duration_ms).toBe(INTERRUPT_MS);
+
+    // An hour later the next prompt arrives. Nothing new is synthesised, and
+    // duration stays the interrupt span — not queue-to-now.
+    clock.t = NEXT_PROMPT_AT;
+    await wd.tick();
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0].payload.duration_ms).toBe(INTERRUPT_MS);
+    expect(DEFAULT_SYNTHESIS_GRACE_MS).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/services/job-history.test.ts
+++ b/src/__tests__/services/job-history.test.ts
@@ -7,6 +7,7 @@ import {
   extractTextOutputs,
   hasAffirmativeSuccessStatus,
   historyCompletionTimeMs,
+  historyTerminalTimeMs,
 } from "../../services/job-history.js";
 
 function historyEntry(messages: unknown): HistoryEntry {
@@ -264,5 +265,33 @@ describe("historyCompletionTimeMs (#751 r4 real-completion-time gate)", () => {
       ["execution_success", { timestamp: NOW + 3_600_000 }],
     ]);
     expect(historyCompletionTimeMs(entry, NOW)).toBeUndefined();
+  });
+});
+
+describe("#2512 interrupted history is a terminal end event", () => {
+  const START = 1_700_000_000_000;
+  const INTERRUPT = START + 21 * 60 * 1000 + 8 * 1000;
+  const interrupted = (): HistoryEntry =>
+    ({
+      prompt: {},
+      outputs: {},
+      status: {
+        status_str: "error",
+        completed: true,
+        messages: [
+          ["execution_start", { timestamp: START }],
+          ["execution_interrupted", { timestamp: INTERRUPT }],
+        ],
+      },
+    }) as HistoryEntry;
+
+  it("extractExecutionStats measures start → execution_interrupted", () => {
+    expect(extractExecutionStats(interrupted())?.total_duration_ms).toBe(INTERRUPT - START);
+  });
+
+  it("historyTerminalTimeMs reads the interrupt timestamp (historyCompletionTimeMs stays success-only)", () => {
+    const entry = interrupted();
+    expect(historyTerminalTimeMs(entry, INTERRUPT + 1_000)).toBe(INTERRUPT);
+    expect(historyCompletionTimeMs(entry, INTERRUPT + 1_000)).toBeUndefined();
   });
 });

--- a/src/__tests__/services/job-watcher.test.ts
+++ b/src/__tests__/services/job-watcher.test.ts
@@ -219,6 +219,24 @@ describe("buildCompletionNotification", () => {
       },
     ]);
   });
+
+  it("#2512 interrupted duration/finished-at come from execution_interrupted, not delivery time", () => {
+    const interruptAt = START + 21 * 60 * 1000 + 8 * 1000;
+    const notification = buildCompletionNotification(
+      PROMPT_ID,
+      historyEntry(
+        [
+          ["execution_start", { prompt_id: PROMPT_ID, timestamp: START }],
+          ["execution_interrupted", { prompt_id: PROMPT_ID, timestamp: interruptAt }],
+        ],
+        "error",
+      ),
+      START,
+    );
+    expect(notification.status).toBe("interrupted");
+    expect(notification.duration_ms).toBe(interruptAt - START);
+    expect(Date.parse(notification.timestamp)).toBe(interruptAt);
+  });
 });
 
 function sampleWorkflow(): WorkflowJSON {

--- a/src/__tests__/services/queue-monitor.poll.test.ts
+++ b/src/__tests__/services/queue-monitor.poll.test.ts
@@ -167,6 +167,49 @@ describe("poll() /history tail diff (#259)", () => {
     expect(QueueMonitor.drainCompletions()[0]?.status).toBe("interrupted");
   });
 
+  it("#2512 completed:true + execution_interrupted is interrupted, not success", async () => {
+    mockFetch({ queue: emptyQueue, history: {} });
+    await QueueMonitor.poll();
+    mockFetch({
+      queue: emptyQueue,
+      history: {
+        "h-int": {
+          status: {
+            status_str: "error",
+            completed: true,
+            messages: [["execution_interrupted", { prompt_id: "h-int" }]],
+          },
+        },
+      },
+    });
+    await QueueMonitor.poll();
+    expect(QueueMonitor.drainCompletions()[0]?.status).toBe("interrupted");
+  });
+
+  it("#2512 a running prompt already in the history tail still records interrupt when the queue empties", async () => {
+    priv.historyPrimed = true;
+    priv.historySeen = new Set(["p-int"]);
+    priv.state.runningPromptId = "p-int";
+    priv.state.lastActivityTs = Date.now() - 1_000;
+    mockFetch({
+      queue: emptyQueue,
+      history: {
+        "p-int": {
+          status: {
+            status_str: "error",
+            completed: true,
+            messages: [["execution_interrupted", { prompt_id: "p-int", timestamp: 1 }]],
+          },
+        },
+      },
+    });
+    await QueueMonitor.poll();
+    expect(QueueMonitor.drainCompletions()[0]).toMatchObject({
+      promptId: "p-int",
+      status: "interrupted",
+    });
+  });
+
   it("completing the tracked running prompt also clears the run state", async () => {
     mockFetch({ queue: { queue_running: [[1, "p-run", {}, {}, []]], queue_pending: [] }, history: {} });
     await QueueMonitor.poll();

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -282,7 +282,7 @@ import {
 } from "./run-completion-idempotency.js";
 import {
   createRunCompletionWatchdog,
-  resolveHistoryCompletionImages,
+  resolveHistoryCompletion,
   resolveHistoryCompletionStatus,
   type RunCompletionWatchdog,
 } from "./run-completion-watchdog.js";
@@ -6765,7 +6765,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   const wd = createRunCompletionWatchdog({
     awaiting: (promptId) => RunCompletions.awaitingCompletion(promptId),
     knownTicket: (promptId) => RunCompletions.ticketFor(promptId),
-    resolveOutputs: (promptId) => resolveHistoryCompletionImages(promptId),
+    resolveOutputs: (promptId) => resolveHistoryCompletion(promptId),
     lookupStatus: (promptId) => resolveHistoryCompletionStatus(promptId),
     deliver: (payload, ticket) => {
       // The SAME arrival path the panel's frame takes: correlated once, here,

--- a/src/orchestrator/run-completion-watchdog.ts
+++ b/src/orchestrator/run-completion-watchdog.ts
@@ -87,12 +87,20 @@
 // promising more than this can keep.
 
 import { getHistory, type HistoryEntry } from "../comfyui/client.js";
-import { buildCompletionNotification } from "../services/job-watcher.js";
+import { buildCompletionNotification, type CompletionNotification } from "../services/job-watcher.js";
 import { logger } from "../utils/logger.js";
 import type { CompletionStatus } from "../services/queue-monitor.js";
 import type { CompletionPayload, RunTicket } from "./run-completion-journal.js";
 
 type CompletionImage = NonNullable<CompletionPayload["images"]>[number];
+
+/** History parse used by the watchdog: images plus ComfyUI's own duration. */
+export interface ResolvedHistoryCompletion {
+  images: CompletionImage[];
+  duration_ms: number;
+  timestamp: string;
+  status: CompletionNotification["status"];
+}
 
 /** One completion QueueMonitor observed, held until its grace expires. */
 interface ArmedCompletion {
@@ -131,11 +139,14 @@ export interface RunCompletionWatchdogDeps {
   /** Journal + flush a synthesised completion for `ticket`. */
   deliver: (payload: CompletionPayload, ticket: RunTicket) => void;
   /**
-   * Resolve output refs from the completed prompt's ComfyUI history. Wired to
-   * `resolveHistoryCompletionImages` in production. Missing / throwing / empty
-   * is the #1789 status-only notice, never a fabricated image.
+   * Resolve output refs (and, when available, history timing) from the
+   * completed prompt's ComfyUI history. Wired to `resolveHistoryCompletion` in
+   * production. Missing / throwing / empty is the #1789 status-only notice,
+   * never a fabricated image.
    */
-  resolveOutputs?: (promptId: string) => Promise<CompletionPayload["images"]>;
+  resolveOutputs?: (
+    promptId: string,
+  ) => Promise<CompletionPayload["images"] | ResolvedHistoryCompletion | undefined>;
   /**
    * Terminal status of a prompt in ComfyUI history, or null if it is missing /
    * still running / unreadable. Wired to `resolveHistoryCompletionStatus` in
@@ -255,15 +266,14 @@ function usableHistoryImages(images: CompletionPayload["images"]): CompletionIma
 }
 
 /**
- * Flatten a history entry's media into the completion-payload `images` shape.
- * Extraction is `buildCompletionNotification` — the same parse JobWatcher and
- * asset reconcile already ship — so a SaveVideo `videos` ref and a SaveImage
- * `images` ref take the same path a watched completion would.
+ * Flatten a history entry through `buildCompletionNotification` — the same
+ * parse JobWatcher and asset reconcile already ship — so duration, finished-at,
+ * status, and media refs are one observation (#2512).
  */
-export function historyOutputRefsFromEntry(
+export function parseHistoryCompletion(
   promptId: string,
   entry: HistoryEntry,
-): CompletionImage[] {
+): ResolvedHistoryCompletion {
   const notification = buildCompletionNotification(promptId, entry, 0);
   const refs: CompletionImage[] = [];
   for (const node of notification.outputs) {
@@ -276,30 +286,56 @@ export function historyOutputRefsFromEntry(
       refs.push({ filename: vid.filename, subfolder: vid.subfolder, type: vid.type });
     }
   }
-  return usableHistoryImages(refs);
+  return {
+    images: usableHistoryImages(refs),
+    duration_ms: notification.duration_ms,
+    timestamp: notification.timestamp,
+    status: notification.status,
+  };
+}
+
+/**
+ * Flatten a history entry's media into the completion-payload `images` shape.
+ * Extraction is `buildCompletionNotification` — the same parse JobWatcher and
+ * asset reconcile already ship — so a SaveVideo `videos` ref and a SaveImage
+ * `images` ref take the same path a watched completion would.
+ */
+export function historyOutputRefsFromEntry(
+  promptId: string,
+  entry: HistoryEntry,
+): CompletionImage[] {
+  return parseHistoryCompletion(promptId, entry).images;
 }
 
 /**
  * Fetch `/history/<promptId>` and return the real output refs, or [] when the
  * record is missing, unreadable, or lists no usable media. Never fabricates.
  */
-export async function resolveHistoryCompletionImages(
+export async function resolveHistoryCompletion(
   promptId: string,
   fetchHistory: (id: string) => Promise<Record<string, HistoryEntry>> = getHistory,
-): Promise<CompletionImage[]> {
+): Promise<ResolvedHistoryCompletion | undefined> {
   const id = typeof promptId === "string" ? promptId.trim() : "";
-  if (!id) return [];
+  if (!id) return undefined;
   try {
     const history = await fetchHistory(id);
     const entry = history?.[id];
-    if (!entry) return [];
-    return historyOutputRefsFromEntry(id, entry);
+    if (!entry) return undefined;
+    return parseHistoryCompletion(id, entry);
   } catch (err) {
     logger.debug(
       `[run-completion-watchdog] history fetch for ${id} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
-    return [];
+    return undefined;
   }
+}
+
+export async function resolveHistoryCompletionImages(
+  promptId: string,
+  fetchHistory: (id: string) => Promise<Record<string, HistoryEntry>> = getHistory,
+): Promise<CompletionImage[]> {
+  const parsed = await resolveHistoryCompletion(promptId, fetchHistory);
+  return parsed?.images ?? [];
 }
 
 /**
@@ -361,17 +397,44 @@ export async function resolveHistoryCompletionStatus(
  * out of a terminal record possibly a minute later. The note states the failure
  * plainly and names the tool that reads the detail.
  */
+function formatRunDuration(ms: number): string {
+  const totalSec = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSec / 60);
+  const seconds = totalSec % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}
+
+function resolvedFromOutputs(
+  value: CompletionPayload["images"] | ResolvedHistoryCompletion | undefined,
+): { images: CompletionImage[]; duration_ms?: number; timestamp?: string } {
+  if (!value) return { images: [] };
+  if (Array.isArray(value)) return { images: usableHistoryImages(value) };
+  return {
+    images: usableHistoryImages(value.images),
+    duration_ms: value.duration_ms,
+    timestamp: value.timestamp,
+  };
+}
+
 export function synthesizeCompletionPayload(
   armed: ArmedCompletion,
-  opts: { deliveredAt: number; images?: CompletionPayload["images"] },
+  opts: {
+    deliveredAt: number;
+    images?: CompletionPayload["images"];
+    durationMs?: number;
+    finishedAt?: string;
+  },
 ): CompletionPayload {
   const waitedS = Math.max(0, Math.round((opts.deliveredAt - armed.observedAt) / 1000));
   const { images, other: otherMedia } = partitionAttachableMedia(usableHistoryImages(opts.images));
+  const durationSuffix =
+    typeof opts.durationMs === "number" ? ` after ${formatRunDuration(opts.durationMs)}` : "";
   const outcome =
     armed.status === "success"
       ? "finished SUCCESSFULLY"
       : armed.status === "interrupted"
-        ? "was INTERRUPTED (cancelled before it finished)"
+        ? `was INTERRUPTED (cancelled before it finished)${durationSuffix}`
         : "FAILED";
   const refName = (m: CompletionImage) => (m.subfolder ? `${m.subfolder}/${m.filename}` : m.filename);
   const names = images.map(refName).join(", ");
@@ -401,6 +464,8 @@ export function synthesizeCompletionPayload(
     // Machine-readable provenance: this completion was NOT reported by the panel.
     completion_source: "orchestrator-history-watchdog",
     run_status: armed.status,
+    ...(typeof opts.durationMs === "number" ? { duration_ms: opts.durationMs } : {}),
+    ...(opts.finishedAt ? { finished_at: opts.finishedAt } : {}),
     note:
       `The render you queued (prompt ${armed.promptId}) ${outcome}. No completion for it reached the ` +
       `orchestrator in the ${waitedS}s after that finish was observed here, so this notice was ` +
@@ -472,7 +537,10 @@ export function createRunCompletionWatchdog({
       // simply means the next tick delivers. There is deliberately no floor —
       // one would be unreachable (proved by mutating it: nothing changed).
       const dueAfter = entry.extended ? storyboardGraceMs : graceMs;
-      if (!ignoreGrace && at - entry.observedAt < dueAfter) continue;
+      // Interrupted has no better panel frame coming (it is deferred until the
+      // next prompt, with wall-clock duration). Deliver at interrupt time (#2512).
+      const skipGrace = ignoreGrace || entry.status === "interrupted";
+      if (!skipGrace && at - entry.observedAt < dueAfter) continue;
       // Disarm FIRST and unconditionally: whatever happens below, this
       // observation is spent. Leaving it armed on a throwing deliver() would
       // re-fire it on every later tick.
@@ -504,9 +572,14 @@ export function createRunCompletionWatchdog({
       }
       try {
         let images: CompletionImage[] = [];
+        let durationMs: number | undefined;
+        let finishedAt: string | undefined;
         if (resolveOutputs) {
           try {
-            images = usableHistoryImages(await resolveOutputs(entry.promptId));
+            const resolved = resolvedFromOutputs(await resolveOutputs(entry.promptId));
+            images = resolved.images;
+            durationMs = resolved.duration_ms;
+            finishedAt = resolved.timestamp;
           } catch (err) {
             logger.debug(
               `[run-completion-watchdog] history outputs for ${entry.promptId} unavailable: ${err instanceof Error ? err.message : String(err)}`,
@@ -536,7 +609,7 @@ export function createRunCompletionWatchdog({
           // Deliberately NOT applied on reconcile(): that path is a missed-WS /
           // hello recovery whose whole point is that it does not wait (#1556).
           if (
-            !ignoreGrace &&
+            !skipGrace &&
             !entry.extended &&
             partitionAttachableMedia(images).other.length > 0
           ) {
@@ -557,7 +630,15 @@ export function createRunCompletionWatchdog({
             (at - entry.observedAt) / 1000,
           )}s ago and NO completion for it has reached the orchestrator — synthesising one from its own ComfyUI observation so the agent that was told to end its turn and wait is not left idle. The panel may never have sent one or may still be composing it; either way this run is answered now (#1789/#2001)`,
         );
-        deliver(synthesizeCompletionPayload(entry, { deliveredAt: at, images }), ticket);
+        deliver(
+          synthesizeCompletionPayload(entry, {
+            deliveredAt: at,
+            images,
+            durationMs,
+            finishedAt,
+          }),
+          ticket,
+        );
       } catch (err) {
         logger.warn(
           `[run-completion-watchdog] could not deliver the synthesised completion for prompt ${entry.promptId}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/services/job-history.ts
+++ b/src/services/job-history.ts
@@ -90,6 +90,32 @@ export function historyCompletionTimeMs(
   return ms;
 }
 
+/** Terminal history message: error wins over interrupt, interrupt over success. */
+export function historyTerminalMessage(
+  entry: HistoryEntry,
+): HistoryStatusMessage | undefined {
+  const messages = normalizeHistoryMessages(entry);
+  return (
+    messages.find((m) => m[0] === "execution_error") ??
+    messages.find((m) => m[0] === "execution_interrupted") ??
+    messages.find((m) => m[0] === "execution_success")
+  );
+}
+
+/**
+ * Real finish time from any terminal history message (success, error, or
+ * interrupt). `historyCompletionTimeMs` stays success-only for asset
+ * registration; interrupt/error timing is a display/duration fact (#2512).
+ */
+export function historyTerminalTimeMs(
+  entry: HistoryEntry,
+  now: number,
+): number | undefined {
+  const ms = normalizeEpochMs(historyTerminalMessage(entry)?.[1]?.timestamp);
+  if (ms === undefined || ms > now + 60_000) return undefined;
+  return ms;
+}
+
 const executionErrorSchema = z.object({
   node_id: z.union([z.string(), z.number()]).optional(),
   node_type: z.string().optional(),
@@ -211,10 +237,7 @@ export function extractExecutionStats(
 ): ExecutionStats | undefined {
   const messages = normalizeHistoryMessages(entry);
   const startTs = timestamp(messageData(entry, "execution_start"));
-  const endMsg = messages.find(
-    (m) => m[0] === "execution_success" || m[0] === "execution_error",
-  );
-  const endTs = timestamp(endMsg?.[1]);
+  const endTs = timestamp(historyTerminalMessage(entry)?.[1]);
   const nodes: ExecutionStats["nodes"] = {};
 
   let previousTs = startTs;

--- a/src/services/job-watcher.ts
+++ b/src/services/job-watcher.ts
@@ -20,6 +20,7 @@ import {
   analyzeHistoryEntry,
   hasAffirmativeSuccessStatus,
   historyCompletionTimeMs,
+  historyTerminalTimeMs,
   normalizeHistoryMessages,
   type ExecutionStats,
   type ExecutionErrorDetails,
@@ -155,18 +156,14 @@ export function buildCompletionNotification(
   const messages = normalizeHistoryMessages(entry);
   const analysis = analyzeHistoryEntry(entry);
 
-  // Timing
-  const startMsg = messages.find((m) => m[0] === "execution_start");
-  const endMsg = messages.find(
-    (m) => m[0] === "execution_success" || m[0] === "execution_error",
-  );
-  const startTs = (startMsg?.[1] as { timestamp?: number })?.timestamp;
-  const endTs = (endMsg?.[1] as { timestamp?: number })?.timestamp;
+  // Timing — interrupt is a terminal end event, same as success/error (#2512).
+  // Duration and finished-at come from ComfyUI's execution record, never from
+  // the moment this notification is later delivered.
+  const observedAt = Date.now();
+  const terminalAt = historyTerminalTimeMs(entry, observedAt);
   const durationMs =
     analysis.execution_stats?.total_duration_ms ??
-    (startTs && endTs
-      ? (endTs - startTs) * 1000 // ComfyUI timestamps are seconds
-      : Date.now() - startTime);
+    (terminalAt !== undefined ? Math.max(0, terminalAt - startTime) : observedAt - startTime);
 
   // Status
   const errorMsg = messages.find((m) => m[0] === "execution_error");
@@ -242,7 +239,7 @@ export function buildCompletionNotification(
     prompt_id: promptId,
     status,
     duration_ms: Math.round(durationMs),
-    timestamp: new Date().toISOString(),
+    timestamp: new Date(terminalAt ?? observedAt).toISOString(),
     error,
     outputs,
     video_outputs,

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -243,6 +243,9 @@ class QueueMonitorImpl {
   private completedReported = new Set<string>();
   // Completions not yet drained by the broadcaster. Bounded.
   private pendingCompletions: CompletionEvent[] = [];
+  /** Prompt that just left /queue this poll — record its history even if the
+   *  id was already in the tail (an in-progress row becoming interrupted). */
+  private vanishedPromptId: string | null = null;
   // ---- self-attribution for the backlog warning (#559) ----
   // Prompt ids THIS orchestrator queued via panel_run, plus the ms timestamp of
   // the most recent self-queue. A backlog made entirely of the agent's own recent
@@ -278,6 +281,7 @@ class QueueMonitorImpl {
     this.historySeen.clear();
     this.completedReported.clear();
     this.pendingCompletions.length = 0;
+    this.vanishedPromptId = null;
     this.state.lastCompleted = null;
     // Self-queued prompt ids belong to the OLD target — a fresh ComfyUI's jobs are
     // foreign to us until we queue them, so drop the attribution (#559).
@@ -798,6 +802,7 @@ class QueueMonitorImpl {
       // Empty queue → the tracked run is over. Skip the clear if a run was
       // adopted AFTER this fetch began (the response would be stale for it).
       if ((this.state.lastActivityTs ?? 0) <= fetchStart) {
+        this.vanishedPromptId = this.state.runningPromptId;
         this.clearRunning();
         this.emitEndIfIdle();
       }
@@ -821,11 +826,16 @@ class QueueMonitorImpl {
     } | null;
     const st = entry && typeof entry === "object" ? entry.status : undefined;
     const messages = Array.isArray(st?.messages) ? (st.messages as unknown[]) : [];
+    const has = (type: string) => messages.some((m) => Array.isArray(m) && m[0] === type);
     let status: CompletionStatus;
-    if (st?.completed === true || st?.status_str === "success" || st === undefined) {
-      status = "success";
-    } else if (messages.some((m) => Array.isArray(m) && m[0] === "execution_interrupted")) {
+    // Interrupt is terminal even when ComfyUI marks completed:true / status_str
+    // success-or-error — that used to classify a cancel as a successful finish.
+    if (has("execution_interrupted")) {
       status = "interrupted";
+    } else if (has("execution_error") || st?.status_str === "error") {
+      status = "error";
+    } else if (st?.completed === true || st?.status_str === "success" || st === undefined) {
+      status = "success";
     } else {
       status = "error";
     }
@@ -877,6 +887,29 @@ class QueueMonitorImpl {
     }
     for (const e of unseen) this.recordCompletion(e.id, e.status);
     this.historySeen = new Set(ids);
+    // A tracked run that left /queue this tick may already have been in the
+    // tail (in-progress). The unseen diff would miss it; record the terminal
+    // status now so an interrupt is not held until the next prompt (#2512).
+    const vanished = this.vanishedPromptId;
+    this.vanishedPromptId = null;
+    if (vanished && h[vanished] && !this.completedReported.has(vanished)) {
+      const terminal = this.terminalHistoryStatus(h[vanished]);
+      if (terminal) this.recordCompletion(vanished, terminal);
+    }
+  }
+
+  /** Fail-closed: only a proven finish (interrupt / error / completed success). */
+  private terminalHistoryStatus(raw: unknown): CompletionStatus | null {
+    if (!raw || typeof raw !== "object") return null;
+    const st = (raw as { status?: unknown }).status;
+    if (!st || typeof st !== "object") return null;
+    const status = st as { status_str?: unknown; completed?: unknown; messages?: unknown };
+    const messages = Array.isArray(status.messages) ? status.messages : [];
+    const has = (type: string) => messages.some((m) => Array.isArray(m) && m[0] === type);
+    if (has("execution_interrupted")) return "interrupted";
+    if (has("execution_error") || status.status_str === "error") return "error";
+    if (status.completed === true || status.status_str === "success") return "success";
+    return null;
   }
 
   /** Cheap snapshot for backpressure (panel_run) and the live `queue_status`


### PR DESCRIPTION
Fixes #2512

## Recurrence

Cancelling a running prompt (queue action:\"cancel\" → ComfyUI Global interrupt) did not emit a run-completion at interrupt time. The panel flushed \"Run finished … workflow completed in 79m 14s\" only when the NEXT got prompt arrived, with duration from original queue time to that later delivery. ComfyUI had already logged `Prompt executed in 00:21:08` at the interrupt.

## Gap this PR closes

- **Interrupt is terminal** — `execution_interrupted` wins over `completed:true` in history status, duration, and finished-at (`buildCompletionNotification` / `extractExecutionStats`).
- **Deliver immediately** — the run-completion watchdog skips the panel-compose grace for interrupted runs and journals via `RunCompletions` at interrupt time.
- **QueueMonitor records a cancel already in the history tail** — a tracked prompt that leaves `/queue` is looked up even if its id was primed as in-progress, so the interrupt is not held until the next prompt.

## Tests

`npx vitest run src/__tests__/orchestrator/run-completion-interrupt-timing.test.ts src/__tests__/orchestrator/run-completion-watchdog.test.ts src/__tests__/services/job-watcher.test.ts src/__tests__/services/job-history.test.ts src/__tests__/services/queue-monitor.poll.test.ts src/__tests__/orchestrator/run-completion-fallback-wiring.test.ts`