### PR TITLE
fix(2648): extract_deps walks UI subgraph inner nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- list_packs action:"extract_deps" walks UI subgraph inner nodes and does not treat subgraph instance UUIDs as class types (#2648)
+
+
 ## [0.52.160] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/services/workflow-deps.test.ts
+++ b/src/__tests__/services/workflow-deps.test.ts
@@ -136,6 +136,41 @@ describe("collectClassTypes", () => {
     };
     expect(collectClassTypes(ui)).toEqual(["CLIPTextEncode", "KSampler"]);
   });
+
+  // #2648 — a UI subgraph INSTANCE is structural (type === definition UUID).
+  // Reading only workflow.nodes treated that UUID as a class_type and never
+  // walked definitions.subgraphs[].nodes, so extract_deps mapped the UUID
+  // through an unrelated Manager pattern and omitted inner packs.
+  it("walks UI subgraph inner nodes and does not treat the instance UUID as a class_type (#2648)", () => {
+    const instanceId = "2d4f2d38-ff62-4ae8-853d-2a359520164b";
+    const ui = {
+      nodes: [
+        { id: 1, type: "LoadImage" },
+        { id: 2, type: instanceId },
+      ],
+      links: [],
+      definitions: {
+        subgraphs: [
+          {
+            id: instanceId,
+            name: "WanSampler",
+            nodes: [
+              { id: 10, type: "WanVideoSampler" },
+              { id: 11, type: "WanVideoWrapper" },
+              { id: 12, type: "SetNode" },
+            ],
+          },
+        ],
+      },
+    };
+    expect(collectClassTypes(ui)).toEqual([
+      "LoadImage",
+      "SetNode",
+      "WanVideoSampler",
+      "WanVideoWrapper",
+    ]);
+    expect(collectClassTypes(ui)).not.toContain(instanceId);
+  });
 });
 
 describe("extractWorkflowDependencies", () => {
@@ -226,6 +261,64 @@ describe("extractWorkflowDependencies", () => {
       installed: false,
       source: "manager_mappings",
     });
+  });
+
+  it("does not map a UI subgraph UUID through an unrelated Manager pattern (#2648)", async () => {
+    const instanceId = "2d4f2d38-ff62-4ae8-853d-2a359520164b";
+    const deps = makeDeps({
+      fetchObjectInfo: vi.fn(async () => ({}) as ObjectInfo),
+      fetchManagerMappings: vi.fn(
+        async () =>
+          ({
+            "https://github.com/DemonGatanjieu/Anomalous_Model_Browser": [
+              [],
+              {
+                title: "Anomalous_Model_Browser",
+                nodename_pattern: "^[0-9a-f]{8}-",
+              },
+            ],
+            "https://github.com/kijai/ComfyUI-WanVideoWrapper": [
+              ["WanVideoSampler", "WanVideoWrapper"],
+              { title: "WanVideoWrapper" },
+            ],
+            "https://github.com/kijai/ComfyUI-KJNodes": [
+              ["SetNode"],
+              { title: "KJNodes" },
+            ],
+          }) as never,
+      ),
+    });
+    const ui = {
+      nodes: [
+        { id: 1, type: "LoadImage" },
+        { id: 2, type: instanceId },
+      ],
+      definitions: {
+        subgraphs: [
+          {
+            id: instanceId,
+            nodes: [
+              { id: 10, type: "WanVideoSampler" },
+              { id: 11, type: "WanVideoWrapper" },
+              { id: 12, type: "SetNode" },
+            ],
+          },
+        ],
+      },
+    };
+    const result = await extractWorkflowDependencies(ui as never, deps);
+
+    expect(result.classTypes).toEqual([
+      "LoadImage",
+      "SetNode",
+      "WanVideoSampler",
+      "WanVideoWrapper",
+    ]);
+    expect(result.classTypes).not.toContain(instanceId);
+    expect(result.requiredPacks).toEqual(["KJNodes", "WanVideoWrapper"]);
+    expect(result.requiredPacks).not.toContain("Anomalous_Model_Browser");
+    expect(result.missingPacks).not.toContain("Anomalous_Model_Browser");
+    expect(result.dependencies.map((d) => d.class_type)).not.toContain(instanceId);
   });
 });
 

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -16,6 +16,7 @@ import {
   MANAGER_CATALOGUE_CURRENCY_CAVEAT,
   managerCatalogueCurrencyUnverified,
 } from "./manager-catalogue-currency.js";
+import { extractWorkflowClassTypes } from "./api-nodes.js";
 
 /**
  * Workflow dependency analysis & installation.
@@ -290,25 +291,15 @@ export function defaultWorkflowDepsDeps(): WorkflowDepsDeps {
  * Collect the distinct, sorted class_types referenced by a workflow. Handles
  * both the API format (object keyed by node id, each `{ class_type }`) and the
  * UI/"full" format (a `nodes` array whose entries carry a `type` field).
+ *
+ * Subgraph-aware via extractWorkflowClassTypes: a UI node whose `type` is a
+ * subgraph definition id is an instance, not a class_type, and inner nodes
+ * from `definitions.subgraphs[].nodes` are walked instead.
  */
 export function collectClassTypes(
   workflow: WorkflowJSON | { nodes?: unknown },
 ): string[] {
-  const set = new Set<string>();
-  const uiNodes = (workflow as { nodes?: unknown }).nodes;
-  if (Array.isArray(uiNodes)) {
-    for (const node of uiNodes) {
-      const t = (node as { type?: unknown } | null)?.type;
-      if (typeof t === "string" && t) set.add(t);
-    }
-    return [...set].sort();
-  }
-  for (const node of Object.values(workflow as WorkflowJSON)) {
-    if (node && typeof node.class_type === "string" && node.class_type) {
-      set.add(node.class_type);
-    }
-  }
-  return [...set].sort();
+  return extractWorkflowClassTypes(workflow).sort();
 }
 
 /**


### PR DESCRIPTION
## Summary

`list_packs` action:"extract_deps" was not subgraph-aware for UI workflows. `collectClassTypes` read only `workflow.nodes`, treated a subgraph instance UUID as a `class_type`, and never walked `definitions.subgraphs[].nodes`. Manager mappings then mapped the UUID through an unrelated `nodename_pattern` (e.g. `2d4f2d38-…` → DemonGatanjieu/Anomalous_Model_Browser) and omitted inner deps (WanVideoWrapper, KJNodes, …).

Reuse the already subgraph-aware `extractWorkflowClassTypes` from `services/api-nodes.js` so instance UUIDs are skipped and inner nodes are collected.

Fixes #2648

## Test plan

- [x] `npx vitest run src/__tests__/services/workflow-deps.test.ts` (26 tests)
- [x] `npm run check:unknown-collapse`
