### PR TITLE
chore: release v0.52.160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.160] - 2026-08-30
+
 ### MCP
 
 #### Fixed
-- get_image list_outputs scans the live server's output dir (and /history if that scan is empty) instead of an unrelated COMFYUI_PATH (#2539)
-- panel_connect refuses a frontend PrimitiveNode wired to a forceInput-only STRING instead of reporting a LiteGraph link that panel_run omits from the prompt (#2536)
-- panel_run retries once after a "Dynamic widget doesn't exist on node" serializer throw so the first queue after graph edits is not a false failure (#2537)
-- get_history and panel_run completion journaling fall back to the connected panel's global /history when the headless `/history/<prompt_id>` is unreachable, and queue.status discloses a cached done when that history still cannot be read (#2532)
-- panel_graph_outline accepts the documented `detail`:"full" argument instead of rejecting it as an unrecognized key (#2541)
-
+- get_image list_outputs scans the live server's output dir (and /history if that scan is empty) instead of an unrelated COMFYUI_PATH (#2539, #2642)
+- panel_connect refuses a frontend PrimitiveNode wired to a forceInput-only STRING instead of reporting a LiteGraph link that panel_run omits from the prompt (#2536, #2646)
+- panel_run retries once after a "Dynamic widget doesn't exist on node" serializer throw so the first queue after graph edits is not a false failure (#2537, #2643)
+- get_history and panel_run completion journaling fall back to the connected panel's global /history when the headless `/history/<prompt_id>` is unreachable, and queue.status discloses a cached done when that history still cannot be read (#2532, #2644)
+- panel_graph_outline accepts the documented `detail`:"full" argument instead of rejecting it as an unrecognized key (#2541, #2645)
+- panel_set_widget writes a promoted subgraph input on the enclosing host node instead of the link-driven inner widget (#2488, #2583)
 
 ## [0.52.159] - 2026-08-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.159",
+  "version": "0.52.160",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.159",
+      "version": "0.52.160",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.159",
+  "version": "0.52.160",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.52.160 covering #2536 (PR 2646), #2537 (PR 2643), #2532 (PR 2644), #2541 (PR 2645), and #2583 (#2488 follow-up).