### PR TITLE
fix(2542): permit panel_connect wildcard-to-wildcard LiteGraph slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_connect retries a LiteGraph wildcard-to-wildcard (`*` → `*`) pairing when the panel reports "No input accepts type *" — PrimitiveNode "connect to widget input" can land on LogicIF.when_true / when_false so the primitive becomes typed from the destination (#2542)
 - panel_query_graph inspects the unsaved live canvas after custom-widget / builder content-only [root-shape-mismatch] instead of recommending a destructive re-open (#2544)
 - node_pack action:"patch" accepts the documented apply-patch (`*** Begin Patch` / `*** Update File`) format in addition to ---/+++ unified diffs (#2496)
 - list_packs action:"extract_deps" walks UI subgraph inner nodes and does not treat subgraph instance UUIDs as class types (#2648)

--- a/src/__tests__/services/slot-compat.test.ts
+++ b/src/__tests__/services/slot-compat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   compatibilityRank,
+  isLiteGraphWildcardType,
   isTypeCompatible,
   RANK_EXACT,
   RANK_INCOMPATIBLE,
@@ -23,6 +24,14 @@ describe("slot-compat", () => {
     expect(compatibilityRank("MODEL", "*")).toBe(RANK_WILDCARD);
     expect(isTypeCompatible("*", "ANYTHING")).toBe(true);
     expect(RANK_WILDCARD).toBeLessThan(RANK_EXACT);
+  });
+
+  it("permits LiteGraph wildcard-to-wildcard (`*` → `*`)", () => {
+    expect(compatibilityRank("*", "*")).toBe(RANK_WILDCARD);
+    expect(isTypeCompatible("*", "*")).toBe(true);
+    expect(isLiteGraphWildcardType("*")).toBe(true);
+    expect(isLiteGraphWildcardType("IMAGE")).toBe(false);
+    expect(isLiteGraphWildcardType(["a"])).toBe(false);
   });
 
   it("orders exact > wildcard > incompatible", () => {

--- a/src/__tests__/services/wildcard-slot-connect.test.ts
+++ b/src/__tests__/services/wildcard-slot-connect.test.ts
@@ -1,0 +1,400 @@
+// #2542 — panel_connect refuses PrimitiveNode wildcard output ("connect to
+// widget input", type *) to LogicIF.when_true / when_false (also *).
+// Both slots advertise *; the primitive is supposed to become typed via the
+// downstream destination. Distinct from #2536 (forceInput-only STRING).
+//
+// Tests drive the shipped helpers AND the panel_connect wrap — a reimplementation
+// here would stay green if the wrap were deleted.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  inferConcreteTypeFromNode,
+  isForceInputOnlyStringSlot,
+  isLiteGraphWildcardSlotType,
+  parseLiveWildcardNodes,
+  resolveLiveWildcardRetry,
+  resolveWildcardConnectRetry,
+  retryWildcardSlotConnect,
+  wildcardToWildcardRefusal,
+  type LiveWildcardNode,
+  type LiveWildcardSlot,
+} from "../../services/wildcard-slot-connect.js";
+import { isTypeCompatible } from "../../services/slot-compat.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const PANEL_SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url)),
+  "utf8",
+);
+const SERVICE_SRC = readFileSync(
+  fileURLToPath(new URL("../../services/wildcard-slot-connect.ts", import.meta.url)),
+  "utf8",
+);
+
+const REPORTER_ERROR =
+  "Error: Could not connect node 2741 (PrimitiveNode) → node 2740 (LogicIF).\n" +
+  ' Node 2741 outputs: [0] "connect to widget input" (*)\n' +
+  ' Node 2740 inputs: [0] "when_true" (*), [1] "when_false" (*)\n' +
+  " No input on node 2740 accepts type *.";
+
+const REQUESTED_LINE_ERROR =
+  "Could not connect node 2741 (PrimitiveNode) → node 2740 (LogicIF).\n" +
+  'Requested: from_output=auto → to_input="when_false".\n' +
+  'Node 2741 outputs: [0] "connect to widget input" (*)\n' +
+  'Node 2740 inputs:  [0] "when_true" (*), [1] "when_false" (*)\n' +
+  "No input on node 2740 accepts type *. Tip: check wiring with panel_query_graph.";
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function jsonResult(payload: unknown, isError = false): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function textResult(text: string, isError = false): ToolResult {
+  return { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}) };
+}
+
+function allText(res: { content: Array<{ type: string; text?: string }> }): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+function slot(partial: Partial<LiveWildcardSlot> & Pick<LiveWildcardSlot, "name">): LiveWildcardSlot {
+  return {
+    slot: 0,
+    type: "*",
+    widget: undefined,
+    forceInput: false,
+    ...partial,
+  };
+}
+
+const PRIMITIVE: LiveWildcardNode = {
+  id: "2741",
+  type: "PrimitiveNode",
+  widgets: null,
+  widgetsKnown: true,
+  inputs: [],
+  outputs: [slot({ name: "connect to widget input", type: "*", slot: 0 })],
+};
+
+const LOGIC_IF = {
+  id: 2740,
+  type: "LogicIF",
+  widgets: { boolean: true },
+  inputs: [
+    { slot: 0, name: "when_true", type: "*" },
+    { slot: 1, name: "when_false", type: "*" },
+    { slot: 2, name: "boolean", type: "BOOLEAN", widget: { name: "boolean" } },
+  ],
+  outputs: [{ slot: 0, name: "*", type: "*" }],
+};
+
+describe("wildcard-to-wildcard refusal parse (#2542)", () => {
+  it("parses the reporter's exact panel sentence", () => {
+    const refusal = wildcardToWildcardRefusal(REPORTER_ERROR);
+    expect(refusal).not.toBeNull();
+    expect(refusal?.outputs).toEqual([{ index: 0, name: "connect to widget input", type: "*" }]);
+    expect(refusal?.inputs.map((s) => s.name)).toEqual(["when_true", "when_false"]);
+    expect(refusal?.inputs.every((s) => isLiteGraphWildcardSlotType(s.type))).toBe(true);
+  });
+
+  it("parses the current slotDiagnostic form with a Requested line", () => {
+    const refusal = wildcardToWildcardRefusal(REQUESTED_LINE_ERROR);
+    expect(refusal?.inputs.map((s) => s.name)).toEqual(["when_true", "when_false"]);
+  });
+
+  it("does not treat a concrete type mismatch as wildcard-to-wildcard", () => {
+    const text =
+      "Could not connect node 4 (CheckpointLoaderSimple) → node 3 (KSampler).\n" +
+      'Node 4 outputs: [0] "MODEL" (MODEL), [1] "CLIP" (CLIP)\n' +
+      'Node 3 inputs:  [0] "model" (MODEL)\n' +
+      "No input on node 3 accepts type CLIP.";
+    expect(wildcardToWildcardRefusal(text)).toBeNull();
+  });
+});
+
+describe("resolveWildcardConnectRetry", () => {
+  it("names LogicIF.when_false when that slot was requested", () => {
+    const refusal = wildcardToWildcardRefusal(REPORTER_ERROR);
+    expect(refusal).not.toBeNull();
+    expect(
+      resolveWildcardConnectRetry(refusal!, {
+        from_node_id: 2741,
+        to_node_id: 2740,
+        to_input: "when_false",
+      }),
+    ).toEqual({
+      from_output: "connect to widget input",
+      to_input: "when_false",
+      via: "explicit",
+      resolvedType: null,
+    });
+  });
+
+  it("does not guess between two `*` inputs when to_input is omitted", () => {
+    const refusal = wildcardToWildcardRefusal(REPORTER_ERROR);
+    expect(refusal).not.toBeNull();
+    expect(
+      resolveWildcardConnectRetry(refusal!, { from_node_id: 2741, to_node_id: 2740 }),
+    ).toBeNull();
+  });
+});
+
+describe("live wildcard retry / #2536 guard", () => {
+  it("infers a concrete type from a sibling widget slot", () => {
+    const nodes = parseLiveWildcardNodes({ truncated: false, nodes: [PRIMITIVE, LOGIC_IF] });
+    expect(nodes).not.toBeNull();
+    const target = nodes!.find((n) => n.id === "2740");
+    expect(inferConcreteTypeFromNode(target!)).toBe("BOOLEAN");
+  });
+
+  it("permits PrimitiveNode `*` → LogicIF.when_false `*`", () => {
+    const nodes = parseLiveWildcardNodes({ truncated: false, nodes: [PRIMITIVE, LOGIC_IF] });
+    const source = nodes!.find((n) => n.id === "2741")!;
+    const target = nodes!.find((n) => n.id === "2740")!;
+    const plan = resolveLiveWildcardRetry(
+      source,
+      target,
+      { from_node_id: 2741, to_node_id: 2740, to_input: "when_false" },
+      {
+        from_output: "connect to widget input",
+        to_input: "when_false",
+        via: "explicit",
+        resolvedType: null,
+      },
+    );
+    expect(plan).toMatchObject({ to_input: "when_false", via: "explicit" });
+    expect(isTypeCompatible("*", "*")).toBe(true);
+  });
+
+  it("uses typed-resolution when the destination slot is already concrete", () => {
+    const source = PRIMITIVE;
+    const target: LiveWildcardNode = {
+      id: "2740",
+      type: "LogicIF",
+      widgets: {},
+      widgetsKnown: true,
+      inputs: [slot({ name: "when_false", type: "INT", slot: 1 })],
+      outputs: [slot({ name: "INT", type: "INT", slot: 0 })],
+    };
+    const plan = resolveLiveWildcardRetry(
+      source,
+      target,
+      { from_node_id: 2741, to_node_id: 2740, to_input: "when_false" },
+      {
+        from_output: "connect to widget input",
+        to_input: "when_false",
+        via: "explicit",
+        resolvedType: null,
+      },
+    );
+    expect(plan).toEqual({
+      from_output: "connect to widget input",
+      to_input: "when_false",
+      via: "typed",
+      resolvedType: "INT",
+    });
+  });
+
+  it("does not retry PrimitiveNode onto a forceInput-only STRING", () => {
+    expect(
+      isForceInputOnlyStringSlot(
+        slot({ name: "lora_path", type: "STRING", forceInput: true }),
+        {},
+        true,
+      ),
+    ).toBe(true);
+
+    const target: LiveWildcardNode = {
+      id: "5",
+      type: "ApplyAnimaLoraFromPath",
+      widgets: {},
+      widgetsKnown: true,
+      inputs: [slot({ name: "lora_path", type: "STRING", forceInput: true, slot: 0 })],
+      outputs: [],
+    };
+    const plan = resolveLiveWildcardRetry(
+      PRIMITIVE,
+      target,
+      { from_node_id: 2741, to_node_id: 5, to_input: "lora_path" },
+      { from_output: "connect to widget input", to_input: "lora_path", via: "explicit", resolvedType: null },
+    );
+    expect(plan).toBeNull();
+  });
+});
+
+describe("retryWildcardSlotConnect", () => {
+  it("THE REPORTED CASE: PrimitiveNode `*` → LogicIF.when_false retries and lands", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryWildcardSlotConnect(
+      { from_node_id: 2741, to_node_id: 2740, to_input: "when_false" },
+      textResult(REPORTER_ERROR, true),
+      async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({ truncated: false, nodes: [PRIMITIVE, LOGIC_IF] });
+        }
+        if (cmd.cmd === "graph_connect") {
+          return jsonResult({
+            connected: {
+              from: { node_id: 2741, output: "connect to widget input" },
+              to: { node_id: 2740, input: "when_false" },
+            },
+          });
+        }
+        return textResult(`unexpected ${String(cmd.cmd)}`, true);
+      },
+    );
+    expect(res.isError).toBeUndefined();
+    expect(allText(res)).toMatch(/#2542/);
+    expect(allText(res)).toMatch(/wildcard-to-wildcard/);
+    expect(calls.map((c) => c.cmd)).toEqual(["graph_query", "graph_connect"]);
+    expect(calls[1]).toMatchObject({
+      cmd: "graph_connect",
+      from_node_id: 2741,
+      from_output: "connect to widget input",
+      to_node_id: 2740,
+      to_input: "when_false",
+      auto_match: false,
+    });
+  });
+
+  it("does not inspect a successful connect", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const connected = jsonResult({ connected: true });
+    const res = await retryWildcardSlotConnect(
+      { from_node_id: 1, to_node_id: 2 },
+      connected,
+      async (cmd) => {
+        calls.push(cmd);
+        return jsonResult({});
+      },
+    );
+    expect(JSON.parse(allText(res))).toEqual({ connected: true });
+    expect(calls).toEqual([]);
+  });
+
+  it("does not guess when_true vs when_false when to_input is omitted", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const res = await retryWildcardSlotConnect(
+      { from_node_id: 2741, to_node_id: 2740 },
+      textResult(REPORTER_ERROR, true),
+      async (cmd) => {
+        calls.push(cmd);
+        return jsonResult({ connected: true });
+      },
+    );
+    expect(res.isError).toBe(true);
+    expect(allText(res)).toMatch(/accepts type \*/);
+    expect(calls).toEqual([]);
+  });
+
+  it("leaves a CLIP mismatch alone", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const failed = textResult("No input on node 3 accepts type CLIP.", true);
+    const res = await retryWildcardSlotConnect(
+      { from_node_id: 4, from_output: "CLIP", to_node_id: 3 },
+      failed,
+      async (cmd) => {
+        calls.push(cmd);
+        return jsonResult({});
+      },
+    );
+    expect(res.isError).toBe(true);
+    expect(allText(res)).toMatch(/accepts type CLIP/);
+    expect(calls).toEqual([]);
+  });
+
+  it("retries from the diagnostic listing when the live probe is truncated", async () => {
+    const res = await retryWildcardSlotConnect(
+      { from_node_id: 2741, to_node_id: 2740, to_input: "when_false" },
+      textResult(REPORTER_ERROR, true),
+      async (cmd) => {
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({ truncated: true, nodes: [PRIMITIVE, LOGIC_IF] });
+        }
+        return jsonResult({ connected: true });
+      },
+    );
+    expect(res.isError).toBeUndefined();
+    expect(allText(res)).toMatch(/#2542/);
+  });
+});
+
+describe("panel_connect ships the wildcard-to-wildcard retry (#2542)", () => {
+  it("handlers dispatch through retryWildcardSlotConnect", () => {
+    expect(PANEL_SRC).toMatch(/retryWildcardSlotConnect\(/);
+    expect(PANEL_SRC).toMatch(/retryConnectAgainstLiveGraph\(/);
+    expect(PANEL_SRC).toMatch(/"panel_connect"/);
+    expect(SERVICE_SRC).toMatch(/cmd: "graph_query"/);
+    expect(SERVICE_SRC).toMatch(/cmd: "graph_connect"/);
+    expect(SERVICE_SRC).toMatch(/auto_match: false/);
+  });
+
+  it("documents wildcard-to-wildcard on the tool itself", () => {
+    const description = defByName("panel_connect").description;
+    expect(description).toContain("wildcard-to-wildcard");
+    expect(description).toContain("PrimitiveNode");
+    expect(description).toContain("LogicIF");
+  });
+
+  it("THE REPORTED CASE through the registered panel_connect handler", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        if (cmd.cmd === "graph_connect") {
+          if (cmd.auto_match === false && cmd.to_input === "when_false") {
+            return jsonResult({
+              connected: {
+                from: { node_id: 2741, output: "connect to widget input" },
+                to: { node_id: 2740, input: "when_false" },
+              },
+            });
+          }
+          return textResult(REPORTER_ERROR, true);
+        }
+        if (cmd.cmd === "graph_query") {
+          return jsonResult({ truncated: false, nodes: [PRIMITIVE, LOGIC_IF] });
+        }
+        return textResult(`unexpected ${String(cmd.cmd)}`, true);
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "wf:2542-reported",
+    };
+
+    const res = await defByName("panel_connect").handler(
+      { from_node_id: 2741, to_node_id: 2740, to_input: "when_false" },
+      ctx,
+    );
+    expect(res.isError).toBeUndefined();
+    expect(allText(res)).toMatch(/#2542/);
+    // graph_connect + #2542 live probe + explicit retry, then #2536 STRING-only verify.
+    expect(calls.map((c) => c.cmd)).toEqual([
+      "graph_connect",
+      "graph_query",
+      "graph_connect",
+      "graph_query",
+    ]);
+    expect(calls[2]).toMatchObject({
+      from_output: "connect to widget input",
+      to_input: "when_false",
+      auto_match: false,
+    });
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -86,6 +86,7 @@ import {
 } from "../services/unexpose-host-link-shift.js";
 import { retryConnectAgainstLiveGraph } from "../services/connect-live-graph.js";
 import { verifyPrimitiveForceInputAfterConnect } from "../services/primitive-force-input-connect.js";
+import { retryWildcardSlotConnect } from "../services/wildcard-slot-connect.js";
 import { retryExposeSubgraphInput } from "../services/expose-ae-wildcard.js";
 import {
   applyLiveRootViewing,
@@ -20200,7 +20201,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_connect",
-      "Connect an output slot of one node to an input slot of another in the user's open graph. Slots accept a name ('MODEL', 'samples') or numeric index. If both slot args are omitted the panel picks the first type-compatible pairing. On failure the error lists every slot with its type and [connected] flag — re-check with panel_query_graph ({ids:[node_id], fields:'detail'}). A frontend PrimitiveNode only serializes through a target widget; connecting one to a forceInput-only / non-widget STRING is refused (panel_run would omit the required input) — use a backend STRING producer such as PrimitiveStringMultiline instead. Undoable.",
+      "Connect an output slot of one node to an input slot of another in the user's open graph. Slots accept a name ('MODEL', 'samples') or numeric index. If both slot args are omitted the panel picks the first type-compatible pairing. On failure the error lists every slot with its type and [connected] flag — re-check with panel_query_graph ({ids:[node_id], fields:'detail'}). LiteGraph wildcard-to-wildcard (`*` → `*`) pairings are compatible (a PrimitiveNode 'connect to widget input' output can land on LogicIF.when_true / when_false so the primitive becomes typed from the destination). A frontend PrimitiveNode only serializes through a target widget; connecting one to a forceInput-only / non-widget STRING is refused (panel_run would omit the required input) — use a backend STRING producer such as PrimitiveStringMultiline instead. Undoable.",
       {
         from_node_id: nodeId().describe("Source node id."),
         from_output: slotRef
@@ -20235,7 +20236,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         };
         const call = (cmd: Record<string, unknown>, timeoutMs?: number) => ctx.call(cmd, timeoutMs);
         const connected = await retryConnectAgainstLiveGraph(connectArgs, call);
-        return verifyPrimitiveForceInputAfterConnect(connectArgs, connected, call);
+        const afterWildcard = await retryWildcardSlotConnect(connectArgs, connected, call);
+        return verifyPrimitiveForceInputAfterConnect(connectArgs, afterWildcard, call);
       },
     ),
     def(

--- a/src/services/primitive-force-input-connect.ts
+++ b/src/services/primitive-force-input-connect.ts
@@ -313,6 +313,9 @@ export async function verifyPrimitiveForceInputAfterConnect<T extends ToolResult
 
   const input = findTargetConnectInput(target, args.from_node_id, args.to_input);
   if (!input) return connected;
+  // #2536 is STRING-only. A LiteGraph wildcard (`*`) with no widget is a typed
+  // destination for PrimitiveNode (#2542), not a forceInput-only STRING omit.
+  if ((input.type ?? "").toUpperCase() !== "STRING") return connected;
   if (!isForceInputOnlyNonWidget(input, target.widgets, target.widgetsKnown)) {
     return connected;
   }

--- a/src/services/slot-compat.ts
+++ b/src/services/slot-compat.ts
@@ -9,7 +9,7 @@
 //
 // Rules:
 //   - exact match (same type name) is compatible and ranks highest;
-//   - `*` wildcard is compatible with anything but ranks LAST;
+//   - `*` wildcard is compatible with anything (including another `*`) but ranks LAST;
 //   - COMBO / enum array types are compatible only when identical;
 //   - comma-joined multi-types ("IMAGE,MASK") match if ANY segment matches.
 
@@ -42,7 +42,11 @@ export function compatibilityRank(output: SlotType, input: SlotType): number {
       : RANK_INCOMPATIBLE;
   }
 
-  // Wildcards accept anything but must rank below every concrete match.
+  // Wildcards accept anything — including another LiteGraph wildcard — but
+  // must rank below every concrete match. `*` → `*` is a valid pairing
+  // (Reroute, PrimitiveNode "connect to widget input", LogicIF when_true /
+  // when_false); the panel's "no input accepts type *" tail is not a
+  // compatibility verdict for that pair (artokun/comfyui-mcp#2542).
   if (output === "*" || input === "*") return RANK_WILDCARD;
 
   // Exact / comma multi-type: any shared segment is an exact-type match.
@@ -56,4 +60,9 @@ export function compatibilityRank(output: SlotType, input: SlotType): number {
 
 export function isTypeCompatible(output: SlotType, input: SlotType): boolean {
   return compatibilityRank(output, input) > RANK_INCOMPATIBLE;
+}
+
+/** True when a slot type is, or contains, LiteGraph's `*` wildcard segment. */
+export function isLiteGraphWildcardType(type: SlotType | null | undefined): boolean {
+  return typeof type === "string" && segments(type).includes("*");
 }

--- a/src/services/wildcard-slot-connect.ts
+++ b/src/services/wildcard-slot-connect.ts
@@ -1,0 +1,499 @@
+/**
+ * #2542 — `panel_connect` can refuse a LiteGraph wildcard (`*`) output onto a
+ * wildcard input even though both slots advertise `*` (PrimitiveNode
+ * "connect to widget input" → LogicIF.when_true / when_false).
+ *
+ * The panel's diagnostic tail ("No input on node N accepts type *") is the
+ * generic connect-failure sentence, not a compatibility verdict: shared
+ * slot-compat ranks `*` → `*` as a valid wildcard pairing, and the primitive
+ * is supposed to become typed from the downstream destination.
+ *
+ * On that refusal, re-read both endpoints and retry once with explicit slot
+ * names. A forceInput-only STRING (no widget) is left alone — that is #2536,
+ * a lying success that `panel_run` would omit, not a wildcard-to-wildcard
+ * link.
+ */
+
+import { normalizeNodeId } from "../orchestrator/node-id.js";
+import {
+  canonicalConnectNodeId,
+  type ConnectArgs,
+  type GraphCall,
+  type ToolResultLike,
+} from "./connect-live-graph.js";
+import { isLiteGraphWildcardType, isTypeCompatible } from "./slot-compat.js";
+
+const ACCEPTS_TYPE_STAR_RE = /No input on node \S+ accepts type \*/i;
+const SLOT_LISTING_RE = /\[(\d+)\] "([^"]*)" \(([^)]*)\)/g;
+const OUTPUTS_LINE_RE = /Node \S+ outputs:\s*(.*)$/im;
+const INPUTS_LINE_RE = /Node \S+ inputs:\s*(.*)$/im;
+
+const DETAIL_MAX_CHARS = 60000;
+const DETAIL_TIMEOUT_MS = 8000;
+
+const FRONTEND_PRIMITIVE_NODE_TYPE = "PrimitiveNode";
+
+export type DiagnosticSlot = {
+  index: number;
+  name: string;
+  type: string;
+};
+
+export type WildcardConnectRefusal = {
+  outputs: DiagnosticSlot[];
+  inputs: DiagnosticSlot[];
+};
+
+export type LiveWildcardSlot = {
+  name: string;
+  slot: number | null;
+  type: string | null;
+  widget: unknown;
+  forceInput: boolean;
+};
+
+export type LiveWildcardNode = {
+  id: string;
+  type: string;
+  widgets: Record<string, unknown> | null;
+  widgetsKnown: boolean;
+  inputs: LiveWildcardSlot[];
+  outputs: LiveWildcardSlot[];
+};
+
+export type WildcardConnectRetry = {
+  from_output: string | number;
+  to_input: string | number;
+  via: "explicit" | "typed";
+  resolvedType: string | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function toolText(res: ToolResultLike): string {
+  return res.content.map((c) => (c.type === "text" ? (c.text ?? "") : "")).join("\n");
+}
+
+function parseJsonPayload(res: ToolResultLike): Record<string, unknown> | null {
+  if (res.isError) return null;
+  const text = res.content.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    return asRecord(JSON.parse(text));
+  } catch {
+    // unknown-ok: unreadable JSON is not evidence the slots are wildcards.
+    return null;
+  }
+}
+
+function uniqueEndpointIds(fromNodeId: unknown, toNodeId: unknown): Array<number | string> {
+  const ids: Array<number | string> = [];
+  const seen = new Set<string>();
+  for (const value of [fromNodeId, toNodeId]) {
+    const canonical = canonicalConnectNodeId(value);
+    if (!canonical || seen.has(canonical)) continue;
+    seen.add(canonical);
+    const wire =
+      typeof value === "number" || typeof value === "string" ? normalizeNodeId(value) : canonical;
+    ids.push(wire);
+  }
+  return ids;
+}
+
+function slotTypeString(raw: string): string {
+  const trimmed = raw.trim();
+  const slash = trimmed.indexOf("/");
+  return slash === -1 ? trimmed : trimmed.slice(0, slash).trim();
+}
+
+function parseSlotListing(line: string | undefined): DiagnosticSlot[] {
+  if (!line) return [];
+  const slots: DiagnosticSlot[] = [];
+  SLOT_LISTING_RE.lastIndex = 0;
+  for (const match of line.matchAll(SLOT_LISTING_RE)) {
+    const index = Number.parseInt(match[1] ?? "", 10);
+    const name = match[2] ?? "";
+    const type = slotTypeString(match[3] ?? "");
+    if (!Number.isSafeInteger(index) || !type) continue;
+    slots.push({ index, name, type });
+  }
+  return slots;
+}
+
+export function isLiteGraphWildcardSlotType(type: string | null | undefined): boolean {
+  return isLiteGraphWildcardType(type);
+}
+
+export function wildcardToWildcardRefusal(text: string): WildcardConnectRefusal | null {
+  if (!ACCEPTS_TYPE_STAR_RE.test(text)) return null;
+  const outputs = parseSlotListing(OUTPUTS_LINE_RE.exec(text)?.[1]);
+  const inputs = parseSlotListing(INPUTS_LINE_RE.exec(text)?.[1]);
+  if (!outputs.some((slot) => isLiteGraphWildcardSlotType(slot.type))) return null;
+  if (!inputs.some((slot) => isLiteGraphWildcardSlotType(slot.type))) return null;
+  return { outputs, inputs };
+}
+
+function slotNameKey(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.toLowerCase() : null;
+}
+
+function findNamedSlot(slots: readonly DiagnosticSlot[], ref: unknown): DiagnosticSlot | null {
+  const key = slotNameKey(ref);
+  if (key) {
+    const byName = slots.find((slot) => slot.name.toLowerCase() === key);
+    if (byName) return byName;
+  }
+  if (typeof ref === "number" && Number.isSafeInteger(ref)) {
+    return slots.find((slot) => slot.index === ref) ?? slots[ref] ?? null;
+  }
+  if (typeof ref === "string" && /^-?\d+$/.test(ref.trim())) {
+    const index = Number.parseInt(ref.trim(), 10);
+    return slots.find((slot) => slot.index === index) ?? slots[index] ?? null;
+  }
+  return null;
+}
+
+function uniqueWildcard(slots: readonly DiagnosticSlot[]): DiagnosticSlot | null {
+  const wild = slots.filter((slot) => isLiteGraphWildcardSlotType(slot.type));
+  return wild.length === 1 ? (wild[0] ?? null) : null;
+}
+
+export function resolveWildcardConnectRetry(
+  refusal: WildcardConnectRefusal,
+  args: ConnectArgs,
+): WildcardConnectRetry | null {
+  const out =
+    findNamedSlot(refusal.outputs, args.from_output) ?? uniqueWildcard(refusal.outputs);
+  if (!out || !isLiteGraphWildcardSlotType(out.type)) return null;
+
+  const inp =
+    findNamedSlot(refusal.inputs, args.to_input) ?? uniqueWildcard(refusal.inputs);
+  if (!inp || !isLiteGraphWildcardSlotType(inp.type)) return null;
+
+  return {
+    from_output: out.name || out.index,
+    to_input: inp.name || inp.index,
+    via: "explicit",
+    resolvedType: null,
+  };
+}
+
+function isForceInputFlag(value: unknown): boolean {
+  return value === true;
+}
+
+function parseLiveSlot(raw: unknown, index: number): LiveWildcardSlot | null {
+  const rec = asRecord(raw);
+  if (!rec || typeof rec.name !== "string" || rec.name.length === 0) return null;
+  const slot =
+    typeof rec.slot === "number" && Number.isSafeInteger(rec.slot)
+      ? rec.slot
+      : typeof rec.slot_index === "number" && Number.isSafeInteger(rec.slot_index)
+        ? rec.slot_index
+        : index;
+  const config = asRecord(rec.config) ?? asRecord(rec.options);
+  return {
+    name: rec.name,
+    slot,
+    type: typeof rec.type === "string" && rec.type.length > 0 ? rec.type : null,
+    widget: rec.widget,
+    forceInput:
+      isForceInputFlag(rec.forceInput) ||
+      isForceInputFlag(rec.force_input) ||
+      isForceInputFlag(config?.forceInput) ||
+      isForceInputFlag(config?.force_input),
+  };
+}
+
+function parseLiveSlots(raw: unknown): LiveWildcardSlot[] {
+  if (!Array.isArray(raw)) return [];
+  const slots: LiveWildcardSlot[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const slot = parseLiveSlot(raw[i], i);
+    if (slot) slots.push(slot);
+  }
+  return slots;
+}
+
+function parseLiveNode(raw: unknown): LiveWildcardNode | null {
+  const rec = asRecord(raw);
+  if (!rec) return null;
+  const id = canonicalConnectNodeId(rec.id);
+  if (!id) return null;
+  const type =
+    typeof rec.type === "string" && rec.type.length > 0
+      ? rec.type
+      : typeof rec.class_type === "string" && rec.class_type.length > 0
+        ? rec.class_type
+        : null;
+  if (!type) return null;
+
+  const widgetsKnown = Object.prototype.hasOwnProperty.call(rec, "widgets");
+  const widgetsRaw = rec.widgets;
+  const widgets =
+    widgetsRaw && typeof widgetsRaw === "object" && !Array.isArray(widgetsRaw)
+      ? (widgetsRaw as Record<string, unknown>)
+      : null;
+
+  return {
+    id,
+    type,
+    widgets: widgetsKnown ? widgets : null,
+    widgetsKnown,
+    inputs: parseLiveSlots(rec.inputs),
+    outputs: parseLiveSlots(rec.outputs),
+  };
+}
+
+function collectDetailRows(payload: Record<string, unknown>): unknown[] {
+  if (Array.isArray(payload.nodes)) return payload.nodes;
+  if (typeof payload.text !== "string") return [];
+  const rows: unknown[] = [];
+  for (const line of payload.text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      rows.push(JSON.parse(trimmed));
+    } catch {
+      // unknown-ok: compact/ids lines are not node rows.
+    }
+  }
+  return rows;
+}
+
+export function parseLiveWildcardNodes(payload: unknown): LiveWildcardNode[] | null {
+  const rec = asRecord(payload);
+  if (!rec) return null;
+  if (Object.prototype.hasOwnProperty.call(rec, "truncated") && rec.truncated !== false) {
+    return null;
+  }
+  const nodes: LiveWildcardNode[] = [];
+  const seen = new Set<string>();
+  for (const row of collectDetailRows(rec)) {
+    const node = parseLiveNode(row);
+    if (!node || seen.has(node.id)) continue;
+    seen.add(node.id);
+    nodes.push(node);
+  }
+  return nodes.length > 0 ? nodes : null;
+}
+
+export function nodeByConnectId(
+  nodes: readonly LiveWildcardNode[],
+  nodeId: unknown,
+): LiveWildcardNode | null {
+  const want = canonicalConnectNodeId(nodeId);
+  if (!want) return null;
+  return nodes.find((node) => node.id === want) ?? null;
+}
+
+function hasSerializableWidgetBinding(slot: LiveWildcardSlot): boolean {
+  const widget = slot.widget;
+  if (widget === true) return true;
+  if (typeof widget === "string") return widget.length > 0;
+  const rec = asRecord(widget);
+  if (!rec) return false;
+  if (typeof rec.name === "string") return rec.name.length > 0;
+  return Object.keys(rec).length > 0;
+}
+
+/**
+ * True when a PrimitiveNode landing here would be the #2536 forceInput-only
+ * STRING case (no widget to bake onto). Wildcard `*` is not STRING — leave
+ * that pairing eligible for retry.
+ */
+export function isForceInputOnlyStringSlot(
+  slot: LiveWildcardSlot,
+  widgets: Record<string, unknown> | null,
+  widgetsKnown: boolean,
+): boolean {
+  if (slot.type !== "STRING") return false;
+  if (hasSerializableWidgetBinding(slot)) return false;
+  if (slot.forceInput) return true;
+  if (!widgetsKnown) return false;
+  return !Object.prototype.hasOwnProperty.call(widgets ?? {}, slot.name);
+}
+
+function findLiveSlot(
+  slots: readonly LiveWildcardSlot[],
+  ref: unknown,
+): LiveWildcardSlot | null {
+  const key = slotNameKey(ref);
+  if (key) {
+    const byName = slots.find((slot) => slot.name.toLowerCase() === key);
+    if (byName) return byName;
+  }
+  if (typeof ref === "number" && Number.isSafeInteger(ref)) {
+    const bySlot = slots.find((slot) => slot.slot === ref);
+    if (bySlot) return bySlot;
+    return slots[ref] ?? null;
+  }
+  if (typeof ref === "string" && /^-?\d+$/.test(ref.trim())) {
+    const index = Number.parseInt(ref.trim(), 10);
+    const bySlot = slots.find((slot) => slot.slot === index);
+    if (bySlot) return bySlot;
+    return slots[index] ?? null;
+  }
+  return null;
+}
+
+function uniqueLiveWildcard(slots: readonly LiveWildcardSlot[]): LiveWildcardSlot | null {
+  const wild = slots.filter((slot) => isLiteGraphWildcardSlotType(slot.type));
+  return wild.length === 1 ? (wild[0] ?? null) : null;
+}
+
+/** First concrete (non-wildcard) type on the node — the destination typing route. */
+export function inferConcreteTypeFromNode(node: LiveWildcardNode): string | null {
+  for (const slot of [...node.outputs, ...node.inputs]) {
+    if (!slot.type || isLiteGraphWildcardSlotType(slot.type)) continue;
+    if (slot.type.toUpperCase() === "COMBO") continue;
+    return slot.type;
+  }
+  return null;
+}
+
+export function resolveLiveWildcardRetry(
+  source: LiveWildcardNode,
+  target: LiveWildcardNode,
+  args: ConnectArgs,
+  diagnostic: WildcardConnectRetry,
+): WildcardConnectRetry | null {
+  const out =
+    findLiveSlot(source.outputs, diagnostic.from_output) ??
+    findLiveSlot(source.outputs, args.from_output) ??
+    uniqueLiveWildcard(source.outputs);
+  const inp =
+    findLiveSlot(target.inputs, diagnostic.to_input) ??
+    findLiveSlot(target.inputs, args.to_input) ??
+    uniqueLiveWildcard(target.inputs);
+  if (!out || !inp) return null;
+
+  if (
+    source.type === FRONTEND_PRIMITIVE_NODE_TYPE &&
+    isForceInputOnlyStringSlot(inp, target.widgets, target.widgetsKnown)
+  ) {
+    return null;
+  }
+
+  const outType = out.type ?? "*";
+  const inType = inp.type ?? "*";
+  if (!isTypeCompatible(outType, inType)) return null;
+
+  const outIsWild = isLiteGraphWildcardSlotType(out.type);
+  const inIsWild = isLiteGraphWildcardSlotType(inp.type);
+  if (!outIsWild && !inIsWild) return null;
+
+  const typedIn = inIsWild ? null : inp.type;
+  return {
+    from_output: out.name || diagnostic.from_output,
+    to_input: inp.name || diagnostic.to_input,
+    via: typedIn ? "typed" : "explicit",
+    resolvedType: typedIn ?? inferConcreteTypeFromNode(target),
+  };
+}
+
+function connectCommand(args: ConnectArgs): Record<string, unknown> {
+  return {
+    cmd: "graph_connect",
+    from_node_id: args.from_node_id,
+    from_output: args.from_output,
+    to_node_id: args.to_node_id,
+    to_input: args.to_input,
+    auto_match: args.auto_match,
+  };
+}
+
+function sameSlotRef(left: unknown, right: unknown): boolean {
+  if (left == null && right == null) return true;
+  if (typeof left === "number" && typeof right === "number") return left === right;
+  const a = slotNameKey(left);
+  const b = slotNameKey(right);
+  if (a && b) return a === b;
+  return left === right;
+}
+
+function retriedNote(retry: WildcardConnectRetry): string {
+  const via =
+    retry.via === "typed" && retry.resolvedType
+      ? `typed-resolution (${retry.resolvedType})`
+      : "explicit wildcard slots";
+  return (
+    `Retried panel_connect over compatible LiteGraph wildcard-to-wildcard slots ` +
+    `(${via}) so a PrimitiveNode \`*\` output can land on a \`*\` input and become ` +
+    `typed from the destination (artokun/comfyui-mcp#2542).`
+  );
+}
+
+function withNote<T extends ToolResultLike>(res: T, note: string | null): T {
+  if (!note) return res;
+  return { ...res, content: [...res.content, { type: "text", text: note }] };
+}
+
+/**
+ * After a failed graph_connect, retry once when the refusal is a compatible
+ * LiteGraph wildcard-to-wildcard pairing (`*` → `*`).
+ */
+export async function retryWildcardSlotConnect<T extends ToolResultLike>(
+  args: ConnectArgs,
+  first: T,
+  call: GraphCall<T>,
+  timeoutMs?: number,
+): Promise<T> {
+  if (!first.isError) return first;
+
+  const text = toolText(first);
+  const refusal = wildcardToWildcardRefusal(text);
+  if (!refusal) return first;
+
+  const diagnosticRetry = resolveWildcardConnectRetry(refusal, args);
+  if (!diagnosticRetry) return first;
+
+  const endpointIds = uniqueEndpointIds(args.from_node_id, args.to_node_id);
+  if (endpointIds.length === 0) return first;
+
+  const live = await call(
+    {
+      cmd: "graph_query",
+      ids: endpointIds,
+      fields: "detail",
+      limit: endpointIds.length,
+      max_chars: DETAIL_MAX_CHARS,
+    },
+    DETAIL_TIMEOUT_MS,
+  );
+  const nodes = parseLiveWildcardNodes(parseJsonPayload(live));
+  let retryPlan: WildcardConnectRetry | null = diagnosticRetry;
+  if (nodes) {
+    const source = nodeByConnectId(nodes, args.from_node_id);
+    const target = nodeByConnectId(nodes, args.to_node_id);
+    retryPlan =
+      source && target
+        ? resolveLiveWildcardRetry(source, target, args, diagnosticRetry)
+        : diagnosticRetry;
+  }
+  if (!retryPlan) return first;
+
+  if (
+    sameSlotRef(args.from_output, retryPlan.from_output) &&
+    sameSlotRef(args.to_input, retryPlan.to_input) &&
+    args.auto_match === false
+  ) {
+    return first;
+  }
+
+  const retryArgs: ConnectArgs = {
+    from_node_id: args.from_node_id,
+    from_output: retryPlan.from_output,
+    to_node_id: args.to_node_id,
+    to_input: retryPlan.to_input,
+    auto_match: false,
+  };
+  const retry = await call(connectCommand(retryArgs), timeoutMs);
+  if (!retry.isError) return withNote(retry, retriedNote(retryPlan));
+  return retry;
+}


### PR DESCRIPTION
## Summary

`panel_connect` refused a LiteGraph PrimitiveNode wildcard output (`"connect to widget input"`, type `*`) onto LogicIF `when_true` / `when_false` (also `*`) with:

> No input on node 2740 accepts type *.

Both slots advertise `*`. That tail is the generic connect-failure sentence, not a compatibility verdict — shared slot-compat already ranks `*` → `*` as a valid wildcard pairing, and the primitive is supposed to become typed from the downstream destination.

After a failed connect, the handler now re-reads both endpoints and retries once with explicit wildcard slot names. A forceInput-only STRING (no widget) is left alone — that is #2536, not this pairing.

## Test plan

- `npx vitest run src/__tests__/services/wildcard-slot-connect.test.ts` — reporter PrimitiveNode → LogicIF.when_false retries through the registered panel_connect handler; omitted to_input does not guess between two `*` inputs; CLIP mismatches and forceInput-only STRING stay refused; truncated probes still retry from the diagnostic listing.
- `npx vitest run src/__tests__/services/slot-compat.test.ts` — `*` → `*` is compatible.
- `npx vitest run src/__tests__/services/connect-live-graph.test.ts` — #2502 live-graph retry still ships.
- `npm run check:unknown-collapse`

Closes #2542