### PR TITLE
fix(2527): wait for late panel_set_widget settle and reconcile retry_of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- keep a pending panel_set_widget receipt until the frontend settles so a following graph read cannot certify a stale widget value, and retry_of reconciles the exact delivered command after a late reply (#2527)
 - install_comfyui(action:"update") prunes a stale origin/dev ref-lock once and switches a detached version-tag checkout onto local master/main when update is explicitly requested (#2524)
 - krea2-identity-edit ships the LoRA widget as a POSIX path so Linux ComfyUI can match the installed file (#2525)
 - panel_strip_workflow applies live capturedWidgetValues to promoted subgraph widgets instead of stale definition defaults (#2522)

--- a/src/__tests__/orchestrator/late-mutation-e2e.test.ts
+++ b/src/__tests__/orchestrator/late-mutation-e2e.test.ts
@@ -192,7 +192,7 @@ describe("late-mutation notice, end to end over a real bridge (#694)", () => {
 
     // 2. THE ASSERTION THIS FILE EXISTS FOR. Nothing else in the suite pins it:
     //    the token an agent is told to quote must be the rid the bridge minted,
-    //    dispatched under, and keyed `timedOutMutations` by.
+    //    dispatched under, and keyed delivered-mutation retention by.
     expect(panel.rids).toHaveLength(1);
     expect(hintRid, "the retry hint quotes a rid the bridge never dispatched").toBe(panel.rids[0]);
 
@@ -212,9 +212,11 @@ describe("late-mutation notice, end to end over a real bridge (#694)", () => {
     expect(textOf(retry)).toContain("tab-e2e");
     // The retry's own result survives underneath the notice.
     expect(retry.content.length).toBeGreaterThan(1);
-    // Not a short-circuit: the retry really was dispatched (#683/#687).
-    expect(panel.rids).toHaveLength(2);
-    expect(panel.rids[1]).not.toBe(panel.rids[0]);
+    // #2527 — once the original has settled, retry_of is answered from the
+    // retained receipt instead of re-dispatching a command the frontend would
+    // reject as a different command or workflow. #683/#687 still forbids
+    // short-circuiting on rid alone when the write has not settled.
+    expect(panel.rids).toHaveLength(1);
   });
 
   it("catches a reply that lands WHILE the retry is in flight", async () => {

--- a/src/__tests__/orchestrator/set-widget-late-timeout-stale-read.test.ts
+++ b/src/__tests__/orchestrator/set-widget-late-timeout-stale-read.test.ts
@@ -1,0 +1,308 @@
+// #2527 — panel_set_widget can time out after the command was already
+// delivered. An immediate panel_query_graph then echoes the pre-write value,
+// a retry_of is rejected as a different command or workflow, and a later
+// ordinary write reports the timed-out value as `previous`.
+//
+// The shipped tools against a real UiBridge must (a) wait for that settlement
+// or disclose the outstanding mutation on the graph read, and (b) answer
+// retry_of from the exact delivered receipt once the frontend has settled.
+
+import { createServer } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { UiBridge } from "../../services/ui-bridge.js";
+import {
+  __panelToolsTestHooks,
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  RETRY_TOKEN_CMDS,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+const TAB = "wf:workflows/Wan Animate 720x1280 49f Test.json";
+const WORKFLOW_UUID = "11111111-1111-4111-8111-111111111111";
+const NODE_ID = 44;
+const WIDGET = "block_size";
+const OLD_VALUE = 8;
+const NEW_VALUE = 12;
+
+let bridge: UiBridge;
+let port: number;
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+async function startBridge(): Promise<void> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    port = await freePort();
+    bridge = new UiBridge(port);
+    bridge.start();
+    if (await bridge.whenReady()) {
+      bridge.setTabWorkflowUuidResolver(() => WORKFLOW_UUID);
+      bridge.setLateMutationFilter((cmdName) => RETRY_TOKEN_CMDS.has(cmdName));
+      return;
+    }
+    lastErr = `bind to ${port} lost a close→rebind race`;
+    await bridge.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+function connectPanel(): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sock.on("open", () => {
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: TAB,
+          title: "Wan Animate",
+          tab_session_id: "browser-tab-2527",
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+          enforces_expected_node_type_at_write: true,
+          enforces_expected_node_identity_at_write: true,
+        }),
+      );
+      resolve(sock);
+    });
+    sock.on("error", reject);
+  });
+}
+
+function viewing() {
+  return {
+    scope: "root",
+    kind: "root",
+    workflow: "Wan Animate.json",
+    workflow_uuid: WORKFLOW_UUID,
+    graph_identity: "graph:root-2527",
+  };
+}
+
+function nodeAt(value: number) {
+  return {
+    id: NODE_ID,
+    type: "WanVideoBlockSwap",
+    is_subgraph: false,
+    node_identity: `node:${NODE_ID}`,
+    widgets: { [WIDGET]: value },
+  };
+}
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ");
+}
+
+function ridFromHint(text: string): string | undefined {
+  return /retry_of:"([^"]+)"/.exec(text)?.[1];
+}
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} is not registered`);
+  return def;
+}
+
+/** Production panel_set_widget passes the 90s refresh budget; the race under
+ *  test is independent of that number, so the write's reply window is shrunk. */
+function fastCtx(): PanelToolCtx {
+  const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+  const inner = ctx.call.bind(ctx);
+  ctx.call = (cmd, timeoutMs, onDispatchedRid, beforeDispatch, options) =>
+    inner(
+      cmd,
+      typeof cmd.cmd === "string" && cmd.cmd === "graph_set_widget" ? 80 : timeoutMs,
+      onDispatchedRid,
+      beforeDispatch,
+      options,
+    );
+  return ctx;
+}
+
+type ScriptedPanel = {
+  applied: number;
+  writes: Array<Record<string, unknown>>;
+};
+
+function attachPanel(
+  sock: WebSocket,
+  opts: { applyDelayMs: number | null; rejectRetryAfterApply?: boolean },
+): ScriptedPanel {
+  const state = { applied: OLD_VALUE, writes: [] as Array<Record<string, unknown>> };
+  let pendingWrite: Record<string, unknown> | null = null;
+  const applyPending = () => {
+    if (!pendingWrite || typeof pendingWrite.rid !== "string") return;
+    state.applied = NEW_VALUE;
+    sock.send(
+      JSON.stringify({
+        rid: pendingWrite.rid,
+        ok: true,
+        result: {
+          set: {
+            node_id: pendingWrite.node_id,
+            widget: pendingWrite.widget,
+            previous: OLD_VALUE,
+            value: NEW_VALUE,
+          },
+        },
+      }),
+    );
+    pendingWrite = null;
+  };
+  sock.on("message", (buf) => {
+    const raw: unknown = JSON.parse(buf.toString());
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+    const msg: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(raw)) msg[key] = value;
+    if (typeof msg.rid !== "string" || typeof msg.cmd !== "string") return;
+    if (msg.cmd === "graph_set_widget") {
+      state.writes.push(msg);
+      if (opts.rejectRetryAfterApply && msg.retry_of && state.applied === NEW_VALUE) {
+        sock.send(
+          JSON.stringify({
+            rid: msg.rid,
+            ok: false,
+            error: "retry_of refers to a different command or workflow.",
+          }),
+        );
+        return;
+      }
+      pendingWrite = msg;
+      if (opts.applyDelayMs === null) return;
+      setTimeout(applyPending, opts.applyDelayMs);
+      return;
+    }
+    const result =
+      msg.cmd === "graph_query"
+        ? {
+            viewing: viewing(),
+            truncated: false,
+            nodes: [nodeAt(state.applied)],
+            node_count: 1,
+          }
+        : msg.cmd === "graph_get_subgraph"
+          ? {
+              viewing: viewing(),
+              truncated: false,
+              node_count: 1,
+              nodes: [nodeAt(state.applied)],
+            }
+          : { ok: true };
+    sock.send(JSON.stringify({ rid: msg.rid, ok: true, result }));
+  });
+  return {
+    get applied() {
+      return state.applied;
+    },
+    get writes() {
+      return state.writes;
+    },
+  };
+}
+
+beforeEach(async () => {
+  await startBridge();
+});
+
+afterEach(async () => {
+  __panelToolsTestHooks.setOutstandingMutationReadSettleMs(null);
+  await bridge.stop();
+});
+
+describe("late panel_set_widget timeout vs stale graph read (#2527)", () => {
+  it("a graph read after the timeout waits for the late apply instead of echoing the old value", async () => {
+    const sock = await connectPanel();
+    attachPanel(sock, { applyDelayMs: 160 });
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+    const ctx = fastCtx();
+
+    const first = await defByName("panel_set_widget").handler(
+      { node_id: NODE_ID, widget: WIDGET, value: NEW_VALUE },
+      ctx,
+    );
+    expect(first.isError, textOf(first)).toBe(true);
+    expect(textOf(first)).toMatch(/did not reply to "graph_set_widget"/);
+    expect(ridFromHint(textOf(first))).toBeTruthy();
+
+    const read = await defByName("panel_query_graph").handler(
+      { ids: [NODE_ID], fields: "detail", limit: 1 },
+      ctx,
+    );
+    expect(read.isError, textOf(read)).not.toBe(true);
+    expect(textOf(read)).toContain(String(NEW_VALUE));
+    expect(textOf(read)).not.toMatch(/"block_size": 8/);
+    expect(textOf(read)).not.toMatch(/OUTCOME UNKNOWN: \d+ delivered mutation/);
+    sock.close();
+  });
+
+  it("discloses an outstanding outcome-unknown mutation when the frontend has not settled", async () => {
+    __panelToolsTestHooks.setOutstandingMutationReadSettleMs(80);
+    const sock = await connectPanel();
+    attachPanel(sock, { applyDelayMs: null });
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+    const ctx = fastCtx();
+
+    const first = await defByName("panel_set_widget").handler(
+      { node_id: NODE_ID, widget: WIDGET, value: NEW_VALUE },
+      ctx,
+    );
+    expect(first.isError).toBe(true);
+    const hintRid = ridFromHint(textOf(first));
+    expect(hintRid).toBeTruthy();
+
+    const read = await defByName("panel_query_graph").handler(
+      { ids: [NODE_ID], fields: "detail", limit: 1 },
+      ctx,
+    );
+    expect(read.isError, textOf(read)).not.toBe(true);
+    expect(textOf(read)).toMatch(/OUTCOME UNKNOWN: 1 delivered mutation/);
+    expect(textOf(read)).toContain(`retry_of:"${hintRid}"`);
+    expect(textOf(read)).toContain("graph_set_widget");
+    expect(textOf(read)).toMatch(/may show values from before those writes applied/);
+    sock.close();
+  });
+
+  it("retry_of of the exact delivered write succeeds after a late frontend reply", async () => {
+    const sock = await connectPanel();
+    const panel = attachPanel(sock, { applyDelayMs: 120, rejectRetryAfterApply: true });
+    await waitFor(() => expect(bridge.canReach(TAB)).toBe(true));
+    const ctx = fastCtx();
+
+    const first = await defByName("panel_set_widget").handler(
+      { node_id: NODE_ID, widget: WIDGET, value: NEW_VALUE },
+      ctx,
+    );
+    const hintRid = ridFromHint(textOf(first));
+    expect(hintRid).toBeTruthy();
+
+    await waitFor(() => {
+      expect(hintRid && bridge.peekLateMutation(hintRid)).toBeTruthy();
+    });
+    expect(panel.applied).toBe(NEW_VALUE);
+    const writesBeforeRetry = panel.writes.length;
+
+    const retry = await defByName("panel_set_widget").handler(
+      { node_id: NODE_ID, widget: WIDGET, value: NEW_VALUE, retry_of: hintRid },
+      ctx,
+    );
+    expect(retry.isError, textOf(retry)).not.toBe(true);
+    expect(textOf(retry)).not.toMatch(/different command or workflow/);
+    expect(textOf(retry)).toMatch(/DID complete|block_size|"value": 12/);
+    expect(panel.writes.length, "settled retry_of must not re-dispatch").toBe(writesBeforeRetry);
+    sock.close();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -383,12 +383,14 @@ import {
   requiresWorkflowStampEnforcement,
 } from "../services/ui-bridge.js";
 import {
+  GRAPH_READ_CMD_BY_TOOL,
   PANEL_TOOL_BY_GRAPH_CMD,
   QUEUE_BUSY_READ_TOOLS,
   RETRY_TOKEN_CMD_BY_TOOL,
   panelToolForGraphCmd,
 } from "../services/panel-graph-cmd-tools.js";
 export {
+  GRAPH_READ_CMD_BY_TOOL,
   PANEL_TOOL_BY_GRAPH_CMD,
   QUEUE_BUSY_READ_TOOLS,
   RETRY_TOKEN_CMD_BY_TOOL,
@@ -1322,6 +1324,10 @@ export const __panelToolsTestHooks = {
   setRunLateAckGraceMs(ms: number | null): void {
     runLateAckGraceMsOverride = ms;
   },
+  /** Shrink the #2527 graph-read wait for an outstanding timed-out mutation. */
+  setOutstandingMutationReadSettleMs(ms: number | null): void {
+    outstandingMutationReadSettleMsOverride = ms;
+  },
   /** Mark a synthetic graph_run result as the bridge's authoritative reply timeout. */
   markRunReplyTimeout(res: ToolResult): ToolResult {
     Object.defineProperty(res, REPLY_TIMEOUT_RESULT, {
@@ -1427,6 +1433,81 @@ const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 90_000;
  *  rather than "wait longer for a chance at completeness". 8 s is the same elective
  *  probe budget the graph_query / graph_serialize probes in this file already use. */
 const GET_ERRORS_COMPLETION_BUDGET_MS = 8_000;
+
+// #2527 — after a mutating graph command times out, the frontend may still be
+// applying it. An immediate graph read can then echo the pre-write value, and a
+// later write reports the timed-out value as `previous`. Graph reads wait this
+// long for that settlement, then disclose any still-outstanding receipt.
+const OUTSTANDING_MUTATION_READ_SETTLE_MS = 8_000;
+let outstandingMutationReadSettleMsOverride: number | null = null;
+function outstandingMutationReadSettleMs(): number {
+  return outstandingMutationReadSettleMsOverride ?? OUTSTANDING_MUTATION_READ_SETTLE_MS;
+}
+
+const GRAPH_READ_SETTLE_CMDS: ReadonlySet<string> = new Set([
+  ...Object.values(GRAPH_READ_CMD_BY_TOOL),
+  "graph_get_subgraph",
+  "graph_get_state",
+  "graph_serialize",
+]);
+
+function isGraphReadSettleCmd(cmd: Record<string, unknown>): boolean {
+  return typeof cmd.cmd === "string" && GRAPH_READ_SETTLE_CMDS.has(cmd.cmd);
+}
+
+function sameMutationScalar(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return a == null && b == null;
+  return String(a) === String(b);
+}
+
+/**
+ * Semantic identity of a delivered mutation vs a retry, ignoring bridge-owned
+ * stamps (`rid`, `retry_of`, `timeout_ms`, `workflow_uuid`) and write-fence
+ * witnesses that a later probe may reconstruct (`expected_*`).
+ */
+function mutationIdentityMatches(
+  retryCmd: Record<string, unknown>,
+  delivered: Record<string, unknown>,
+): boolean {
+  if (retryCmd.cmd !== delivered.cmd) return false;
+  if (retryCmd.cmd === "graph_set_widget") {
+    return (
+      sameMutationScalar(retryCmd.node_id, delivered.node_id) &&
+      sameMutationScalar(retryCmd.widget, delivered.widget) &&
+      sameMutationScalar(retryCmd.value, delivered.value)
+    );
+  }
+  if ("node_id" in delivered) return sameMutationScalar(retryCmd.node_id, delivered.node_id);
+  return true;
+}
+
+async function awaitOutstandingMutationSettle(
+  bridge: PanelToolCtx["bridge"],
+  tabId: string,
+): Promise<void> {
+  const wait = bridge.waitForOutstandingMutations;
+  if (typeof wait !== "function") return;
+  await wait.call(bridge, tabId, outstandingMutationReadSettleMs());
+}
+
+function discloseOutstandingMutations(
+  bridge: PanelToolCtx["bridge"],
+  tabId: string,
+  res: ToolResult,
+): ToolResult {
+  const list = bridge.listOutstandingMutations?.(tabId);
+  if (!list?.length) return res;
+  const named = list
+    .map((m) => `"${m.cmd}" retry_of:"${m.rid}"`)
+    .join(", ");
+  return appendReplyNote(
+    res,
+    `OUTCOME UNKNOWN: ${list.length} delivered mutation(s) still unsettled on this tab (${named}). ` +
+      `This graph read may show values from before those writes applied. Do not treat this snapshot ` +
+      `as proof the write failed; wait, or retry the named mutation with its retry_of token.`,
+  );
+}
 
 // #1639 — while a ComfyUI prompt is running the frontend main thread often
 // cannot service graph_* at all. Waiting out the 20/90 s ack bound only
@@ -15250,6 +15331,12 @@ export function makePanelToolCtx(
       // so they are dispatched on the bounded budget above instead.
       const blocked = graphCmdBlockedByRunningPrompt(cmd);
       if (blocked) return fail(blocked);
+      // #2527 — a timed-out mutation may still be applying. Graph reads wait for
+      // that settlement (or disclose the outstanding receipt) so they cannot
+      // certify a stale widget value as current.
+      if (isGraphReadSettleCmd(cmd)) {
+        await awaitOutstandingMutationSettle(bridge, ctx.tabId);
+      }
       // The bridge owns the graph lane and re-resolves the live connection after
       // waiting. Pass the fence through so it runs at the actual socket dispatch,
       // not before that retarget window.
@@ -15259,7 +15346,9 @@ export function makePanelToolCtx(
       // first-attempt success left the old run in place, and a later unrelated
       // switch inherited its age and was announced as stuck at once (codex r4).
       if (successProvesSwitchCleared(cmd.cmd)) clearSwitchHold(ctx.tabId);
-      return firstTry;
+      return isGraphReadSettleCmd(cmd)
+        ? discloseOutstandingMutations(bridge, ctx.tabId, firstTry)
+        : firstTry;
     } catch (err) {
       onFailure?.(err); // #1560 — the error this attempt failed on (see the wrapper).
       // Post-reconnect retry-once: a reboot/free_vram/reconnect can drop the tab's
@@ -15338,6 +15427,9 @@ export function makePanelToolCtx(
           await awaitReachable();
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
           holdTab = ctx.tabId;
+          if (isGraphReadSettleCmd(cmd)) {
+            await awaitOutstandingMutationSettle(bridge, ctx.tabId);
+          }
           const retried = ok(
             await sendRouted(cmd, timeoutMs, observeRid, beforeDispatch, options),
           );
@@ -15353,7 +15445,9 @@ export function makePanelToolCtx(
           if (isWorkflowSwitchGuardRefusal(err) && successProvesSwitchCleared(cmd.cmd)) {
             clearSwitchHold(holdTab);
           }
-          return retried;
+          return isGraphReadSettleCmd(cmd)
+            ? discloseOutstandingMutations(bridge, ctx.tabId, retried)
+            : retried;
         } catch (err2) {
           // #1560 — the RETRY's failure is the one every exit below describes, so it
           // supersedes the first. A retried read that comes back refused is a panel
@@ -15938,7 +16032,9 @@ export function makePanelToolCtx(
               if (fenceNow.known && fenceNow.uuid) corroborateTabStamp(ctx, fenceNow.uuid);
               const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));
               if (successProvesSwitchCleared(cmd.cmd)) clearSwitchHold(ctx.tabId);
-              return retried;
+              return isGraphReadSettleCmd(cmd)
+                ? discloseOutstandingMutations(bridge, ctx.tabId, retried)
+                : retried;
             }
           } catch {
             // query refused, tab moved, or the outline retry still mismatched —
@@ -15969,7 +16065,9 @@ export function makePanelToolCtx(
             try {
               const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));
               if (successProvesSwitchCleared(cmd.cmd)) clearSwitchHold(ctx.tabId);
-              return retried;
+              return isGraphReadSettleCmd(cmd)
+                ? discloseOutstandingMutations(bridge, ctx.tabId, retried)
+                : retried;
             } catch (retryErr) {
               onFailure?.(retryErr);
               return fail(retryErr instanceof Error ? retryErr : new Error(String(retryErr)));
@@ -15984,7 +16082,9 @@ export function makePanelToolCtx(
             try {
               const retried = ok(await sendRouted(cmd, timeoutMs, observeRid));
               if (successProvesSwitchCleared(cmd.cmd)) clearSwitchHold(ctx.tabId);
-              return retried;
+              return isGraphReadSettleCmd(cmd)
+                ? discloseOutstandingMutations(bridge, ctx.tabId, retried)
+                : retried;
             } catch (retryErr) {
               onFailure?.(retryErr);
               if (!isWorkflowInstanceMismatch(retryErr)) {
@@ -18412,22 +18512,42 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
       // they just named it. Drained here (once) and reported alongside the
       // retry's own outcome.
       //
-      // Deliberately NOT a short-circuit. Skipping the dispatch would be wrong
-      // whenever the token is stale or pasted onto different args -- the bridge
-      // stores the rid, not a fingerprint of what it carried, so "the write for
-      // this rid landed" does not prove "the write you are asking for now is
-      // that same write". Suppressing a real mutation on that inference is the
-      // #683 mistake with the arrow reversed, and #687 reverted it for cause.
-      // Double-apply is already the #521 panel ledger's job; this only makes the
-      // outcome VISIBLE, which is the half of #694 nothing else does.
+      // #683/#687 — do NOT short-circuit on rid alone. The token names an
+      // attempt, not a fingerprint of its args, so "this rid landed" does not
+      // prove "the write you are asking for now is that same write".
+      //
+      // #2527 — when the receipt for that rid is the SAME command (semantic
+      // identity) and the frontend has already settled it, re-dispatching is
+      // what gets rejected as "retry_of refers to a different command or
+      // workflow". Answer from the receipt instead. A sibling mutation inside
+      // the same handler (enter_subgraph during a set_widget retry) must not
+      // carry this token at all.
       const wrapped = Object.create(ctx) as PanelToolCtx;
       wrapped.call = (
         cmd: Record<string, unknown>,
         timeoutMs?: number,
         onDispatchedRid?: (rid: string) => void,
         beforeDispatch?: () => void,
-      ) =>
-        ctx.call(
+      ) => {
+        const cmdName = typeof cmd.cmd === "string" ? cmd.cmd : "";
+        const original = ctx.bridge?.peekDeliveredMutation?.(retryOf);
+        if (original) {
+          if (original.cmd !== cmdName) {
+            return ctx.call(cmd, timeoutMs, onDispatchedRid, beforeDispatch);
+          }
+          const settled = ctx.bridge.peekLateMutation?.(retryOf);
+          if (settled && mutationIdentityMatches(cmd, original.frame)) {
+            return Promise.resolve(
+              ok(settled.result !== undefined ? settled.result : { ok: true, retry_of: retryOf }),
+            );
+          }
+          if (mutationIdentityMatches(cmd, original.frame)) {
+            const replay: Record<string, unknown> = { ...original.frame, retry_of: retryOf };
+            delete replay.rid;
+            return ctx.call(replay, timeoutMs, onDispatchedRid, beforeDispatch);
+          }
+        }
+        return ctx.call(
           // Ask the RETRY MAP's question, not the workflow fence's (codex gate).
           // These were the same answer only while isMutatingGraphCommand
           // over-classified — the #778 defect. Once the fence got its own effect
@@ -18441,13 +18561,12 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
           // A read probe inside a mutating handler (panel_flatten_workflow's
           // graph_serialize) is still excluded — RETRY_TOKEN_CMDS contains no
           // reads, which is asserted in panel-retry-identity.test.ts.
-          RETRY_TOKEN_CMDS.has(typeof cmd.cmd === "string" ? cmd.cmd : "")
-            ? { ...cmd, retry_of: retryOf }
-            : cmd,
+          RETRY_TOKEN_CMDS.has(cmdName) ? { ...cmd, retry_of: retryOf } : cmd,
           timeoutMs,
           onDispatchedRid,
           beforeDispatch,
         );
+      };
       const out = await d.handler(args, wrapped);
       // Drained AFTER the handler, deliberately, for two measured reasons.
       //

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1918,6 +1918,30 @@ export type LateMutation = {
   result?: unknown;
 };
 
+/**
+ * A mutation that was written to the panel and has not yet been acknowledged
+ * (#2527). Keyed by the dispatched rid so a late frontend reply, a graph read,
+ * or a retry_of can reconcile the exact delivered command instead of racing a
+ * stale snapshot.
+ */
+export type DeliveredMutationReceipt = {
+  rid: string;
+  cmd: string;
+  tabId: string;
+  ts: number;
+  frame: Record<string, unknown>;
+  status: "in_flight" | "timed_out";
+};
+
+/** Peek of a delivered mutation, including one that already settled late. */
+export type PeekedDeliveredMutation = {
+  rid: string;
+  cmd: string;
+  tabId: string;
+  frame: Record<string, unknown>;
+  status: "in_flight" | "timed_out" | "settled";
+};
+
 /** A prompt id captured by the Panel after the graph_run reply window (#1728). */
 export type LateRunReceipt = {
   runRid: string;
@@ -1970,6 +1994,19 @@ function retainableLateResult(result: unknown): { result?: unknown } {
   } catch {
     return {};
   }
+}
+
+/** Clone the dispatched command minus rid so a later retry can replay it. */
+function cloneDeliveredMutationFrame(frame: Record<string, unknown>): Record<string, unknown> {
+  let cloned: Record<string, unknown>;
+  try {
+    const json = JSON.stringify(frame);
+    cloned = typeof json === "string" ? (JSON.parse(json) as Record<string, unknown>) : { ...frame };
+  } catch {
+    cloned = { ...frame };
+  }
+  delete cloned.rid;
+  return cloned;
 }
 
 /** Tag an error as a reply-timeout and return it (for throw/reject). */
@@ -2338,22 +2375,23 @@ export class UiBridge {
   /** TTL for a BUFFERED late ask answer — see the exported LATE_ASK_TTL_MS. */
   private static readonly LATE_ASK_TTL_MS = LATE_ASK_TTL_MS;
   /**
-   * Mutations whose reply timer fired (rid -> what it was), so a reply arriving
-   * afterwards can be RECOGNISED as the late completion of a known write rather
-   * than an unknown rid to drop (#694).
+   * Mutations written to the panel and not yet acknowledged (#2527 / #694).
    *
-   * Deliberately narrow, and the negatives matter more than the positive:
-   *  - MUTATIONS only. A read that is abandoned costs nothing because you just
-   *    retry it (#1154's asymmetry); retaining reads would make this unbounded
-   *    noise for no recoverable information.
-   *  - populated when we STOP WAITING for a reply we already wrote — the reply
-   *    timer firing (#694), OR a mid-command disconnect of a filtered mutation
-   *    (panel#1524). A mutation that replies in time resolves its caller directly
-   *    and has nothing to report later. Without the disconnect arm, the panel's
-   *    lost-reply replay of a `graph_run` that already queued is an unknown rid
-   *    and is dropped — the caller is stuck with OUTCOME UNKNOWN for a paid render.
+   * Populated at dispatch (not only at timeout) so a graph read or retry_of can
+   * still name the exact delivered command while the frontend is settling.
+   * Status becomes `timed_out` when we STOP WAITING — the reply timer firing
+   * (#694) or a mid-command disconnect of a filtered mutation (panel#1524).
+   * A mutation that replies in time is forgotten: the caller already has the
+   * outcome. Without the disconnect arm, the panel's lost-reply replay of a
+   * `graph_run` that already queued is an unknown rid and is dropped.
+   *
+   * Deliberately mutations only. A read that is abandoned costs a retry
+   * (#1154's asymmetry); retaining reads would make this unbounded noise.
    */
-  private timedOutMutations = new Map<string, { cmd: string; tabId: string; ts: number }>();
+  private deliveredMutations = new Map<
+    string,
+    { cmd: string; tabId: string; ts: number; frame: Record<string, unknown>; status: "in_flight" | "timed_out" }
+  >();
   /** Installed by the retry-token layer; see setLateMutationFilter. Null means
    *  retain nothing. */
   private lateMutationFilter: ((cmdName: string) => boolean) | null = null;
@@ -2361,8 +2399,18 @@ export class UiBridge {
    *  takeLateMutation(). Success only: see the recordLateMutation comment. */
   private lateMutations = new Map<
     string,
-    { ok: true; cmd: string; tabId: string; ts: number; lateByMs: number; result?: unknown }
+    {
+      ok: true;
+      cmd: string;
+      tabId: string;
+      ts: number;
+      lateByMs: number;
+      result?: unknown;
+      frame: Record<string, unknown>;
+    }
   >();
+  /** Waiters blocked on a tab's outcome-unknown mutations settling (#2527). */
+  private mutationSettleWaiters: Array<{ tabId: string; finish: () => void }> = [];
   /** Exact prompt receipts sent by the Panel after its graph_run command returned. */
   private lateRunReceipts = new Map<
     string,
@@ -4585,10 +4633,13 @@ export class UiBridge {
    * caller does not already have.
    */
   private recordLateMutation(rid: string, msg: { ok?: unknown; result?: unknown }): void {
-    const started = this.timedOutMutations.get(rid);
+    const started = this.deliveredMutations.get(rid);
     if (!started) return;
-    this.timedOutMutations.delete(rid);
-    if (msg.ok !== true) return;
+    this.deliveredMutations.delete(rid);
+    if (msg.ok !== true) {
+      this.notifyMutationSettled(started.tabId);
+      return;
+    }
     const now = Date.now();
     this.pruneLateMutations();
     this.lateMutations.set(rid, {
@@ -4597,11 +4648,13 @@ export class UiBridge {
       tabId: started.tabId,
       ts: now,
       lateByMs: now - started.ts,
+      frame: started.frame,
       ...retainableLateResult(msg.result),
     });
     logger.debug(
       `[ui-bridge] "${started.cmd}" on tab ${started.tabId} completed ${now - started.ts} ms AFTER its reply timeout — retained for the caller (#694)`,
     );
