### PR TITLE
chore: release v0.52.158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.158] - 2026-08-30
+
 ### MCP
 
 #### Fixed
-- panel_open_workflow and a verified pin align turn routing onto the switched canvas so the next origin-less turn does not inherit the previous workflow (#2531)
-- panel_set_widget settles a missing ACK on a Power Lora lora_N row with a graph read-back instead of reporting outcome-unknown for a row that already landed (#2495)
-- panel_open_workflow does not report a successful tab switch as an error when only frontend-owned ue_properties / widget representations differ, including a live serialize that omits nested subgraph definitions (#2494)
-- upload_image action:image returns a LoadImage-selectable root filename when a nested path is stored but not enumerated (#2498)
+- panel_open_workflow and a verified pin align turn routing onto the switched canvas so the next origin-less turn does not inherit the previous workflow (#2531, #2638)
+- panel_set_widget settles a missing ACK on a Power Lora lora_N row with a graph read-back instead of reporting outcome-unknown for a row that already landed (#2495, #2597)
+- panel_open_workflow does not report a successful tab switch as an error when only frontend-owned ue_properties / widget representations differ, including a live serialize that omits nested subgraph definitions (#2494, #2596)
+- upload_image action:image returns a LoadImage-selectable root filename when a nested path is stored but not enumerated (#2498, #2595)
 
 ## [0.52.157] - 2026-08-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.157",
+  "version": "0.52.158",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.157",
+      "version": "0.52.158",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.157",
+  "version": "0.52.158",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cut v0.52.158 covering:
- #2531 turn routing after open/pin
- #2495 Power Lora lora_N ACK read-back
- #2494 open success vs ue_properties/widget diffs