### PR TITLE
fix(2536): refuse PrimitiveNode connections to forceInput-only STRING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_connect refuses a frontend PrimitiveNode wired to a forceInput-only STRING instead of reporting a LiteGraph link that panel_run omits from the prompt (#2536)
 - panel_run retries once after a "Dynamic widget doesn't exist on node" serializer throw so the first queue after graph edits is not a false failure (#2537)
 - get_history and panel_run completion journaling fall back to the connected panel's global /history when the headless `/history/<prompt_id>` is unreachable, and queue.status discloses a cached done when that history still cannot be read (#2532)
 - panel_graph_outline accepts the documented `detail`:"full" argument instead of rejecting it as an unrecognized key (#2541)

--- a/src/__tests__/services/connect-live-graph.test.ts
+++ b/src/__tests__/services/connect-live-graph.test.ts
@@ -248,7 +248,12 @@ describe("panel_connect ships the live-graph lookup (#2502)", () => {
       ctx,
     );
     expect(res.isError).toBeUndefined();
-    expect(calls.map((c) => c.cmd)).toEqual(["graph_connect", "graph_query", "graph_connect"]);
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_connect",
+      "graph_query",
+      "graph_connect",
+      "graph_query",
+    ]);
     expect(allText(res)).toMatch(/#2502/);
   });
 });