+    this.notifyMutationSettled(started.tabId);
   }
 
   /**
@@ -4645,6 +4698,81 @@ export class UiBridge {
       lateByMs: hit.lateByMs,
       ...("result" in hit ? { result: hit.result } : {}),
     };
+  }
+
+  /**
+   * Outcome-unknown (timed-out, not yet settled) mutations on `tabId` (#2527).
+   * Graph reads wait on these, or disclose them when the frontend has not
+   * acknowledged yet.
+   */
+  listOutstandingMutations(tabId: string): DeliveredMutationReceipt[] {
+    this.pruneLateMutations();
+    const out: DeliveredMutationReceipt[] = [];
+    for (const [rid, e] of this.deliveredMutations) {
+      if (e.tabId !== tabId || e.status !== "timed_out") continue;
+      out.push({ rid, cmd: e.cmd, tabId: e.tabId, ts: e.ts, frame: e.frame, status: e.status });
+    }
+    return out;
+  }
+
+  /** Look up a delivered mutation by rid without draining a late completion. */
+  peekDeliveredMutation(rid: string): PeekedDeliveredMutation | undefined {
+    this.pruneLateMutations();
+    const settled = this.lateMutations.get(rid);
+    if (settled) {
+      return {
+        rid,
+        cmd: settled.cmd,
+        tabId: settled.tabId,
+        frame: settled.frame,
+        status: "settled",
+      };
+    }
+    const live = this.deliveredMutations.get(rid);
+    if (!live) return undefined;
+    return { rid, cmd: live.cmd, tabId: live.tabId, frame: live.frame, status: live.status };
+  }
+
+  /**
+   * Wait until every timed-out mutation on `tabId` has a frontend settlement,
+   * or `budgetMs` elapses (#2527). Resolves without throwing.
+   */
+  waitForOutstandingMutations(tabId: string, budgetMs: number): Promise<void> {
+    this.pruneLateMutations();
+    if (this.listOutstandingMutations(tabId).length === 0) return Promise.resolve();
+    const budget = Number.isFinite(budgetMs) ? Math.max(0, Math.floor(budgetMs)) : 0;
+    if (budget <= 0) return Promise.resolve();
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        this.mutationSettleWaiters = this.mutationSettleWaiters.filter((w) => w !== waiter);
+        resolve();
+      };
+      const waiter = { tabId, finish };
+      const timer = setTimeout(finish, budget);
+      this.mutationSettleWaiters.push(waiter);
+      if (this.listOutstandingMutations(tabId).length === 0) finish();
+    });
+  }
+
+  private outstandingTimedOutCount(tabId: string): number {
+    let n = 0;
+    for (const e of this.deliveredMutations.values()) {
+      if (e.tabId === tabId && e.status === "timed_out") n += 1;
+    }
+    return n;
+  }
+
+  private notifyMutationSettled(tabId: string): void {
+    if (this.mutationSettleWaiters.length === 0) return;
+    if (this.outstandingTimedOutCount(tabId) > 0) return;
+    const waiters = this.mutationSettleWaiters.filter((w) => w.tabId === tabId);
+    if (waiters.length === 0) return;
+    this.mutationSettleWaiters = this.mutationSettleWaiters.filter((w) => w.tabId !== tabId);
+    for (const waiter of waiters) waiter.finish();
   }
 
   /** Record one exact prompt id from the Panel's late graph_run capture. */
