### PR TITLE
fix(2531): align turn routing after panel_open_workflow and a verified pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_open_workflow and a verified pin align turn routing onto the switched canvas so the next origin-less turn does not inherit the previous workflow (#2531)
 - panel_set_widget settles a missing ACK on a Power Lora lora_N row with a graph read-back instead of reporting outcome-unknown for a row that already landed (#2495)
 
 ## [0.52.157] - 2026-08-30

--- a/src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts
+++ b/src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts
@@ -118,6 +118,38 @@ describe("#888 a HEALTHY pin is still never displaced", () => {
     expect((out as { reason: string }).reason).toMatch(/still reaches a live tab/);
     expect(repinTo).not.toHaveBeenCalled();
   });
+
+  it("still refuses when the named dest is the ACTIVE canvas but the caller did not prove a switch", () => {
+    // #2531's alignLiveCanvas is extra consent from a verified open/pin. Without
+    // it, an active named dest is still not license to steal a live turn.
+    const { handler, repinTo } = harness({ pin: TAB_A, tabs: [TAB_A, TAB_B], active: TAB_B });
+
+    const out = handler(KEY, PATH_B);
+    expect(typeof out).toBe("object");
+    expect((out as { reason: string }).reason).toMatch(/still reaches a live tab/);
+    expect(repinTo).not.toHaveBeenCalled();
+  });
+});
+
+describe("#2531 alignLiveCanvas rewrites lastOrigin onto THIS canvas", () => {
+  it("returns the live tab instead of declining a healthy pin", () => {
+    const { handler, repinTo } = harness({ pin: TAB_A, tabs: [TAB_A, TAB_B] });
+
+    expect(handler(KEY, PATH_A, { alignLiveCanvas: true })).toBe(TAB_A);
+    expect(repinTo).toHaveBeenCalledWith(KEY, TAB_A);
+  });
+
+  it("does not steal onto another tab even when that tab is active and uniquely named", () => {
+    const { handler, repinTo } = harness({
+      pin: TAB_A,
+      tabs: [TAB_A, TAB_B],
+      active: TAB_B,
+    });
+
+    expect(handler(KEY, PATH_B, { alignLiveCanvas: true })).toBe(TAB_A);
+    expect(repinTo).toHaveBeenCalledWith(KEY, TAB_A);
+    expect(repinTo).not.toHaveBeenCalledWith(KEY, TAB_B);
+  });
 });
 
 describe("#2419 a tmp: predecessor pin is rewritten onto the named save dest", () => {

--- a/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
+++ b/src/__tests__/orchestrator/pin-vs-graph-target.test.ts
@@ -126,6 +126,10 @@ class FakePanel {
     public open: Wf[],
     public activeIdx: number,
     public listShape: ListShape = "full",
+    /** When false, skip the same-socket re-hello so tab ids still name the
+     *  pre-switch workflow — the delayed-hello shape that made #2531 report
+     *  pin success while turn routing retained the previous key. */
+    public rehello = true,
   ) {}
 
   get active(): Wf {
@@ -259,7 +263,7 @@ class FakePanel {
         });
         // A real panel re-helloes under the NEW workflow's route id on the SAME
         // socket when the active workflow changes (per-workflow routes, #640).
-        setTimeout(() => this.hello(`wf:r1:${this.active.path}`), 5);
+        if (this.rehello) setTimeout(() => this.hello(`wf:r1:${this.active.path}`), 5);
         return;
       }
       case "graph_outline":
@@ -486,5 +490,73 @@ describe("panel#1529 — a pin may not claim a graph target it did not establish
     const outline = await tool("panel_graph_outline").handler({}, ctx);
     expect(outline.isError, textOf(outline)).toBeFalsy();
     expect(textOf(outline)).toContain("SeedanceVideoExtendApi");
+  });
+});
+
+describe("mcp#2531 — a verified open/pin aligns turn routing onto the switched canvas", () => {
+  const flushMicrotasks = () => new Promise<void>((r) => setTimeout(r, 0));
+
+  it("does not report pin success while retaining the pre-open routing key", async () => {
+    // Delayed hello: the socket switched to B but still advertises A's route id,
+    // so named-dest matching cannot see B and the #884 healthy-pin gate used to
+    // decline. The tool then said the graph target moved AND that turn routing
+    // stayed on A.
+    const page = new FakePanel("wf:r1:workflows/wan_video_edit.json", [A, B], 0, "full", false);
+    await page.connect();
+    tabStamp.set(page.tabId, A.uuid);
+    tracker.recordForMid("m-origin", A.uuid, page.tabId);
+    tracker.onSeen(SCOPE, "m-origin");
+    await flushMicrotasks();
+    const ctx = ctxFor(SCOPE);
+
+    const opened = await tool("panel_open_workflow").handler({ path: B.path }, ctx);
+    expect(opened.isError, textOf(opened)).toBeFalsy();
+    await settle();
+
+    const res = await pin(ctx, B);
+    expect(res.isError, textOf(res)).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.pin_verified_active).toBe(true);
+    expect(body.turn_routing).toBe("repinned");
+    expect(String(body.note ?? "")).toContain("turn routing now follows this workflow");
+    expect(String(body.note ?? "")).not.toMatch(/NOT re-pinned/);
+
+    const outline = await tool("panel_graph_outline").handler({}, ctx);
+    expect(outline.isError, textOf(outline)).toBeFalsy();
+    expect(textOf(outline)).toContain("SeedanceVideoExtendApi");
+  });
+
+  it("the next origin-less turn inherits the switched canvas, not a later tab still showing the old workflow", async () => {
+    const page = new FakePanel("wf:r1:workflows/wan_video_edit.json", [A, B], 0, "full", false);
+    await page.connect();
+    tabStamp.set(page.tabId, A.uuid);
+    // In-flight pin without a lastOrigin (repinTo does not write one — that's
+    // the pre-#2531 state after a healthy pin was left alone). A later tab
+    // showing A must not become the inherited route.
+    tracker.repinTo(SCOPE, page.tabId);
+    const ctx = ctxFor(SCOPE);
+
+    const opened = await tool("panel_open_workflow").handler({ path: B.path }, ctx);
+    expect(opened.isError, textOf(opened)).toBeFalsy();
+    const pinned = await pin(ctx, B);
+    expect(pinned.isError, textOf(pinned)).toBeFalsy();
+    await settle();
+
+    const other = new FakePanel("wf:r2:workflows/wan_video_edit.json", [A], 0, "full", false);
+    await other.connect();
+    tabStamp.set(other.tabId, A.uuid);
+
+    tracker.turnEnded(SCOPE);
+    const mid = tracker.mintInheritedOrigin();
+    tracker.onSeen(SCOPE, mid);
+    await flushMicrotasks();
+
+    expect(tracker.pinOf(SCOPE)).toBe(page.tabId);
+    expect(tracker.pinOf(SCOPE)).not.toBe(other.tabId);
+
+    const outline = await tool("panel_graph_outline").handler({}, ctxFor(SCOPE));
+    expect(outline.isError, textOf(outline)).toBeFalsy();
+    expect(textOf(outline)).toContain("SeedanceVideoExtendApi");
+    expect(other.seen.filter((f) => f.cmd.startsWith("graph_"))).toHaveLength(0);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -13281,6 +13281,26 @@ function noReachableTabFail(cmd: string, ctx?: PanelToolCtx): ToolResult {
   );
 }
 
+/**
+ * #2531 — after a successful open or a verified-active pin, align the
+ * conversation's turn-routing key onto THIS canvas. A live pin is still never
+ * stolen onto a different tab (#884); `alignLiveCanvas` only rewrites lastOrigin
+ * onto the canonical live id so the next origin-less turn (a run completion)
+ * inherits the switched workflow instead of the pre-open one, and so the tool
+ * does not report pin success while retaining a different healthy routing key.
+ *
+ * Best-effort: the open/pin already succeeded. A failed align must not retract it.
+ */
+function alignTurnRoutingAfterSwitch(ctx: PanelToolCtx, workflowPath: string): ScopeRepinOutcome | undefined {
+  if (!isScopeAddress(ctx.tabId)) return undefined;
+  if (typeof ctx.bridge.repinScopeToWorkflow !== "function") return undefined;
+  try {
+    return ctx.bridge.repinScopeToWorkflow(ctx.tabId, workflowPath, { alignLiveCanvas: true });
+  } catch {
+    return undefined; // never worse than the pre-#2531 silence
+  }
+}
+
 async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<ToolResult> {
   // #971 — consume the explicit-current proof BEFORE the first await. This
   // makes it one-shot even when this open fails, and prevents a concurrent or
@@ -13387,6 +13407,7 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
       }
       await tryRebindImportedTmpIdentity(ctx, path);
     }
+    alignTurnRoutingAfterSwitch(ctx, path);
     return res;
   }
 
