### PR TITLE
fix(2522): prefer capturedWidgetValues when expanding subgraph promotions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- panel_strip_workflow applies live capturedWidgetValues to promoted subgraph widgets instead of stale definition defaults (#2522)
+
+
 ## [0.52.156] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -1096,6 +1096,7 @@ const SG_ID = "sg-uuid";
 function subgraphGraph(opts: {
   proxy: [string, string][];
   values: unknown[];
+  captured?: Record<string, unknown>;
   innerInputs?: unknown[];
   linkWidth?: boolean;
 }) {
@@ -1158,6 +1159,7 @@ function subgraphGraph(opts: {
         ],
         outputs: [{ name: "LATENT", type: "LATENT", links: [] }],
         widgets_values: opts.values,
+        ...(opts.captured ? { capturedWidgetValues: opts.captured } : {}),
       },
     ],
     links: opts.linkWidth ? [[200, 60, 0, 706, 0, "INT"]] : [],
@@ -1225,6 +1227,23 @@ describe("#361 — promoted subgraph widget values", () => {
     );
     expect(joined(warnings)).toContain('"not_a_widget"');
     expect(joined(warnings)).toContain("could not be applied");
+  });
+
+  it("a live capturedWidgetValues map wins over stale positional widgets_values (#2522)", () => {
+    // graph_get_state stores the user's current name-keyed values on
+    // capturedWidgetValues and leaves widgets_values as the serialized snapshot.
+    // The expander used to read only the array, so a live 1920 became the inner
+    // node's stale 512 with no warning.
+    const { workflow, warnings } = convertUiToApi(
+      subgraphGraph({
+        proxy: [["-1", "width"]],
+        values: [512],
+        captured: { width: 1920 },
+      }),
+      OBJECT_INFO,
+    );
+    expect(onlyInner(workflow as never).inputs.width).toBe(1920);
+    expect(warnings).toEqual([]);
   });
 
   it("a NAME-KEYED widgets_values on the subgraph node is read by promoted-widget name", () => {

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1848,9 +1848,14 @@ function expandSingleComponent(
   const proxyWidgets: [string, string][] = Array.isArray(compNode.properties?.proxyWidgets)
     ? (compNode.properties!.proxyWidgets as [string, string][])
     : [];
-  // Typed `unknown` on purpose: `widgets_values` is declared as an array, but the
-  // name-keyed capture below arrives in the same field as a plain object.
-  const rawWidgetValues: unknown = compNode.widgets_values ?? [];
+  // Typed `unknown` on purpose: `widgets_values` is declared as an array, but a
+  // name-keyed capture arrives as a plain object. Prefer capturedWidgetValues
+  // (the live-canvas overlay) over widgets_values — the same preference the
+  // main converter uses — because graph_get_state puts current name-keyed
+  // values in the former and leaves the latter as the serialized snapshot,
+  // which for a subgraph instance is often STALE (#2522).
+  const rawWidgetValues: unknown =
+    compNode.capturedWidgetValues ?? compNode.widgets_values ?? [];
   // A subgraph instance normally serializes its promoted values POSITIONALLY,
   // parallel to proxyWidgets. Some captures key every widget BY NAME instead (the
   // shape the main converter already accepts). Read both, or a name-keyed capture


### PR DESCRIPTION
## Summary
- `panel_strip_workflow` expands subgraph instances by reading promoted widget values off the subgraph node. That path used only `widgets_values`.
- Live-canvas capture stores the user's current name-keyed values in `capturedWidgetValues` and leaves the positional array as the serialized (often stale) snapshot.
- The expander now prefers `capturedWidgetValues` first, matching the main converter, so inner nodes receive the live model/seed/shift instead of definition defaults.

## Tests
- `npx vitest run src/__tests__/services/strip-workflow-preservation.test.ts` — 45/45 passed. The new case failed with width=512 on unfixed code and passed with 1920 after the change.

Closes #2522
