### PR TITLE
fix(2537): retry panel_run after dynamic-widget serializer throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_run retries once after a "Dynamic widget doesn't exist on node" serializer throw so the first queue after graph edits is not a false failure (#2537)
 - get_history and panel_run completion journaling fall back to the connected panel's global /history when the headless `/history/<prompt_id>` is unreachable, and queue.status discloses a cached done when that history still cannot be read (#2532)
 - panel_graph_outline accepts the documented `detail`:"full" argument instead of rejecting it as an unrecognized key (#2541)
 

--- a/src/__tests__/orchestrator/panel-run-2537-dynamic-widget.test.ts
+++ b/src/__tests__/orchestrator/panel-run-2537-dynamic-widget.test.ts
@@ -1,0 +1,271 @@
+// #2537 — panel_run fails with the bare frontend throw
+// "Dynamic widget doesn't exist on node" on the first queue after graph edits,
+// then an identical retry a few seconds later succeeds. The throw is
+// graphToPrompt racing a COMFY_DYNAMICCOMBO_V3 widget rebuild (SaveVideo
+// format.codec, MinimaxH3LatentUpscaler3D mode.scale); it happens BEFORE
+// /prompt is posted, so the first dispatch queued nothing.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  __panelRunTestHooks,
+  __panelToolsTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+
+const DYNAMIC_WIDGET = "Dynamic widget doesn't exist on node";
+const WRAPPED =
+  `NOT queued: this workflow could not be serialized into a prompt because ` +
+  `graphToPrompt threw. The frontend serializer reported: "${DYNAMIC_WIDGET}". ` +
+  `Nothing was queued and the queue is untouched. This is the ComfyUI frontend ` +
+  `or an extension's serializer error, not evidence that a node type is missing; ` +
+  `inspect the named widget or extension before retrying.`;
+
+function panelRun() {
+  const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_run");
+  if (!def) throw new Error("panel_run tool not found");
+  return def;
+}
+
+function textOf(res: ToolResult): string {
+  return (res.content ?? [])
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+}
+
+/** A ctx whose graph_run replies are scripted per attempt. */
+function runCtx(replies: Array<Record<string, unknown>>): {
+  ctx: PanelToolCtx;
+  runs: Record<string, unknown>[];
+} {
+  const runs: Record<string, unknown>[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      if (cmd.cmd !== "graph_run") return { content: [{ type: "text", text: "{}" }] };
+      const reply = replies[runs.length] ?? { queued: true };
+      runs.push(cmd);
+      if (typeof reply.__throw === "string") throw new Error(reply.__throw);
+      if (typeof reply.__error === "string") {
+        return { content: [{ type: "text", text: `Error: ${reply.__error}` }], isError: true };
+      }
+      return { content: [{ type: "text", text: JSON.stringify(reply) }] };
+    },
+    confirm: async () => "yes" as const,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "t-2537",
+  };
+  return { ctx, runs };
+}
+
+beforeEach(() => {
+  RunCompletions.reset();
+  __panelToolsTestHooks.setRetrySettleMs(0);
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setRetrySettleMs(null);
+  RunCompletions.reset();
+});
+
+describe("panel_run dynamic-widget serializer race (#2537)", () => {
+  it("re-issues a full-graph run EXACTLY ONCE after the bare frontend throw", async () => {
+    const { ctx, runs } = runCtx([
+      { __error: DYNAMIC_WIDGET },
+      { queued: true, prompt_id: "p-2537" },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(2);
+    expect(runs[1]).toMatchObject({ cmd: "graph_run" });
+    expect(runs[1]?.to_node_id).toBeUndefined();
+    expect(textOf(res)).toMatch(/re-issued once/i);
+    expect(textOf(res)).toMatch(/nothing was queued/i);
+    expect(RunCompletions.ticketFor("p-2537")).toBeDefined();
+  });
+
+  it("re-issues a scoped run the same way — the race is not full-graph-only", async () => {
+    const { ctx, runs } = runCtx([
+      { __error: DYNAMIC_WIDGET },
+      { queued: true, prompt_id: "p-2537-scoped" },
+    ]);
+    const res = await panelRun().handler({ to_node_id: 202 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(2);
+    expect(runs[1]).toMatchObject({ cmd: "graph_run", to_node_id: 202 });
+  });
+
+  it("also retries the panel's NOT queued / graphToPrompt wrap (#1654)", async () => {
+    const { ctx, runs } = runCtx([
+      { __error: WRAPPED },
+      { queued: true, prompt_id: "p-1654" },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(2);
+  });
+
+  it("retries a parsed JSON error carrying the same throw", async () => {
+    const { ctx, runs } = runCtx([
+      { queued: false, error: DYNAMIC_WIDGET },
+      { queued: true, prompt_id: "p-json" },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(2);
+  });
+
+  it("caps recovery at one retry and tells the caller they MAY re-issue without retry_of", async () => {
+    const { ctx, runs } = runCtx([
+      { __error: DYNAMIC_WIDGET },
+      { __error: DYNAMIC_WIDGET },
+      { queued: true, prompt_id: "must-not-dispatch" },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+    const text = textOf(res);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(2);
+    expect(text).toContain(DYNAMIC_WIDGET);
+    expect(text).toMatch(/SECOND dispatch/i);
+    expect(text).toMatch(/You MAY re-issue panel_run/i);
+    expect(text).toMatch(/do NOT pass retry_of/i);
+    expect(text).not.toContain("must-not-dispatch");
+  });
+
+  it("does NOT retry an unrelated thrown queuePrompt (#248)", async () => {
+    const { ctx, runs } = runCtx([
+      {
+        __error:
+          "app.queuePrompt failed:\nTypeError: Cannot read properties of undefined (reading 'output')",
+      },
+      { queued: true, prompt_id: "must-not-dispatch" },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+    expect(textOf(res)).not.toMatch(/re-issued/i);
+  });
+
+  it("does NOT retry a validation failure", async () => {
+    const { ctx, runs } = runCtx([
+      {
+        node_errors: {
+          "5": { class_type: "KSampler", errors: [{ message: "bad seed" }] },
+        },
+      },
+      { queued: true },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("STRUCTURED queue evidence vetoes the throw — queued:true never retries", async () => {
+    const { ctx, runs } = runCtx([
+      { queued: true, error: DYNAMIC_WIDGET },
+      { queued: true, prompt_id: "must-not-dispatch" },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("a reported prompt_id also vetoes the retry", async () => {
+    const { ctx, runs } = runCtx([
+      { error: DYNAMIC_WIDGET, prompt_id: "p-already-queued" },
+      { queued: true },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("does NOT retry a timeout wrapper that merely quotes the phrase", async () => {
+    const timeout =
+      `the panel tab "wf:workflows/a.json" did not reply to "graph_run" within 20000ms ` +
+      `(the last panel error was: ${DYNAMIC_WIDGET}); retry_of:"rid-timeout"`;
+    const { ctx, runs } = runCtx([{ __error: timeout }, { queued: true }]);
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("a THROWING second dispatch reports both facts instead of destroying them", async () => {
+    const { ctx, runs } = runCtx([
+      { __error: DYNAMIC_WIDGET },
+      { __throw: "socket exploded" },
+    ]);
+    const res = await panelRun().handler({}, ctx);
+    const text = textOf(res);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(2);
+    expect(text).toMatch(/outcome is UNKNOWN and it may have queued a render/);
+    expect(text).toMatch(/FIRST dispatch threw inside graphToPrompt/);
+    expect(text).toMatch(/queued nothing/);
+    expect(text).toMatch(/socket exploded/);
+  });
+
+  it("waits before re-dispatching instead of racing in the same tick", async () => {
+    __panelToolsTestHooks.setRetrySettleMs(40);
+    const { ctx, runs } = runCtx([
+      { __error: DYNAMIC_WIDGET },
+      { queued: true, prompt_id: "p-settle" },
+    ]);
+    const started = Date.now();
+    const res = await panelRun().handler({}, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(2);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(35);
+  });
+
+  it("the classifier itself refuses unknown outcomes and queue evidence", () => {
+    const throwRes: ToolResult = {
+      content: [{ type: "text", text: `Error: ${DYNAMIC_WIDGET}` }],
+      isError: true,
+    };
+    const wrapped: ToolResult = {
+      content: [{ type: "text", text: `Error: ${WRAPPED}` }],
+      isError: true,
+    };
+    const jsonErr: ToolResult = {
+      content: [{ type: "text", text: JSON.stringify({ error: DYNAMIC_WIDGET }) }],
+    };
+    const queued: ToolResult = {
+      content: [{ type: "text", text: JSON.stringify({ queued: true, error: DYNAMIC_WIDGET }) }],
+    };
+    const timeout: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: `Error: the panel tab "x" did not reply to "graph_run" (${DYNAMIC_WIDGET})`,
+        },
+      ],
+      isError: true,
+    };
+    const unrelated: ToolResult = {
+      content: [{ type: "text", text: "Error: app.queuePrompt failed" }],
+      isError: true,
+    };
+
+    expect(__panelRunTestHooks.isRetryableDynamicWidgetRace(throwRes, throwRes)).toBe(true);
+    expect(__panelRunTestHooks.isRetryableDynamicWidgetRace(wrapped, wrapped)).toBe(true);
+    expect(__panelRunTestHooks.isRetryableDynamicWidgetRace(jsonErr, jsonErr)).toBe(true);
+    expect(__panelRunTestHooks.isRetryableDynamicWidgetRace(queued, queued)).toBe(false);
+    expect(__panelRunTestHooks.isRetryableDynamicWidgetRace(timeout, timeout)).toBe(false);
+    expect(__panelRunTestHooks.isRetryableDynamicWidgetRace(unrelated, unrelated)).toBe(false);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10134,11 +10134,53 @@ function isSeedRunToNodeStampRace(res: ToolResult, rejection: ToolResult): boole
   );
 }
 
+/**
+ * #2537 — the ONE full-graph (and scoped) graph_run throw that is safe to re-issue:
+ * ComfyUI's V3 dynamic-combo serializer racing a widget rebuild.
+ *
+ * After a burst of panel_* mutations, `graphToPrompt` can throw the bare frontend
+ * error `Dynamic widget doesn't exist on node` because a COMFY_DYNAMICCOMBO_V3
+ * sub-widget (SaveVideo `format.codec` / `format.codec.encoding`, MinimaxH3
+ * `mode.scale`, …) has not been recreated yet. The user's Queue button works on
+ * the same graph, and an identical `panel_run` a few seconds later succeeds —
+ * nothing about the widget VALUES was wrong. The throw is inside serialization,
+ * which runs BEFORE POST /prompt, so the first dispatch queued nothing.
+ *
+ * FAILS CLOSED in every other direction, because a wrong "yes" here queues a
+ * second render:
+ *  - a tagged reply-timeout or mid-command disconnect is UNKNOWN — the command
+ *    may already be queued — and an unknown must never be retried;
+ *  - STRUCTURED queue evidence VETOES the retry (`queued:true` / any prompt id);
+ *  - a timeout/transport wrapper that merely QUOTES the phrase is not this
+ *    throw (those carry `did not reply`, `outcome is UNKNOWN`, or a minted
+ *    `retry_of:"…"` token);
+ *  - the text must actually name the frontend throw. A generic widget/validation
+ *    failure is terminal.
+ */
+const DYNAMIC_WIDGET_MISSING_RE = /Dynamic widget doesn't exist on node/i;
+const MAX_DYNAMIC_WIDGET_RACE_RETRIES = 1;
+
+function isRetryableDynamicWidgetRace(res: ToolResult, rejection: ToolResult): boolean {
+  if (isReplyTimeoutResult(res) || isMidCommandDisconnectResult(res)) return false;
+  const parsed = parseToolResultJson(res);
+  if (parsed) {
+    if (parsed.queued === true) return false;
+    if (acceptedPromptIds(parsed).length > 0) return false;
+  }
+  const text = toolResultText(rejection);
+  if (!DYNAMIC_WIDGET_MISSING_RE.test(text)) return false;
+  if (/\bdid not reply to\b/i.test(text)) return false;
+  if (/\boutcome is UNKNOWN\b/i.test(text)) return false;
+  if (/\bretry_of:"/i.test(text)) return false;
+  return true;
+}
+
 export const __panelRunTestHooks = {
   detectRunRejection,
   formatRunRejection,
   isRetryableRunToNodeStampRace,
   isSeedRunToNodeStampRace,
+  isRetryableDynamicWidgetRace,
   describeDroppedOutputs,
   applyQueuedUnknownRetryGuidance,
   applyUnobservedQueuedUnknownRetryGuidance,
@@ -21661,6 +21703,49 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // "you'll be notified automatically" guidance. Only a genuine queue
         // gets the anti-poll note below.
         let rejection = detectRunRejection(res);
+        // #2537 — the frontend's dynamic-combo serializer can throw
+        // "Dynamic widget doesn't exist on node" on the first queue after graph
+        // edits, then succeed on an identical retry once those widgets exist.
+        // Serialization is pre-/prompt, so the first dispatch queued nothing.
+        // One settle-and-retry, same pause #1050 uses for the stamp race; a
+        // second miss is surfaced rather than spent again.
+        let dynamicWidgetRetryCount = 0;
+        while (
+          rejection &&
+          isRetryableDynamicWidgetRace(res, rejection) &&
+          dynamicWidgetRetryCount < MAX_DYNAMIC_WIDGET_RACE_RETRIES
+        ) {
+          dynamicWidgetRetryCount += 1;
+          let retryResultReceived = false;
+          try {
+            await sleep(retrySettleMs());
+            runDispatchedAt = Date.now();
+            res = await ctx.call(runCmd, 20000, observeRunRid);
+            retryResultReceived = true;
+            await reconcileRun();
+            rejection = detectRunRejection(res);
+          } catch (err) {
+            installLateReceiptHandoff();
+            if (retryResultReceived) {
+              return appendToolResultText(
+                res,
+                `\n\n(Dispatch history: the retry dispatch returned the result above, but local ` +
+                  `late-ack reconciliation failed before this handler could finish ` +
+                  `interpreting it. That result is preserved and no further dispatch was ` +
+                  `made. Do not infer an additional queue entry from the reconciliation ` +
+                  `failure alone. (${err instanceof Error ? err.message : String(err)})`,
+              );
+            }
+            return fail(
+              `panel_run re-issued the run after ComfyUI's frontend threw ` +
+                `"Dynamic widget doesn't exist on node" during graph serialization, and that ` +
+                `SECOND dispatch failed before any reply could be read — its outcome is UNKNOWN ` +
+                `and it may have queued a render. The FIRST dispatch threw inside graphToPrompt, ` +
+                `which runs before /prompt is posted, so it queued nothing. Do NOT re-run blindly: ` +
+                `check the queue (action:"list") or get_history before deciding. (${err instanceof Error ? err.message : String(err)})`,
+            );
+          }
+        }
         // #772/#2120 — re-issue only the scoped-run stamp race the panel explicitly
         // certifies as not-queued. Gated on OUR OWN args (this really was a scoped run)
         // and on the panel having ANSWERED, so an unknown outcome is never retried.
@@ -21770,6 +21855,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // as the failure it is — but it still has to say it arrived late, or the
           // caller reads a refusal for a dispatch they were told was unknown and
           // cannot tell whether these are one event or two.
+          if (dynamicWidgetRetryCount > 0) {
+            return appendToolResultText(
+              rejection,
+              `\n\n(Dispatch history: the first graph_run failed because ComfyUI's frontend threw ` +
+                `"Dynamic widget doesn't exist on node" while serializing the graph — a race after ` +
+                `recent graph edits while dynamic-combo sub-widgets were still rebuilding. That throw ` +
+                `happens BEFORE /prompt is posted, so the first dispatch queued nothing. The run was ` +
+                `re-issued once after a short pause to let those widgets settle (#2537). The failure ` +
+                `above is that SECOND dispatch; it was not retried again. You MAY re-issue panel_run ` +
+                `after a brief wait — do NOT pass retry_of: nothing was applied to dedupe. The ` +
+                `frontend error names no node id or widget.)` +
+                lateAckNote,
+            );
+          }
           if (!scopeRebuilt)
             return lateAckNote ? appendToolResultText(rejection, lateAckNote) : rejection;
           return appendToolResultText(
@@ -21992,16 +22091,25 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // dispatch can enqueue several, and the panel reports one prompt id, not a count.
         // The certified fact is about DISPATCHES, not renders: the prior dispatches
         // queued nothing, so everything in the queue came from the final dispatch.
+        const dynamicWidgetRetryNote =
+          dynamicWidgetRetryCount === 0
+            ? ""
+            : `\n\n[NOTE] The first dispatch failed with "Dynamic widget doesn't exist on node" ` +
+              `(ComfyUI's frontend serializer racing a dynamic-combo widget rebuild after graph edits). ` +
+              `That throw is pre-queue, so nothing was queued; the run was re-issued once after a short ` +
+              `pause, and THAT is the run above (#2537).`;
         const retryNote =
           scopeRetryCount === 0
-            ? ""
+            ? dynamicWidgetRetryNote
             : scopeRetryCount === 1
-              ? "\n\n[NOTE] The first dispatch of this scoped run was refused by the panel's run-to-node " +
+              ? dynamicWidgetRetryNote +
+                "\n\n[NOTE] The first dispatch of this scoped run was refused by the panel's run-to-node " +
                 "graph-stamp race (the graph changed between dispatch and apply); the panel certified that " +
                 "nothing was queued, so the scope was rebuilt and re-issued once, and THAT is the run above. " +
                 "The first dispatch contributed NOTHING to the queue, so whatever this run queued was " +
                 "queued once, not twice."
-              : `\n\n[NOTE] The first ${scopeRetryCount} dispatches of this scoped run were refused by the ` +
+              : dynamicWidgetRetryNote +
+                `\n\n[NOTE] The first ${scopeRetryCount} dispatches of this scoped run were refused by the ` +
                 `panel's run-to-node graph-stamp race (the graph changed between dispatch and apply), ` +
                 `and each was certified to have queued NOTHING. The scope was rebuilt and re-issued ` +
                 `${scopeRetryCount} times, and THAT is the run above. Whatever this run queued came ` +


### PR DESCRIPTION
## Summary

`panel_run` (full graph, no `to_node_id`) returned the bare frontend throw `Dynamic widget doesn't exist on node` on the first queue after a burst of panel_* graph edits. An identical `panel_run` a few seconds later — after only read-only calls — succeeded. The user's Queue button on the same graph always worked.

The throw comes from ComfyUI's V3 dynamic-combo serializer (`graphToPrompt`) racing a widget rebuild. Graphs with `SaveVideo` (`format` → `format.codec` → `format.codec.encoding`) and `MinimaxH3LatentUpscaler3D` (`mode.scale`) hit it. Serialization runs **before** POST `/prompt`, so the first dispatch queued nothing.

`panel_run` treated every `isError` as outcome-unknown and never retried. It now:

- Recognizes this specific serializer throw (bare, `#1654` wrap, or JSON `error`)
- Retries `graph_run` **once** after the same settle pause as the #1050 stamp-race retry
- Fails closed on `queued:true`, any prompt id, reply-timeout / disconnect marks, and timeout wrappers that merely quote the phrase
- If the retry still fails, tells the agent they MAY re-issue `panel_run` after a brief wait — **without** `retry_of` (nothing was applied to dedupe)

Fixes #2537

## Test plan

- [x] `npx vitest run src/__tests__/orchestrator/panel-run-2537-dynamic-widget.test.ts`
- [x] Existing #772 stamp-race panel_run tests still pass
