### PR TITLE
fix(2521): do not claim queued_unknown left the panel when ComfyUI never got the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_run does not claim a /prompt left the panel when ComfyUI never logged a prompt; id-less queued_unknown fails closed as not queued (#2521)
 - panel_set_widget treats a root-scope promoted widget as the authoritative parent rail and suppresses the inner link-driven warning (#2514)
 - drain an empty-success Git install enqueue before using the verified local clone fallback (#2620)
 

--- a/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
+++ b/src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildPanelToolDefs,
   makePanelToolCtx,
+  __panelRunTestHooks,
   __panelToolsTestHooks,
   type PanelToolCtx,
 } from "../../orchestrator/panel-tools.js";
@@ -39,6 +40,7 @@ function textOf(res: { content?: Array<{ type: string; text?: string }> }): stri
 
 beforeEach(() => {
   __panelToolsTestHooks.setRunLateAckGraceMs(450);
+  __panelRunTestHooks.setGotPromptLinesProbe(async () => null);
   RunCompletions.reset();
   qm.selfQueuedIds.clear();
   qm.lastSelfQueueTs = null;
@@ -52,6 +54,7 @@ beforeEach(() => {
 
 afterEach(() => {
   __panelToolsTestHooks.setRunLateAckGraceMs(null);
+  __panelRunTestHooks.setGotPromptLinesProbe(null);
   RunCompletions.reset();
   qm.selfQueuedIds.clear();
   qm.lastSelfQueueTs = null;
@@ -427,7 +430,11 @@ describe("panel_run late prompt reconciliation (#1728)", () => {
       return true;
     });
     expect(frames).toHaveLength(1);
-    expect(res.isError).toBeFalsy();
+    // Idle observed queue + unread logs fail closed as not queued (#2521). The
+    // beyond-grace receipt still tickets; the handler result is that closed
+    // verdict, not a claim that /prompt left the panel.
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).not.toContain("already left the panel");
   });
 
   it("registers a timeout handoff before returning so a beyond-grace receipt still tickets", async () => {

--- a/src/__tests__/orchestrator/panel-run-2521-queued-unknown-no-prompt.test.ts
+++ b/src/__tests__/orchestrator/panel-run-2521-queued-unknown-no-prompt.test.ts
@@ -1,0 +1,333 @@
+// #2521 — panel_run returned queued_unknown three times while ComfyUI never
+// logged "got prompt" and the queue stayed empty. retry_guidance still said a
+// /prompt had left the panel and may have been accepted. Fail closed as not
+// queued when there is no prompt_id and the server never logged a prompt.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  __panelRunTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+
+const LEFT_THE_PANEL = "already left the panel";
+const MAY_HAVE_BEEN_ACCEPTED = "may have been accepted";
+const UNFIXED_QUEUE_LIST = 'queue (action:"list")';
+
+type QueueMonitorPrivate = {
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    queueRemaining: number;
+    lastCompleted: { promptId: string; status: string; at: number } | null;
+  };
+};
+
+const qm = QueueMonitor as QueueMonitorPrivate;
+
+function panelRun() {
+  const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_run");
+  if (!def) throw new Error("panel_run tool not found");
+  return def;
+}
+
+function textOf(res: { content?: Array<{ type: string; text?: string }> }): string {
+  return res.content?.find((content) => content.type === "text")?.text ?? "";
+}
+
+function queuedUnknownReply(extra: Record<string, unknown> = {}): ToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          queued_unknown: true,
+          indeterminate_count: 1,
+          error:
+            "The full-graph run could not be confirmed: the frontend's queue call did not answer within this run's 15s command budget (#1565).",
+          retry_guidance:
+            "No prompt was CONFIRMED queued, but 1 /prompt request(s) DID leave the panel — ComfyUI may have been accepted them.",
+          ...extra,
+        }),
+      },
+    ],
+  };
+}
+
+function makeRunCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: unknown[] } {
+  const calls: unknown[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      calls.push(cmd);
+      return reply;
+    },
+    confirm: async () => "yes" as const,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "test-tab-2521",
+  };
+  return { ctx, calls };
+}
+
+function resetQueueMonitor(): void {
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.connected = false;
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.queueRemaining = 0;
+  qm.state.lastCompleted = null;
+}
+
+beforeEach(() => {
+  RunCompletions.reset();
+  resetQueueMonitor();
+});
+
+afterEach(() => {
+  __panelRunTestHooks.setGotPromptLinesProbe(null);
+  RunCompletions.reset();
+  resetQueueMonitor();
+});
+
+describe("classifyQueuedUnknownReach (#2521)", () => {
+  const dispatchedAt = Date.parse("2026-08-29T14:09:00");
+
+  it("fail-closes when logs are readable and have no post-dispatch got prompt", () => {
+    const reach = __panelRunTestHooks.classifyQueuedUnknownReach({
+      dispatchedAt,
+      logLines: [
+        "2026-08-29T14:08:24 - [INFO] got prompt",
+        "2026-08-29T14:08:48 - [INFO] Prompt executed in 24.18 seconds",
+      ],
+      queueObserved: true,
+      queueIdle: true,
+      newPromptVisible: false,
+      completedAfterDispatch: false,
+    });
+    expect(reach.kind).toBe("not-queued");
+    expect(reach.gotPrompt).toBe(false);
+  });
+
+  it("treats an empty readable log as not queued", () => {
+    const reach = __panelRunTestHooks.classifyQueuedUnknownReach({
+      dispatchedAt,
+      logLines: [],
+      queueObserved: false,
+      queueIdle: true,
+      newPromptVisible: false,
+      completedAfterDispatch: false,
+    });
+    expect(reach.kind).toBe("not-queued");
+  });
+
+  it("keeps reached when a got prompt lands after dispatch", () => {
+    const reach = __panelRunTestHooks.classifyQueuedUnknownReach({
+      dispatchedAt,
+      logLines: [
+        "2026-08-29T14:08:24 - [INFO] got prompt",
+        "2026-08-29T14:09:05 - [INFO] got prompt",
+      ],
+      queueObserved: true,
+      queueIdle: true,
+      newPromptVisible: false,
+      completedAfterDispatch: false,
+    });
+    expect(reach.kind).toBe("reached");
+    expect(reach.gotPrompt).toBe(true);
+  });
+
+  it("does not fail closed when logs are unread and the queue was not observed", () => {
+    const reach = __panelRunTestHooks.classifyQueuedUnknownReach({
+      dispatchedAt,
+      logLines: null,
+      queueObserved: false,
+      queueIdle: true,
+      newPromptVisible: false,
+      completedAfterDispatch: false,
+    });
+    expect(reach.kind).toBe("unobserved");
+  });
+
+  it("fail-closes on an observed idle queue when logs are unread", () => {
+    const reach = __panelRunTestHooks.classifyQueuedUnknownReach({
+      dispatchedAt,
+      logLines: null,
+      queueObserved: true,
+      queueIdle: true,
+      newPromptVisible: false,
+      completedAfterDispatch: false,
+    });
+    expect(reach.kind).toBe("not-queued");
+  });
+
+  it("keeps reached when a new queue prompt is visible even without a log line", () => {
+    const reach = __panelRunTestHooks.classifyQueuedUnknownReach({
+      dispatchedAt,
+      logLines: null,
+      queueObserved: true,
+      queueIdle: false,
+      newPromptVisible: true,
+      completedAfterDispatch: false,
+    });
+    expect(reach.kind).toBe("reached");
+  });
+});
+
+describe("logHasGotPromptAfter (#2521)", () => {
+  const dispatchedAt = Date.parse("2026-08-29T14:09:00");
+
+  it("ignores a got prompt that finished before this dispatch", () => {
+    expect(
+      __panelRunTestHooks.logHasGotPromptAfter(
+        ["2026-08-29T14:08:24 - [INFO] got prompt"],
+        dispatchedAt,
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts ISO and space-separated ComfyUI timestamps after dispatch", () => {
+    expect(
+      __panelRunTestHooks.logHasGotPromptAfter(
+        ["2026-08-29T14:09:12 - [INFO] got prompt"],
+        dispatchedAt,
+      ),
+    ).toBe(true);
+    expect(
+      __panelRunTestHooks.logHasGotPromptAfter(
+        ["2026-08-29 14:09:12 [INFO] got prompt"],
+        dispatchedAt,
+      ),
+    ).toBe(true);
+  });
+
+  it("treats an untimestamped got prompt as possible evidence", () => {
+    expect(__panelRunTestHooks.logHasGotPromptAfter(["[INFO] got prompt"], dispatchedAt)).toBe(
+      true,
+    );
+  });
+});
+
+describe("panel_run id-less queued_unknown fails closed when ComfyUI never got the prompt (#2521)", () => {
+  it("full-graph: empty logs + idle queue is not queued, and does not claim the request left the panel", async () => {
+    __panelRunTestHooks.setGotPromptLinesProbe(async () => [
+      "2026-08-29T14:08:24 - [INFO] got prompt",
+      "2026-08-29T14:08:48 - [INFO] Prompt executed in 24.18 seconds",
+    ]);
+    qm.state.connected = true;
+    const { ctx, calls } = makeRunCtx(queuedUnknownReply());
+
+    const res = await panelRun().handler({}, ctx);
+    const text = textOf(res);
+
+    expect(calls).toHaveLength(1);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/not queued|did not queue|never logged/i);
+    expect(text).toContain("got prompt");
+    expect(text.toLowerCase()).toContain("you may retry");
+    expect(text).not.toContain(LEFT_THE_PANEL);
+    expect(text.toLowerCase()).not.toContain(MAY_HAVE_BEEN_ACCEPTED);
+    expect(text).not.toContain(UNFIXED_QUEUE_LIST);
+    expect(text).not.toContain("[UNCERTAIN]");
+    expect(QueueMonitor.attributeRun("anything")).toBe("not-mine");
+  });
+
+  it("scoped run: the same empty-log idle-queue shape is not queued", async () => {
+    __panelRunTestHooks.setGotPromptLinesProbe(async () => []);
+    qm.state.connected = true;
+    const { ctx, calls } = makeRunCtx(
+      queuedUnknownReply({
+        error:
+          "The queue acknowledgement did not include a usable prompt_id, so the panel cannot confirm or correlate this run.",
+      }),
+    );
+
+    const res = await panelRun().handler({ to_node_id: 35 }, ctx);
+    const text = textOf(res);
+
+    expect(calls).toHaveLength(1);
+    expect(res.isError).toBe(true);
+    expect(text).not.toContain(LEFT_THE_PANEL);
+    expect(text.toLowerCase()).not.toContain(MAY_HAVE_BEEN_ACCEPTED);
+    expect(text.toLowerCase()).toContain("you may retry");
+    expect(text).toContain("enqueue_workflow");
+  });
+
+  it("keeps queued_unknown when ComfyUI DID log got prompt after dispatch", async () => {
+    __panelRunTestHooks.setGotPromptLinesProbe(async () => [
+      "2099-01-01T00:00:00 - [INFO] got prompt",
+    ]);
+    qm.state.connected = true;
+    const { ctx, calls } = makeRunCtx(queuedUnknownReply());
+
+    const res = await panelRun().handler({ to_node_id: 9 }, ctx);
+    const text = textOf(res);
+
+    expect(calls).toHaveLength(1);
+    expect(res.isError).toBeFalsy();
+    expect(text).toContain("[UNCERTAIN]");
+    expect(text).toContain("Do NOT re-run panel_run");
+    expect(text).toContain(LEFT_THE_PANEL);
+  });
+
+  it("unread logs + unobserved queue do not claim the request left the panel", async () => {
+    __panelRunTestHooks.setGotPromptLinesProbe(async () => null);
+    const { ctx, calls } = makeRunCtx(queuedUnknownReply());
+
+    const res = await panelRun().handler({}, ctx);
+    const text = textOf(res);
+
+    expect(calls).toHaveLength(1);
+    expect(res.isError).toBeFalsy();
+    expect(text).toContain("[UNCERTAIN]");
+    expect(text).not.toContain(LEFT_THE_PANEL);
+    expect(text.toLowerCase()).not.toContain(MAY_HAVE_BEEN_ACCEPTED);
+    expect(text).toContain(__panelRunTestHooks.PANEL_QUEUED_UNKNOWN_UNOBSERVED_RETRY_GUIDANCE);
+    expect(text).not.toContain(UNFIXED_QUEUE_LIST);
+  });
+
+  it("partial queued_unknown with known ids is still ticketed, not fail-closed", async () => {
+    __panelRunTestHooks.setGotPromptLinesProbe(async () => []);
+    qm.state.connected = true;
+    const { ctx, calls } = makeRunCtx(
+      queuedUnknownReply({
+        queued: true,
+        complete: false,
+        partially_queued: true,
+        queued_prompt_ids: ["p-known-2521"],
+      }),
+    );
+
+    const res = await panelRun().handler({ batch_count: 2, to_node_id: 9 }, ctx);
+    const text = textOf(res);
+
+    expect(calls).toHaveLength(1);
+    expect(res.isError).toBeFalsy();
+    expect(RunCompletions.ticketFor("p-known-2521")).toBeDefined();
+    expect(text).toContain("p-known-2521");
+    expect(text).toContain("[UNCERTAIN]");
+  });
+
+  it("the not-queued fail string itself never claims a /prompt left the panel", () => {
+    const msg = __panelRunTestHooks.panelQueueNotQueuedMessage({
+      kind: "not-queued",
+      gotPrompt: false,
+      queueIdle: true,
+      queueObserved: true,
+    });
+    expect(msg.toLowerCase()).toContain("did not queue");
+    expect(msg.toLowerCase()).toContain("nothing was queued");
+    expect(msg).toContain("got prompt");
+    expect(msg.toLowerCase()).toContain("you may retry");
+    expect(msg).toContain("enqueue_workflow");
+    expect(msg).not.toContain(LEFT_THE_PANEL);
+    expect(msg.toLowerCase()).not.toContain(MAY_HAVE_BEEN_ACCEPTED);
+    expect(msg).not.toContain(UNFIXED_QUEUE_LIST);
+    expect(msg).not.toContain("Do NOT re-run panel_run");
+  });
+});

--- a/src/__tests__/orchestrator/panel-run-queued-unknown-guidance.test.ts
+++ b/src/__tests__/orchestrator/panel-run-queued-unknown-guidance.test.ts
@@ -44,9 +44,11 @@ function makeRunCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: unknown[] } 
 
 beforeEach(() => {
   RunCompletions.reset();
+  __panelRunTestHooks.setGotPromptLinesProbe(async () => null);
 });
 
 afterEach(() => {
+  __panelRunTestHooks.setGotPromptLinesProbe(null);
   RunCompletions.reset();
 });
 
