### PR TITLE
fix(2539): list_outputs follows the live output dir, not a stale COMFYUI_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- get_image list_outputs scans the live server's output dir (and /history if that scan is empty) instead of an unrelated COMFYUI_PATH (#2539)
 - panel_connect refuses a frontend PrimitiveNode wired to a forceInput-only STRING instead of reporting a LiteGraph link that panel_run omits from the prompt (#2536)
 - panel_run retries once after a "Dynamic widget doesn't exist on node" serializer throw so the first queue after graph edits is not a false failure (#2537)
 - get_history and panel_run completion journaling fall back to the connected panel's global /history when the headless `/history/<prompt_id>` is unreachable, and queue.status discloses a cached done when that history still cannot be read (#2532)

--- a/src/__tests__/services/list-outputs-history-fallback.test.ts
+++ b/src/__tests__/services/list-outputs-history-fallback.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, writeFile, rm, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// #2539 — get_image list_outputs scanned an unrelated COMFYUI_PATH (empty)
+// while live /view had the files. resolveOutputDir is mocked to that empty
+// directory so the history fallback is the thing under test, not path
+// resolution.
+
+let outputDir = "";
+let tempDir = "";
+let outputDirError: Error | null = null;
+let tempDirError: Error | null = null;
+vi.mock("../../services/output-dir.js", () => ({
+  resolveOutputDir: () =>
+    outputDirError ? Promise.reject(outputDirError) : Promise.resolve(outputDir),
+  resolveInputDir: () => Promise.resolve(outputDir),
+  resolveTempDir: () =>
+    tempDirError ? Promise.reject(tempDirError) : Promise.resolve(tempDir),
+}));
+
+const getHistoryMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+  fetchImage: vi.fn(),
+  uploadImageHttp: vi.fn(),
+  MAX_VIEW_RESPONSE_BYTES: 32 * 1024 * 1024,
+}));
+
+let remoteFlag = false;
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return { ...actual, isRemoteMode: () => remoteFlag };
+});
+
+import { config } from "../../config.js";
+import { listOutputMedia } from "../../services/image-management.js";
+
+interface HistoryMedia {
+  filename: string;
+  subfolder: string;
+  type: "output" | "temp";
+}
+
+function historyWithImages(images: HistoryMedia[]): Record<string, unknown> {
+  return {
+    prompt: { outputs: { "9": { images } } },
+  };
+}
+
+async function touch(name: string, when: Date, bytes = 1024): Promise<void> {
+  const p = join(outputDir, name);
+  await writeFile(p, Buffer.alloc(bytes));
+  await utimes(p, when, when);
+}
+
+let prevComfyuiPath: string | undefined;
+
+beforeEach(async () => {
+  outputDir = await mkdtemp(join(tmpdir(), "comfy-out-"));
+  tempDir = await mkdtemp(join(tmpdir(), "comfy-temp-"));
+  prevComfyuiPath = config.comfyuiPath;
+  config.comfyuiPath = outputDir;
+  remoteFlag = false;
+  outputDirError = null;
+  tempDirError = null;
+  getHistoryMock.mockReset();
+});
+
+afterEach(async () => {
+  await rm(outputDir, { recursive: true, force: true });
+  await rm(tempDir, { recursive: true, force: true });
+  config.comfyuiPath = prevComfyuiPath;
+  vi.clearAllMocks();
+});
+
+describe("#2539 list_outputs empty local scan of an unrelated COMFYUI_PATH", () => {
+  it("returns matching /history entries instead of an empty local-scan", async () => {
+    // The scanned directory is empty — the unrelated COMFYUI_PATH from the report.
+    // Live /history (and therefore /view) still has the three panel outputs.
+    getHistoryMock.mockResolvedValue(
+      historyWithImages([
+        { filename: "panel_00001_.png", subfolder: "sub", type: "output" },
+        { filename: "panel_00002_.png", subfolder: "sub", type: "output" },
+        { filename: "panel_00003_.png", subfolder: "sub", type: "output" },
+      ]),
+    );
+
+    const result = await listOutputMedia({ pattern: "panel", limit: 20 });
+
+    expect(result.images.map((i) => i.filename)).toEqual([
+      "panel_00001_.png",
+      "panel_00002_.png",
+      "panel_00003_.png",
+    ]);
+    expect(result.images.every((i) => i.subfolder === "sub")).toBe(true);
+    expect(result.source.basis).toBe("server-history-fallback");
+    expect(result.source.directory).toBe(outputDir);
+    expect(getHistoryMock).toHaveBeenCalled();
+  });
+
+  it("does not consult /history when the local scan already found files", async () => {
+    await touch("local_only.png", new Date("2026-08-29T12:00:00Z"));
+    getHistoryMock.mockResolvedValue(
+      historyWithImages([{ filename: "from_history.png", subfolder: "", type: "output" }]),
+    );
+
+    const result = await listOutputMedia({ limit: 20 });
+
+    expect(result.images.map((i) => i.filename)).toEqual(["local_only.png"]);
+    expect(result.source.basis).toBe("local-scan");
+    expect(getHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps an empty local-scan when /history is also empty", async () => {
+    getHistoryMock.mockResolvedValue({});
+
+    const result = await listOutputMedia({ pattern: "panel", limit: 20 });
+
+    expect(result.images).toEqual([]);
+    expect(result.source.basis).toBe("local-scan");
+    expect(result.source.directory).toBe(outputDir);
+  });
+
+  it("keeps an empty local-scan when /history cannot be read", async () => {
+    getHistoryMock.mockRejectedValue(new Error("unreachable"));
+
+    const result = await listOutputMedia({ limit: 20 });
+
+    expect(result.images).toEqual([]);
+    expect(result.source.basis).toBe("local-scan");
+  });
+
+  it("applies the filename pattern to the /history fallback", async () => {
+    getHistoryMock.mockResolvedValue(
+      historyWithImages([
+        { filename: "panel_00001_.png", subfolder: "", type: "output" },
+        { filename: "other_00001_.png", subfolder: "", type: "output" },
+      ]),
+    );
+
+    const result = await listOutputMedia({ pattern: "panel", limit: 20 });
+
+    expect(result.images.map((i) => i.filename)).toEqual(["panel_00001_.png"]);
+    expect(result.source.basis).toBe("server-history-fallback");
+  });
+});

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1359,6 +1359,22 @@ describe("#1052: I/O dirs follow the CONNECTED server, not a second install", ()
     getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
     expect(await resolveOutputDir()).toBe(resolve(DESKTOP, "output"));
   });
