### PR TITLE
fix(2283): inspect panel outputs when headless ComfyUI is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- get_image list_assets and get_system_stats logs fall back to the connected panel same-origin history/logs/view reads when the configured headless route is unreachable, and panel_run completion events name PreviewImage outputs with type temp (#2283)
 - panel_set_widget does not treat a MiniMaxH3Director duration write as failed when the value landed and only a setting-store onValueChange callback threw (#2545, #2654)
 - panel_connect retries a LiteGraph wildcard-to-wildcard (`*` → `*`) pairing when the panel reports "No input accepts type *" — PrimitiveNode "connect to widget input" can land on LogicIF.when_true / when_false so the primitive becomes typed from the destination (#2542, #2653)
 - panel_query_graph inspects the unsaved live canvas after custom-widget / builder content-only [root-shape-mismatch] instead of recommending a destructive re-open (#2544, #2652)

--- a/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
+++ b/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
@@ -10,6 +10,10 @@ describe("panel image relay orchestrator wiring (#2149)", () => {
     expect(SOURCE).toContain("resolvePanelAgent: panelImageRelayAgentFor");
     expect(SOURCE).toContain("resolvePanelTab: scopeToRealTab");
     expect(SOURCE).toContain("resolveCurrentTarget: () => ({");
+    expect(SOURCE).toContain("resolvePanelTarget: (tabId) => {");
+    expect(SOURCE).toContain("const tabOrigin = bridge.tabOrigin(tabId);");
+    expect(SOURCE).toContain("const serverOrigin = bridge.tabServerOrigin(tabId);");
+    expect(SOURCE).toContain("claimedOrigin !== observedOrigin");
     expect(SOURCE).toContain("generation: getComfyuiTargetGeneration(),");
     expect(SOURCE).toContain("COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor");
     expect(SOURCE).toContain("COMFYUI_MCP_RELAY_URL: panelImageRelayEndpoint");

--- a/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
+++ b/src/__tests__/orchestrator/panel-image-relay-wiring.test.ts
@@ -9,8 +9,12 @@ describe("panel image relay orchestrator wiring (#2149)", () => {
     expect(SOURCE).toContain("isScopeAddress(tabId) ? bridge.resolveSharedTabId(tabId) : panelTabOf(tabId)");
     expect(SOURCE).toContain("resolvePanelAgent: panelImageRelayAgentFor");
     expect(SOURCE).toContain("resolvePanelTab: scopeToRealTab");
+    expect(SOURCE).toContain("resolveCurrentTarget: () => ({");
+    expect(SOURCE).toContain("generation: getComfyuiTargetGeneration(),");
     expect(SOURCE).toContain("COMFYUI_MCP_RELAY_SECRET: panelImageRelaySecretFor");
     expect(SOURCE).toContain("COMFYUI_MCP_RELAY_URL: panelImageRelayEndpoint");
+    expect(SOURCE).toContain("COMFYUI_URL: comfyuiUrl");
+    expect(SOURCE).toContain("COMFYUI_MCP_TARGET_GENERATION: String(getComfyuiTargetGeneration())");
     expect(SOURCE).not.toContain("processPanelImageRequests({");
   });
 

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -849,7 +849,7 @@ describe("run completion across automatic goal continuation (#468)", () => {
   });
 
   it("#2283: a matched PreviewImage completion names type:temp so get_image can fetch it without history", async () => {
-    // Headless get_image / list_assets / history can be ECONNREFUSED while the
+    // Headless get_image (action:"list_assets") / history can be ECONNREFUSED while the
     // panel still queued the run. Filename-only completion text defaults
     // get_image to type:"output" and misses PreviewImage's temp/ file.
     const backend = new ContinuationBackend();

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -848,6 +848,90 @@ describe("run completion across automatic goal continuation (#468)", () => {
     expect(text).toContain('get_image action:"get"');
   });
 
+  it("#2283: a matched PreviewImage completion names type:temp so get_image can fetch it without history", async () => {
+    // Headless get_image / list_assets / history can be ECONNREFUSED while the
+    // panel still queued the run. Filename-only completion text defaults
+    // get_image to type:"output" and misses PreviewImage's temp/ file.
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-preview-temp-ref";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+
+    arrive(tab, {
+      kind: "executed",
+      prompt_id: PROMPT_A,
+      images: [
+        { filename: "ComfyUI_temp_00001_.png", type: "temp" },
+        { filename: "final_00001_.png" },
+      ],
+    });
+    await waitFor(() => backend.turns.length >= 2);
+
+    const text = backend.turns[1];
+    expect(backend.turnImages[1]).toEqual(["ComfyUI_temp_00001_.png", "final_00001_.png"]);
+    expect(text).toContain("This is the run YOU queued");
+    expect(text).toContain('ComfyUI_temp_00001_.png (type:"temp")');
+    expect(text).toContain("final_00001_.png");
+    expect(text).toContain("produced 2 output image(s)");
+  });
+
+  it("#2283: a custom completion note still names PreviewImage type:temp for get_image", async () => {
+    // A panel note replaces the default filename list, so the temp ref has to
+    // ride the inspect pointer or get_image defaults to type:"output".
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-preview-temp-note";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+
+    arrive(tab, {
+      kind: "executed",
+      prompt_id: PROMPT_A,
+      note: "Preview tap on VAEDecode.",
+      images: [{ filename: "ComfyUI_temp_00001_.png", type: "temp" }],
+    });
+    await waitFor(() => backend.turns.length >= 2);
+
+    const text = backend.turns[1];
+    expect(text).toContain("Preview tap on VAEDecode.");
+    expect(text).toContain('ComfyUI_temp_00001_.png (type:"temp")');
+    expect(text).toContain('get_image action:"get"');
+  });
+
+  it("#2283: a text-only backend still gets PreviewImage temp coordinates", async () => {
+    class TextOnlyBackend extends ContinuationBackend {
+      readonly capabilities = { ...CLAUDE_CAPABILITIES, vision: false };
+    }
+    const backend = new TextOnlyBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-preview-temp-text-only";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+
+    arrive(tab, {
+      kind: "executed",
+      prompt_id: PROMPT_A,
+      images: [{ filename: "ComfyUI_temp_00002_.png", type: "temp", subfolder: "previews" }],
+    });
+    await waitFor(() => backend.turns.length >= 2);
+
+    const text = backend.turns[1];
+    expect(backend.turnImages[1]).toEqual([]);
+    expect(text).toContain("You cannot view images on this provider");
+    expect(text).toContain('ComfyUI_temp_00002_.png (type:"temp", subfolder:"previews")');
+    expect(text).toContain('get_image action:"get"');
+  });
+
   it("#1516: a completion whose outputs have no usable filename promises nothing", async () => {
     // attachedImgs is empty here for a reason that is NOT the budget, and the
     // old wording said "The image(s) are attached below" while attaching none.

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHmac } from "node:crypto";
 import { createServer } from "node:http";
 import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
@@ -35,6 +35,8 @@ import {
 
 const dirs: string[] = [];
 const SECRET = "a".repeat(64);
+const TARGET_URL = "http://127.0.0.1:8188";
+const TARGET_GENERATION = 7;
 const PRODUCTION_OBJECT_INFO_DELAY_MS = 20_841;
 
 /** Model the Panel bridge's command dispatcher at the wire boundary: the MCP
@@ -94,6 +96,8 @@ function request(id: string, patch: Partial<PanelImageRelayRequest> = {}): Panel
   const value = {
     version: 1,
     requestId: id,
+    targetUrl: TARGET_URL,
+    targetGeneration: TARGET_GENERATION,
     filename: "render.png",
     subfolder: "shots",
     type: "output",
@@ -117,6 +121,8 @@ function readRequest(id: string, operation: PanelComfyUIReadRelayRequest["operat
   const value = {
     version: 1 as const,
     requestId: id,
+    targetUrl: TARGET_URL,
+    targetGeneration: TARGET_GENERATION,
     operation,
     createdAt,
     deadlineAt: createdAt + 8_000,
@@ -135,12 +141,19 @@ function readResponse(dir: string, id: string): Record<string, unknown> {
   return JSON.parse(readFileSync(responseFile(dir, id), "utf8")) as Record<string, unknown>;
 }
 
+beforeEach(() => {
+  process.env.COMFYUI_URL = TARGET_URL;
+  process.env.COMFYUI_MCP_TARGET_GENERATION = String(TARGET_GENERATION);
+});
+
 afterEach(() => {
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
   delete process.env.COMFYUI_MCP_PROGRESS_DIR;
   delete process.env.COMFYUI_MCP_TAB;
   delete process.env.COMFYUI_MCP_RELAY_SECRET;
   delete process.env.COMFYUI_MCP_RELAY_URL;
+  delete process.env.COMFYUI_URL;
+  delete process.env.COMFYUI_MCP_TARGET_GENERATION;
   vi.restoreAllMocks();
 });
 
@@ -165,6 +178,8 @@ describe("panel image relay child channel", () => {
       "filename",
       "requestId",
       "subfolder",
+      "targetGeneration",
+      "targetUrl",
       "type",
       "version",
     ]);
@@ -551,6 +566,7 @@ describe("authenticated loopback panel image relay", () => {
     const server = await startPanelImageRelayServer({
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab: (agentKey) => agentKey === "orchestrator::claude" ? "pinned-live-panel" : undefined,
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: { canReach: () => true, send },
     });
     try {
@@ -570,11 +586,103 @@ describe("authenticated loopback panel image relay", () => {
     }
   });
 
+  it("rejects a previous target before resolving or dispatching the live panel", async () => {
+    const resolvePanelTab = vi.fn(() => "victim-panel");
+    const send = vi.fn();
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab,
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      bridge: { canReach: () => true, send },
+    });
+    try {
+      const stale = request("stale-target-123456", {
+        targetUrl: TARGET_URL,
+        targetGeneration: TARGET_GENERATION - 1,
+      });
+      const response = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(stale),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ ok: false, error: "STALE_TARGET", requestId: stale.requestId });
+      expect(resolvePanelTab).not.toHaveBeenCalled();
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("drops a bridge result when the panel retargets during the in-flight request", async () => {
+    let currentTarget = { url: TARGET_URL, generation: TARGET_GENERATION };
+    let release: (() => void) | undefined;
+    const bridgeReply = new Promise<Record<string, unknown>>((resolve) => {
+      release = () => resolve({ ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 });
+    });
+    const send = vi.fn(() => bridgeReply);
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => currentTarget,
+      bridge: { canReach: () => true, send },
+    });
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+      const pending = requestPanelImage("render.png", "output", "shots");
+      for (let i = 0; i < 100 && !send.mock.calls.length; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(send).toHaveBeenCalledOnce();
+      currentTarget = { url: "http://127.0.0.1:8189", generation: TARGET_GENERATION + 1 };
+      release?.();
+      await expect(pending).rejects.toMatchObject({ code: "STALE_TARGET" });
+    } finally {
+      release?.();
+      await server.close();
+    }
+  });
+
+  it("fails closed when the live target identity is unavailable", async () => {
+    const resolvePanelTab = vi.fn(() => "panel-tab");
+    const send = vi.fn();
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab,
+      resolveCurrentTarget: () => { throw new Error("target identity unavailable"); },
+      bridge: { canReach: () => true, send },
+    });
+    try {
+      const response = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(request("ambiguous-target-123456")),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ ok: false, error: "STALE_TARGET", requestId: "ambiguous-target-123456" });
+      expect(resolvePanelTab).not.toHaveBeenCalled();
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not contact the relay when the child target identity is missing", async () => {
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_RELAY_URL = "http://127.0.0.1:9";
+    delete process.env.COMFYUI_URL;
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(requestPanelImage("render.png", "output", "shots")).resolves.toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("rejects forged HMACs before resolving or dispatching a panel tab", async () => {
     const send = vi.fn();
     const server = await startPanelImageRelayServer({
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab: () => "victim-panel",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: { canReach: () => true, send },
     });
     try {
@@ -690,6 +798,7 @@ describe("authenticated loopback panel image relay", () => {
     const server = await startPanelImageRelayServer({
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async (_command, options) => {
@@ -743,6 +852,7 @@ describe("authenticated loopback panel image relay", () => {
             ? { agentKey: "orchestrator::claude", secret: SECRET }
             : undefined,
         resolvePanelTab: () => "panel-tab",
+        resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
         bridge: {
           canReach: () => true,
           send: async (command) => {
@@ -797,6 +907,7 @@ describe("authenticated loopback panel image relay", () => {
           ? { agentKey: "orchestrator::claude", secret: SECRET }
           : undefined,
       resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async (command) => {
@@ -833,6 +944,7 @@ describe("authenticated loopback panel image relay", () => {
           ? { agentKey: "orchestrator::claude", secret: SECRET }
           : undefined,
       resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async () => ({
@@ -876,6 +988,7 @@ describe("authenticated loopback panel image relay", () => {
           ? { agentKey: "orchestrator::claude", secret: SECRET }
           : undefined,
       resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: productionShapedPanelDispatcher(body, (timeoutMs) => { bridgeTimeoutMs = timeoutMs; }),
@@ -903,6 +1016,7 @@ describe("authenticated loopback panel image relay", () => {
           ? { agentKey: "orchestrator::claude", secret: SECRET }
           : undefined,
       resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async () => ({ operation: "object_info", body, contentType: "application/json", bytes: body.length }),
@@ -925,6 +1039,7 @@ describe("authenticated loopback panel image relay", () => {
           ? { agentKey: "orchestrator::claude", secret: SECRET }
           : undefined,
       resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async (_command, options) => {
@@ -961,6 +1076,7 @@ describe("authenticated loopback panel image relay", () => {
           ? { agentKey: "orchestrator::claude", secret: SECRET }
           : undefined,
       resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async () => {
@@ -989,6 +1105,7 @@ describe("authenticated loopback panel image relay", () => {
     const server = await startPanelImageRelayServer({
       resolvePanelAgent: () => ({ agentKey: "orchestrator::claude", secret: SECRET }),
       resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: { canReach: () => true, send: vi.fn() },
     });
     try {

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -36,6 +36,7 @@ import {
 const dirs: string[] = [];
 const SECRET = "a".repeat(64);
 const TARGET_URL = "http://127.0.0.1:8188";
+const OTHER_TARGET_URL = "http://127.0.0.1:8189";
 const TARGET_GENERATION = 7;
 const PRODUCTION_OBJECT_INFO_DELAY_MS = 20_841;
 
@@ -567,6 +568,7 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab: (agentKey) => agentKey === "orchestrator::claude" ? "pinned-live-panel" : undefined,
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: { canReach: () => true, send },
     });
     try {
@@ -593,6 +595,7 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab,
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: { canReach: () => true, send },
     });
     try {
@@ -614,6 +617,60 @@ describe("authenticated loopback panel image relay", () => {
     }
   });
 
+  it("refuses a valid target-B capability when the selected panel tab proves target A", async () => {
+    const send = vi.fn();
+    const resolvePanelTarget = vi.fn(() => ({ url: OTHER_TARGET_URL, generation: TARGET_GENERATION }));
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab: () => "panel-A",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget,
+      bridge: { canReach: () => true, send },
+    });
+    try {
+      const targetB = request("cross-target-123456", { targetUrl: TARGET_URL, targetGeneration: TARGET_GENERATION });
+      const response = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(targetB),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ ok: false, error: "STALE_TARGET", requestId: targetB.requestId });
+      expect(resolvePanelTarget).toHaveBeenCalledWith("panel-A");
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("refuses missing or ambiguous per-tab target proof before dispatch", async () => {
+    for (const resolvePanelTarget of [
+      () => undefined,
+      () => { throw new Error("panel target identity is ambiguous"); },
+    ]) {
+      const send = vi.fn();
+      const server = await startPanelImageRelayServer({
+        resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+        resolvePanelTab: () => "panel-tab",
+        resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+        resolvePanelTarget,
+        bridge: { canReach: () => true, send },
+      });
+      try {
+        const response = await fetch(server.endpointUrl, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(request("missing-panel-target-123456")),
+        });
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({ ok: false, error: "STALE_TARGET" });
+        expect(send).not.toHaveBeenCalled();
+      } finally {
+        await server.close();
+      }
+    }
+  });
+
   it("drops a bridge result when the panel retargets during the in-flight request", async () => {
     let currentTarget = { url: TARGET_URL, generation: TARGET_GENERATION };
     let release: (() => void) | undefined;
@@ -625,6 +682,7 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => currentTarget,
+      resolvePanelTarget: () => currentTarget,
       bridge: { canReach: () => true, send },
     });
     try {
@@ -644,6 +702,67 @@ describe("authenticated loopback panel image relay", () => {
     }
   });
 
+  it("refuses dispatch when the selected tab retargets before the final send fence", async () => {
+    let panelTarget = { url: TARGET_URL, generation: TARGET_GENERATION };
+    let reads = 0;
+    const send = vi.fn();
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => {
+        reads += 1;
+        if (reads === 2) panelTarget = { url: OTHER_TARGET_URL, generation: TARGET_GENERATION };
+        return panelTarget;
+      },
+      bridge: { canReach: () => true, send },
+    });
+    try {
+      const response = await fetch(server.endpointUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(request("pre-retarget-123456")),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ ok: false, error: "STALE_TARGET" });
+      expect(reads).toBeGreaterThanOrEqual(2);
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("drops a bridge result when the selected tab retargets in flight", async () => {
+    let panelTarget = { url: TARGET_URL, generation: TARGET_GENERATION };
+    let release: (() => void) | undefined;
+    const bridgeReply = new Promise<Record<string, unknown>>((resolve) => {
+      release = () => resolve({ ok: true, base64: "AQID", mimeType: "image/png", bytes: 3 });
+    });
+    const send = vi.fn(() => bridgeReply);
+    const server = await startPanelImageRelayServer({
+      resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
+      resolvePanelTab: () => "panel-tab",
+      resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => panelTarget,
+      bridge: { canReach: () => true, send },
+    });
+    try {
+      process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+      process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+      const pending = requestPanelImage("render.png", "output", "shots");
+      for (let i = 0; i < 100 && !send.mock.calls.length; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(send).toHaveBeenCalledOnce();
+      panelTarget = { url: OTHER_TARGET_URL, generation: TARGET_GENERATION };
+      release?.();
+      await expect(pending).rejects.toMatchObject({ code: "STALE_TARGET" });
+    } finally {
+      release?.();
+      await server.close();
+    }
+  });
+
   it("fails closed when the live target identity is unavailable", async () => {
     const resolvePanelTab = vi.fn(() => "panel-tab");
     const send = vi.fn();
@@ -651,6 +770,7 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab,
       resolveCurrentTarget: () => { throw new Error("target identity unavailable"); },
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: { canReach: () => true, send },
     });
     try {
@@ -683,6 +803,7 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab: () => "victim-panel",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: { canReach: () => true, send },
     });
     try {
@@ -799,6 +920,7 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelAgent: (value) => verifyPanelImageRelayCapability(SECRET, value) ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined,
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async (_command, options) => {
@@ -853,6 +975,7 @@ describe("authenticated loopback panel image relay", () => {
             : undefined,
         resolvePanelTab: () => "panel-tab",
         resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+        resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
         bridge: {
           canReach: () => true,
           send: async (command) => {
@@ -908,6 +1031,7 @@ describe("authenticated loopback panel image relay", () => {
           : undefined,
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async (command) => {
@@ -945,6 +1069,7 @@ describe("authenticated loopback panel image relay", () => {
           : undefined,
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async () => ({
@@ -989,6 +1114,7 @@ describe("authenticated loopback panel image relay", () => {
           : undefined,
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: productionShapedPanelDispatcher(body, (timeoutMs) => { bridgeTimeoutMs = timeoutMs; }),
@@ -1017,6 +1143,7 @@ describe("authenticated loopback panel image relay", () => {
           : undefined,
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async () => ({ operation: "object_info", body, contentType: "application/json", bytes: body.length }),
@@ -1040,6 +1167,7 @@ describe("authenticated loopback panel image relay", () => {
           : undefined,
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async (_command, options) => {
@@ -1077,6 +1205,7 @@ describe("authenticated loopback panel image relay", () => {
           : undefined,
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: {
         canReach: () => true,
         send: async () => {
@@ -1106,6 +1235,7 @@ describe("authenticated loopback panel image relay", () => {
       resolvePanelAgent: () => ({ agentKey: "orchestrator::claude", secret: SECRET }),
       resolvePanelTab: () => "panel-tab",
       resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+      resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
       bridge: { canReach: () => true, send: vi.fn() },
     });
     try {

--- a/src/__tests__/tools/list-assets-logs-panel-fallback.test.ts
+++ b/src/__tests__/tools/list-assets-logs-panel-fallback.test.ts
@@ -1,5 +1,5 @@
 // #2283 — a connected sidebar panel can queue and complete renders while
-// headless get_image list_assets and get_system_stats logs fail with
+// headless get_image (action:"list_assets") and get_system_stats logs fail with
 // ECONNREFUSED against COMFYUI_URL. History fallback already landed for
 // prompt-scoped get_history (#2532/#2644); these production handlers must use
 // the same authenticated panel read (and /view image relay) instead of guessing
@@ -174,8 +174,8 @@ function assertNeverGuessed8188() {
   expect(fetchTargets.join("\n")).not.toMatch(/:8188\b/);
 }
 
-describe("get_image list_assets and get_system_stats logs use panel fallback (#2283)", () => {
-  it("list_assets registers a panel_run output when headless /history is ECONNREFUSED", async () => {
+describe('get_image (action:"list_assets") and get_system_stats logs use panel fallback (#2283)', () => {
+  it('get_image (action:"list_assets") registers a panel_run output when headless /history is ECONNREFUSED', async () => {
     const successTs = Date.now() - 4000;
     panelRead.mockImplementation(async (operation: string) => {
       if (operation !== "history") return undefined;

--- a/src/__tests__/tools/list-assets-logs-panel-fallback.test.ts
+++ b/src/__tests__/tools/list-assets-logs-panel-fallback.test.ts
@@ -1,0 +1,285 @@
+// #2283 — a connected sidebar panel can queue and complete renders while
+// headless get_image list_assets and get_system_stats logs fail with
+// ECONNREFUSED against COMFYUI_URL. History fallback already landed for
+// prompt-scoped get_history (#2532/#2644); these production handlers must use
+// the same authenticated panel read (and /view image relay) instead of guessing
+// 8188. No live panel identity → fail closed.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const panelRead = vi.hoisted(() => vi.fn());
+const panelImage = vi.hoisted(() => vi.fn());
+const fetchApi = vi.hoisted(() => vi.fn());
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    config: { ...actual.config, comfyuiBasePath: "/comfyapi", comfyuiPath: "" },
+    getComfyUIApiHost: () => "127.0.0.1:8000",
+    getComfyUIBasePath: () => "/comfyapi",
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8000/comfyapi",
+    getComfyUIAuthHeaders: () => ({ Authorization: "Bearer headless-token" }),
+    isCloudMode: () => false,
+    isRemoteMode: () => true,
+  };
+});
+
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    apiURL(path: string): string {
+      return path;
+    }
+
+    apiHeaders(init?: { headers?: HeadersInit }) {
+      return init?.headers ?? {};
+    }
+
+    async fetch(url: string, init?: RequestInit) {
+      return await fetchApi(url, init);
+    }
+
+    fetchApi = fetchApi;
+    close() {}
+  },
+}));
+
+vi.mock("../../services/panel-image-relay.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/panel-image-relay.js")>(
+    "../../services/panel-image-relay.js",
+  );
+  return {
+    ...actual,
+    requestPanelComfyUIRead: panelRead,
+    requestPanelImage: panelImage,
+  };
+});
+
+vi.mock("../../services/view-image.js", () => ({ viewAssetImage: vi.fn() }));
+vi.mock("../../services/image-convert.js", () => ({ convertImage: vi.fn() }));
+vi.mock("../../services/color-analysis.js", () => ({ analyzeColor: vi.fn() }));
+vi.mock("../../services/storage-upload.js", () => ({ uploadOutput: vi.fn() }));
+
+import { resetClient } from "../../comfyui/client.js";
+import { PanelComfyUIReadRelayError } from "../../services/panel-image-relay.js";
+import { registerImageManagementTools } from "../../tools/image-management.js";
+import { registerSystemStatsTools } from "../../tools/system-stats.js";
+import { AssetRegistry } from "../../services/asset-registry.js";
+import type { WorkflowJSON } from "../../comfyui/types.js";
+
+const VALID_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+const PROMPT = "panel-run-2283";
+const FILENAME = "ComfyUI_00042_.png";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function registerTool(
+  register: (server: { tool: (...args: unknown[]) => void }) => void,
+  name: string,
+): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: unknown, ...rest: unknown[]) => {
+      if (n === name) {
+        const candidate = rest.find((arg) => typeof arg === "function");
+        if (typeof candidate === "function") handler = candidate as ToolHandler;
+      }
+    },
+  };
+  register(server as never);
+  if (!handler) throw new Error(`${name} was not registered`);
+  return handler;
+}
+
+function transportFailure(url = "http://127.0.0.1:8000/comfyapi"): TypeError {
+  return new TypeError("fetch failed", {
+    cause: Object.assign(new Error(`connect ECONNREFUSED ${url}`), { code: "ECONNREFUSED" }),
+  });
+}
+
+function sampleGraph(): WorkflowJSON {
+  return {
+    "3": { class_type: "KSampler", inputs: { seed: 42, steps: 20, cfg: 7 } },
+    "9": { class_type: "SaveImage", inputs: { filename_prefix: "ComfyUI", images: ["8", 0] } },
+  };
+}
+
+function historyEntry(promptId: string, filename: string, successTs: number) {
+  return {
+    prompt: [12, promptId, sampleGraph(), {}, []],
+    outputs: { "9": { images: [{ filename, subfolder: "", type: "output" }] } },
+    status: {
+      status_str: "success",
+      completed: true,
+      messages: [
+        ["execution_start", { prompt_id: promptId, timestamp: successTs - 8000 }],
+        ["execution_success", { prompt_id: promptId, timestamp: successTs }],
+      ],
+    },
+  };
+}
+
+function panelHistoryBody(payload: Record<string, unknown>) {
+  const body = JSON.stringify(payload);
+  return {
+    operation: "history" as const,
+    body,
+    contentType: "application/json",
+    bytes: Buffer.byteLength(body, "utf8"),
+  };
+}
+
+function panelLogsBody(text: string) {
+  const body = JSON.stringify(text);
+  return {
+    operation: "logs" as const,
+    body,
+    contentType: "text/plain",
+    bytes: Buffer.byteLength(body, "utf8"),
+  };
+}
+
+let fetchTargets: string[];
+
+beforeEach(() => {
+  fetchApi.mockReset();
+  panelRead.mockReset();
+  panelImage.mockReset();
+  fetchTargets = [];
+  resetClient();
+  AssetRegistry.configure({ ttlMs: 24 * 60 * 60 * 1000, now: Date.now });
+  AssetRegistry.clear();
+  fetchApi.mockImplementation(async (url: string) => {
+    fetchTargets.push(String(url));
+    throw transportFailure(String(url));
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      fetchTargets.push(String(input));
+      throw transportFailure(String(input));
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function assertNeverGuessed8188() {
+  expect(fetchTargets.join("\n")).not.toMatch(/:8188\b/);
+}
+
+describe("get_image list_assets and get_system_stats logs use panel fallback (#2283)", () => {
+  it("list_assets registers a panel_run output when headless /history is ECONNREFUSED", async () => {
+    const successTs = Date.now() - 4000;
+    panelRead.mockImplementation(async (operation: string) => {
+      if (operation !== "history") return undefined;
+      return panelHistoryBody({
+        [PROMPT]: historyEntry(PROMPT, FILENAME, successTs),
+      });
+    });
+    panelImage.mockResolvedValue({
+      base64: VALID_PNG_BASE64,
+      mimeType: "image/png",
+      bytes: 68,
+    });
+
+    const listAssets = registerTool(registerImageManagementTools, "get_image");
+    const res = await listAssets({ action: "list_assets", limit: 20 });
+    expect(res.isError).toBeUndefined();
+    const out = JSON.parse(res.content[0].text) as {
+      count: number;
+      assets: Array<{ filename: string; prompt_id: string; source: string; type: string }>;
+      note?: string;
+    };
+
+    expect(out.count).toBe(1);
+    expect(out.note).toBeUndefined();
+    expect(out.assets[0]).toMatchObject({
+      filename: FILENAME,
+      prompt_id: PROMPT,
+      source: "history-reconcile",
+      type: "output",
+    });
+    expect(panelRead).toHaveBeenCalledWith("history");
+    expect(panelImage).toHaveBeenCalledWith(FILENAME, "output", "");
+    assertNeverGuessed8188();
+  });
+
+  it("get_system_stats logs returns panel /internal/logs when headless logs are ECONNREFUSED", async () => {
+    panelRead.mockImplementation(async (operation: string) => {
+      if (operation !== "logs") return undefined;
+      return panelLogsBody("line one\nPreviewImage executed\nline three");
+    });
+
+    const stats = registerTool(registerSystemStatsTools, "get_system_stats");
+    const res = await stats({ action: "logs", keyword: "PreviewImage", max_lines: 50 });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toBe("PreviewImage executed");
+    expect(panelRead).toHaveBeenCalledWith("logs");
+    assertNeverGuessed8188();
+  });
+
+  it("fails closed when panel identity is unavailable and does not guess 8188", async () => {
+    panelRead.mockResolvedValue(undefined);
+    panelImage.mockResolvedValue(undefined);
+
+    const listAssets = registerTool(registerImageManagementTools, "get_image");
+    const listed = await listAssets({ action: "list_assets" });
+    expect(listed.isError).toBeUndefined();
+    const out = JSON.parse(listed.content[0].text) as { count: number; note?: string };
+    expect(out.count).toBe(0);
+    expect(out.note).toMatch(/Could not refresh from ComfyUI history/i);
+    expect(out.note).toMatch(/ECONNREFUSED|fetch failed/i);
+
+    const stats = registerTool(registerSystemStatsTools, "get_system_stats");
+    const logs = await stats({ action: "logs" });
+    expect(logs.isError).toBe(true);
+    expect(logs.content[0].text).toMatch(/Failed to fetch ComfyUI logs after reconnect retry/);
+    expect(logs.content[0].text).toMatch(/ECONNREFUSED|fetch failed/);
+    expect(logs.content[0].text).not.toMatch(/127\.0\.0\.1:8188/);
+    assertNeverGuessed8188();
+  });
+
+  it("does not use the panel for a configured-route HTTP error", async () => {
+    fetchApi.mockReset();
+    fetchApi.mockImplementation(async (url: string) => {
+      fetchTargets.push(String(url));
+      // Production Client.fetchApi throws outside [200, 400). A 503 body is
+      // not a transport failure, so the panel must not be consulted.
+      throw new Error("HTTP 503 from the configured route");
+    });
+
+    const listAssets = registerTool(registerImageManagementTools, "get_image");
+    const listed = await listAssets({ action: "list_assets" });
+    expect(listed.isError).toBeUndefined();
+    const out = JSON.parse(listed.content[0].text) as { count: number; note?: string };
+    expect(out.count).toBe(0);
+    expect(out.note).toMatch(/Could not refresh from ComfyUI history/i);
+    expect(panelRead).not.toHaveBeenCalled();
+    expect(panelImage).not.toHaveBeenCalled();
+
+    const stats = registerTool(registerSystemStatsTools, "get_system_stats");
+    const logs = await stats({ action: "logs" });
+    expect(logs.isError).toBe(true);
+    expect(logs.content[0].text).toMatch(/HTTP 503 from the configured route/);
+    expect(panelRead).not.toHaveBeenCalled();
+    assertNeverGuessed8188();
+  });
+
+  it("surfaces an authenticated panel timeout without retrying unrelated origins", async () => {
+    panelRead.mockRejectedValue(new PanelComfyUIReadRelayError("panel timed out", "TIMEOUT"));
+
+    const stats = registerTool(registerSystemStatsTools, "get_system_stats");
+    const logs = await stats({ action: "logs" });
+    expect(logs.isError).toBe(true);
+    expect(logs.content[0].text).toMatch(/read fallback failed safely \(TIMEOUT\)/);
+    expect(panelRead).toHaveBeenCalledWith("logs");
+    assertNeverGuessed8188();
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1877,6 +1877,10 @@ export async function runPanelOrchestrator(): Promise<void> {
       bridge,
       resolvePanelAgent: panelImageRelayAgentFor,
       resolvePanelTab: scopeToRealTab,
+      resolveCurrentTarget: () => ({
+        url: getComfyUIBaseUrl(),
+        generation: getComfyuiTargetGeneration(),
+      }),
     });
     panelImageRelayEndpoint = panelImageRelayServer.endpointUrl;
   } catch (error) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1881,6 +1881,21 @@ export async function runPanelOrchestrator(): Promise<void> {
         url: getComfyUIBaseUrl(),
         generation: getComfyuiTargetGeneration(),
       }),
+      resolvePanelTarget: (tabId) => {
+        // The hello URL names the exact target (including a mounted base path),
+        // while the WS Origin independently corroborates its server origin.
+        // Require both before allowing a targetless bridge command to use this
+        // tab; neither missing nor contradictory identity is safe to guess.
+        const tabOrigin = bridge.tabOrigin(tabId);
+        const serverOrigin = bridge.tabServerOrigin(tabId);
+        const claimedOrigin = canonicalOrigin(tabOrigin);
+        const observedOrigin = canonicalOrigin(serverOrigin);
+        if (!tabOrigin || !serverOrigin || !claimedOrigin || claimedOrigin !== observedOrigin) return undefined;
+        return {
+          url: tabOrigin,
+          generation: getComfyuiTargetGeneration(),
+        };
+      },
     });
     panelImageRelayEndpoint = panelImageRelayServer.endpointUrl;
   } catch (error) {

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1011,15 +1011,15 @@ export class PanelAgent {
       // sibling branches already refuse.
       const unnamedImgs = imgs.length - attachableImgs.length;
       // What the agent is NOT being shown, in coordinates it can actually call
-      // get_image with. `names` is filenames only and a `note` replaces it
-      // outright, so neither can carry a withheld PreviewImage that lives in
-      // `temp` or a subfolder — get_image would default to type "output" and
-      // miss it. Withholding pixels is only honest if the pointer works.
+      // get_image with. A custom `note` (video storyboard, etc.) replaces the
+      // default name list outright, so that list cannot carry a PreviewImage
+      // that lives in `temp` — get_image would default to type "output" and
+      // miss it (#2283). Withholding pixels is only honest if the pointer works.
       const withheldImgs = correlationIsUntrusted
         ? attachableImgs
         : attachableImgs.slice(attachedImgs.length);
       const withheldRefs = describeImageRefs(withheldImgs);
-      const names = imgs.map((i) => i.filename).filter(Boolean).join(", ") || "(unnamed)";
+      const names = describeImageRefs(attachableImgs) || "(unnamed)";
       // A custom `note` (e.g. the panel's video-storyboard summary) replaces the
       // default image-acknowledgement wording so the agent is told accurately
       // what it's looking at (a contact sheet of a video, not a still image).
@@ -1083,8 +1083,12 @@ export class PanelAgent {
                     ? sessionBound
                       ? `The first ${attachedImgs.length} image(s) are attached below; all ${imgs.length} outputs are already shown to the user in the panel. ${omittedImgs} further preview(s) were omitted because this conversation's cumulative automatic-preview budget (${MAX_SESSION_PREVIEW_ATTACHMENTS} images / ~${previewByteBudgetLabel()}) is nearly spent — fetch one with get_image action:"get" if you need it: ${withheldRefs}. `
                       : `The first ${attachedImgs.length} image(s) are attached below; all ${imgs.length} outputs are already shown to the user in the panel. ${omittedImgs} further preview(s) were omitted to keep this TURN's image context bounded — fetch one with get_image action:"get" if you need it: ${withheldRefs}. `
-                    : `The image(s) are attached below and already shown to the user in the panel. `
-            : `You cannot view images on this provider, but they are already shown to the user in the panel. `
+                    : note && names !== "(unnamed)"
+                      ? `The image(s) are attached below and already shown to the user in the panel. Fetch one with get_image action:"get" if you need to inspect or stage it: ${names}. `
+                      : `The image(s) are attached below and already shown to the user in the panel. `
+            : names !== "(unnamed)"
+              ? `You cannot view images on this provider, but they are already shown to the user in the panel. Fetch one with get_image action:"get": ${names}. `
+              : `You cannot view images on this provider, but they are already shown to the user in the panel. `
           : ``) +
         // Said on TOP of whichever branch fired, because every one of them is
         // arithmetically incomplete while an unnamed output is in the event: the

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -304,6 +304,34 @@ function currentRelayTarget(options: PanelImageRelayServerOptions): PanelImageRe
   }
 }
 
+function currentPanelRelayTarget(
+  options: PanelImageRelayServerOptions,
+  tabId: string,
+): PanelImageRelayTarget | undefined {
+  try {
+    const target = options.resolvePanelTarget(tabId);
+    if (
+      !target ||
+      typeof target.url !== "string" ||
+      !Number.isSafeInteger(target.generation) ||
+      target.generation < 0 ||
+      !canonicalRelayTargetUrl(target.url)
+    ) return undefined;
+    return target;
+  } catch {
+    return undefined;
+  }
+}
+
+function relayTargetsMatch(
+  options: PanelImageRelayServerOptions,
+  request: PanelRelayRequest,
+  panelTab: string,
+): boolean {
+  return relayTargetMatches(request, currentRelayTarget(options)) &&
+    relayTargetMatches(request, currentPanelRelayTarget(options, panelTab));
+}
+
 function relayAuthPayload(input: PanelImageRelayAuthInput): string {
   return JSON.stringify([
     input.requestId,
@@ -961,6 +989,8 @@ export interface PanelImageRelayServerOptions {
   resolvePanelTab: (agentKey: string) => string | undefined;
   /** The orchestrator's authoritative target and monotonic generation. */
   resolveCurrentTarget: () => PanelImageRelayTarget;
+  /** The exact target identity currently proven for the selected live panel tab. */
+  resolvePanelTarget: (tabId: string) => PanelImageRelayTarget | undefined;
 }
 
 export interface PanelImageRelayServer {
@@ -1042,11 +1072,16 @@ export async function startPanelImageRelayServer(
               request.requestId,
               options.bridge.resolveFailure?.(auth.agentKey) === "ambiguous" ? "AMBIGUOUS_REQUESTER" : "NO_LIVE_PANEL",
             );
+          } else if (!relayTargetsMatch(options, request, panelTab)) {
+            // The global target fence does not prove that this particular tab
+            // fronts the child target. Missing, stale, or ambiguous tab proof
+            // must refuse before the targetless bridge command is dispatched.
+            response = failureResponse(request.requestId, "STALE_TARGET");
           } else {
             const remainingMs = requestDeadline(request) - Date.now();
             if (remainingMs <= 0) {
               response = failureResponse(request.requestId, "TIMEOUT", requestDeadline(request));
-            } else if (!relayTargetMatches(request, currentRelayTarget(options))) {
+            } else if (!relayTargetsMatch(options, request, panelTab)) {
               response = failureResponse(request.requestId, "STALE_TARGET");
             } else {
               try {
@@ -1063,7 +1098,7 @@ export async function startPanelImageRelayServer(
                 const imagePayload = !isReadRelayRequest(request) && replyRecord
                   ? validateImagePayload({ base64: replyRecord.base64, mimeType: replyRecord.mimeType, bytes: replyRecord.bytes })
                   : undefined;
-                if (!relayTargetMatches(request, currentRelayTarget(options))) {
+                if (!relayTargetsMatch(options, request, panelTab)) {
                   response = failureResponse(request.requestId, "STALE_TARGET");
                 } else if (Date.now() >= requestDeadline(request)) {
                   response = failureResponse(request.requestId, "TIMEOUT", requestDeadline(request));

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -14,8 +14,10 @@ import { join } from "node:path";
  * The only production path for a /view retry when the configured headless
  * ComfyUI target is unreachable. The child writes a reference-only request;
  * the orchestrator resolves an in-memory capability to a live panel and
- * performs the authenticated bridge command. No URL, origin, or file-supplied
- * tab identity crosses this channel.
+ * performs the authenticated bridge command. The child supplies only the
+ * canonical target identity it was spawned for; the orchestrator compares it
+ * with its current target before and after the bridge command. No origin or
+ * file-supplied tab identity crosses this channel.
  */
 export const PANEL_IMAGE_RELAY_VERSION = 1;
 export const PANEL_IMAGE_RELAY_MAX_BYTES = 32 * 1024 * 1024;
@@ -65,6 +67,9 @@ export interface PanelImageRelayRequest {
   version: typeof PANEL_IMAGE_RELAY_VERSION;
   requestId: string;
   capability: string;
+  /** Target identity captured by the child at spawn time. */
+  targetUrl: string;
+  targetGeneration: number;
   filename: string;
   subfolder: string;
   type: PanelImageType;
@@ -76,6 +81,9 @@ export interface PanelComfyUIReadRelayRequest {
   version: typeof PANEL_IMAGE_RELAY_VERSION;
   requestId: string;
   capability: string;
+  /** Target identity captured by the child at spawn time. */
+  targetUrl: string;
+  targetGeneration: number;
   operation: PanelComfyUIReadOperation;
   createdAt: number;
   deadlineAt: number;
@@ -83,9 +91,14 @@ export interface PanelComfyUIReadRelayRequest {
 
 export type PanelRelayRequest = PanelImageRelayRequest | PanelComfyUIReadRelayRequest;
 
+export interface PanelImageRelayTarget {
+  url: string;
+  generation: number;
+}
+
 export type PanelImageRelayAuthInput = Pick<
   PanelImageRelayRequest,
-  "requestId" | "filename" | "subfolder" | "type" | "createdAt" | "deadlineAt"
+  "requestId" | "targetUrl" | "targetGeneration" | "filename" | "subfolder" | "type" | "createdAt" | "deadlineAt"
 >;
 
 export interface PanelImageRelaySuccess {
@@ -240,9 +253,62 @@ function isSafeRelaySecret(value: unknown): value is string {
   return typeof value === "string" && RELAY_SECRET_RE.test(value);
 }
 
+const RELAY_TARGET_URL_MAX_LENGTH = 4_096;
+
+/** Keep only the identity-bearing, non-secret parts of a ComfyUI URL. */
+function canonicalRelayTargetUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0 || value.length > RELAY_TARGET_URL_MAX_LENGTH) return undefined;
+  try {
+    const url = new URL(value.trim());
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) return undefined;
+    return `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function relayTargetFromEnv(): PanelImageRelayTarget | undefined {
+  const url = canonicalRelayTargetUrl(process.env.COMFYUI_URL);
+  const rawGeneration = process.env.COMFYUI_MCP_TARGET_GENERATION?.trim();
+  if (!url || !rawGeneration || !/^\d+$/.test(rawGeneration)) return undefined;
+  const generation = Number(rawGeneration);
+  if (!Number.isSafeInteger(generation) || generation < 0) return undefined;
+  return { url, generation };
+}
+
+function relayTargetMatches(request: PanelRelayRequest, target: PanelImageRelayTarget | undefined): boolean {
+  return !!target &&
+    canonicalRelayTargetUrl(request.targetUrl) === canonicalRelayTargetUrl(target.url) &&
+    request.targetGeneration === target.generation;
+}
+
+function currentRelayTarget(options: PanelImageRelayServerOptions): PanelImageRelayTarget | undefined {
+  try {
+    const target = options.resolveCurrentTarget();
+    if (
+      !target ||
+      typeof target.url !== "string" ||
+      !Number.isSafeInteger(target.generation) ||
+      target.generation < 0 ||
+      !canonicalRelayTargetUrl(target.url)
+    ) return undefined;
+    return target;
+  } catch {
+    return undefined;
+  }
+}
+
 function relayAuthPayload(input: PanelImageRelayAuthInput): string {
   return JSON.stringify([
     input.requestId,
+    input.targetUrl,
+    input.targetGeneration,
     input.filename,
     input.subfolder,
     input.type,
@@ -267,13 +333,21 @@ export function verifyPanelImageRelayCapability(
   return timingSafeEqual(Buffer.from(request.capability, "hex"), Buffer.from(expected, "hex"));
 }
 
-function readRelayAuthPayload(input: Pick<PanelComfyUIReadRelayRequest, "requestId" | "operation" | "createdAt" | "deadlineAt">): string {
-  return JSON.stringify(["fetch_comfyui_read", input.requestId, input.operation, input.createdAt, input.deadlineAt]);
+function readRelayAuthPayload(input: Pick<PanelComfyUIReadRelayRequest, "requestId" | "targetUrl" | "targetGeneration" | "operation" | "createdAt" | "deadlineAt">): string {
+  return JSON.stringify([
+    "fetch_comfyui_read",
+    input.requestId,
+    input.targetUrl,
+    input.targetGeneration,
+    input.operation,
+    input.createdAt,
+    input.deadlineAt,
+  ]);
 }
 
 export function makePanelComfyUIReadRelayCapability(
   secret: string,
-  input: Pick<PanelComfyUIReadRelayRequest, "requestId" | "operation" | "createdAt" | "deadlineAt">,
+  input: Pick<PanelComfyUIReadRelayRequest, "requestId" | "targetUrl" | "targetGeneration" | "operation" | "createdAt" | "deadlineAt">,
 ): string {
   return createHmac("sha256", secret).update(readRelayAuthPayload(input)).digest("hex");
 }
@@ -478,10 +552,14 @@ function validateRequest(value: unknown, requestId: string): PanelImageRelayRequ
   const createdAt = record.createdAt;
   const deadlineAt = record.deadlineAt;
   if (
-    !hasOnlyKeys(record, ["version", "requestId", "capability", "filename", "subfolder", "type", "createdAt", "deadlineAt"]) ||
+    !hasOnlyKeys(record, ["version", "requestId", "capability", "targetUrl", "targetGeneration", "filename", "subfolder", "type", "createdAt", "deadlineAt"]) ||
     record.version !== PANEL_IMAGE_RELAY_VERSION ||
     record.requestId !== requestId ||
     !isSafeRelayCapability(capability) ||
+    !canonicalRelayTargetUrl(record.targetUrl) ||
+    typeof record.targetGeneration !== "number" ||
+    !Number.isSafeInteger(record.targetGeneration) ||
+    record.targetGeneration < 0 ||
     !isSafePanelImageRef(record.filename, record.subfolder, record.type) ||
     typeof createdAt !== "number" ||
     typeof deadlineAt !== "number" ||
@@ -500,10 +578,14 @@ function validateReadRequest(value: unknown, requestId: string): PanelComfyUIRea
   const createdAt = record.createdAt;
   const deadlineAt = record.deadlineAt;
   if (
-    !hasOnlyKeys(record, ["version", "requestId", "capability", "operation", "createdAt", "deadlineAt"]) ||
+    !hasOnlyKeys(record, ["version", "requestId", "capability", "targetUrl", "targetGeneration", "operation", "createdAt", "deadlineAt"]) ||
     record.version !== PANEL_IMAGE_RELAY_VERSION ||
     record.requestId !== requestId ||
     !isSafeRelayCapability(capability) ||
+    !canonicalRelayTargetUrl(record.targetUrl) ||
+    typeof record.targetGeneration !== "number" ||
+    !Number.isSafeInteger(record.targetGeneration) ||
+    record.targetGeneration < 0 ||
     typeof record.operation !== "string" ||
     !isPanelComfyUIReadOperation(record.operation) ||
     typeof createdAt !== "number" ||
@@ -585,6 +667,7 @@ function responseFailureMessage(response: PanelImageRelayResponseFailure): never
     "MALFORMED_REPLY",
     "NO_LIVE_PANEL",
     "PANEL_FETCH_FAILED",
+    "STALE_TARGET",
     "STALE_REQUEST",
     "TIMEOUT",
   ]);
@@ -876,6 +959,8 @@ export interface PanelImageRelayServerOptions {
   bridge: PanelImageRelayBridge;
   resolvePanelAgent: (request: PanelRelayRequest) => PanelImageRelayResolvedAgent | undefined;
   resolvePanelTab: (agentKey: string) => string | undefined;
+  /** The orchestrator's authoritative target and monotonic generation. */
+  resolveCurrentTarget: () => PanelImageRelayTarget;
 }
 
 export interface PanelImageRelayServer {
@@ -945,6 +1030,11 @@ export async function startPanelImageRelayServer(
             now >= requestDeadline(request) ? "TIMEOUT" : "STALE_REQUEST",
             now >= requestDeadline(request) ? requestDeadline(request) : now,
           );
+        } else if (!relayTargetMatches(request, currentRelayTarget(options))) {
+          // A child can remain on the previous target while its agent turn drains
+          // across a retarget. Never let that authenticated child address the new
+          // live panel: the capability proves ownership, not target freshness.
+          response = failureResponse(request.requestId, "STALE_TARGET");
         } else {
           const panelTab = options.resolvePanelTab(auth.agentKey);
           if (!panelTab || !options.bridge.canReach(panelTab)) {
@@ -956,6 +1046,8 @@ export async function startPanelImageRelayServer(
             const remainingMs = requestDeadline(request) - Date.now();
             if (remainingMs <= 0) {
               response = failureResponse(request.requestId, "TIMEOUT", requestDeadline(request));
+            } else if (!relayTargetMatches(request, currentRelayTarget(options))) {
+              response = failureResponse(request.requestId, "STALE_TARGET");
             } else {
               try {
                 const reply = await withinDeadline(
@@ -971,7 +1063,9 @@ export async function startPanelImageRelayServer(
                 const imagePayload = !isReadRelayRequest(request) && replyRecord
                   ? validateImagePayload({ base64: replyRecord.base64, mimeType: replyRecord.mimeType, bytes: replyRecord.bytes })
                   : undefined;
-                if (Date.now() >= requestDeadline(request)) {
+                if (!relayTargetMatches(request, currentRelayTarget(options))) {
+                  response = failureResponse(request.requestId, "STALE_TARGET");
+                } else if (Date.now() >= requestDeadline(request)) {
                   response = failureResponse(request.requestId, "TIMEOUT", requestDeadline(request));
                 } else if (isReadRelayRequest(request)) {
                   const payload = replyRecord ? validateReadPayload(replyRecord) : undefined;
@@ -1053,11 +1147,15 @@ export async function requestPanelImage(
   const endpoint = relayEndpoint();
   const secret = process.env.COMFYUI_MCP_RELAY_SECRET;
   if (!endpoint || !isSafeRelaySecret(secret)) return undefined;
+  const target = relayTargetFromEnv();
+  if (!target) return undefined;
   const createdAt = Date.now();
   const request: PanelImageRelayRequest = {
     version: PANEL_IMAGE_RELAY_VERSION,
     requestId: `${Date.now().toString(36)}-${process.pid.toString(36)}-${randomBytes(8).toString("hex")}`,
     capability: "",
+    targetUrl: target.url,
+    targetGeneration: target.generation,
     filename,
     subfolder,
     type,
@@ -1127,12 +1225,16 @@ export async function requestPanelComfyUIRead(
   const endpoint = relayEndpoint();
   const secret = process.env.COMFYUI_MCP_RELAY_SECRET;
   if (!endpoint || !isSafeRelaySecret(secret)) return undefined;
+  const target = relayTargetFromEnv();
+  if (!target) return undefined;
   const createdAt = Date.now();
   const timeoutMs = readTimeoutMs(operation);
   const request: PanelComfyUIReadRelayRequest = {
     version: PANEL_IMAGE_RELAY_VERSION,
     requestId: `${Date.now().toString(36)}-${process.pid.toString(36)}-${randomBytes(8).toString("hex")}`,
     capability: "",
+    targetUrl: target.url,
+    targetGeneration: target.generation,
     operation,
     createdAt,
     deadlineAt: createdAt + timeoutMs,
@@ -1192,6 +1294,7 @@ export async function requestPanelComfyUIRead(
       "MALFORMED_REPLY",
       "NO_LIVE_PANEL",
       "PANEL_FETCH_FAILED",
+      "STALE_TARGET",
       "STALE_REQUEST",
       "TIMEOUT",
     ]);
@@ -1220,6 +1323,8 @@ export async function requestPanelImageFromFileChannel(
   const dir = process.env.COMFYUI_MCP_PROGRESS_DIR?.trim() ?? "";
   const secret = process.env.COMFYUI_MCP_RELAY_SECRET;
   if (!dir || !isSafeRelaySecret(secret)) return undefined;
+  const target = relayTargetFromEnv();
+  if (!target) return undefined;
   if (!isSafePanelImageRef(filename, subfolder, type)) {
     throw new PanelImageRelayError("The image reference is unsafe and was refused.", "UNSAFE_REFERENCE");
   }
@@ -1237,6 +1342,8 @@ export async function requestPanelImageFromFileChannel(
     version: PANEL_IMAGE_RELAY_VERSION,
     requestId,
     capability: "",
+    targetUrl: target.url,
+    targetGeneration: target.generation,
     filename,
     subfolder,
     type,


### PR DESCRIPTION
## Summary

A connected sidebar panel can queue and complete renders while headless `get_image` (`list_assets` / `get`) and `get_system_stats` (`logs`) fail with `ECONNREFUSED` against `COMFYUI_URL`. Two production paths:

1. **Panel-backed same-origin fallback** (extends the #2532/#2644 history pattern): `get_image list_assets` and `get_system_stats logs` use the authenticated panel `fetch_comfyui_read` / image relay when the configured headless route is unreachable. HTTP errors and timeouts still fail closed. No origin guessing (no 8188 fallback). Missing panel identity still fails closed.

2. **PreviewImage temp refs**: completion events listed filenames only, so `get_image action:"get"` defaulted to `type:"output"` and missed PreviewImage files in `temp/`. `describeImageRefs` now names `type:"temp"` (and subfolder) on matched completions, including when a custom note replaces the default filename list, and on text-only backends.

## Test plan

- `npx vitest run src/__tests__/tools/list-assets-logs-panel-fallback.test.ts src/__tests__/orchestrator/run-completion-continuation.test.ts src/__tests__/comfyui/panel-read-fallback.test.ts src/__tests__/comfyui/history-prompt-panel-fallback.test.ts`

Fixes #2283