@@ -110,9 +112,9 @@ describe("panel_run queued_unknown guidance stays on this surface (#2438)", () =
     expect(text.toLowerCase()).not.toContain(UNFIXED_QUEUE_ACTION_LIST);
     expect(text).not.toContain(UNFIXED_FOLLOW_PANEL);
     expect(text).toContain("[UNCERTAIN]");
-    expect(text).toContain("Do NOT re-run panel_run");
-    expect(text).toContain("no render-queue inspection tool");
-    expect(text).toContain("UNDETERMINED completion");
+    expect(text).not.toContain("already left the panel");
+    expect(text.toLowerCase()).not.toContain("may have been accepted");
+    expect(text).toContain(__panelRunTestHooks.PANEL_QUEUED_UNKNOWN_UNOBSERVED_RETRY_GUIDANCE);
     expect(text).toContain("No second panel_run was dispatched");
   });
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1914,21 +1914,25 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
         },
       ],
     };
+    __panelRunTestHooks.setGotPromptLinesProbe(async () => null);
     const { ctx, calls } = makeRunCtx(reply);
-    const res = await defByName("panel_run").handler({ to_node_id: 9 }, ctx);
+    try {
+      const res = await defByName("panel_run").handler({ to_node_id: 9 }, ctx);
 
-    // A normal Panel timeout receipt must stay non-error. #2438 rewrites the
-    // Panel's retry_guidance onto this surface (no live render-queue inspector)
-    // rather than forwarding it verbatim. The handler still performs no second
-    // dispatch and cannot ticket an unidentifiable completion.
-    expect(res.isError).toBeFalsy();
-    expect(calls).toHaveLength(1);
-    const text = textOf(res);
-    expect(text).toContain("[UNCERTAIN]");
-    expect(text).toContain("Do NOT re-run panel_run");
-    expect(text).toContain("UNDETERMINED completion");
-    expect(text).not.toContain(QUEUED_NOTE);
-    expect(text).not.toContain("ComfyUI refused to queue");
+      // Logs unread and the watchdog was not observed: stay non-error UNCERTAIN,
+      // but #2521 forbids claiming a /prompt left the panel. A readable empty
+      // log (or an observed idle queue) fails closed as not queued instead.
+      expect(res.isError).toBeFalsy();
+      expect(calls).toHaveLength(1);
+      const text = textOf(res);
+      expect(text).toContain("[UNCERTAIN]");
+      expect(text).not.toContain("already left the panel");
+      expect(text.toLowerCase()).not.toContain("may have been accepted");
+      expect(text).not.toContain(QUEUED_NOTE);
+      expect(text).not.toContain("ComfyUI refused to queue");
+    } finally {
+      __panelRunTestHooks.setGotPromptLinesProbe(null);
+    }
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -438,6 +438,7 @@ import {
 } from "./ask-answer-journal.js";
 import {
   getClient,
+  getLogs,
   getQueueVerified,
   resetClient,
   resetObjectInfoCache,
@@ -9466,6 +9467,10 @@ function isPanelQueueUncertainty(parsed: Record<string, unknown> | null): boolea
  * headless stdio tool and may be unreachable (ECONNREFUSED) even while the
  * panel is connected. The only safe next step on this surface is to wait for
  * an eventual UNDETERMINED completion and not re-dispatch.
+ *
+ * #2521 — this string is only honest when something actually reached ComfyUI
+ * (a post-dispatch `got prompt` log line, or a new queue/history entry). An
+ * id-less `queued_unknown` with neither is fail-closed as not queued instead.
  */
 const PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE =
   `Do NOT re-run panel_run: the /prompt request already left the panel, and a second ` +
@@ -9474,10 +9479,42 @@ const PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE =
   `event for this tab; if one arrives, treat it as this run's possible outcome rather ` +
   `than queuing another.`;
 
-function applyQueuedUnknownRetryGuidance(res: ToolResult): ToolResult {
+/** #2521 — used when queued_unknown has no prompt_id and this tool also could
+ *  not prove a /prompt reached ComfyUI. Must not claim the request left the
+ *  panel or was accepted. */
+const PANEL_QUEUED_UNKNOWN_UNOBSERVED_RETRY_GUIDANCE =
+  `This tool is NOT claiming a /prompt request left the panel or was accepted: there is ` +
+  `no prompt_id, and it could not prove ComfyUI received the run. If ComfyUI is idle, ` +
+  `you MAY retry panel_run or use enqueue_workflow; if a render may already be in flight, ` +
+  `wait rather than stacking a duplicate.`;
+
+const GOT_PROMPT_RE = /got prompt/i;
+const COMFY_LOG_TS_RE = /^(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?)/;
+const GOT_PROMPT_CLOCK_SLACK_MS = 2000;
+const GOT_PROMPT_LOG_BUDGET_MS = 2500;
+
+export type QueuedUnknownReach = {
+  kind: "reached" | "not-queued" | "unobserved";
+  gotPrompt: boolean;
+  queueIdle: boolean;
+  queueObserved: boolean;
+};
+
+export type QueuedUnknownReachInput = {
+  dispatchedAt: number;
+  logLines: string[] | null;
+  queueObserved: boolean;
+  queueIdle: boolean;
+  newPromptVisible: boolean;
+  completedAfterDispatch: boolean;
+};
+
+let gotPromptLinesProbe: (() => Promise<string[] | null>) | null = null;
+
+function rewriteQueuedUnknownRetryGuidance(res: ToolResult, guidance: string): ToolResult {
   const parsed = parseToolResultJson(res);
   if (!parsed || !isPanelQueueUncertainty(parsed)) return res;
-  if (parsed.retry_guidance === PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE) return res;
+  if (parsed.retry_guidance === guidance) return res;
   return {
     ...res,
     content: [
@@ -9485,12 +9522,133 @@ function applyQueuedUnknownRetryGuidance(res: ToolResult): ToolResult {
         type: "text",
         text: JSON.stringify({
           ...parsed,
-          retry_guidance: PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE,
+          retry_guidance: guidance,
         }),
       },
       ...res.content.slice(1),
     ],
   };
+}
+
+function applyQueuedUnknownRetryGuidance(res: ToolResult): ToolResult {
+  return rewriteQueuedUnknownRetryGuidance(res, PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE);
+}
+
+function applyUnobservedQueuedUnknownRetryGuidance(res: ToolResult): ToolResult {
+  return rewriteQueuedUnknownRetryGuidance(res, PANEL_QUEUED_UNKNOWN_UNOBSERVED_RETRY_GUIDANCE);
+}
+
+function logLineTimestampMs(line: string): number | null {
+  const m = line.match(COMFY_LOG_TS_RE);
+  if (!m) return null;
+  const raw = m[1]!;
+  const ts = Date.parse(raw.includes("T") ? raw : raw.replace(" ", "T"));
+  return Number.isFinite(ts) ? ts : null;
+}
+
+/** True when `/internal/logs` contains a `got prompt` that is not clearly
+ *  earlier than this dispatch. Untimestamped lines are possible evidence: the
+ *  in-memory deque is recent, so fail-closed would be a guess. */
+function logHasGotPromptAfter(lines: readonly string[], dispatchedAt: number): boolean {
+  let untimestamped = false;
+  for (const line of lines) {
+    if (!GOT_PROMPT_RE.test(line)) continue;
+    const ts = logLineTimestampMs(line);
+    if (ts === null) {
+      untimestamped = true;
+      continue;
+    }
+    if (ts >= dispatchedAt - GOT_PROMPT_CLOCK_SLACK_MS) return true;
+  }
+  return untimestamped;
+}
+
+function classifyQueuedUnknownReach(input: QueuedUnknownReachInput): QueuedUnknownReach {
+  const gotPrompt =
+    input.logLines !== null && logHasGotPromptAfter(input.logLines, input.dispatchedAt);
+  if (gotPrompt || input.newPromptVisible || input.completedAfterDispatch) {
+    return {
+      kind: "reached",
+      gotPrompt,
+      queueIdle: input.queueIdle,
+      queueObserved: input.queueObserved,
+    };
+  }
+  const logNegative = input.logLines !== null;
+  if (logNegative || (input.queueObserved && input.queueIdle)) {
+    return {
+      kind: "not-queued",
+      gotPrompt: false,
+      queueIdle: input.queueIdle,
+      queueObserved: input.queueObserved,
+    };
+  }
+  return {
+    kind: "unobserved",
+    gotPrompt: false,
+    queueIdle: input.queueIdle,
+    queueObserved: input.queueObserved,
+  };
+}
+
+function panelQueueNotQueuedMessage(reach: QueuedUnknownReach): string {
+  const logBit = reach.gotPrompt
+    ? ""
+    : "and ComfyUI never logged 'got prompt' for this dispatch";
+  const queueBit = reach.queueObserved && reach.queueIdle ? ", and the queue is idle" : "";
+  return (
+    `panel_run did not queue this run. The Panel returned queued_unknown with no prompt_id, ` +
+    `${logBit}${queueBit}. This tool is NOT claiming a /prompt request left the panel or was ` +
+    `accepted — that request never reached ComfyUI. You MAY retry panel_run, or use ` +
+    `enqueue_workflow. Nothing was queued.`
+  );
+}
+
+async function readGotPromptLines(): Promise<string[] | null> {
+  if (gotPromptLinesProbe) {
+    try {
+      return await gotPromptLinesProbe();
+    } catch {
+      return null;
+    }
+  }
+  try {
+    return await Promise.race([
+      // unknown-ok: failed log read and empty log both fail closed as not queued (#2521)
+      getLogs({ keyword: "got prompt" }).catch(() => null),
+      sleep(GOT_PROMPT_LOG_BUDGET_MS).then(() => null),
+    ]);
+  } catch {
+    return null;
+  }
+}
+
+async function observeQueuedUnknownReach(opts: {
+  dispatchedAt: number;
+  preRunningPromptId: string | null;
+  preQueueDepth: number;
+}): Promise<QueuedUnknownReach> {
+  try {
+    await QueueMonitor.poll();
+  } catch {
+    /* best-effort — classify from whatever snapshot we already have */
+  }
+  const snap = QueueMonitor.snapshot();
+  const newPromptVisible =
+    promptAppearedAfterDispatch(opts.preRunningPromptId) !== null ||
+    snap.queueDepth > opts.preQueueDepth;
+  const completedAfterDispatch =
+    snap.lastCompleted !== null && snap.lastCompleted.at >= opts.dispatchedAt;
+  const queueIdle = !snap.running && snap.queueDepth === 0;
+  const logLines = await readGotPromptLines();
+  return classifyQueuedUnknownReach({
+    dispatchedAt: opts.dispatchedAt,
+    logLines,
+    queueObserved: snap.connected,
+    queueIdle,
+    newPromptVisible,
+    completedAfterDispatch,
+  });
 }
 
 function detectRunRejection(res: ToolResult): ToolResult | null {
@@ -9654,7 +9812,15 @@ export const __panelRunTestHooks = {
   isSeedRunToNodeStampRace,
   describeDroppedOutputs,
   applyQueuedUnknownRetryGuidance,
+  applyUnobservedQueuedUnknownRetryGuidance,
   PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE,
+  PANEL_QUEUED_UNKNOWN_UNOBSERVED_RETRY_GUIDANCE,
+  classifyQueuedUnknownReach,
+  logHasGotPromptAfter,
+  panelQueueNotQueuedMessage,
+  setGotPromptLinesProbe(fn: (() => Promise<string[] | null>) | null): void {
+    gotPromptLinesProbe = fn;
+  },
 };
 
 /** Drop a trailing .json (case-insensitive) so filename/path forms compare equal. */
@@ -17099,6 +17265,11 @@ function panelLateReceiptNote(promptId: string): string {
  * #2143 / #2438 — a normal Panel timeout receipt is neither a confirmed queue
  * nor a refusal. Name the next step that exists on THIS surface rather than
  * forwarding Panel retry_guidance that points at a headless queue inspector.
+ *
+ * #2521 — the "left the panel" wording is only used when this tool saw a
+ * post-dispatch `got prompt` or a new queue/history entry. An id-less receipt
+ * with neither is fail-closed as not queued; an unread/unobserved case uses
+ * panelQueueUnobservedNote instead of this string.
  */
 function panelQueueUncertaintyNote(queuedPromptIds: readonly string[]): string {
   if (queuedPromptIds.length > 0) {
@@ -17113,6 +17284,17 @@ function panelQueueUncertaintyNote(queuedPromptIds: readonly string[]): string {
     `\n\n[UNCERTAIN] The Panel could not determine whether this run entered ComfyUI's queue. ` +
     `This is not a confirmed refusal, and no completion ticket can be opened without a prompt id. ` +
     `${PANEL_QUEUED_UNKNOWN_RETRY_GUIDANCE} No second panel_run was dispatched.`
+  );
+}
+
+/** #2521 — id-less queued_unknown, and this tool could not read a prompt
+ *  reaching ComfyUI either. Honest about the gap; does not forbid a retry. */
+function panelQueueUnobservedNote(): string {
+  return (
+    `\n\n[UNCERTAIN] The Panel could not confirm whether this run entered ComfyUI's queue, ` +
+    `and this tool also could not prove a /prompt reached ComfyUI (no prompt_id; logs unread; ` +
+    `no live queue observation). It is NOT claiming a request left the panel or was accepted. ` +
+    `${PANEL_QUEUED_UNKNOWN_UNOBSERVED_RETRY_GUIDANCE} No second panel_run was dispatched.`
   );
 }
 
@@ -21004,6 +21186,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
         const panelQueueUncertain = isPanelQueueUncertainty(runReply);
+        // #2521 — an id-less queued_unknown is not proof that /prompt left the
+        // panel. Check ComfyUI's log + queue before claiming acceptance: no
+        // prompt_id and no `got prompt` (or an observed idle queue) fails closed
+        // as not queued. A late Panel receipt can still open a ticket.
+        let queuedUnknownReach: QueuedUnknownReach | null = null;
+        if (panelQueueUncertain && queuedIds.length === 0) {
+          queuedUnknownReach = await observeQueuedUnknownReach({
+            dispatchedAt: runDispatchedAt,
+            preRunningPromptId: pre.runningPromptId,
+            preQueueDepth: pre.queueDepth,
+          });
+          if (queuedUnknownReach.kind === "not-queued") {
+            installLateReceiptHandoff();
+            return fail(panelQueueNotQueuedMessage(queuedUnknownReach));
+          }
+        }
         // #944: a run ComfyUI accepted while dropping some outputs reaches here
         // (a minted prompt id outranks the rejection signals). Say which outputs
         // were dropped, or the caller waits for files that will never be written.
@@ -21025,12 +21223,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               `and this dispatch stacked a duplicate.`
             : "";
         // markSelfQueued with NO id still stamps the recent-self-queue timestamp,
-        // so both the id-less genuine queue and the Panel's explicit uncertainty
-        // receipt must call it exactly once (#559/#2143). The latter must not be
-        // mistaken for a definite queue, but it is still unsafe to immediately
-        // redispatch a request that the Panel says left its tab.
-        if (queuedIds.length === 0 || panelQueueUncertain) QueueMonitor.markSelfQueued(null);
-        for (const id of queuedIds) QueueMonitor.markSelfQueued(id);
+        // so both the id-less genuine queue and a queued_unknown that DID reach
+        // ComfyUI must call it (#559/#2143/#2521). An unobserved id-less receipt
+        // must not pretend a request left the tab.
+        if (queuedIds.length > 0) {
+          if (panelQueueUncertain) QueueMonitor.markSelfQueued(null);
+          for (const id of queuedIds) QueueMonitor.markSelfQueued(id);
+        } else if (!panelQueueUncertain || queuedUnknownReach?.kind === "reached") {
+          QueueMonitor.markSelfQueued(null);
+        }
         // #468 — open a run ticket so the render's completion can be CORRELATED
         // to this exact call by prompt id. This is what lets the orchestrator
         // journal an undelivered completion and replay it into the right run
@@ -21115,7 +21316,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             ? ""
             : ` (this run queued ${queuedIds.length} prompts, so the check is the queue as a whole; get_history settles the outcome of any that are no longer in flight)`;
         const note = panelQueueUncertain
-          ? panelQueueUncertaintyNote(ticketedPromptIds)
+          ? queuedUnknownReach?.kind === "unobserved"
+            ? panelQueueUnobservedNote()
+            : panelQueueUncertaintyNote(ticketedPromptIds)
           : correlatable
           ? "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll queue (action:\"list\"), get_history, or get_image (action:\"list_outputs\"). Just end your turn now and wait for the result to be delivered to you." +
             `\n[FALLBACK] That notification is journaled and replayed if an agent is not there to take it, and the orchestrator will fill one in from ComfyUI itself — its execution event or its history record — if the panel never reports the finish. But it cannot be GUARANTEED, so do not wait forever on it. If nothing has arrived LONG after this render should have finished (roughly twice the time you expect it to take), make ONE check with ${fallbackCheck} instead of idling indefinitely${fallbackTail}. One check, not a loop — and not before then.`
@@ -21170,7 +21373,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // #2438 — rewrite Panel retry_guidance BEFORE the notes are spliced so
         // a headless `queue (action:"list")` inspector is not left in the JSON
         // for a surface that cannot call it.
-        if (panelQueueUncertain) res = applyQueuedUnknownRetryGuidance(res);
+        // #2521 — the "left the panel" wording is only for a reach we observed.
+        if (panelQueueUncertain) {
+          res =
+            queuedUnknownReach?.kind === "unobserved"
+              ? applyUnobservedQueuedUnknownRetryGuidance(res)
+              : applyQueuedUnknownRetryGuidance(res);
+        }
         if (res.content?.[0]?.type === "text") {
           return {
             ...res,


### PR DESCRIPTION
## Summary
- `panel_run` no longer claims a `/prompt` request left the panel (or may have been accepted) when there is no `prompt_id` and ComfyUI never logged `got prompt`.
- Id-less `queued_unknown` fails closed as not queued when logs show no post-dispatch prompt or the observed queue is idle; the caller may retry or use `enqueue_workflow`.
- If logs and the queue were unread, keep `[UNCERTAIN]` but drop the false “left the panel” wording. Partial receipts with known ids still ticket.

## Tests
- `npx vitest run src/__tests__/orchestrator/panel-run-2521-queued-unknown-no-prompt.test.ts src/__tests__/orchestrator/panel-run-queued-unknown-guidance.test.ts src/__tests__/orchestrator/panel-run-1728-late-prompt.test.ts src/__tests__/orchestrator/panel-tools.test.ts src/__tests__/orchestrator/run-late-ack-reconcile.test.ts --passWithNoTests`
- `npx tsc --noEmit`
- `node scripts/check-anti-slop.mjs`

Closes #2521
