### PR TITLE
fix(2518): do not classify a root widget as promoted after a root graph read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_set_widget does not classify a root widget as promoted after a root-scope graph read, and a successful mode:current rebind clears leftover subgraph identity (#2518)
 - panel_set_widget treats a root-scope promoted widget as the authoritative parent rail and suppresses the inner link-driven warning (#2514)
 - drain an empty-success Git install enqueue before using the verified local clone fallback (#2620)
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -164,6 +164,8 @@ function bridge(opts: {
   };
   omitWorkflowUuid?: boolean;
   workflowUuid?: string;
+  /** Leave graph_query without a viewing witness so the scope is genuinely unknown. */
+  omitViewing?: boolean;
   /** The outer node id used by the current fake viewing scope. */
   ownerNodeId?: number;
   /** #2394: begin the fake panel inside a subgraph for active-view scope tests. */
@@ -221,9 +223,11 @@ function bridge(opts: {
     ...(opts.omitWorkflowUuid ? {} : { workflow_uuid: workflowUuid }),
   });
   const withCurrentViewing = (value: Record<string, unknown>): Record<string, unknown> => {
-    let result = Object.prototype.hasOwnProperty.call(value, "viewing")
+    let result = opts.omitViewing
       ? value
-      : { ...value, viewing: currentViewing() };
+      : Object.prototype.hasOwnProperty.call(value, "viewing")
+        ? value
+        : { ...value, viewing: currentViewing() };
     if (
       !legacyBuild &&
       identityFenceCapability &&
@@ -1217,6 +1221,7 @@ describe("panel_set_widget ordinary-node scope probe fence (#2401)", () => {
       { node_id: 82, widget: "lora_1", value },
       {
         firstWrite: "ok",
+        omitViewing: true,
         promotedDetail: { nodes: [{ id: 82, type: "Power Lora Loader (rgthree)" }] },
         subgraph: new Error("graph_get_subgraph unavailable"),
       },
@@ -1231,6 +1236,76 @@ describe("panel_set_widget ordinary-node scope probe fence (#2401)", () => {
     ]);
     expect(writesApplied).toBe(0);
     expect(mutations).toBe(0);
+  });
+});
+
+describe("panel_set_widget root-scope write after a root graph read (#2518)", () => {
+  const STRING_CONCAT_ID = 53;
+  const ROOT_GRAPH_IDENTITY = "graph:workflow-a-root";
+  const stalePromotedEnvelope = {
+    subgraph_of: { node_id: STRING_CONCAT_ID, title: "stale-subgraph" },
+    instance_widgets: { string_a: "old" },
+    node_count: 1,
+    nodes: [{ id: 99, type: "PrimitiveStringMultiline", widgets: { value: "old" } }],
+  };
+
+  it("writes a truncated root StringConcatenate widget without the promoted-subgraph path", async () => {
+    const { text, isError, calls, writesApplied, mutations } = await setWidget(
+      { node_id: STRING_CONCAT_ID, widget: "string_a", value: "hello" },
+      {
+        firstWrite: "ok",
+        unusableConnectionIdentity: true,
+        subgraph: stalePromotedEnvelope,
+        promotedDetail: {
+          truncated: true,
+          viewing: {
+            scope: "root",
+            graph_identity: ROOT_GRAPH_IDENTITY,
+            workflow_uuid: "workflow-a",
+          },
+          nodes: [
+            {
+              id: STRING_CONCAT_ID,
+              type: "StringConcatenate",
+              is_subgraph: false,
+              widgets: { string_a: "old", string_b: "world", delimiter: " " },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(text).not.toMatch(/refused the promoted/);
+    expect(text).not.toMatch(/panel connection identity was unavailable/);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(0);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({
+        node_id: STRING_CONCAT_ID,
+        widget: "string_a",
+        value: "hello",
+      }),
+    ]);
+    expect(writesApplied).toBe(1);
+    expect(mutations).toBe(1);
+  });
+
+  it("still maps a root subgraph container through the promoted path", async () => {
+    const { isError, calls, writesApplied, mutations } = await setWidget(
+      { node_id: 78, widget: "width", value: 1920 },
+      {
+        firstWrite: "ok",
+        promotedDetail: {
+          truncated: false,
+          nodes: [{ id: 78, type: "Krea2", is_subgraph: true, widgets: { width: 1024 } }],
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(calls.filter((call) => call.cmd === "graph_get_subgraph").length).toBeGreaterThan(0);
+    expect(writesApplied).toBe(1);
+    expect(mutations).toBe(1);
   });
 });
 

--- a/src/__tests__/orchestrator/root-widget-promoted-misclass.test.ts
+++ b/src/__tests__/orchestrator/root-widget-promoted-misclass.test.ts
@@ -1,0 +1,257 @@
+// #2518 — after a root panel_query_graph, panel_set_widget must not classify a
+// root StringConcatenate widget as promoted. Rebind mode current must clear
+// stale subgraph/promoted identity so a retry is not stuck on the same path.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import {
+  clearRememberedViewingScope,
+  noteConfirmedViewing,
+  rememberedSubgraphOwner,
+  rememberedViewingScope,
+} from "../../services/subgraph-viewing-scope.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url)),
+  "utf8",
+);
+
+const TAB = "wf:2518-root-concat";
+const NODE_ID = 53;
+const ROOT_GRAPH_IDENTITY = "graph:2518-root";
+const WORKFLOW_UUID = "25180000-0000-4000-8000-000000000000";
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function textOf(result: ToolResult): string {
+  return result.content.map((block) => (block as { text?: string }).text ?? "").join(" ");
+}
+
+afterEach(() => {
+  clearRememberedViewingScope();
+});
+
+function rootViewing(scope: "root" | "subgraph" = "root") {
+  return scope === "root"
+    ? {
+        scope: "root" as const,
+        workflow_uuid: WORKFLOW_UUID,
+        graph_identity: ROOT_GRAPH_IDENTITY,
+      }
+    : {
+        scope: "subgraph" as const,
+        owner_node_id: 12,
+        workflow_uuid: WORKFLOW_UUID,
+        graph_identity: "graph:2518-stale-subgraph",
+      };
+}
+
+function makeRootSequenceBridge() {
+  const calls: Array<Record<string, unknown>> = [];
+  let writes = 0;
+  let currentScope: {
+    known: true;
+    scope: "root" | "subgraph";
+    ownerNodeId: string | null;
+    workflowUuid: string;
+    graphIdentity: string;
+  } = {
+    known: true,
+    scope: "subgraph",
+    ownerNodeId: "12",
+    workflowUuid: WORKFLOW_UUID,
+    graphIdentity: "graph:2518-stale-subgraph",
+  };
+
+  const applyRootScope = () => {
+    currentScope = {
+      known: true,
+      scope: "root",
+      ownerNodeId: null,
+      workflowUuid: WORKFLOW_UUID,
+      graphIdentity: ROOT_GRAPH_IDENTITY,
+    };
+  };
+
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      if (cmd.cmd === "graph_query") {
+        applyRootScope();
+        const wantId = Array.isArray(cmd.ids) && cmd.ids.length ? String(cmd.ids[0]) : null;
+        const concatNode = {
+          id: NODE_ID,
+          type: "StringConcatenate",
+          is_subgraph: false,
+          widgets: { string_a: "old", string_b: "world", delimiter: "," },
+        };
+        if (wantId === String(NODE_ID) || cmd.fields === "detail") {
+          return {
+            viewing: rootViewing("root"),
+            truncated: true,
+            nodes: [concatNode],
+          };
+        }
+        return {
+          viewing: rootViewing("root"),
+          truncated: false,
+          nodes: [concatNode, { id: 9, type: "SaveImage", widgets: { filename_prefix: "ComfyUI" } }],
+        };
+      }
+      if (cmd.cmd === "graph_disconnect") {
+        return { disconnected: { node_id: cmd.node_id, input: cmd.input } };
+      }
+      if (cmd.cmd === "graph_connect") {
+        return {
+          connected: {
+            from_node_id: cmd.from_node_id,
+            to_node_id: cmd.to_node_id,
+            to_input: cmd.to_input,
+          },
+        };
+      }
+      if (cmd.cmd === "graph_get_subgraph") {
+        throw new Error("stale subgraph identity must not be consulted on a root-scope write");
+      }
+      if (cmd.cmd === "graph_set_widget") {
+        writes += 1;
+        return {
+          set: { node_id: cmd.node_id, widget: cmd.widget, previous: "old", value: cmd.value },
+        };
+      }
+      if (cmd.cmd === "workflow_list") {
+        const active = {
+          path: "workflows/2518.json",
+          routing_key: TAB,
+          workflow_uuid: WORKFLOW_UUID,
+        };
+        return { active, workflows: [active] };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    tabConnectionIdentity: () => undefined,
+    promotedScopeFor: () => currentScope,
+    clearPromotedSubgraphIdentity: (tabId: string) => {
+      if (tabId === TAB && currentScope.scope === "subgraph") {
+        currentScope = {
+          known: true,
+          scope: "root",
+          ownerNodeId: null,
+          workflowUuid: WORKFLOW_UUID,
+          graphIdentity: ROOT_GRAPH_IDENTITY,
+        };
+      }
+    },
+    applyLiveRootViewing: (tabId: string) => {
+      if (tabId === TAB) applyRootScope();
+    },
+    tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedNodeIdentityFenceCapability: () => true,
+    tabExpectedScopeGraphIdentityFenceCapability: () => true,
+    tabPromotedTerminalWitnessCapability: () => true,
+    tabPromotedParentRailFenceCapability: () => true,
+    tabReceiverResolvable: () => true,
+    workflowUuidFor: () => ({ known: true, uuid: WORKFLOW_UUID }),
+    refreshWorkflowUuid: () => true,
+    corroborateTabStamp: () => true,
+  } as PanelToolCtx["bridge"];
+
+  return {
+    bridge,
+    calls,
+    get writes() {
+      return writes;
+    },
+    get currentScope() {
+      return currentScope;
+    },
+  };
+}
+
+describe("root widget promoted misclassification (#2518)", () => {
+  it("handlers apply a live root viewing and clear stale subgraph identity on current rebind", () => {
+    expect(SRC).toMatch(/applyLiveRootViewing\(/);
+    expect(SRC).toMatch(/clearStaleSubgraphIdentity\(/);
+    expect(SRC).toMatch(/clearPromotedSubgraphIdentity/);
+  });
+
+  it("THE REPORTED CASE: root detail query, disconnect/connect, then set_widget on StringConcatenate", async () => {
+    noteConfirmedViewing(TAB, { viewing: rootViewing("subgraph") });
+    expect(rememberedSubgraphOwner(TAB)).toBe("12");
+
+    const harness = makeRootSequenceBridge();
+    const ctx = makePanelToolCtx(harness.bridge, TAB, new WorkflowTargetStore());
+
+    const queried = await defByName("panel_query_graph").handler(
+      { fields: "detail", max_chars: 4000 },
+      ctx,
+    );
+    expect(queried.isError).toBeFalsy();
+    expect(rememberedViewingScope(TAB)?.scope).toBe("root");
+
+    const disconnected = await defByName("panel_disconnect").handler(
+      { node_id: NODE_ID, input: "string_b" },
+      ctx,
+    );
+    expect(disconnected.isError).toBeFalsy();
+
+    const connected = await defByName("panel_connect").handler(
+      { from_node_id: 9, from_output: 0, to_node_id: NODE_ID, to_input: "string_b" },
+      ctx,
+    );
+    expect(connected.isError).toBeFalsy();
+
+    const written = await defByName("panel_set_widget").handler(
+      { node_id: NODE_ID, widget: "string_a", value: "hello" },
+      ctx,
+    );
+    expect(written.isError).toBeFalsy();
+    expect(textOf(written)).not.toMatch(/refused the promoted/);
+    expect(harness.calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(0);
+    expect(harness.calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: NODE_ID, widget: "string_a", value: "hello" }),
+    ]);
+    expect(harness.writes).toBe(1);
+    expect(rememberedSubgraphOwner(TAB)).toBeNull();
+  });
+
+  it("a successful mode:current rebind clears stale subgraph identity so a retry is not stuck", async () => {
+    noteConfirmedViewing(TAB, { viewing: rootViewing("subgraph") });
+    expect(rememberedSubgraphOwner(TAB)).toBe("12");
+
+    const harness = makeRootSequenceBridge();
+    const ctx = makePanelToolCtx(harness.bridge, TAB, new WorkflowTargetStore());
+    const rebound = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    expect(rebound.isError).toBeFalsy();
+    expect(rememberedSubgraphOwner(TAB)).toBeNull();
+    expect(harness.currentScope.scope).toBe("root");
+
+    const written = await defByName("panel_set_widget").handler(
+      { node_id: NODE_ID, widget: "delimiter", value: " | " },
+      ctx,
+    );
+    expect(written.isError).toBeFalsy();
+    expect(harness.calls.filter((call) => call.cmd === "graph_get_subgraph")).toHaveLength(0);
+    expect(harness.writes).toBe(1);
+  });
+});

--- a/src/__tests__/services/subgraph-viewing-scope.test.ts
+++ b/src/__tests__/services/subgraph-viewing-scope.test.ts
@@ -4,9 +4,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  applyLiveRootViewing,
   callAndRememberViewing,
   callWithRememberedSubgraph,
   clearRememberedViewingScope,
+  clearStaleSubgraphIdentity,
   isOutsideSubgraphRefusal,
   noteConfirmedViewing,
   parseViewingScope,
@@ -82,6 +84,22 @@ describe("noteConfirmedViewing", () => {
     noteConfirmedViewing(TAB, { viewing: { scope: "root" } });
     expect(rememberedSubgraphOwner(TAB)).toBeNull();
     expect(rememberedViewingScope(TAB)).toEqual({ scope: "root", ownerNodeId: null });
+  });
+
+  it("applyLiveRootViewing and clearStaleSubgraphIdentity drop a leftover subgraph owner (#2518)", () => {
+    noteConfirmedViewing(TAB, { viewing: { scope: "subgraph", owner_node_id: 96 } });
+    expect(applyLiveRootViewing(TAB, { scope: "root", workflow_uuid: "aaa" })).toBe(true);
+    expect(rememberedSubgraphOwner(TAB)).toBeNull();
+    expect(rememberedViewingScope(TAB)).toEqual({
+      scope: "root",
+      ownerNodeId: null,
+      workflowUuid: "aaa",
+    });
+
+    noteConfirmedViewing(TAB, { viewing: { scope: "subgraph", owner_node_id: 12 } });
+    clearStaleSubgraphIdentity(TAB);
+    expect(rememberedSubgraphOwner(TAB)).toBeNull();
+    expect(rememberedViewingScope(TAB)).toBeNull();
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -700,6 +700,52 @@ describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
     a.close();
   });
 
+  it("clears a cached subgraph identity after a live root viewing (#2518)", async () => {
+    const a = await connectPanel("tab-scope-2518");
+    a.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_query") {
+        a.send(
+          JSON.stringify({
+            rid: msg.rid,
+            ok: true,
+            result: {
+              viewing: {
+                scope: "subgraph",
+                owner_node_id: 12,
+                workflow_uuid: "25180000-0000-4000-8000-000000000000",
+                graph_identity: "graph:stale-subgraph",
+              },
+              nodes: [{ id: 53, type: "StringConcatenate" }],
+            },
+          }),
+        );
+      }
+    });
+    await waitFor(() => expect(bridge.connected()).toBe(true));
+    await bridge.send(
+      { cmd: "graph_query", ids: [53], fields: "detail", limit: 1 },
+      { tabId: "tab-scope-2518" },
+    );
+    expect(bridge.promotedScopeFor("tab-scope-2518")).toMatchObject({
+      known: true,
+      scope: "subgraph",
+    });
+    bridge.clearPromotedSubgraphIdentity("tab-scope-2518");
+    expect(bridge.promotedScopeFor("tab-scope-2518").known).toBe(false);
+    bridge.applyLiveRootViewing("tab-scope-2518", {
+      scope: "root",
+      workflow_uuid: "25180000-0000-4000-8000-000000000000",
+      graph_identity: "graph:2518-root",
+    });
+    expect(bridge.promotedScopeFor("tab-scope-2518")).toMatchObject({
+      known: true,
+      scope: "root",
+      graphIdentity: "graph:2518-root",
+    });
+    a.close();
+  });
+
   it("freshly reads the current promoted owner after the cached owner goes stale (#2314)", async () => {
     const a = await connectPanel("tab-scope-read-2314");
     let ownerNodeId = 78;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -87,9 +87,12 @@ import {
 import { retryConnectAgainstLiveGraph } from "../services/connect-live-graph.js";
 import { retryExposeSubgraphInput } from "../services/expose-ae-wildcard.js";
 import {
+  applyLiveRootViewing,
   callAndRememberViewing,
   callWithRememberedSubgraph,
+  clearStaleSubgraphIdentity,
   noteConfirmedViewingFromToolResult,
+  parseViewingScope,
 } from "../services/subgraph-viewing-scope.js";
 import {
   assertScreenshotPersistAllowed,
@@ -6344,23 +6347,29 @@ type QueriedNodeScope = {
   graphIdentity?: string;
 };
 
+function rememberLiveRootViewing(ctx: PanelToolCtx, viewing: unknown): void {
+  applyLiveRootViewing(ctx.tabId, viewing);
+  ctx.bridge?.applyLiveRootViewing?.(ctx.tabId, viewing);
+}
+
+function forgetStaleSubgraphIdentity(ctx: PanelToolCtx): void {
+  clearStaleSubgraphIdentity(ctx.tabId);
+  ctx.bridge?.clearPromotedSubgraphIdentity?.(ctx.tabId);
+}
+
 /** Read the active viewing scope and node's explicit container bit before
  * attempting promoted-widget resolution. The pinpoint detail projection carries
  * the node bit even when the widget list is empty (which is how a fresh rgthree
- * Power Lora Loader appears). Anything short of one exact, non-truncated row
- * with an explicit root/subgraph witness is deliberately indeterminate; callers
- * retain the existing fail-closed promoted-container path in that case. */
+ * Power Lora Loader appears). A clipped widget value (`truncated: true`) is not
+ * a reason to discard a one-row pinpoint: that is how a root StringConcatenate
+ * appears after a long-string detail read (#2518). A missing `is_subgraph` is
+ * still indeterminate. Anything short of a root/subgraph witness plus an
+ * explicit container bit retains the fail-closed promoted-container path. */
 function parseVerifiedQueriedNodeScope(
   payload: Record<string, unknown> | null,
   nodeId: unknown,
 ): QueriedNodeScope | null {
   if (!payload) return null;
-  if (
-    Object.prototype.hasOwnProperty.call(payload, "truncated") &&
-    payload.truncated !== false
-  ) {
-    return null;
-  }
   const viewing = payload.viewing;
   if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return null;
   const viewingRecord = viewing as Record<string, unknown>;
@@ -7178,7 +7187,11 @@ async function readPromotedTargetScope(
     limit: 1,
   }, undefined, undefined, undefined, options);
   if (probe.isError) return null;
-  return parseVerifiedQueriedNodeScope(parseToolResultJson(probe), nodeId);
+  const payload = parseToolResultJson(probe);
+  if (parseViewingScope(payload?.viewing)?.scope === "root") {
+    rememberLiveRootViewing(ctx, payload?.viewing);
+  }
+  return parseVerifiedQueriedNodeScope(payload, nodeId);
 }
 
 function currentPromotedBindingError(
@@ -7652,6 +7665,11 @@ async function preparePromotedWidgetWrite(
     nodeId,
     PROMOTED_PREFLIGHT_READ_OPTIONS,
   );
+  // #2518 — a live root query names the current root workflow instance. Do not
+  // enter the promoted-subgraph identity path for an ordinary (or unproven)
+  // root node; a truncated StringConcatenate pinpoint used to fall through,
+  // reuse a stale subgraph envelope, and refuse because connection identity
+  // was unavailable after that subgraph read.
   if (targetScope?.activeView === "root" && targetScope.node === "ordinary") {
     // The scope probe crossed an await. Re-read the binding before taking the
     // ordinary fast path; otherwise a tab/connection rebind can make this
@@ -14416,6 +14434,8 @@ interface BridgeProbe {
   workflowUuidFor?: (tabId: string) => TabWorkflowUuidRead;
   promotedScopeFor?: (tabId: string) => TabPromotedScopeRead;
   readPromotedScope?: (tabId: string, innerNodeId: number | string) => Promise<TabPromotedScopeRead>;
+  applyLiveRootViewing?: (tabId: string, viewing: unknown) => void;
+  clearPromotedSubgraphIdentity?: (tabId: string) => void;
   tabPromotedTerminalWitnessCapability?: (tabId: string) => boolean;
   tabPromotedParentRailFenceCapability?: (tabId: string) => boolean;
   tabExpectedNodeIdentityFenceCapability?: (tabId: string) => boolean;
@@ -18228,6 +18248,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           },
           (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
         );
+        rememberLiveRootViewing(ctx, parseToolResultJson(panelReply)?.viewing);
         return fitQueryGraphReply(
           panelReply,
           args.max_chars,
@@ -23116,6 +23137,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 ? fenceRebind.before.uuid
                 : undefined;
             if (turnPinStillAmbiguous()) return refuseBoundWhileAmbiguous();
+            forgetStaleSubgraphIdentity(ctx);
             return ok({
               ...target,
               graph_binding: "bound",
@@ -23158,6 +23180,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               : "";
         if (fence?.binding === "bound" && turnPinStillAmbiguous()) {
           return refuseBoundWhileAmbiguous();
+        }
+        if (mode === "current" && !deferredBind) {
+          // #2518 — mode:"current" already named the live canvas; a leftover
+          // subgraph/promoted identity from an earlier inspect must not keep
+          // classifying root widgets as promoted.
+          forgetStaleSubgraphIdentity(ctx);
         }
         return ok({
           ...target,

--- a/src/services/subgraph-viewing-scope.ts
+++ b/src/services/subgraph-viewing-scope.ts
@@ -126,6 +126,23 @@ export function clearRememberedViewingScope(tabId?: string): void {
   rememberedByTab.delete(tabId);
 }
 
+/** Drop a remembered subgraph owner. A later live root read or an explicit
+ * current-mode rebind must not keep authorizing the promoted-subgraph path. */
+export function clearStaleSubgraphIdentity(tabId: string): void {
+  if (!tabId) return;
+  const rec = rememberedByTab.get(tabId);
+  if (rec?.scope === "subgraph") rememberedByTab.delete(tabId);
+}
+
+/** Record a live root viewing so a prior subgraph confirmation cannot linger. */
+export function applyLiveRootViewing(tabId: string, viewing: unknown): boolean {
+  if (!tabId) return false;
+  const parsed = parseViewingScope(viewing);
+  if (parsed?.scope !== "root") return false;
+  rememberedByTab.set(tabId, parsed);
+  return true;
+}
+
 export function noteConfirmedViewing(
   tabId: string,
   payload: unknown,

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -4158,6 +4158,34 @@ export class UiBridge {
     return this.promotedScopes.get(key) ?? unknown;
   }
 
+  /** Overwrite a stale subgraph witness with a live root viewing. */
+  applyLiveRootViewing(tabId: string, viewing: unknown): void {
+    const parsed = this.parsePromotedScopeResult({ viewing });
+    if (!parsed || parsed.known !== true || parsed.scope !== "root") return;
+    let key = tabId;
+    try {
+      key = this.resolveTarget(tabId).tabId;
+    } catch {
+      key = tabId;
+    }
+    this.promotedScopes.set(key, parsed);
+  }
+
+  /** Drop a cached subgraph/promoted current-view identity after a root read
+   * or a successful mode:current rebind. */
+  clearPromotedSubgraphIdentity(tabId: string): void {
+    let key = tabId;
+    try {
+      key = this.resolveTarget(tabId).tabId;
+    } catch {
+      key = tabId;
+    }
+    const current = this.promotedScopes.get(key);
+    if (current?.known === true && current.scope === "subgraph") {
+      this.promotedScopes.delete(key);
+    }
+  }
+
   /** Read the current panel view from the live graph immediately before a
    *  promoted write. `promotedScopeFor` is intentionally only a cached witness
    *  for synchronous dispatch fences; this method performs the authoritative


### PR DESCRIPTION
## Summary

After a root `panel_query_graph(detail)`, `panel_set_widget` classified a root `StringConcatenate` widget as promoted and refused:

> panel_set_widget refused the promoted "string_a" write because the panel connection identity was unavailable after the subgraph read.

The same refusal hit `delimiter` and `SaveImage.filename_prefix`. `panel_set_workflow_target({mode:"current"})` reported `already_current` / `graph_binding:bound` but did not clear leftover subgraph identity, so the retry failed the same way.

This is not #2551 (ordinary-root write when identity is missing after a successful scope probe). Here the live query is root, but the ordinary classification was thrown away and the promoted-subgraph identity path ran anyway.

## Root cause

`parseVerifiedQueriedNodeScope()` discarded a one-row pinpoint whenever `truncated !== false`. A root `StringConcatenate` with clipped widget values is that shape: viewing.scope is root, `is_subgraph: false`, but `truncated: true`. The ordinary-root fast path was skipped, `graph_get_subgraph` ran, and the write was refused as promoted.

A leftover subgraph/promoted current-view identity also survived a root-scope read and a successful mode:current rebind.

## Fix

- Keep a one-row root pinpoint even when widget values are clipped (`truncated: true`)
- When the live query viewing is root, record that as the current root workflow instance and do not enter the promoted-subgraph identity path for an ordinary node
- After a root-scope `panel_query_graph` or a successful `panel_set_workflow_target({mode:"current"})`, clear leftover subgraph/promoted identity
- Proven subgraph containers on the root graph still use the promoted path
- A genuinely unknown viewing (no `viewing` witness) still stays off the ordinary fast path

## Tests

- `src/__tests__/orchestrator/promoted-widget.test.ts` — truncated root StringConcatenate writes without `graph_get_subgraph`; root subgraph containers still map through the promoted path; unknown viewing still refuses
- `src/__tests__/orchestrator/root-widget-promoted-misclass.test.ts` — reported sequence: root `panel_query_graph(detail)` → disconnect/connect → `panel_set_widget`; mode:current rebind clears stale subgraph identity
- `src/__tests__/services/subgraph-viewing-scope.test.ts` — `applyLiveRootViewing` / `clearStaleSubgraphIdentity`
- `src/__tests__/services/ui-bridge.test.ts` — live root viewing overwrites, and `clearPromotedSubgraphIdentity` drops a cached subgraph witness

Fixes #2518
