### PR TITLE
fix(2541): accept panel_graph_outline detail:full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- panel_graph_outline accepts the documented `detail`:"full" argument instead of rejecting it as an unrecognized key (#2541)
+
+
 ## [0.52.159] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/orchestrator/graph-outline-detail-arg.test.ts
+++ b/src/__tests__/orchestrator/graph-outline-detail-arg.test.ts
@@ -1,0 +1,112 @@
+// #2541 — panel_graph_outline({ detail: "full" }) was rejected at the schema
+// boundary before the handler ran.
+//
+// The outline result names its default rung `detail_level:"full"`, and the
+// max_chars parameter description printed that as `(detail_level:"refused")` /
+// "detail_level names the rung used". A Codex session read that as an input,
+// called `{ detail: "full" }`, and got:
+//
+//   Unrecognized key 'detail' — accepted keys: 'max_chars'
+//
+// The call never reached graph_outline. `full` is already the default — the
+// outline starts there and sheds rungs only to fit max_chars — so accepting
+// the documented name lands the read. A test that calls `def.handler` directly
+// would pass with the schema still rejecting the key: the reporter never
+// reached the handler. Parse through `strictPanelSchema`, the validator both
+// transports install.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  strictPanelSchema,
+  type PanelToolCtx,
+} from "../../orchestrator/panel-tools.js";
+
+type Cmd = Record<string, unknown>;
+
+const REPORTED = { detail: "full" } as const;
+
+function defOf(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  return def;
+}
+
+function harness() {
+  const sent: Cmd[] = [];
+  const bridge = {
+    send: async (cmd: Cmd) => {
+      sent.push(cmd);
+      return {
+        ok: true,
+        outline: "1 KSampler",
+        node_count: 1,
+        group_count: 0,
+        detail_level: "full",
+        max_chars: 24000,
+      };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+  } as PanelToolCtx["bridge"];
+  return { sent, ctx: makePanelToolCtx(bridge, "tab-1") };
+}
+
+/** Parse args the way the MCP boundary does, then run the handler. */
+async function callOutline(args: Cmd, ctx: PanelToolCtx) {
+  const def = defOf("panel_graph_outline");
+  const parsed = strictPanelSchema(def.schema).parse(args) as Cmd;
+  return def.handler(parsed, ctx);
+}
+
+describe("#2541 panel_graph_outline accepts the documented detail argument", () => {
+  let h: ReturnType<typeof harness>;
+  beforeEach(() => {
+    h = harness();
+  });
+
+  it("the reported call is a schema success, not unrecognized_keys", () => {
+    const parsed = strictPanelSchema(defOf("panel_graph_outline").schema).safeParse(REPORTED);
+    expect(parsed.success, "unfixed: Unrecognized key 'detail' — accepted keys: 'max_chars'").toBe(
+      true,
+    );
+  });
+
+  it("the reported call reaches graph_outline instead of dying at the boundary", async () => {
+    const res = await callOutline({ ...REPORTED }, h.ctx);
+    expect(res.isError).toBeFalsy();
+    expect(h.sent).toHaveLength(1);
+    expect(h.sent[0]).toMatchObject({ cmd: "graph_outline" });
+    // The panel executor only takes max_chars. Forwarding `detail` would be a
+    // no-op there and would look like a second lever this tool does not have.
+    expect(h.sent[0]).not.toHaveProperty("detail");
+  });
+
+  it("still forwards max_chars when both are supplied", async () => {
+    await callOutline({ detail: "full", max_chars: 4000 }, h.ctx);
+    expect(h.sent[0]).toMatchObject({ cmd: "graph_outline", max_chars: 4000 });
+    expect(h.sent[0]).not.toHaveProperty("detail");
+  });
+
+  it("the no-argument call still works", async () => {
+    const parsed = strictPanelSchema(defOf("panel_graph_outline").schema).safeParse({});
+    expect(parsed.success).toBe(true);
+    await callOutline({}, h.ctx);
+    expect(h.sent[0]).toMatchObject({ cmd: "graph_outline" });
+  });
+
+  it("does not treat a non-full rung name as a lever", () => {
+    // `groups` is a RESULT rung the outline may degrade to. Accepting it as
+    // input would document an unimplemented pin; the call must still name the
+    // miss rather than silently return a full outline.
+    const parsed = strictPanelSchema(defOf("panel_graph_outline").schema).safeParse({
+      detail: "groups",
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -2292,9 +2292,11 @@ describe("panel-tools: panel_graph_outline (compact text map)", () => {
   // #809: the outline gained ONE optional argument — `max_chars`, deliberately the same
   // name and clamp as panel_query_graph's, so there is one budget concept to learn. It
   // stays argument-free for the "just show me the canvas" call.
-  it("is registered and takes only the optional max_chars budget", () => {
+  // #2541 — `detail` is an accepted alias for that default full-resolution
+  // request, not a second lever.
+  it("is registered and takes optional max_chars plus the documented detail alias", () => {
     expect(buildPanelToolDefs().map((d) => d.name)).toContain("panel_graph_outline");
-    expect(Object.keys(defByName("panel_graph_outline").schema)).toEqual(["max_chars"]);
+    expect(Object.keys(defByName("panel_graph_outline").schema)).toEqual(["max_chars", "detail"]);
   });
 
   it("forwards graph_outline", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -19049,8 +19049,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .describe(
             `Output character bound for the outline (default ${OUTLINE_MAX_CHARS_DEFAULT}, max ${OUTLINE_MAX_CHARS_CEILING}) — the SAME budget concept as panel_query_graph's max_chars. ` +
               `COVERAGE IS NEVER TRADED AWAY: over budget the outline sheds RESOLUTION, not nodes — first per-node widget values, then titles, and at the floor a per-group summary — so any outline it DOES return describes the whole graph, with real node/group counts. ` +
-              `If even the group-level floor will not fit, it returns NO outline and says so (detail_level:"refused") rather than a partial one that would read as complete. ` +
-              `detail_level names the rung used and degraded_reason says why. Panel builds older than this budget ignore it and return the full outline; the result carries a max_chars field when the budget was actually applied.`,
+              `If even the group-level floor will not fit, it returns NO outline and says so — the RESULT field detail_level is "refused" rather than a partial outline that would read as complete. ` +
+              `The result's detail_level names the rung used; degraded_reason says why. Those are outputs. Panel builds older than this budget ignore max_chars and return the full outline; the result carries a max_chars field when the budget was actually applied.`,
+          ),
+        // #2541 — the result names its default rung `detail_level:"full"`, and
+        // the max_chars prose used to print that as if it were an argument. A
+        // Codex session then called `{ detail: "full" }` and died at the
+        // strict schema (`Unrecognized key 'detail' — accepted keys: 'max_chars'`)
+        // before the handler ran. `full` is already the default; accepting it
+        // lands the call. It is not forwarded: the panel's graph_outline only
+        // takes max_chars, and resolution is still chosen by that bound.
+        detail: z
+          .enum(["full"])
+          .optional()
+          .describe(
+            "Optional request for the default full-resolution outline. The outline already starts at full and sheds rungs only to fit max_chars; passing `full` does not change that. Raise max_chars for more detail. Omit this for the no-argument call.",
           ),
       },
       async (args: A, ctx) =>


### PR DESCRIPTION
## Summary
`panel_graph_outline({ detail: "full" })` was rejected at the MCP schema boundary before the handler ran:

```
Unrecognized key 'detail' — accepted keys: 'max_chars'
```

The outline result names its default rung `detail_level:"full"`, and the `max_chars` parameter description printed that as if it were an argument. A Codex session then passed `detail:"full"` and never reached `graph_outline`.

`full` is already the default — the outline starts there and sheds rungs only to fit `max_chars`. The schema now accepts `detail:"full"` so that call lands. It is not forwarded: the panel executor still only takes `max_chars`. Other rung names (`groups`, …) stay rejected so they are not documented as an unimplemented lever.

## Test plan
- `npx vitest run src/__tests__/orchestrator/graph-outline-detail-arg.test.ts`
- `npx vitest run src/__tests__/orchestrator/panel-tools.test.ts src/__tests__/orchestrator/outline-budget-enforced.test.ts src/__tests__/tools/graph-read-description-collision.test.ts`

Fixes #2541
