### PR TITLE
fix(2545): don't fail a landed Director duration write on callback throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_set_widget does not treat a MiniMaxH3Director duration write as failed when the value landed and only a setting-store onValueChange callback threw (#2545)
 - panel_connect retries a LiteGraph wildcard-to-wildcard (`*` → `*`) pairing when the panel reports "No input accepts type *" — PrimitiveNode "connect to widget input" can land on LogicIF.when_true / when_false so the primitive becomes typed from the destination (#2542)
 - panel_query_graph inspects the unsaved live canvas after custom-widget / builder content-only [root-shape-mismatch] instead of recommending a destructive re-open (#2544)
 - node_pack action:"patch" accepts the documented apply-patch (`*** Begin Patch` / `*** Update File`) format in addition to ---/+++ unified diffs (#2496)

--- a/src/__tests__/orchestrator/set-widget-director-duration-callback.test.ts
+++ b/src/__tests__/orchestrator/set-widget-director-duration-callback.test.ts
@@ -1,0 +1,236 @@
+// #2545 — panel_set_widget changed MiniMaxH3Director duration 5→6 (read-back
+// confirmed) then reported a frontend setting-store onValueChange throw:
+// write_warning: Cannot read properties of undefined (reading 'options')
+// write_warning_frame: at onValueChange (/assets/settingStore-*.js)
+//
+// The assignment already landed. Treating that callback throw as a failed write
+// invites a retry of a mutation that is already in effect.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const NODE_ID = 12;
+const REQUESTED = 6;
+const PREVIOUS = 5;
+const OPTIONS_THROW = "Cannot read properties of undefined (reading 'options')";
+const SETTING_STORE_FRAME =
+  "at onValueChange (/assets/settingStore-KkBYyEnh.js:153:120812)";
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  return def;
+}
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ");
+}
+
+function parseJson(res: ToolResult): Record<string, unknown> | null {
+  const text = textOf(res).replace(/^Error:\s*/i, "").trim();
+  const start = text.indexOf("{");
+  if (start < 0) return null;
+  try {
+    return JSON.parse(text.slice(start)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function durationNode(widgets: Record<string, unknown>) {
+  return {
+    truncated: false,
+    viewing: { scope: "root", graph_identity: "graph:2545", workflow_uuid: "wf-2545" },
+    nodes: [
+      {
+        id: NODE_ID,
+        type: "MiniMaxH3Director",
+        is_subgraph: false,
+        inputs: [],
+        widgets,
+      },
+    ],
+  };
+}
+
+function setEnvelope(extra: Record<string, unknown> = {}) {
+  return {
+    set: {
+      node_id: NODE_ID,
+      widget: "duration",
+      previous: PREVIOUS,
+      value: REQUESTED,
+      ...extra,
+    },
+  };
+}
+
+function okResult(body: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
+}
+
+function errResult(text: string): ToolResult {
+  return { isError: true, content: [{ type: "text", text: `Error: ${text}` }] };
+}
+
+async function runSetWidget(
+  call: PanelToolCtx["call"],
+  args: Record<string, unknown> = { node_id: NODE_ID, widget: "duration", value: REQUESTED },
+): Promise<ToolResult> {
+  return defByName("panel_set_widget").handler(args as never, {
+    call,
+    confirm: async () => "yes" as const,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "t-2545",
+  } as PanelToolCtx);
+}
+
+function scriptedCall(opts: {
+  write: ToolResult;
+  queryWidgets?: Record<string, unknown>;
+  queryError?: string;
+}): { call: PanelToolCtx["call"]; cmds: string[] } {
+  const cmds: string[] = [];
+  const call: PanelToolCtx["call"] = async (cmd) => {
+    cmds.push(String(cmd.cmd));
+    if (cmd.cmd === "graph_set_widget") return opts.write;
+    if (cmd.cmd === "graph_query") {
+      if (opts.queryError) return errResult(opts.queryError);
+      return okResult(durationNode(opts.queryWidgets ?? { duration: REQUESTED }));
+    }
+    return okResult({});
+  };
+  return { call, cmds };
+}
+
+describe("panel_set_widget MiniMaxH3Director duration callback throw (#2545)", () => {
+  it("THE REPORTED CASE: duration 5→6 with setting-store onValueChange write_warning is success", async () => {
+    const { call, cmds } = scriptedCall({
+      write: okResult(
+        setEnvelope({
+          write_warning: OPTIONS_THROW,
+          write_warning_frame: SETTING_STORE_FRAME,
+          write_warning_source: "widget_callback",
+        }),
+      ),
+    });
+    const res = await runSetWidget(call);
+    const payload = parseJson(res);
+    const set = payload?.set as Record<string, unknown> | undefined;
+
+    expect(cmds).toContain("graph_set_widget");
+    expect(res.isError).toBeUndefined();
+    expect(set).toMatchObject({
+      node_id: NODE_ID,
+      widget: "duration",
+      previous: PREVIOUS,
+      value: REQUESTED,
+    });
+    expect(set?.write_warning).toBeUndefined();
+    expect(set?.write_warning_frame).toBeUndefined();
+    expect(set?.write_warning_source).toBeUndefined();
+    expect(textOf(res)).not.toMatch(/write_warning/);
+  });
+
+  it("reclassifies an isError write_warning when the set envelope already shows the value landed", async () => {
+    const { call } = scriptedCall({
+      write: errResult(
+        JSON.stringify(
+          setEnvelope({
+            write_warning: OPTIONS_THROW,
+            write_warning_frame: SETTING_STORE_FRAME,
+          }),
+        ),
+      ),
+    });
+    const res = await runSetWidget(call);
+    const set = parseJson(res)?.set as Record<string, unknown> | undefined;
+
+    expect(res.isError).toBeUndefined();
+    expect(set?.value).toBe(REQUESTED);
+    expect(set?.write_warning).toBeUndefined();
+  });
+
+  it("settles a write_warning error without a set envelope from a graph read-back of the landed value", async () => {
+    const { call, cmds } = scriptedCall({
+      write: errResult(
+        `write_warning: ${OPTIONS_THROW}\nwrite_warning_frame: ${SETTING_STORE_FRAME}`,
+      ),
+      queryWidgets: { duration: REQUESTED },
+    });
+    const res = await runSetWidget(call);
+    const set = parseJson(res)?.set as Record<string, unknown> | undefined;
+
+    expect(cmds.filter((c) => c === "graph_query").length).toBeGreaterThan(0);
+    expect(res.isError).toBeUndefined();
+    expect(set?.value).toBe(REQUESTED);
+    expect(textOf(res)).not.toMatch(/write_warning/);
+  });
+
+  it("does NOT succeed when the same warning fired but duration did not land", async () => {
+    const { call } = scriptedCall({
+      write: errResult(
+        `write_warning: ${OPTIONS_THROW}\nwrite_warning_frame: ${SETTING_STORE_FRAME}`,
+      ),
+      queryWidgets: { duration: PREVIOUS },
+    });
+    const res = await runSetWidget(call);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/write_warning/);
+    expect(textOf(res)).toMatch(/reading 'options'/);
+  });
+
+  it("does NOT swallow a real duration write failure", async () => {
+    const { call, cmds } = scriptedCall({
+      write: errResult(`Cannot set widget "duration" on node ${NODE_ID}: widget not found`),
+    });
+    const res = await runSetWidget(call);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/widget not found/);
+    expect(cmds.filter((c) => c === "graph_set_widget")).toHaveLength(1);
+  });
+
+  it("does NOT strip an unrelated write_warning on a landed duration write", async () => {
+    const { call } = scriptedCall({
+      write: okResult(
+        setEnvelope({
+          write_warning: "Cannot delete property 'foo' of undefined",
+          write_warning_source: "widget_callback",
+        }),
+      ),
+    });
+    const res = await runSetWidget(call);
+    const set = parseJson(res)?.set as Record<string, unknown> | undefined;
+
+    expect(res.isError).toBeUndefined();
+    expect(set?.value).toBe(REQUESTED);
+    expect(set?.write_warning).toMatch(/Cannot delete property/);
+  });
+
+  it("does NOT swallow the same warning on a different widget", async () => {
+    const { call } = scriptedCall({
+      write: okResult({
+        set: {
+          node_id: NODE_ID,
+          widget: "steps",
+          previous: 20,
+          value: 30,
+          write_warning: OPTIONS_THROW,
+          write_warning_frame: SETTING_STORE_FRAME,
+        },
+      }),
+    });
+    const res = await runSetWidget(call, { node_id: NODE_ID, widget: "steps", value: 30 });
+    const set = parseJson(res)?.set as Record<string, unknown> | undefined;
+
+    expect(res.isError).toBeUndefined();
+    expect(set?.value).toBe(30);
+    expect(set?.write_warning).toBe(OPTIONS_THROW);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6359,6 +6359,135 @@ function stripVerifiedLastObservedSchemaNote(res: ToolResult): ToolResult {
   return rewriteToolResultJson(res, next);
 }
 
+// ---- #2545: MiniMaxH3Director duration onValueChange write_warning ----------
+// The panel assigns duration, verifies the value, then invokes the widget
+// callback. ComfyUI's settingStore onValueChange throws
+// `Cannot read properties of undefined (reading 'options')` when editor/options
+// is missing. That throw is a post-write disclosure, not a failed assignment.
+// Relaying it as isError (or leaving write_warning as the salient failure)
+// makes a landed 5→6 write look like a retryable error.
+
+function isDirectorDurationCallbackWarning(widget: string, text: string): boolean {
+  if (widget.toLowerCase() !== "duration") return false;
+  if (!/reading ['"]options['"]/.test(text)) return false;
+  return /onValueChange|settingStore|widget_callback/i.test(text);
+}
+
+function scalarWidgetValuesMatch(requested: unknown, observed: unknown): boolean {
+  if (Object.is(requested, observed)) return true;
+  if (
+    (typeof requested === "number" || typeof requested === "string") &&
+    (typeof observed === "number" || typeof observed === "string")
+  ) {
+    return String(requested) === String(observed);
+  }
+  return false;
+}
+
+function recordFromUnknown(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function parseJsonObjectFromToolText(res: ToolResult): Record<string, unknown> | null {
+  const parsed = parseToolResultJson(res);
+  if (parsed) return parsed;
+  const text = res?.content?.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  const trimmed = text.replace(/^Error:\s*/i, "").trim();
+  const start = trimmed.indexOf("{");
+  if (start < 0) return null;
+  try {
+    return recordFromUnknown(JSON.parse(trimmed.slice(start)));
+  // unknown-ok: the reply is not JSON; keep the original widget-write result.
+  } catch {
+    return null;
+  }
+}
+
+function stripWriteWarningFields(record: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...record };
+  delete next.write_warning;
+  delete next.write_warning_frame;
+  delete next.write_warning_source;
+  return next;
+}
+
+function landedDurationWriteResult(
+  payload: Record<string, unknown> | null,
+  set: Record<string, unknown>,
+): ToolResult {
+  const next: Record<string, unknown> = payload
+    ? stripWriteWarningFields({ ...payload, set: stripWriteWarningFields(set) })
+    : { set: stripWriteWarningFields(set) };
+  return ok(next);
+}
+
+async function readNamedWidgetValue(
+  ctx: PanelToolCtx,
+  nodeId: unknown,
+  widget: string,
+): Promise<unknown> {
+  const probe = await ctx.call(
+    {
+      cmd: "graph_query",
+      ids: [nodeId],
+      fields: "detail",
+      limit: 1,
+      max_chars: DYNAMIC_COMBO_PROBE_MAX_CHARS,
+    },
+    8000,
+  );
+  if (probe.isError) return undefined;
+  const detail = parseVerifiedQueriedNodeDetail(normalizeGraphQueryResult(probe));
+  const requestedId = canonicalQueriedNodeId(nodeId);
+  if (!detail || !requestedId || detail.id !== requestedId || !detail.widgets) {
+    return undefined;
+  }
+  if (!Object.prototype.hasOwnProperty.call(detail.widgets, widget)) return undefined;
+  return detail.widgets[widget];
+}
+
+/**
+ * #2545 — a verified Director duration write whose setting-store callback
+ * threw is still a landed write. Swallow that write_warning when `set.value`
+ * matches the request; if the panel reported it as an error without a set
+ * envelope, one graph_query may prove the value. Anything else stays failed.
+ */
+async function classifyLandedDirectorDurationWriteWarning(
+  ctx: PanelToolCtx,
+  res: ToolResult,
+  nodeId: unknown,
+  widget: string,
+  requested: unknown,
+): Promise<ToolResult> {
+  const text = textOfToolResult(res);
+  const payload = parseJsonObjectFromToolText(res);
+  const set = recordFromUnknown(payload?.set);
+  const warningText = [
+    typeof set?.write_warning === "string" ? set.write_warning : "",
+    typeof set?.write_warning_frame === "string" ? set.write_warning_frame : "",
+    typeof set?.write_warning_source === "string" ? set.write_warning_source : "",
+    text,
+  ].join("\n");
+  if (!isDirectorDurationCallbackWarning(widget, warningText)) return res;
+  if (set && scalarWidgetValuesMatch(requested, set.value)) {
+    return landedDurationWriteResult(payload, set);
+  }
+  if (!res.isError) return res;
+  const observed = await readNamedWidgetValue(ctx, nodeId, widget);
+  if (observed === undefined || !scalarWidgetValuesMatch(requested, observed)) {
+    return res;
+  }
+  return ok({
+    set: {
+      node_id: nodeId,
+      widget,
+      value: observed,
+    },
+  });
+}
+
 async function exitSubgraphLevels(
   ctx: PanelToolCtx,
   count: number,
@@ -18100,7 +18229,7 @@ async function pollLateAskReply(
   askId: string,
   timing: AskTiming,
   hardDeadline?: number,
-): Promise<unknown | undefined> {
+) {
   const probe: BridgeProbe = bridge;
   const take = probe.takeLateAskReply;
   if (typeof take !== "function") return undefined;
@@ -20410,16 +20539,23 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           const echoed = stripVerifiedLastObservedSchemaNote(
             summarizeSetWidgetEcho(written, echoFull),
           );
+          const classified = await classifyLandedDirectorDurationWriteWarning(
+            ctx,
+            echoed,
+            nodeId,
+            widget,
+            value,
+          );
           // #2495 — ONLY a tagged no-reply on a named Power Lora row is settled
           // by a read. An acked executor error is a definite outcome.
           if (
-            isReplyTimeoutResult(echoed) &&
+            isReplyTimeoutResult(classified) &&
             isPowerLoraDynamicRowWidget(widget) &&
             args.defer_until_idle !== true
           ) {
             return settlePowerLoraWidgetAfterAckTimeout(
               ctx,
-              echoed,
+              classified,
               nodeId,
               widget,
               value,
@@ -20427,7 +20563,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               dispatchTab,
             );
           }
-          return echoed;
+          return classified;
         };
         let writePromotedInner: (plan: PromotedWritePlan) => Promise<ToolResult>;
         const guardedWrite = async (


### PR DESCRIPTION
## Summary

`panel_set_widget` successfully changed MiniMaxH3Director `duration` from 5 to 6 (verified by read-back), then reported a frontend setting-store callback exception as if the write failed:

```
write_warning: Cannot read properties of undefined (reading 'options')
write_warning_frame: at onValueChange (/assets/settingStore-*.js)
```

The assignment already landed. The throw comes from ComfyUI's `onValueChange` when `editor/options` is missing during a programmatic callback. Relaying that as a failed write invites a retry of a mutation that is already in effect.

`panel_set_widget` now:

- Recognizes this Director `duration` write_warning (`reading 'options'` plus `onValueChange` / `settingStore` / `widget_callback`)
- Returns success when `set.value` already matches the request, stripping the error-looking `write_warning` fields
- If the panel reported it as an error without a `set` envelope, takes one graph read-back and succeeds only when that value matches
- Leaves real write failures, unrelated write_warnings, and other widgets unchanged

Fixes #2545

## Test plan

- [x] `npx vitest run src/__tests__/orchestrator/set-widget-director-duration-callback.test.ts` (7 tests)
- [x] `npm run check:unknown-collapse`
- [x] Existing panel_set_widget suites still pass (`panel-tools.test.ts`, Power Lora ack-timeout, promoted-link-driven-warning)
