### PR TITLE
fix(2532): panel-side fallback for prompt-scoped completed-run history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- get_history and panel_run completion journaling fall back to the connected panel's global /history when the headless `/history/<prompt_id>` is unreachable, and queue.status discloses a cached done when that history still cannot be read (#2532)
 - panel_graph_outline accepts the documented `detail`:"full" argument instead of rejecting it as an unrecognized key (#2541)
 
 

--- a/src/__tests__/comfyui/history-prompt-panel-fallback.test.ts
+++ b/src/__tests__/comfyui/history-prompt-panel-fallback.test.ts
@@ -1,0 +1,198 @@
+// #2532 — queue(action:"status") can return done:true from the client's cached
+// prompt status while get_history(action:"list") and the run-completion journal
+// fail with ECONNREFUSED against COMFYUI_URL. The live panel still holds the
+// completed run. The panel fetch_comfyui_read command is global /history only,
+// so a prompt-scoped lookup must use that body and keep only the requested id.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const panelRead = vi.hoisted(() => vi.fn());
+const fetchApi = vi.hoisted(() => vi.fn());
+const promptStatus = vi.hoisted(() =>
+  vi.fn(async () => ({ running: false, pending: false, done: true })),
+);
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    config: { ...actual.config, comfyuiBasePath: "/comfyapi", comfyuiPath: "" },
+    getComfyUIApiHost: () => "127.0.0.1:8000",
+    getComfyUIBasePath: () => "/comfyapi",
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8000/comfyapi",
+    getComfyUIAuthHeaders: () => ({ Authorization: "Bearer headless-token" }),
+    isCloudMode: () => false,
+    isRemoteMode: () => true,
+  };
+});
+
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    apiURL(path: string): string {
+      return path;
+    }
+
+    apiHeaders(init?: { headers?: HeadersInit }) {
+      return init?.headers ?? {};
+    }
+
+    async fetch(url: string, init?: RequestInit) {
+      return await fetchApi(url, init);
+    }
+
+    fetchApi = fetchApi;
+    getPromptStatus = promptStatus;
+    close() {}
+  },
+}));
+
+vi.mock("../../services/panel-image-relay.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/panel-image-relay.js")>(
+    "../../services/panel-image-relay.js",
+  );
+  return { ...actual, requestPanelComfyUIRead: panelRead };
+});
+
+import { getHistory, resetClient } from "../../comfyui/client.js";
+import { resolveHistoryCompletion } from "../../orchestrator/run-completion-watchdog.js";
+import { getJobStatus } from "../../services/queue-manager.js";
+import { PanelComfyUIReadRelayError } from "../../services/panel-image-relay.js";
+
+const PROMPT = "e7f0b7a0-completed-run";
+const OTHER = "other-prompt-must-not-leak";
+
+function transportFailure(): TypeError {
+  return new TypeError("fetch failed", {
+    cause: Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8000"), { code: "ECONNREFUSED" }),
+  });
+}
+
+function historyEntry(promptId: string, filename: string): Record<string, unknown> {
+  return {
+    prompt: {},
+    outputs: {
+      "9": { images: [{ filename, subfolder: "", type: "output" }] },
+    },
+    status: {
+      status_str: "success",
+      completed: true,
+      messages: [["execution_success", { prompt_id: promptId, timestamp: 1_705_505_423 }]],
+    },
+  };
+}
+
+function panelHistoryBody(payload: Record<string, unknown>): {
+  operation: "history";
+  body: string;
+  contentType: string;
+  bytes: number;
+} {
+  const body = JSON.stringify(payload);
+  return {
+    operation: "history",
+    body,
+    contentType: "application/json",
+    bytes: Buffer.byteLength(body, "utf8"),
+  };
+}
+
+beforeEach(() => {
+  fetchApi.mockReset();
+  panelRead.mockReset();
+  promptStatus.mockReset();
+  promptStatus.mockResolvedValue({ running: false, pending: false, done: true });
+  resetClient();
+  vi.stubGlobal("fetch", vi.fn(async () => {
+    throw transportFailure();
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("prompt-scoped history uses the panel fallback (#2532)", () => {
+  it("selects the requested prompt from the global panel /history body", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockResolvedValue(
+      panelHistoryBody({
+        [PROMPT]: historyEntry(PROMPT, "ComfyUI_00042_.png"),
+        [OTHER]: historyEntry(OTHER, "must-not-leak.png"),
+      }),
+    );
+
+    await expect(getHistory(PROMPT)).resolves.toEqual({
+      [PROMPT]: historyEntry(PROMPT, "ComfyUI_00042_.png"),
+    });
+    expect(panelRead).toHaveBeenCalledWith("history");
+    expect(panelRead).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns {} when the panel history does not contain the requested prompt", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockResolvedValue(
+      panelHistoryBody({
+        [OTHER]: historyEntry(OTHER, "must-not-leak.png"),
+      }),
+    );
+
+    await expect(getHistory(PROMPT)).resolves.toEqual({});
+    expect(panelRead).toHaveBeenCalledWith("history");
+  });
+
+  it("exposes the completed run's output ref to the completion journal", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockResolvedValue(
+      panelHistoryBody({
+        [PROMPT]: historyEntry(PROMPT, "ComfyUI_00042_.png"),
+        [OTHER]: historyEntry(OTHER, "must-not-leak.png"),
+      }),
+    );
+
+    const resolved = await resolveHistoryCompletion(PROMPT);
+    expect(resolved?.images).toEqual([{ filename: "ComfyUI_00042_.png", type: "output" }]);
+    expect(resolved?.status).toBe("success");
+  });
+
+  it("enriches queue.status from the panel history instead of a silent cached done", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockResolvedValue(
+      panelHistoryBody({
+        [PROMPT]: historyEntry(PROMPT, "ComfyUI_00042_.png"),
+      }),
+    );
+
+    const status = await getJobStatus(PROMPT);
+    expect(status).toMatchObject({
+      running: false,
+      pending: false,
+      done: true,
+      status_str: "success",
+    });
+    expect(status.done_from).toBeUndefined();
+    expect(status.note).toBeUndefined();
+    expect(panelRead).toHaveBeenCalledWith("history");
+  });
+
+  it("discloses that done came from local cache when history is unreachable even via the panel", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockRejectedValue(new PanelComfyUIReadRelayError("panel timed out", "TIMEOUT"));
+
+    const status = await getJobStatus(PROMPT);
+    expect(status).toMatchObject({
+      running: false,
+      pending: false,
+      done: true,
+      done_from: "local_cache",
+    });
+    expect(status.note).toMatch(/cached prompt status/i);
+    expect(status.note).toMatch(/unreachable/i);
+    expect(status.note).toMatch(/get_history/);
+  });
+
+  it("does not use the panel for a configured-route HTTP error on prompt-scoped history", async () => {
+    fetchApi.mockResolvedValue(new Response("gateway down", { status: 503 }));
+    await expect(getHistory(PROMPT)).rejects.toThrow();
+    expect(panelRead).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -193,7 +193,7 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
     expect(panelRead).toHaveBeenCalledTimes(2);
   });
 
-  it("does not use the panel for a configured-route HTTP error, timeout, or prompt-scoped history", async () => {
+  it("does not use the panel for a configured-route HTTP error, timeout, or fetchImage", async () => {
     fetchApi.mockResolvedValue(new Response("gateway down", { status: 503 }));
     await expect(getHistory()).rejects.toThrow();
     expect(panelRead).not.toHaveBeenCalled();
@@ -207,7 +207,6 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
     expect(panelRead).not.toHaveBeenCalled();
 
     vi.stubGlobal("fetch", vi.fn(async () => { throw transportFailure(); }));
-    await expect(getHistory("prompt-1")).rejects.toThrow(/fetch failed/);
     await expect(fetchImage("render.png")).rejects.toThrow(/fetch failed/);
     expect(panelRead).not.toHaveBeenCalled();
 

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1336,6 +1336,21 @@ export interface HistoryEntry {
 
 export { MAX_HISTORY_RESPONSE_BYTES } from "./bounded-response.js";
 
+/** The panel `fetch_comfyui_read` command has one fixed global `/history`
+ * route. A prompt-scoped caller still uses that body, then we keep only the
+ * requested id — never the rest of the map. */
+function historyForPrompt(
+  history: Record<string, HistoryEntry>,
+  promptId: string | undefined,
+): Record<string, HistoryEntry> {
+  if (!promptId) return history;
+  if (!history || typeof history !== "object" || Array.isArray(history)) return {};
+  if (!Object.prototype.hasOwnProperty.call(history, promptId)) return {};
+  const entry = history[promptId];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return {};
+  return { [promptId]: entry };
+}
+
 export async function getHistory(
   promptId?: string,
   options: { signal?: AbortSignal } = {},
@@ -1346,17 +1361,20 @@ export async function getHistory(
   try {
     res = await comfyApiFetch(path, options.signal ? { signal: options.signal } : {});
   } catch (err) {
-    // The panel command has one fixed global /history route. A prompt-scoped
-    // request is therefore deliberately not eligible for this fallback.
-    if (!promptId && isComfyTransportFailure(err)) {
+    // #2532 — prompt-scoped `/history/<id>` used to skip this fallback because
+    // the panel command is global-only. That left get_history(action:"list")
+    // and the run-completion journal unable to name a finished panel_run's
+    // outputs while queue.status still reported done:true from local cache.
+    if (isComfyTransportFailure(err)) {
       const relayed = await panelReadFallback("history", err);
       if (relayed) {
-        return await readComfyJson<Record<string, HistoryEntry>>(panelReadResponse(relayed), {
-          url: path,
+        const all = await readComfyJson<Record<string, HistoryEntry>>(panelReadResponse(relayed), {
+          url: "/history",
           maxBytes: MAX_HISTORY_RESPONSE_BYTES,
           bodyTimeoutMs: Math.round(comfyHttpTimeoutSeconds() * 1000),
           signal: options.signal,
         });
+        return historyForPrompt(all, promptId);
       }
     }
     throw err;

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -9,6 +9,7 @@ import {
   enqueuePrompt as clientEnqueuePrompt,
   freeMemory as clientFreeMemory,
 } from "../comfyui/client.js";
+import { isComfyTransportFailure } from "../comfyui/fetch.js";
 import * as cloudClient from "../comfyui/cloud-client.js";
 import { isCloudMode } from "../config.js";
 import type { QueueItem, WorkflowJSON } from "../comfyui/types.js";
@@ -59,7 +60,22 @@ export interface JobStatus {
    *  These write no file, so without this a text-producing workflow finishes
    *  with nothing for the agent to report. Omitted when the run produced none. */
   text_outputs?: TextOutput[];
+  /** Present only when `done` came from this client's cached prompt status
+   *  because ComfyUI `/history` was unreachable from this process (#2532). */
+  done_from?: "local_cache";
+  note?: string;
 }
+
+/** True when history enrichment failed because the headless target (and any
+ * panel fallback) could not be reached — not a parse/HTTP-status failure. */
+function historyUnreachableFromHere(err: unknown): boolean {
+  if (isComfyTransportFailure(err)) return true;
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("read fallback failed safely");
+}
+
+const LOCAL_CACHE_DONE_NOTE =
+  'done:true is from this client\'s cached prompt status; ComfyUI /history was unreachable from this process (COMFYUI_URL). A connected sidebar panel can still read the completed run. Retry get_history (action:"list") for this prompt_id — it uses a panel-origin fallback when available — or inspect the live canvas.';
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -304,6 +320,13 @@ export async function getJobStatus(
       prompt_id: promptId,
       error: err instanceof Error ? err.message : err,
     });
+    if (status.done && historyUnreachableFromHere(err)) {
+      return {
+        ...status,
+        done_from: "local_cache",
+        note: LOCAL_CACHE_DONE_NOTE,
+      };
+    }
     return status;
   }
 }


### PR DESCRIPTION
## Summary

After `panel_run` completed, `queue(action:"status")` returned `done:true` from the client's cached prompt status while `get_history(action:"list")` and `get_system_stats(action:"health")` failed with `ECONNREFUSED` against `COMFYUI_URL`. The live panel canvas was still bound. The #2283 panel relay already covered **global** `/history`, but a prompt-scoped lookup hit `/history/<id>` and was skipped because `fetch_comfyui_read` has one fixed global `/history` route. That left no panel-side history/output bridge for the just-finished run.

This uses the global panel `/history` body on a transport failure and keeps **only** the requested prompt id (never sibling runs). The run-completion journal then sees the same output refs through `getHistory`. `queue.status` discloses `done_from:"local_cache"` when history is still unreachable after that fallback.

## Test plan

- `npx vitest run src/__tests__/comfyui/history-prompt-panel-fallback.test.ts`
- `npx vitest run src/__tests__/comfyui/panel-read-fallback.test.ts`
- `npx vitest run src/__tests__/services/queue-manager.test.ts`

Fixes #2532