+
+  // #2539 — ComfyUI Desktop / Windows portable report a RELATIVE
+  // `ComfyUI/main.py` with no cwd and no --output-directory. argv alone cannot
+  // resolve the live root, so list_outputs scanned the unrelated COMFYUI_PATH
+  // while /view served the live server's files. The OS-observed process is the
+  // same rung models already use for this argv shape.
+  it("#2539: relative ComfyUI/main.py without cwd uses the OS-observed live root, not COMFYUI_PATH", async () => {
+    const liveRoot = resolve("/portable2/ComfyUI");
+    observedLiveRoot = liveRoot;
+    getSystemStats.mockResolvedValue({
+      system: { argv: [join("ComfyUI", "main.py"), "--windows-standalone-build"] },
+    });
+    const got = await resolveOutputDir();
+    expect(got).toBe(join(liveRoot, "output"));
+    expect(got).not.toBe(resolve(DESKTOP, "output"));
+  });
 });
 
 describe("#1371 — a configured base the server demonstrably does not read is refused", () => {

--- a/src/__tests__/tools/get-image-local-fallback.test.ts
+++ b/src/__tests__/tools/get-image-local-fallback.test.ts
@@ -45,6 +45,14 @@ vi.mock("../../services/workspace-env.js", async () => {
   return {
     ...actual,
     resolveLiveComfyUIBase: (...args: unknown[]) => mocks.liveRoot(...args),
+    // #1263 — this file pins the #2194 argv live-root rung. The OS process table
+    // is not a fixture; observed-process for relative ComfyUI/main.py lives in
+    // output-dir.test.ts (#2539).
+    resolveLiveServerRoot: (argv?: string[], cwd?: string) => {
+      const fromArgv = actual.liveRootFromArgv(argv, cwd);
+      if (fromArgv) return { root: fromArgv, source: "argv" };
+      return { source: "unresolved" };
+    },
   };
 });
 

--- a/src/__tests__/tools/image-assets.test.ts
+++ b/src/__tests__/tools/image-assets.test.ts
@@ -31,7 +31,7 @@ const stageOutputAsInputMock = vi.fn();
 let listSourceMock: {
   directory?: string;
   tempDirectory?: string;
-  basis: "local-scan" | "server-history";
+  basis: "local-scan" | "server-history" | "server-history-fallback";
 } = {
   directory: "C:\\Comfy\\output",
   basis: "local-scan",

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -294,7 +294,7 @@ export interface OutputListingSource {
    *  /history path. */
   tempDirectory?: string;
   /** How the answer was produced, so a caller never has to guess which. */
-  basis: "local-scan" | "server-history";
+  basis: "local-scan" | "server-history" | "server-history-fallback";
 }
 
 /**
@@ -434,6 +434,35 @@ export async function listOutputMedia(options?: {
         `This is NOT a finding that there are no outputs.`,
       "OUTPUT_ENTRIES_UNREADABLE",
     );
+  }
+
+  // #2539 — a successful local scan of the WRONG directory looks identical to
+  // a genuine empty folder: resolveOutputDir fell back to an unrelated
+  // COMFYUI_PATH (relative `ComfyUI/main.py`, no --output-directory, no cwd)
+  // while the live /view endpoint served the files. Returning `{images:[],
+  // source: local-scan}` here is a silent miss, not an error. /history is the
+  // same source action:"get" uses; if it has matches, those are the answer.
+  // An unreadable history is not a finding that the empty scan was right —
+  // keep the empty local result rather than convert a readable empty folder
+  // into HISTORY_UNREADABLE.
+  if (images.length === 0) {
+    try {
+      const fromHistory = await listOutputImagesFromHistory(limit, pattern);
+      if (fromHistory.length > 0) {
+        return {
+          images: fromHistory,
+          source: {
+            directory: outputDir,
+            ...(tempDirectory ? { tempDirectory } : {}),
+            basis: "server-history-fallback",
+          },
+        };
+      }
+    } catch (err) {
+      logger.debug("Could not fall back to /history after an empty local output scan", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   // Sort newest first

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -4,8 +4,6 @@ import { config, isRemoteMode } from "../config.js";
 import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import {
   resolveEffectiveComfyUIBase,
-  resolveLiveComfyUIBase,
-  liveRootFromArgv,
   resolveLiveServerRoot,
   hasComfyUIEntrypoint,
 } from "./workspace-env.js";
@@ -1311,13 +1309,14 @@ export function localTempDirFallback(): string {
  * ComfyUI (/system_stats argv) first; falls back to <COMFYUI_PATH>/input.
  */
 /**
- * `<live install root>/<kind>` when the CONNECTED server's own argv identifies
- * it, else undefined (#1052).
+ * `<live install root>/<kind>` when the CONNECTED server identifies it, else
+ * undefined (#1052, #2539).
  *
  * The argv parse above only answers when ComfyUI was launched with an EXPLICIT
- * --input-directory / --output-directory. Without one, resolution fell straight
- * through to the configured/auto-detected install — and on a machine with more
- * than one ComfyUI that is a different tree from the one actually running.
+ * --input-directory / --output-directory. Without one, resolution used to fall
+ * straight through to the configured/auto-detected install — and on a machine
+ * with more than one ComfyUI that is a different tree from the one actually
+ * running.
  *
  * A reporter with ComfyUI Desktop installed alongside the git checkout they were
  * connected to had `train_prepare_dataset` refs resolve against Desktop and fail
@@ -1326,15 +1325,26 @@ export function localTempDirFallback(): string {
  * connected ComfyUI's output/input dirs", so the contract was right and the
  * resolution was not.
  *
- * `resolveLiveComfyUIBase` derives the root from the running server's argv
- * main.py + cwd, which is the same live-first move #463 made for models. It is
- * only a middle rung: an explicit --output-directory still wins above, and the
- * configured install still catches everything below.
+ * This is the same live-first move #463/#369 made for models: `resolveLiveServerRoot`
+ * uses argv `main.py` + cwd when that is absolute, and otherwise the OS-observed
+ * process for the relative `ComfyUI/main.py` shape Desktop and the Windows
+ * portable bundle both report (no --output-directory, no cwd). That last shape
+ * is #2539: `get_image list_outputs` scanned an unrelated COMFYUI_PATH while
+ * `/view` served the live server's files. An explicit --output-directory still
+ * wins above, and the configured install still catches everything below.
  */
 async function liveIoDirFallback(kind: "input" | "output" | "temp"): Promise<string | undefined> {
   try {
-    const base = await resolveLiveComfyUIBase();
-    return base ? join(base, kind) : undefined;
+    const stats = await getSystemStats();
+    const live = resolveLiveServerRoot(
+      stats.system?.argv,
+      (stats.system as { cwd?: string } | undefined)?.cwd,
+      { remote: isRemoteMode() },
+    );
+    // A Docker/forwarded server reports a container-side path that is not
+    // host-local. Same gate resolveModelsDir uses for this root.
+    if (!live.root || !existsSync(live.root)) return undefined;
+    return join(live.root, kind);
   } catch {
     return undefined; // never let a probe failure outrank the configured install
   }

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -4,6 +4,7 @@ import { config, isRemoteMode } from "../config.js";
 import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import {
   resolveEffectiveComfyUIBase,
+  resolveLiveComfyUIBase,
   resolveLiveServerRoot,
   hasComfyUIEntrypoint,
 } from "./workspace-env.js";
@@ -1325,16 +1326,28 @@ export function localTempDirFallback(): string {
  * connected ComfyUI's output/input dirs", so the contract was right and the
  * resolution was not.
  *
- * This is the same live-first move #463/#369 made for models: `resolveLiveServerRoot`
- * uses argv `main.py` + cwd when that is absolute, and otherwise the OS-observed
- * process for the relative `ComfyUI/main.py` shape Desktop and the Windows
- * portable bundle both report (no --output-directory, no cwd). That last shape
- * is #2539: `get_image list_outputs` scanned an unrelated COMFYUI_PATH while
- * `/view` served the live server's files. An explicit --output-directory still
- * wins above, and the configured install still catches everything below.
+ * Two live rungs, in this order:
+ *
+ *  1. `resolveLiveComfyUIBase` (#2194 / #1052) — argv `main.py` + cwd when that
+ *     is absolute. `get_image` action:get type:input uses this when no
+ *     `--input-directory` is present, so a second install in COMFYUI_PATH is
+ *     not preferred over the connected server.
+ *  2. `resolveLiveServerRoot` (#2539 / #369) — OS-observed process when argv is
+ *     the relative `ComfyUI/main.py` shape Desktop and the Windows portable
+ *     bundle both report (no --output-directory, no cwd). That last shape is
+ *     why `get_image list_outputs` scanned an unrelated COMFYUI_PATH while
+ *     `/view` served the live server's files.
+ *
+ * An explicit --output-directory still wins above, and the configured install
+ * still catches everything below.
  */
 async function liveIoDirFallback(kind: "input" | "output" | "temp"): Promise<string | undefined> {
   try {
+    // #2194 — get_image action:get type:input when no --input-directory is set.
+    const fromArgv = await resolveLiveComfyUIBase();
+    if (fromArgv) return join(fromArgv, kind);
+
+    // #2539 — relative ComfyUI/main.py with no cwd cannot be derived from argv.
     const stats = await getSystemStats();
     const live = resolveLiveServerRoot(
       stats.system?.argv,

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -620,18 +620,23 @@ export function registerImageManagementTools(server: McpServer): void {
             // So the history branch states the OMISSION as a property of the source,
             // and names the check that does work on a remote target.
             const scannedTemp = Boolean(source.tempDirectory);
+            const historyWhereFrom =
+              "Read from ComfyUI's generation history over HTTP — NOT from disk. This listing is " +
+              "INCOMPLETE BY CONSTRUCTION: VHS_VideoCombine and similar video nodes write their " +
+              "file without registering an output entry, so those videos never appear here even " +
+              "though they are on disk, and a server restart clears the history besides. Absence " +
+              "from this list is NOT evidence the file is missing. To check a specific file, fetch " +
+              'it by name with action:"get" or upload_image (action:"stage") — both read the server\'s ' +
+              "/view endpoint, which serves straight from the output directory.";
             const whereFrom =
               source.basis === "local-scan"
                 ? scannedTemp
                   ? `Read from \`${source.directory}\` and \`${source.tempDirectory}\` (scanned on disk).`
                   : `Read from \`${source.directory}\` (scanned on disk).`
-                : "Read from ComfyUI's generation history over HTTP — NOT from disk. This listing is " +
-                  "INCOMPLETE BY CONSTRUCTION: VHS_VideoCombine and similar video nodes write their " +
-                  "file without registering an output entry, so those videos never appear here even " +
-                  "though they are on disk, and a server restart clears the history besides. Absence " +
-                  "from this list is NOT evidence the file is missing. To check a specific file, fetch " +
-                  'it by name with action:"get" or upload_image (action:"stage") — both read the server\'s ' +
-                  "/view endpoint, which serves straight from the output directory.";
+                : source.basis === "server-history-fallback"
+                  ? `Local scan of \`${source.directory}\` found nothing; listing comes from ComfyUI's /history instead (the same source action:"get" /view uses). ` +
+                    historyWhereFrom
+                  : historyWhereFrom;
             // Only when temp/ could not be scanned: VHS with save_output unchecked
             // writes the completed .mp4 there, and an empty output/ listing without
             // that scan is not evidence the file is missing (#2370). Production


### PR DESCRIPTION
Fixes #2539

`get_image action:list_outputs` scanned `COMFYUI_PATH/output` and returned `{source: local-scan, images: []}` immediately after a panel render whose files were still fetchable through `/view`.

Root cause: live ComfyUI was launched as `ComfyUI/main.py --windows-standalone-build` with no `--output-directory` and no cwd. `resolveOutputDir` could not pin that relative argv to the running install, so it fell back to an unrelated Desktop `COMFYUI_PATH`. Models already resolve that argv shape via the OS-observed process; I/O dirs did not.

## Fix
- `liveIoDirFallback` uses `resolveLiveServerRoot` (argv, then OS-observed process) so `list_outputs` scans the live server's `output/`.
- If that local scan is still empty, query `/history` and return matching entries with `basis: server-history-fallback` instead of a silent empty local-scan.

## Tests
- `src/__tests__/services/list-outputs-history-fallback.test.ts` — empty unrelated dir + live history returns the files; populated local scan does not consult history.
- `src/__tests__/services/output-dir.test.ts` — relative `ComfyUI/main.py` without cwd uses the observed live root, not `COMFYUI_PATH`.