@@ -13401,6 +13422,7 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
   const verify = await waitForOpenReceipt(ctx, path, dispatchedRid, timing);
   if (verify.receipt === "applied") {
     if (verify.workflowUuid) refreshWorkflowUuid(ctx, { workflow_uuid: verify.workflowUuid });
+    alignTurnRoutingAfterSwitch(ctx, path);
     return ok({
       opened: { path },
       recovered: true,
@@ -23563,8 +23585,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // source-text "wiring" assertion passed, because grepping for a call
           // cannot tell reachable code from dead code. The handler now does the
           // matching against the routes the bridge actually holds.
+          //
+          // #2531 — a pin the panel just verified as the live canvas is an
+          // explicit switch: align lastOrigin onto this canvas rather than
+          // reporting success while turn routing still names the previous
+          // workflow. An UNVERIFIED (lenient) pin keeps the #884 gate: a
+          // healthy pin is left alone.
           try {
-            scopeRepin = ctx.bridge.repinScopeToWorkflow?.(ctx.tabId, pinPath);
+            scopeRepin = pinVerifiedActive
+              ? alignTurnRoutingAfterSwitch(ctx, pinPath)
+              : ctx.bridge.repinScopeToWorkflow?.(ctx.tabId, pinPath);
           } catch {
             scopeRepin = undefined; // never worse than the pre-#888 silence
           }
@@ -23980,7 +24010,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // A refusal carries its own reason out for the same reason.
         const scopeRepinNote =
           typeof scopeRepin === "string"
-            ? ` This session's turn routing was AMBIGUOUS (a reconnect delivered messages from several workflows at once) and is now pinned to this workflow, so graph tools will resolve deterministically.`
+            ? ` This session's turn routing now follows this workflow, so graph tools will resolve deterministically.`
             : scopeRepin && typeof scopeRepin === "object" && scopeRepin.reason
               ? ` NOTE — the workflow target was set, but this session's turn routing was NOT re-pinned: ${scopeRepin.reason}.`
               : "";

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -676,6 +676,25 @@ export class TurnOriginTracker {
     this.turnTargetTabByKey.set(key, tab);
     this.lastTurnUuidByKey.set(key, uuid);
   }
+
+  /**
+   * #2531 — an explicit `panel_open_workflow` / verified pin is a
+   * message-equivalent origin: the agent moved this conversation onto that
+   * canvas. Rewrite the in-flight pin, the issue-time stamp, AND the last
+   * established origin so the NEXT origin-less turn (a run completion) inherits
+   * this canvas instead of the pre-switch workflow.
+   *
+   * Distinct from {@link repinTo}, which must not re-establish a rewind-cleared
+   * inheritance source. Callers are the open/verified-pin alignment in
+   * {@link makeScopeRepinHandler} and the #2419 same-canvas rewrite (the dest
+   * IS this canvas under a new id).
+   */
+  alignTo(key: string, tab: string): void {
+    const uuid = this.deps.uuidOfTab(tab);
+    this.turnTargetTabByKey.set(key, tab);
+    this.lastTurnUuidByKey.set(key, uuid);
+    this.lastOriginByKey.set(key, { tab, uuid });
+  }
 }
 
 /** The scope target resolver the UiBridge consults while resolving a
@@ -783,6 +802,19 @@ export function tabRouteCarriesPath(tabId: string, path: string): boolean {
   });
 }
 
+/** Extra consent for {@link makeScopeRepinHandler} when the caller has already
+ *  proven the named workflow is the live canvas (a successful
+ *  `panel_open_workflow`, or a verified-active pin). */
+export type ScopeRepinRequest = {
+  /**
+   * #2531 — rewrite lastOrigin onto this pin's live canonical id. Never
+   * steals onto a different tab: a healthy pin stays on the socket that just
+   * opened/pinned the canvas. Without this, the tool reports pin success while
+   * the next origin-less turn inherits the pre-switch workflow.
+   */
+  alignLiveCanvas?: boolean;
+};
+
 export function makeScopeRepinHandler(opts: {
   bridge: ScopeRepinBridge;
   tracker: TurnOriginTracker;
@@ -797,10 +829,14 @@ export function makeScopeRepinHandler(opts: {
    * pin we just wrote is immediately invalidated by {@link TurnOriginTracker.resolvedPinOf}.
    */
   claimTab?: (tabId: string, backend: string) => void;
-}): (scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome {
-  return (scopeId, preferredWorkflowPath) => {
+}): (scopeId: string, preferredWorkflowPath?: string, request?: ScopeRepinRequest) => ScopeRepinOutcome {
+  return (scopeId, preferredWorkflowPath, request) => {
     const key = opts.scopeAgentKeyOf(scopeId);
     const backend = opts.backendOfKey(key);
+    const movePin = (tab: string): void => {
+      if (typeof opts.tracker.alignTo === "function") opts.tracker.alignTo(key, tab);
+      else opts.tracker.repinTo(key, tab);
+    };
     const eligible = opts.bridge
       .tabs()
       .map((t) => t.tab_id)
@@ -828,11 +864,25 @@ export function makeScopeRepinHandler(opts: {
       const live = opts.bridge.liveTabIdFor?.(existing) ?? existing;
       const predecessor = existing.startsWith("tmp:");
       if (named && existing !== named && (live === named || predecessor)) {
-        opts.tracker.repinTo(key, named);
+        movePin(named);
         opts.info(
           `[panel-orchestrator] ${key} re-pinned onto ${named.slice(0, 8)} as the save dest successor of ${existing.slice(0, 8)} (#2419)`,
         );
         return named;
+      }
+      // #2531 — a successful open / verified pin already proved THIS canvas is
+      // the named workflow. Do not steal onto another tab whose id happens to
+      // carry that path (a second window showing the same file). Rewrite
+      // lastOrigin onto the canonical live id so the next origin-less turn
+      // inherits this canvas instead of the pre-switch workflow, and so the
+      // tool does not report pin success while retaining a different routing
+      // key.
+      if (request?.alignLiveCanvas && preferredWorkflowPath) {
+        movePin(live);
+        opts.info(
+          `[panel-orchestrator] ${key} aligned turn routing onto ${live.slice(0, 8)} after an explicit open/pin (#2531)`,
+        );
+        return live;
       }
       return {
         repinned: false,

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -34,7 +34,7 @@ import {
 import { primePanelBase, verifiedPanelDiskVersion } from "./panel-workspace.js";
 import { compareSemver, detectInstallMode } from "./self-update.js";
 import { SHARED_SESSION_SCOPE, isScopeAddress } from "./session-scope.js";
-import type { ScopeRepinOutcome } from "../orchestrator/turn-origins.js";
+import type { ScopeRepinOutcome, ScopeRepinRequest } from "../orchestrator/turn-origins.js";
 import {
   QUEUE_BUSY_READ_TOOLS,
   panelToolForGraphCmd,
@@ -2180,7 +2180,13 @@ export class UiBridge {
    *  in-flight turn onto the tab that is active now (the documented
    *  panel_set_workflow_target({mode:"current"}) consent). Returns the tab it
    *  repinned to, or undefined when nothing is resolvable. */
-  private scopeRepinHandler: ((scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome) | null = null;
+  private scopeRepinHandler:
+    | ((
+        scopeId: string,
+        preferredWorkflowPath?: string,
+        request?: ScopeRepinRequest,
+      ) => ScopeRepinOutcome)
+    | null = null;
   /**
    * panel#1292 — an in-flight `mode:"current"` bind that is recovering a null
    * turn pin. Same-batch siblings (`panel_graph_outline`, `panel_set_todo`)
@@ -4270,7 +4276,13 @@ export class UiBridge {
   }
 
   /** #884 — inject the explicit-repin recovery handler (see the field doc). */
-  setScopeRepinHandler(fn: (scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome): void {
+  setScopeRepinHandler(
+    fn: (
+      scopeId: string,
+      preferredWorkflowPath?: string,
+      request?: ScopeRepinRequest,
+    ) => ScopeRepinOutcome,
+  ): void {
     this.scopeRepinHandler = fn;
   }
 
@@ -4290,14 +4302,23 @@ export class UiBridge {
    * of "the active one".
    *
    * Same handler, so the P0 gate is shared by construction: a pin that still
-   * reaches a live tab of this conversation is never displaced, however explicit
-   * the request. What a NAME adds is recovery in the state where "current" is
-   * legitimately refused — several eligible tabs and no active one among them —
-   * which is precisely the state that refusal already tells the agent to escape
-   * by naming a workflow. Until now nothing made the pin follow the name.
+   * reaches a live tab of this conversation is never displaced onto a
+   * background tab, however explicit the request. What a NAME adds is recovery
+   * in the state where "current" is legitimately refused — several eligible
+   * tabs and no active one among them — which is precisely the state that
+   * refusal already tells the agent to escape by naming a workflow.
+   *
+   * #2531 — `alignLiveCanvas` is extra consent from a successful
+   * panel_open_workflow / verified-active pin: rewrite lastOrigin onto THIS
+   * canvas's live id rather than reporting pin success while the next
+   * origin-less turn still inherits the pre-switch workflow.
    */
-  repinScopeToWorkflow(scopeId: string, workflowPath: string): ScopeRepinOutcome {
-    return this.scopeRepinHandler?.(scopeId, workflowPath);
+  repinScopeToWorkflow(
+    scopeId: string,
+    workflowPath: string,
+    request?: ScopeRepinRequest,
+  ): ScopeRepinOutcome {
+    return this.scopeRepinHandler?.(scopeId, workflowPath, request);
   }
 
   /**


### PR DESCRIPTION
## Summary
After `panel_open_workflow` switched the live canvas and `panel_set_workflow_target({mode:"pinned"})` verified that pin, turn routing still named the previous workflow because that route was healthy (#884). The next origin-less turn (a run completion) then inherited the old canvas while graph tools carried the new pin/stamp, so mutations failed with workflow mismatch.

This aligns lastOrigin onto the switched canvas's live id after a proven open/verified pin. It does **not** steal onto a different tab. A healthy pin is still refused when the caller has not proven the canvas moved.

## Test plan
- `npx vitest run src/__tests__/orchestrator/pin-vs-graph-target.test.ts`
- `npx vitest run src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts`

Fixes #2531