--- a/src/__tests__/services/primitive-force-input-connect.test.ts
+++ b/src/__tests__/services/primitive-force-input-connect.test.ts
@@ -1,0 +1,344 @@
+// #2536 — panel_connect reports success for a frontend PrimitiveNode wired to a
+// forceInput-only STRING (ApplyAnimaLoraFromPath.lora_path). panel_query_graph
+// shows the LiteGraph link, then panel_run omits the required input.
+//
+// Tests drive the shipped helpers AND the panel_connect wrap — a reimplementation
+// here would stay green if the wrap were deleted.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  findTargetConnectInput,
+  hasSerializableWidgetBinding,
+  isForceInputOnlyNonWidget,
+  isFrontendPrimitiveNodeType,
+  parseLiveConnectNodes,
+  primitiveForceInputRefusal,
+  verifyPrimitiveForceInputAfterConnect,
+  type LiveConnectInput,
+} from "../../services/primitive-force-input-connect.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const PANEL_SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url)),
+  "utf8",
+);
+const SERVICE_SRC = readFileSync(
+  fileURLToPath(new URL("../../services/primitive-force-input-connect.ts", import.meta.url)),
+  "utf8",
+);
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function jsonResult(payload: unknown, isError = false): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function textResult(text: string, isError = false): ToolResult {
+  return { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}) };
+}
+
+function allText(res: { content: Array<{ type: string; text?: string }> }): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+function input(partial: Partial<LiveConnectInput> & Pick<LiveConnectInput, "name">): LiveConnectInput {
+  return {
+    slot: 0,
+    type: "STRING",
+    widget: undefined,
+    forceInput: false,
+    connectedFrom: null,
+    ...partial,
+  };
+}
+
+const PRIMITIVE = {
+  id: 12,
+  type: "PrimitiveNode",
+  widgets: { value: "C:/models/loras/foo.safetensors" },
+  inputs: [],
+  outputs: [{ name: "STRING", type: "STRING" }],
+};
+
+const FORCE_INPUT_TARGET = {
+  id: 5,
+  type: "ApplyAnimaLoraFromPath",
+  widgets: {},
+  inputs: [
+    {
+      slot: 0,
+      name: "lora_path",
+      type: "STRING",
+      forceInput: true,
+      connected_from: { node_id: 12, output_slot: 0 },
+    },
+  ],
+};
+
+describe("PrimitiveNode widget-binding helpers (#2536)", () => {
+  it("identifies only the frontend PrimitiveNode", () => {
+    expect(isFrontendPrimitiveNodeType("PrimitiveNode")).toBe(true);
+    expect(isFrontendPrimitiveNodeType("PrimitiveStringMultiline")).toBe(false);
+    expect(isFrontendPrimitiveNodeType("CLIPTextEncode")).toBe(false);
+  });
+
+  it("treats input.widget as a serializable binding", () => {
+    expect(hasSerializableWidgetBinding(input({ name: "text", widget: { name: "text" } }))).toBe(true);
+    expect(hasSerializableWidgetBinding(input({ name: "text", widget: "text" }))).toBe(true);
+    expect(hasSerializableWidgetBinding(input({ name: "lora_path" }))).toBe(false);
+  });
+
+  it("proves forceInput-only / non-widget from the live row", () => {
+    expect(
+      isForceInputOnlyNonWidget(input({ name: "lora_path", forceInput: true }), {}, true),
+    ).toBe(true);
+    expect(isForceInputOnlyNonWidget(input({ name: "lora_path" }), {}, true)).toBe(true);
+    expect(
+      isForceInputOnlyNonWidget(input({ name: "text", widget: { name: "text" } }), {}, true),
+    ).toBe(false);
+    expect(isForceInputOnlyNonWidget(input({ name: "text" }), { text: "a cat" }, true)).toBe(false);
+    expect(isForceInputOnlyNonWidget(input({ name: "text" }), null, false)).toBe(false);
+  });
+
+  it("finds the reporter's lora_path by name and by connected_from", () => {
+    const nodes = parseLiveConnectNodes({ truncated: false, nodes: [PRIMITIVE, FORCE_INPUT_TARGET] });
+    expect(nodes).not.toBeNull();
+    const target = nodes!.find((n) => n.id === "5");
+    expect(target).toBeDefined();
+    expect(findTargetConnectInput(target!, 12, "lora_path")?.name).toBe("lora_path");
+    expect(findTargetConnectInput(target!, 12, undefined)?.name).toBe("lora_path");
+  });
+
+  it("names PrimitiveStringMultiline in the refusal", () => {
+    const text = primitiveForceInputRefusal({
+      fromNodeId: 12,
+      toNodeId: 5,
+      toType: "ApplyAnimaLoraFromPath",
+      inputName: "lora_path",
+      inputType: "STRING",
+      disconnected: true,
+    });
+    expect(text).toMatch(/PrimitiveNode #12/);
+    expect(text).toMatch(/lora_path/);
+    expect(text).toMatch(/forceInput-only/);
+    expect(text).toMatch(/PrimitiveStringMultiline/);
+    expect(text).toMatch(/disconnected/);
+    expect(text).toMatch(/#2536/);
+  });
+});
+
+describe("verifyPrimitiveForceInputAfterConnect", () => {
+  it("THE REPORTED CASE: PrimitiveNode → forceInput STRING is refused and undone", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const connected = jsonResult({
+      connected: { from_node_id: 12, to_node_id: 5, to_input: "lora_path" },
+    });
+    const res = await verifyPrimitiveForceInputAfterConnect(
+      { from_node_id: 12, from_output: "STRING", to_node_id: 5, to_input: "lora_path" },
+      connected,
+      async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({ truncated: false, nodes: [PRIMITIVE, FORCE_INPUT_TARGET] });
+        }
+        if (cmd.cmd === "graph_disconnect") {
+          return jsonResult({ disconnected: { node_id: 5, input: "lora_path" } });
+        }
+        return textResult(`unexpected ${String(cmd.cmd)}`, true);
+      },
+    );
+    expect(res.isError).toBe(true);
+    expect(allText(res)).toMatch(/PrimitiveStringMultiline/);
+    expect(allText(res)).toMatch(/lora_path/);
+    expect(allText(res)).not.toMatch(/"connected"/);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_disconnect"]);
+    expect(calls[1]).toMatchObject({ cmd: "graph_disconnect", node_id: 5, input: "lora_path" });
+  });
+
+  it("refuses a forceInput-less STRING that has no widget map entry either", async () => {
+    const res = await verifyPrimitiveForceInputAfterConnect(
+      { from_node_id: 12, to_node_id: 5, to_input: "lora_path" },
+      jsonResult({ connected: true }),
+      async (cmd) => {
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            truncated: false,
+            nodes: [
+              PRIMITIVE,
+              {
+                id: 5,
+                type: "ApplyAnimaLoraFromPath",
+                widgets: {},
+                inputs: [
+                  {
+                    name: "lora_path",
+                    type: "STRING",
+                    connected_from: { node_id: 12, output_slot: 0 },
+                  },
+                ],
+              },
+            ],
+          });
+        }
+        return jsonResult({ disconnected: true });
+      },
+    );
+    expect(res.isError).toBe(true);
+    expect(allText(res)).toMatch(/no serializable widget binding/);
+  });
+
+  it("allows PrimitiveNode → a widget STRING (CLIPTextEncode.text)", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const connected = jsonResult({ connected: true });
+    const res = await verifyPrimitiveForceInputAfterConnect(
+      { from_node_id: 12, from_output: "STRING", to_node_id: 6, to_input: "text" },
+      connected,
+      async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            truncated: false,
+            nodes: [
+              PRIMITIVE,
+              {
+                id: 6,
+                type: "CLIPTextEncode",
+                widgets: { text: "a cat" },
+                inputs: [
+                  {
+                    name: "text",
+                    type: "STRING",
+                    widget: { name: "text" },
+                    connected_from: { node_id: 12, output_slot: 0 },
+                  },
+                ],
+              },
+            ],
+          });
+        }
+        return textResult(`unexpected ${String(cmd.cmd)}`, true);
+      },
+    );
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(allText(res))).toEqual({ connected: true });
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query"]);
+  });
+
+  it("allows a backend PrimitiveStringMultiline on the same forceInput STRING", async () => {
+    const res = await verifyPrimitiveForceInputAfterConnect(
+      { from_node_id: 9, from_output: "STRING", to_node_id: 5, to_input: "lora_path" },
+      jsonResult({ connected: true }),
+      async (cmd) => {
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({
+            truncated: false,
+            nodes: [
+              { id: 9, type: "PrimitiveStringMultiline", widgets: { value: "foo" }, inputs: [] },
+              FORCE_INPUT_TARGET,
+            ],
+          });
+        }
+        return textResult(`unexpected ${String(cmd.cmd)}`, true);
+      },
+    );
+    expect(res.isError).toBeUndefined();
+  });
+
+  it("does not inspect a failed connect", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const failed = textResult("Error: type mismatch", true);
+    const res = await verifyPrimitiveForceInputAfterConnect(
+      { from_node_id: 12, to_node_id: 5, to_input: "lora_path" },
+      failed,
+      async (cmd) => {
+        calls.push(cmd);
+        return jsonResult({});
+      },
+    );
+    expect(res.isError).toBe(true);
+    expect(allText(res)).toMatch(/type mismatch/);
+    expect(calls).toEqual([]);
+  });
+
+  it("falls open on a truncated or unreadable detail probe", async () => {
+    const connected = jsonResult({ connected: true });
+    const truncated = await verifyPrimitiveForceInputAfterConnect(
+      { from_node_id: 12, to_node_id: 5, to_input: "lora_path" },
+      connected,
+      async () => jsonResult({ truncated: true, nodes: [PRIMITIVE, FORCE_INPUT_TARGET] }),
+    );
+    expect(truncated.isError).toBeUndefined();
+
+    const unreadable = await verifyPrimitiveForceInputAfterConnect(
+      { from_node_id: 12, to_node_id: 5, to_input: "lora_path" },
+      connected,
+      async () => textResult("not json"),
+    );
+    expect(unreadable.isError).toBeUndefined();
+  });
+});
+
+describe("panel_connect ships the PrimitiveNode forceInput guard (#2536)", () => {
+  it("handlers dispatch through verifyPrimitiveForceInputAfterConnect", () => {
+    expect(PANEL_SRC).toMatch(/verifyPrimitiveForceInputAfterConnect\(/);
+    expect(PANEL_SRC).toMatch(/"panel_connect"/);
+    expect(SERVICE_SRC).toMatch(/cmd: "graph_query"/);
+    expect(SERVICE_SRC).toMatch(/cmd: "graph_disconnect"/);
+    expect(SERVICE_SRC).toMatch(/PrimitiveStringMultiline/);
+  });
+
+  it("documents the PrimitiveNode forceInput refusal on the tool itself", () => {
+    const description = defByName("panel_connect").description;
+    expect(description).toContain("PrimitiveNode");
+    expect(description).toContain("forceInput");
+    expect(description).toContain("PrimitiveStringMultiline");
+  });
+
+  it("THE REPORTED CASE through the registered panel_connect handler", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_connect") {
+          return jsonResult({
+            connected: { from_node_id: 12, to_node_id: 5, to_input: "lora_path" },
+          });
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({ truncated: false, nodes: [PRIMITIVE, FORCE_INPUT_TARGET] });
+        }
+        if (cmd.cmd === "graph_disconnect") {
+          return jsonResult({ disconnected: { node_id: cmd.node_id, input: cmd.input } });
+        }
+        return textResult(`unexpected ${String(cmd.cmd)}`, true);
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "wf:2536-reported",
+    };
+
+    const res = await defByName("panel_connect").handler(
+      { from_node_id: 12, from_output: "STRING", to_node_id: 5, to_input: "lora_path" },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(allText(res)).toMatch(/PrimitiveStringMultiline/);
+    expect(allText(res)).toMatch(/lora_path/);
+    expect(allText(res)).toMatch(/#2536/);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_connect", "graph_query", "graph_disconnect"]);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -85,6 +85,7 @@ import {
   unexposeHostLinkShiftNote,
 } from "../services/unexpose-host-link-shift.js";
 import { retryConnectAgainstLiveGraph } from "../services/connect-live-graph.js";
+import { verifyPrimitiveForceInputAfterConnect } from "../services/primitive-force-input-connect.js";
 import { retryExposeSubgraphInput } from "../services/expose-ae-wildcard.js";
 import {
   applyLiveRootViewing,
@@ -20165,7 +20166,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_connect",
-      "Connect an output slot of one node to an input slot of another in the user's open graph. Slots accept a name ('MODEL', 'samples') or numeric index. If both slot args are omitted the panel picks the first type-compatible pairing. On failure the error lists every slot with its type and [connected] flag — re-check with panel_query_graph ({ids:[node_id], fields:'detail'}). Undoable.",
+      "Connect an output slot of one node to an input slot of another in the user's open graph. Slots accept a name ('MODEL', 'samples') or numeric index. If both slot args are omitted the panel picks the first type-compatible pairing. On failure the error lists every slot with its type and [connected] flag — re-check with panel_query_graph ({ids:[node_id], fields:'detail'}). A frontend PrimitiveNode only serializes through a target widget; connecting one to a forceInput-only / non-widget STRING is refused (panel_run would omit the required input) — use a backend STRING producer such as PrimitiveStringMultiline instead. Undoable.",
       {
         from_node_id: nodeId().describe("Source node id."),
         from_output: slotRef
@@ -20190,17 +20191,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         output: slotRef.optional().describe("Alias for from_output."),
         input: slotRef.optional().describe("Alias for to_input."),
       },
-      async (args: A, ctx) =>
-        retryConnectAgainstLiveGraph(
-          {
-            from_node_id: args.from_node_id,
-            from_output: args.from_output ?? args.from_slot_name ?? args.from_slot ?? args.output,
-            to_node_id: args.to_node_id,
-            to_input: args.to_input ?? args.to_slot_name ?? args.to_slot ?? args.input,
-            auto_match: args.auto_match,
-          },
-          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
-        ),
+      async (args: A, ctx) => {
+        const connectArgs = {
+          from_node_id: args.from_node_id,
+          from_output: args.from_output ?? args.from_slot_name ?? args.from_slot ?? args.output,
+          to_node_id: args.to_node_id,
+          to_input: args.to_input ?? args.to_slot_name ?? args.to_slot ?? args.input,
+          auto_match: args.auto_match,
+        };
+        const call = (cmd: Record<string, unknown>, timeoutMs?: number) => ctx.call(cmd, timeoutMs);
+        const connected = await retryConnectAgainstLiveGraph(connectArgs, call);
+        return verifyPrimitiveForceInputAfterConnect(connectArgs, connected, call);
+      },
     ),
     def(
       "panel_disconnect",

--- a/src/services/primitive-force-input-connect.ts
+++ b/src/services/primitive-force-input-connect.ts
@@ -1,0 +1,339 @@
+/**
+ * #2536 — `panel_connect` can report success for a frontend PrimitiveNode wired
+ * to a forceInput-only STRING, then `panel_run` omits the required input.
+ *
+ * PrimitiveNode is LiteGraph-native: it is skipped from the queued prompt and
+ * only serializes by copying its literal onto a target widget. A forceInput
+ * socket has no widget, so the visible link disappears from `/prompt` and
+ * ComfyUI rejects with `Required input is missing`.
+ *
+ * After a successful connect, prove the source is PrimitiveNode AND the target
+ * input has no serializable widget binding, then disconnect and refuse with a
+ * backend STRING producer (PrimitiveStringMultiline). Unreadable / truncated
+ * probes fall open — they do not prove the force-only shape.
+ */
+
+import { normalizeNodeId } from "../orchestrator/node-id.js";
+import {
+  canonicalConnectNodeId,
+  sameConnectNodeId,
+  type ConnectArgs,
+  type GraphCall,
+  type ToolResultLike,
+} from "./connect-live-graph.js";
+
+export const FRONTEND_PRIMITIVE_NODE_TYPE = "PrimitiveNode";
+
+const DETAIL_MAX_CHARS = 60000;
+const DETAIL_TIMEOUT_MS = 8000;
+
+export type LiveConnectInput = {
+  name: string;
+  slot: number | null;
+  type: string | null;
+  widget: unknown;
+  forceInput: boolean;
+  connectedFrom: unknown;
+};
+
+export type LiveConnectNode = {
+  id: string;
+  type: string;
+  widgets: Record<string, unknown> | null;
+  widgetsKnown: boolean;
+  inputs: LiveConnectInput[];
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function toolText(res: ToolResultLike): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+function parseJsonPayload(res: ToolResultLike): Record<string, unknown> | null {
+  if (res.isError) return null;
+  const text = res.content.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    return asRecord(JSON.parse(text));
+  } catch {
+    return null;
+  }
+}
+
+function uniqueEndpointIds(fromNodeId: unknown, toNodeId: unknown): Array<number | string> {
+  const ids: Array<number | string> = [];
+  const seen = new Set<string>();
+  for (const value of [fromNodeId, toNodeId]) {
+    const canonical = canonicalConnectNodeId(value);
+    if (!canonical || seen.has(canonical)) continue;
+    seen.add(canonical);
+    const wire =
+      typeof value === "number" || typeof value === "string" ? normalizeNodeId(value) : canonical;
+    ids.push(wire);
+  }
+  return ids;
+}
+
+function isForceInputFlag(value: unknown): boolean {
+  return value === true;
+}
+
+function parseLiveConnectInput(raw: unknown, index: number): LiveConnectInput | null {
+  const rec = asRecord(raw);
+  if (!rec || typeof rec.name !== "string" || rec.name.length === 0) return null;
+  const slot =
+    typeof rec.slot === "number" && Number.isSafeInteger(rec.slot)
+      ? rec.slot
+      : typeof rec.slot_index === "number" && Number.isSafeInteger(rec.slot_index)
+        ? rec.slot_index
+        : index;
+  const config = asRecord(rec.config) ?? asRecord(rec.options);
+  return {
+    name: rec.name,
+    slot,
+    type: typeof rec.type === "string" && rec.type.length > 0 ? rec.type : null,
+    widget: rec.widget,
+    forceInput:
+      isForceInputFlag(rec.forceInput) ||
+      isForceInputFlag(rec.force_input) ||
+      isForceInputFlag(config?.forceInput) ||
+      isForceInputFlag(config?.force_input),
+    connectedFrom: rec.connected_from ?? rec.connectedFrom ?? rec.link ?? null,
+  };
+}
+
+function parseLiveConnectNode(raw: unknown): LiveConnectNode | null {
+  const rec = asRecord(raw);
+  if (!rec) return null;
+  const id = canonicalConnectNodeId(rec.id);
+  if (!id) return null;
+  const type =
+    typeof rec.type === "string" && rec.type.length > 0
+      ? rec.type
+      : typeof rec.class_type === "string" && rec.class_type.length > 0
+        ? rec.class_type
+        : null;
+  if (!type) return null;
+  if (!Array.isArray(rec.inputs)) return null;
+
+  const widgetsKnown = Object.prototype.hasOwnProperty.call(rec, "widgets");
+  const widgetsRaw = rec.widgets;
+  const widgets =
+    widgetsRaw && typeof widgetsRaw === "object" && !Array.isArray(widgetsRaw)
+      ? (widgetsRaw as Record<string, unknown>)
+      : null;
+
+  const inputs: LiveConnectInput[] = [];
+  for (let i = 0; i < rec.inputs.length; i++) {
+    const input = parseLiveConnectInput(rec.inputs[i], i);
+    if (input) inputs.push(input);
+  }
+
+  return {
+    id,
+    type,
+    widgets: widgetsKnown ? widgets : null,
+    widgetsKnown,
+    inputs,
+  };
+}
+
+function collectDetailRows(payload: Record<string, unknown>): unknown[] {
+  if (Array.isArray(payload.nodes)) return payload.nodes;
+  if (typeof payload.text !== "string") return [];
+  const rows: unknown[] = [];
+  for (const line of payload.text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      rows.push(JSON.parse(trimmed));
+    } catch {
+      /* compact/ids line */
+    }
+  }
+  return rows;
+}
+
+export function isFrontendPrimitiveNodeType(type: string | null | undefined): boolean {
+  return type === FRONTEND_PRIMITIVE_NODE_TYPE;
+}
+
+/** True when the live input carries a widget object/name the Primitive can bake onto. */
+export function hasSerializableWidgetBinding(input: LiveConnectInput): boolean {
+  const widget = input.widget;
+  if (widget === true) return true;
+  if (typeof widget === "string") return widget.length > 0;
+  const rec = asRecord(widget);
+  if (!rec) return false;
+  if (typeof rec.name === "string") return rec.name.length > 0;
+  return Object.keys(rec).length > 0;
+}
+
+/**
+ * True when the live target input is proven forceInput-only / non-widget.
+ * A missing widgets map is not evidence — that probe falls open.
+ */
+export function isForceInputOnlyNonWidget(
+  input: LiveConnectInput,
+  widgets: Record<string, unknown> | null,
+  widgetsKnown: boolean,
+): boolean {
+  if (input.forceInput) return true;
+  if (hasSerializableWidgetBinding(input)) return false;
+  if (!widgetsKnown) return false;
+  return !Object.prototype.hasOwnProperty.call(widgets ?? {}, input.name);
+}
+
+function connectedFromNodeId(connectedFrom: unknown): string | null {
+  if (connectedFrom == null) return null;
+  if (typeof connectedFrom === "number") return canonicalConnectNodeId(connectedFrom);
+  if (typeof connectedFrom === "string") {
+    const idPart = connectedFrom.split(".")[0] ?? connectedFrom;
+    return canonicalConnectNodeId(idPart);
+  }
+  const rec = asRecord(connectedFrom);
+  if (!rec) return null;
+  return canonicalConnectNodeId(rec.node_id ?? rec.id);
+}
+
+export function findTargetConnectInput(
+  target: LiveConnectNode,
+  fromNodeId: unknown,
+  toInput: unknown,
+): LiveConnectInput | null {
+  if (typeof toInput === "string" && toInput.length > 0) {
+    const byName = target.inputs.find((input) => input.name === toInput);
+    if (byName) return byName;
+    const lower = toInput.toLowerCase();
+    return target.inputs.find((input) => input.name.toLowerCase() === lower) ?? null;
+  }
+  if (typeof toInput === "number" && Number.isSafeInteger(toInput)) {
+    const bySlot = target.inputs.find((input) => input.slot === toInput);
+    if (bySlot) return bySlot;
+    return target.inputs[toInput] ?? null;
+  }
+  const fromId = canonicalConnectNodeId(fromNodeId);
+  if (!fromId) return null;
+  return (
+    target.inputs.find((input) => sameConnectNodeId(connectedFromNodeId(input.connectedFrom), fromId)) ??
+    null
+  );
+}
+
+export function parseLiveConnectNodes(payload: unknown): LiveConnectNode[] | null {
+  const rec = asRecord(payload);
+  if (!rec) return null;
+  if (Object.prototype.hasOwnProperty.call(rec, "truncated") && rec.truncated !== false) {
+    return null;
+  }
+  const nodes: LiveConnectNode[] = [];
+  const seen = new Set<string>();
+  for (const row of collectDetailRows(rec)) {
+    const node = parseLiveConnectNode(row);
+    if (!node || seen.has(node.id)) continue;
+    seen.add(node.id);
+    nodes.push(node);
+  }
+  return nodes.length > 0 ? nodes : null;
+}
+
+export function nodeByConnectId(
+  nodes: readonly LiveConnectNode[],
+  nodeId: unknown,
+): LiveConnectNode | null {
+  const want = canonicalConnectNodeId(nodeId);
+  if (!want) return null;
+  return nodes.find((node) => node.id === want) ?? null;
+}
+
+export function primitiveForceInputRefusal(opts: {
+  fromNodeId: unknown;
+  toNodeId: unknown;
+  toType: string;
+  inputName: string;
+  inputType: string | null;
+  disconnected: boolean;
+}): string {
+  const from = canonicalConnectNodeId(opts.fromNodeId) ?? String(opts.fromNodeId);
+  const to = canonicalConnectNodeId(opts.toNodeId) ?? String(opts.toNodeId);
+  const slot = opts.inputType ? `${opts.toType}.${opts.inputName} (${opts.inputType})` : `${opts.toType}.${opts.inputName}`;
+  const undo = opts.disconnected
+    ? "The LiteGraph link was disconnected so this is not reported as success."
+    : "Disconnect that input before retrying with a backend STRING producer.";
+  return (
+    `Error: panel_connect refused frontend PrimitiveNode #${from} → #${to} ${slot}. ` +
+    `A PrimitiveNode only serializes through a target widget; this input is forceInput-only ` +
+    `(no serializable widget binding), so panel_run would omit the required input from the ` +
+    `queued prompt. Add a backend STRING producer such as PrimitiveStringMultiline, set its ` +
+    `STRING widget, then panel_connect that STRING output to "${opts.inputName}". ${undo} ` +
+    `(artokun/comfyui-mcp#2536)`
+  );
+}
+
+function errorResult<T extends ToolResultLike>(text: string, base: T): T {
+  return { ...base, isError: true, content: [{ type: "text", text }] };
+}
+
+/**
+ * After a successful graph_connect, refuse a frontend PrimitiveNode that landed
+ * on a forceInput-only / non-widget input. Fail-open when the live detail cannot
+ * prove that shape.
+ */
+export async function verifyPrimitiveForceInputAfterConnect<T extends ToolResultLike>(
+  args: ConnectArgs,
+  connected: T,
+  call: GraphCall<T>,
+): Promise<T> {
+  if (connected.isError) return connected;
+
+  const endpointIds = uniqueEndpointIds(args.from_node_id, args.to_node_id);
+  if (endpointIds.length === 0) return connected;
+
+  const detail = await call(
+    {
+      cmd: "graph_query",
+      ids: endpointIds,
+      fields: "detail",
+      limit: endpointIds.length,
+      max_chars: DETAIL_MAX_CHARS,
+    },
+    DETAIL_TIMEOUT_MS,
+  );
+  const nodes = parseLiveConnectNodes(parseJsonPayload(detail));
+  if (!nodes) return connected;
+
+  const source = nodeByConnectId(nodes, args.from_node_id);
+  const target = nodeByConnectId(nodes, args.to_node_id);
+  if (!source || !target) return connected;
+  if (!isFrontendPrimitiveNodeType(source.type)) return connected;
+
+  const input = findTargetConnectInput(target, args.from_node_id, args.to_input);
+  if (!input) return connected;
+  if (!isForceInputOnlyNonWidget(input, target.widgets, target.widgetsKnown)) {
+    return connected;
+  }
+
+  let disconnected = false;
+  const undone = await call({
+    cmd: "graph_disconnect",
+    node_id: args.to_node_id,
+    input: input.name,
+  });
+  disconnected = undone.isError !== true;
+
+  return errorResult(
+    primitiveForceInputRefusal({
+      fromNodeId: args.from_node_id,
+      toNodeId: args.to_node_id,
+      toType: target.type,
+      inputName: input.name,
+      inputType: input.type,
+      disconnected,
+    }),
+    connected,
+  );
+}


### PR DESCRIPTION
## Summary
- panel_connect treated a visible LiteGraph link as success when a frontend PrimitiveNode was wired to a forceInput:true STRING (e.g. ApplyAnimaLoraFromPath.lora_path).
- A PrimitiveNode only serializes by baking its literal onto a target widget. A force-only socket has no widget, so panel_run omitted the required input (Required input is missing) even though panel_query_graph still showed the link and value.
- After a successful connect, the handler now reads both endpoints. If the source is PrimitiveNode and the target input is proven forceInput-only / non-widget, it disconnects the lying link and refuses with an actionable PrimitiveStringMultiline remedy.

## Test plan
- [x] `npx vitest run src/__tests__/services/primitive-force-input-connect.test.ts` — reported PrimitiveNode to lora_path fails closed through the registered panel_connect handler; widget STRING and backend PrimitiveStringMultiline stay allowed; truncated probes fall open.
- [x] `npx vitest run src/__tests__/services/connect-live-graph.test.ts` — #2502 live-graph retry still ships, plus the extra post-connect detail query.
- [x] Related panel_connect suites (panel-tools, fence/stamp, root-widget-promoted-misclass) still pass.

Closes #2536
