### PR TITLE
fix(2524): recover install_comfyui update from stale refs and detached tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- install_comfyui(action:"update") prunes a stale origin/dev ref-lock once and switches a detached version-tag checkout onto local master/main when update is explicitly requested (#2524)
 - krea2-identity-edit ships the LoRA widget as a POSIX path so Linux ComfyUI can match the installed file (#2525)
 - panel_strip_workflow applies live capturedWidgetValues to promoted subgraph widgets instead of stale definition defaults (#2522)
 - panel_strip_workflow honors a verified pin when capturing the live canvas instead of refusing a stale last-advertised workflow instance (#2487)

--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -82,6 +82,8 @@ import { tmpdir } from "node:os";
 import {
   updateComfyUICore,
   updateAllCustomNodes,
+  isStaleRemoteRefLock,
+  isDetachedPullFailure,
 } from "../../services/update-comfyui.js";
 import { resetManagerApiCacheForTests } from "../../services/node-management.js";
 
@@ -423,6 +425,233 @@ describe("updateComfyUICore", () => {
       throw new Error("no uv");
     });
     await expect(updateComfyUICore()).rejects.toThrow(/Command failed: git pull/);
+  });
+
+  // #2524 — install_comfyui(action:"update") used a bare `git pull`. A checkout
+  // pinned at a detached release tag first failed because stale origin/dev
+  // conflicted with new origin/dev/* refs, then (after a manual prune) failed
+  // again because HEAD was detached. The tool threw PROCESS_CONTROL_ERROR with
+  // raw git output instead of recovering or returning a structured action.
+  describe("#2524: stale origin refs and detached version-tag checkouts", () => {
+    const STALE_REF_LOCK =
+      "error: cannot lock ref 'refs/remotes/origin/dev/Combo-RemoteOptions': " +
+      "'refs/remotes/origin/dev' exists; cannot create " +
+      "'refs/remotes/origin/dev/Combo-RemoteOptions'\n" +
+      "error: some local refs could not be updated; try running\n" +
+      " 'git remote prune origin' to remove any old, conflicting branches";
+    const DETACHED_PULL =
+      "You are not currently on a branch.\n" +
+      "Please specify which branch you want to merge with.\n" +
+      "See git-pull(1) for details.";
+
+    it("classifies the reported ref-lock and detached-pull texts, and no others", () => {
+      expect(isStaleRemoteRefLock(STALE_REF_LOCK)).toBe(true);
+      expect(
+        isStaleRemoteRefLock(
+          "cannot lock ref refs/remotes/origin/dev/Combo-RemoteOptions: refs/remotes/origin/dev exists",
+        ),
+      ).toBe(true);
+      expect(
+        isStaleRemoteRefLock("fatal: Unable to create '/x/.git/index.lock': File exists."),
+      ).toBe(false);
+      expect(isStaleRemoteRefLock("fatal: not a git repository")).toBe(false);
+      expect(isDetachedPullFailure(DETACHED_PULL)).toBe(true);
+      expect(isDetachedPullFailure(STALE_REF_LOCK)).toBe(false);
+    });
+
+    const gitFail = (stderr: string): never => {
+      const err = new Error("exit 1") as Error & { stderr: string };
+      err.stderr = stderr;
+      throw err;
+    };
+
+    const scriptGit = (probe: (args: string[]) => string | undefined) => {
+      mockedExists.mockImplementation((p: string) => {
+        if (p === "/fake/ComfyUI") return true;
+        if (p.endsWith("requirements.txt")) return true;
+        return false;
+      });
+      mockedExec.mockImplementation((file: string, args: string[]) => {
+        if (file === "uv" || file === "uv.exe") throw new Error("uv not found");
+        if (file === "git") {
+          const out = probe(args);
+          if (out === undefined) throw new Error(`git ${args.join(" ")} failed`);
+          return out;
+        }
+        return "ok";
+      });
+    };
+
+    const gitCalls = (name: string) =>
+      mockedExec.mock.calls.filter(
+        (c) => c[0] === "git" && Array.isArray(c[1]) && c[1][0] === name,
+      );
+
+    it("prunes origin once on a stale origin/dev ref-lock and retries the pull", async () => {
+      let pulls = 0;
+      scriptGit((args) => {
+        if (args[0] === "pull") {
+          pulls += 1;
+          if (pulls === 1) gitFail(STALE_REF_LOCK);
+          return "Updating dec5d94..2eb6079";
+        }
+        if (args[0] === "remote" && args[1] === "prune") return "Pruning origin";
+        if (args[0] === "rev-parse" && args[1] === "HEAD") {
+          return pulls >= 2 ? "2eb60796bbbb" : "dec5d945aaaa";
+        }
+        if (args[0] === "symbolic-ref") return "master";
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return "origin/master";
+        if (args[0] === "rev-parse" && args[1] === "origin/master") return "2eb60796bbbb";
+        return undefined;
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(true);
+      expect(gitCalls("pull")).toHaveLength(2);
+      expect(gitCalls("remote").map((c) => c[1])).toEqual([["remote", "prune", "origin"]]);
+      expect(gitCalls("checkout")).toHaveLength(0);
+    });
+
+    it("does not prune-retry a second ref-lock (recovery is once)", async () => {
+      scriptGit((args) => {
+        if (args[0] === "pull") gitFail(STALE_REF_LOCK);
+        if (args[0] === "remote" && args[1] === "prune") return "Pruning origin";
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "dec5d945aaaa";
+        if (args[0] === "symbolic-ref") return "master";
+        return undefined;
+      });
+
+      await expect(updateComfyUICore()).rejects.toThrow(/cannot lock ref/);
+      expect(gitCalls("pull")).toHaveLength(2);
+      expect(gitCalls("remote")).toHaveLength(1);
+    });
+
+    it("attaches a clean detached tag checkout to local master, then recovers a stale ref-lock", async () => {
+      // THE reported sequence: detached at v0.16.4, stale origin/dev, local
+      // master present. Workaround was prune + checkout master + retry.
+      let onMaster = false;
+      let pulls = 0;
+      scriptGit((args) => {
+        if (args[0] === "symbolic-ref") return onMaster ? "master" : undefined;
+        if (args[0] === "show-ref" && args.includes("refs/heads/master")) {
+          return "dec5d945aaaa refs/heads/master";
+        }
+        if (args[0] === "status" && args.includes("--porcelain")) return "";
+        if (args[0] === "checkout" && args[1] === "master") {
+          onMaster = true;
+          return "Switched to branch 'master'";
+        }
+        if (args[0] === "pull") {
+          pulls += 1;
+          if (pulls === 1) gitFail(STALE_REF_LOCK);
+          return "Updating dec5d94..2eb6079";
+        }
+        if (args[0] === "remote" && args[1] === "prune") return "Pruning origin";
+        if (args[0] === "rev-parse" && args[1] === "HEAD") {
+          return pulls >= 2 ? "2eb60796bbbb" : "dec5d945aaaa";
+        }
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+          return onMaster ? "origin/master" : undefined;
+        }
+        if (args[0] === "rev-parse" && args[1] === "origin/master") return "2eb60796bbbb";
+        return undefined;
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(true);
+      expect(r.revision?.branch).toBe("master");
+      expect(gitCalls("checkout").map((c) => c[1])).toEqual([["checkout", "master"]]);
+      expect(gitCalls("remote")).toHaveLength(1);
+      expect(gitCalls("pull")).toHaveLength(2);
+      const mutating = mockedExec.mock.calls
+        .filter(
+          (c) =>
+            c[0] === "git" &&
+            Array.isArray(c[1]) &&
+            (c[1][0] === "checkout" || c[1][0] === "pull" || c[1][0] === "remote"),
+        )
+        .map((c) => (Array.isArray(c[1]) ? c[1].join(" ") : ""));
+      expect(mutating).toEqual([
+        "checkout master",
+        "pull",
+        "remote prune origin",
+        "pull",
+      ]);
+    });
+
+    it("returns a structured DETACHED action instead of PROCESS_CONTROL_ERROR when pull has no branch", async () => {
+      scriptGit((args) => {
+        if (args[0] === "pull") gitFail(DETACHED_PULL);
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "dec5d945aaaa";
+        if (args[0] === "symbolic-ref") return undefined;
+        return undefined;
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(false);
+      expect(r.message).toMatch(/DETACHED/);
+      expect(r.message).toMatch(/git checkout master/);
+      expect(r.message).not.toMatch(/Command failed: git pull/);
+      expect(r.revision?.branch).toBeNull();
+      expect(gitCalls("checkout")).toHaveLength(0);
+    });
+
+    it("does not switch a dirty detached checkout onto local master", async () => {
+      scriptGit((args) => {
+        if (args[0] === "symbolic-ref") return undefined;
+        if (args[0] === "show-ref" && args.includes("refs/heads/master")) {
+          return "dec5d945aaaa refs/heads/master";
+        }
+        if (args[0] === "status" && args.includes("--porcelain")) {
+          return " M main.py";
+        }
+        if (args[0] === "pull") gitFail(DETACHED_PULL);
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "dec5d945aaaa";
+        return undefined;
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(false);
+      expect(r.message).toMatch(/not clean/);
+      expect(r.message).toMatch(/git checkout master/);
+      expect(gitCalls("checkout")).toHaveLength(0);
+    });
+
+    it("does not treat an index.lock collision as a stale origin ref", async () => {
+      scriptGit((args) => {
+        if (args[0] === "pull") {
+          gitFail("fatal: Unable to create '/fake/ComfyUI/.git/index.lock': File exists.");
+        }
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "dec5d945aaaa";
+        if (args[0] === "symbolic-ref") return "master";
+        return undefined;
+      });
+
+      await expect(updateComfyUICore()).rejects.toThrow(/index\.lock/);
+      expect(gitCalls("pull")).toHaveLength(1);
+      expect(gitCalls("remote")).toHaveLength(0);
+    });
+
+    it("after prune, a still-detached pull is a structured refusal not a raw git dump", async () => {
+      let pulls = 0;
+      scriptGit((args) => {
+        if (args[0] === "pull") {
+          pulls += 1;
+          gitFail(pulls === 1 ? STALE_REF_LOCK : DETACHED_PULL);
+        }
+        if (args[0] === "remote" && args[1] === "prune") return "Pruning origin";
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "dec5d945aaaa";
+        if (args[0] === "symbolic-ref") return undefined;
+        return undefined;
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(false);
+      expect(r.message).toMatch(/DETACHED/);
+      expect(r.message).not.toMatch(/Command failed: git pull/);
+      expect(gitCalls("pull")).toHaveLength(2);
+      expect(gitCalls("remote")).toHaveLength(1);
+    });
   });
 
   it("refuses before git pull when the running server's interpreter cannot be verified (#651)", async () => {

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -119,6 +119,124 @@ function gitProbe(args: string[], cwd: string): string | null {
   }
 }
 
+/** ComfyUI's historical default, then the generic git default. */
+const UPDATE_BRANCHES = ["master", "main"] as const;
+
+/**
+ * Stale remote-tracking ref vs new nested ref: `refs/remotes/origin/dev` exists
+ * as a file, so git cannot create `refs/remotes/origin/dev/<child>` (#2524).
+ * Git's own hint is `git remote prune origin`. Other lock failures (index.lock,
+ * another process) must NOT match — those are not cured by pruning.
+ */
+export function isStaleRemoteRefLock(output: string): boolean {
+  const nestedLock = /cannot lock ref\s+['"]?refs\/remotes\/origin\//i.test(output);
+  const parentExists = /exists/i.test(output);
+  const pruneHint = /git remote prune origin/i.test(output);
+  return (nestedLock && parentExists) || pruneHint;
+}
+
+/** `git pull` on a DETACHED HEAD: fetch may work, merge has no branch (#2524). */
+export function isDetachedPullFailure(output: string): boolean {
+  return /you are not currently on a branch/i.test(output);
+}
+
+interface AttachAttempt {
+  switched: boolean;
+  branch: string | null;
+  dirty: boolean;
+}
+
+function localUpdateBranch(cwd: string): string | null {
+  for (const name of UPDATE_BRANCHES) {
+    if (gitProbe(["show-ref", "--verify", `refs/heads/${name}`], cwd)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/** Empty porcelain = clean. A failed status is NOT clean — we cannot prove it. */
+function workingTreeClean(cwd: string): boolean {
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 30_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return (out ?? "").trim() === "";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * `install_comfyui(action:"update")` is an explicit request to move the
+ * checkout. A detached release-tag HEAD (Comfy Desktop / `git checkout vX.Y.Z`)
+ * has no branch for `git pull` to merge with. When a local master/main exists
+ * and the tree is clean, switch onto it before pulling. Dirty trees and
+ * missing local branches are left untouched — switching those is not ours.
+ */
+function tryAttachUpdateBranch(
+  cwd: string,
+  currentBranch: string | null,
+  steps: CommandResult[],
+): AttachAttempt {
+  if (currentBranch) return { switched: false, branch: currentBranch, dirty: false };
+  const branch = localUpdateBranch(cwd);
+  if (!branch) return { switched: false, branch: null, dirty: false };
+  const dirty = !workingTreeClean(cwd);
+  if (dirty) return { switched: false, branch, dirty: true };
+  steps.push(runCommand("git", ["checkout", branch], cwd));
+  return { switched: true, branch, dirty: false };
+}
+
+function detachedPullRefusalMessage(comfyuiPath: string, attach: AttachAttempt): string {
+  const intro =
+    `ComfyUI core was NOT updated in ${comfyuiPath}: HEAD is DETACHED ` +
+    `(a tag or bare commit, which is how release-tag and Comfy Desktop installs are set up), ` +
+    `so \`git pull\` has no branch to merge with.`;
+  const tail = "Python requirements were NOT reinstalled, because nothing changed that would need them.";
+  if (attach.branch && attach.dirty) {
+    return (
+      `${intro} Local branch "${attach.branch}" exists, but the working tree is not clean ` +
+      `so this tool will not switch branches. Commit or stash local changes, then ` +
+      `\`git checkout ${attach.branch}\` and retry. ${tail}`
+    );
+  }
+  if (attach.branch) {
+    return (
+      `${intro} Switch to "${attach.branch}" first ` +
+      `(\`git checkout ${attach.branch} && git pull --ff-only\`) and retry. ${tail}`
+    );
+  }
+  return (
+    `${intro} Switch to a branch first, e.g. \`git checkout master && git pull --ff-only\`. ` +
+    `Check for local edits before switching (\`git status\`). ${tail}`
+  );
+}
+
+/**
+ * `git pull`, recovering once from the stale origin/dev vs origin/dev/* ref-lock
+ * by pruning origin. Other pull failures propagate unchanged.
+ */
+function runGitPullWithStaleRefRetry(cwd: string, steps: CommandResult[]): CommandResult {
+  try {
+    const pulled = runCommand("git", ["pull"], cwd);
+    steps.push(pulled);
+    return pulled;
+  } catch (err) {
+    if (!(err instanceof ProcessControlError) || !isStaleRemoteRefLock(err.message)) {
+      throw err;
+    }
+    steps.push({ command: "git pull", ok: false, output: err.message });
+    steps.push(runCommand("git", ["remote", "prune", "origin"], cwd));
+    const retried = runCommand("git", ["pull"], cwd);
+    steps.push(retried);
+    return retried;
+  }
+}
+
 /**
  * Decide whether `git pull` actually updated the checkout (#945).
  *
@@ -320,8 +438,36 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
 
   // 1. git pull the core repo — bracketed by a revision read, because a pull
   //    that exits 0 is NOT evidence that anything moved (#945).
+  //    A detached version-tag checkout is attached to local master/main first
+  //    when the tree is clean (#2524); a stale origin/dev vs origin/dev/*
+  //    ref-lock is pruned once and the pull retried.
   const before = readGitState(comfyuiPath);
-  steps.push(runCommand("git", ["pull"], comfyuiPath));
+  const attach = tryAttachUpdateBranch(comfyuiPath, before.branch, steps);
+  try {
+    runGitPullWithStaleRefRetry(comfyuiPath, steps);
+  } catch (err) {
+    if (err instanceof ProcessControlError && isDetachedPullFailure(err.message)) {
+      if (!steps.some((s) => s.command === "git pull" && !s.ok)) {
+        steps.push({ command: "git pull", ok: false, output: err.message });
+      }
+      const afterDetached = readGitState(comfyuiPath);
+      return {
+        updated: false,
+        comfyui_path: comfyuiPath,
+        package_manager: pm,
+        steps,
+        revision: {
+          before: before.head,
+          after: afterDetached.head,
+          branch: afterDetached.branch,
+          upstream: afterDetached.upstream,
+          matches_upstream: null,
+        },
+        message: detachedPullRefusalMessage(comfyuiPath, attach),
+      };
+    }
+    throw err;
+  }
   const after = readGitState(comfyuiPath);
   const verdict = classifyCoreUpdate({
     before: before.head,


### PR DESCRIPTION
## Summary

`install_comfyui(action:"update")` ran a bare `git pull`. On a ComfyUI checkout pinned at a detached release tag (e.g. v0.16.4) that also had a stale `origin/dev` remote-tracking ref, it failed twice:

1. `cannot lock ref refs/remotes/origin/dev/<child>: refs/remotes/origin/dev exists`
2. After a manual `git remote prune origin`, `You are not currently on a branch`

Both surfaced as `PROCESS_CONTROL_ERROR` with raw git output. The tool now:

- prunes `origin` once on that specific nested-ref lock and retries the pull
- when update is explicitly requested, attaches a **clean** detached checkout to local `master`/`main` before pulling
- if it still cannot pull (still detached, dirty tree, no local branch), returns a structured `updated: false` action instead of dumping git's stderr

`index.lock` collisions and other pull failures are unchanged.

Fixes #2524

## Test plan

- [x] `npx vitest run src/__tests__/services/update-comfyui.test.ts src/__tests__/services/update-core-verification.test.ts` (38 passed)
- [ ] On a detached tag checkout with a stale `origin/dev` file-ref, `install_comfyui(action:"update")` prunes, switches to local master, and updates
- [ ] A dirty detached checkout is not switched; the result names `git checkout master` instead of throwing `PROCESS_CONTROL_ERROR`