@@ -4776,8 +4904,12 @@ export class UiBridge {
   /** TTL + cardinality bound for both #694 maps. */
   private pruneLateMutations(): void {
     const now = Date.now();
-    for (const [rid, e] of this.timedOutMutations) {
-      if (now - e.ts > UiBridge.LATE_MUTATION_TTL_MS) this.timedOutMutations.delete(rid);
+    const prunedTabs = new Set<string>();
+    for (const [rid, e] of this.deliveredMutations) {
+      if (now - e.ts > UiBridge.LATE_MUTATION_TTL_MS) {
+        this.deliveredMutations.delete(rid);
+        prunedTabs.add(e.tabId);
+      }
     }
     for (const [rid, e] of this.lateMutations) {
       if (now - e.ts > UiBridge.LATE_MUTATION_TTL_MS) this.lateMutations.delete(rid);
@@ -4792,13 +4924,18 @@ export class UiBridge {
     // oldest. Quiet, unlike the ask-mapping overflow: losing one of 256 late
     // completions costs the caller a notice they can still get by looking, where
     // losing an ask mapping loses a user's answer outright.
-    for (const map of [this.timedOutMutations, this.lateMutations, this.lateRunReceipts, this.lateRunReceiptHandoffs]) {
+    for (const map of [this.deliveredMutations, this.lateMutations, this.lateRunReceipts, this.lateRunReceiptHandoffs]) {
       while (map.size > UiBridge.MAX_LATE_MUTATIONS) {
         const oldest = map.keys().next();
         if (oldest.done) break;
+        const dropped = map.get(oldest.value);
+        if (dropped && "tabId" in dropped && typeof dropped.tabId === "string") {
+          prunedTabs.add(dropped.tabId);
+        }
         map.delete(oldest.value);
       }
     }
+    for (const tabId of prunedTabs) this.notifyMutationSettled(tabId);
   }
 
   private pruneLateAsk(): void {
@@ -5106,6 +5243,7 @@ export class UiBridge {
     clearTimeout(pending.timer);
     this.pending.delete(rid);
     this.askRidToId.delete(rid);
+    this.forgetDeliveredMutation(rid);
     if (msg.ok) {
       // #422 — the panel DEMONSTRABLY served this command. Record it on the LIVE
       // connection (following a same-socket tmp:→wf: migration whose reply landed
@@ -6558,10 +6696,12 @@ export class UiBridge {
       if (ctx.workflowUuid) frame.workflow_uuid = ctx.workflowUuid;
       else delete frame.workflow_uuid;
       conn.sock.send(JSON.stringify(frame));
+      this.rememberDeliveredMutation(rid, cmd.cmd, ctx.tabId, frame);
       try { ctx.onDispatchedRid?.(rid); } catch { /* observer faults are non-fatal */ }
     } catch (err) {
       clearTimeout(timer);
       this.pending.delete(rid);
+      this.forgetDeliveredMutation(rid);
       // The write to the socket FAILED — the command was NEVER transmitted, so nothing
       // was dispatched (distinct from a POST-write mid-command drop). Surface that
       // explicitly so callers don't mistake it for an in-flight/accepted command (a
@@ -6582,6 +6722,34 @@ export class UiBridge {
   }
 
   /**
+   * Remember a mutation the moment it is written, so a graph read or retry_of
+   * can name the exact delivered command until the frontend settles (#2527).
+   */
+  private rememberDeliveredMutation(
+    rid: string,
+    cmd: string,
+    tabId: string,
+    frame: Record<string, unknown>,
+  ): void {
+    if (!rid || !this.lateMutationFilter?.(cmd)) return;
+    this.pruneLateMutations();
+    this.deliveredMutations.set(rid, {
+      cmd,
+      tabId,
+      ts: Date.now(),
+      frame: cloneDeliveredMutationFrame(frame),
+      status: "in_flight",
+    });
+  }
+
+  private forgetDeliveredMutation(rid: string): void {
+    const hit = this.deliveredMutations.get(rid);
+    if (!hit) return;
+    this.deliveredMutations.delete(rid);
+    if (hit.status === "timed_out") this.notifyMutationSettled(hit.tabId);
+  }
+
+  /**
    * Remember that we stopped waiting for `rid` so a later reply — a frozen tab
    * catching up, or a lost-reply replay after reconnect — is retained instead of
    * dropped as an unknown rid (#694, panel#1524).
@@ -6589,7 +6757,19 @@ export class UiBridge {
   private retainAbandonedMutation(rid: string, cmd: string, tabId: string): void {
     if (!rid || !this.lateMutationFilter?.(cmd)) return;
     this.pruneLateMutations();
-    this.timedOutMutations.set(rid, { cmd, tabId, ts: Date.now() });
+    const prior = this.deliveredMutations.get(rid);
+    if (prior) {
+      prior.status = "timed_out";
+      prior.ts = Date.now();
+      return;
+    }
+    this.deliveredMutations.set(rid, {
+      cmd,
+      tabId,
+      ts: Date.now(),
+      frame: { cmd },
+      status: "timed_out",
+    });
   }
 
   /** A pending command's socket died before its reply arrived. Decide, WITHOUT


### PR DESCRIPTION
Fixes a late-receipt / graph-settle race in `panel_set_widget`.

A nested-subgraph write could time out after the command was already delivered. An immediate `panel_query_graph` then echoed the pre-write value, `retry_of` was rejected as a different command or workflow, and a later ordinary write reported the timed-out value as `previous`.

## Changes
- Keep a delivered mutation receipt keyed by rid from dispatch until the frontend settles.
- Graph reads wait for that settlement (bounded) or disclose the outstanding outcome-unknown mutation instead of certifying a stale widget value.
- `retry_of` of the exact delivered command is answered from the receipt after a late frontend reply, and is not attached to a sibling command in the same handler.

## Test
- `npx vitest run src/__tests__/orchestrator/set-widget-late-timeout-stale-read.test.ts`

Fixes #2527
