### PR TITLE
fix(2523): artokun-flow SAM3 checkpoint, VHS saver, honor git origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- artokun-flow installs the SAM3 checkpoint its REPLACEMENT MODE subgraph requires, saves with VHS_VideoCombine (an OUTPUT_NODE), and honors the requested artokun/comfyui-teskors-utils git origin instead of Manager teskor-hub alias (#2523)
+
 ## [0.52.172] - 2026-09-02
 
 ### MCP

--- a/packs/artokun-flow/install-runpod.sh
+++ b/packs/artokun-flow/install-runpod.sh
@@ -47,5 +47,6 @@ grab "models/detection/vitpose_h_wholebody_data.bin" "https://huggingface.co/Kij
 grab "models/detection/yolov10m.onnx" "https://huggingface.co/onnx-community/yolov10m/resolve/main/onnx/model.onnx"
 grab "models/insightface/inswapper_128.onnx" "https://huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/inswapper_128.onnx"
 grab "models/facerestore_models/GPEN-BFR-512.onnx" "https://huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/facerestore_models/GPEN-BFR-512.onnx"
+grab "models/checkpoints/sam3.1_multiplex_fp16.safetensors" "https://huggingface.co/Comfy-Org/sam3.1/resolve/main/checkpoints/sam3.1_multiplex_fp16.safetensors"
 
 echo "DONE. Restart ComfyUI, then load workflow.json."

--- a/packs/artokun-flow/install-windows.bat
+++ b/packs/artokun-flow/install-windows.bat
@@ -37,6 +37,7 @@ call :grab "models\detection\vitpose_h_wholebody_data.bin" "https://huggingface.
 call :grab "models\detection\yolov10m.onnx" "https://huggingface.co/onnx-community/yolov10m/resolve/main/onnx/model.onnx"
 call :grab "models\insightface\inswapper_128.onnx" "https://huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/inswapper_128.onnx"
 call :grab "models\facerestore_models\GPEN-BFR-512.onnx" "https://huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/facerestore_models/GPEN-BFR-512.onnx"
+call :grab "models\checkpoints\sam3.1_multiplex_fp16.safetensors" "https://huggingface.co/Comfy-Org/sam3.1/resolve/main/checkpoints/sam3.1_multiplex_fp16.safetensors"
 
 echo DONE. Restart ComfyUI, then load workflow.json.
 pause

--- a/packs/artokun-flow/manifest.yaml
+++ b/packs/artokun-flow/manifest.yaml
@@ -12,10 +12,11 @@
 # up to date so SAM3_VideoTrack/SAM3_TrackToMask exist.
 #
 # TS UTILITY NODES (now auto-installed): TSColorMatch (reference-free temporal color
-# stabilizer), TSPoseDataSmoother (pose-jitter smoother), TSVideoCombineNoMetadata
-# (metadata-free video save) — all three from github.com/artokun/comfyui-teskors-utils,
-# a public fork of teskor-hub/comfyui-teskors-utils. The color/pose nodes have no public
-# drop-in equivalents, so the pack ships its own maintained fork.
+# stabilizer) and TSPoseDataSmoother (pose-jitter smoother) from
+# github.com/artokun/comfyui-teskors-utils, a public fork of teskor-hub/comfyui-teskors-utils.
+# Video is saved with VHS_VideoCombine (OUTPUT_NODE). The color/pose nodes have no public
+# drop-in equivalents, so the pack ships its own maintained fork. apply_manifest must
+# clone this exact origin — Manager v4 may otherwise alias the bare name to teskor-hub.
 #
 # MODEL NAMING: the base-model host serves them under short placeholder names. The
 # workflow references the REAL Kijai filenames, so base models are downloaded and SAVED
@@ -29,7 +30,7 @@ custom_nodes:
   - https://github.com/kijai/ComfyUI-KJNodes               # ImageResizeKJv2, GetImageSizeAndCount, DrawMaskOnImage, ImageConcatMulti, PreviewAnimation
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite # VHS_LoadVideo, VHS_VideoInfoLoaded
   - https://github.com/Gourieff/ComfyUI-ReActor            # ReActorFaceSwap, ReActorBuildFaceModel (first-frame face-lock; auto-fetches inswapper_128 + GPEN-BFR-512)
-  - https://github.com/artokun/comfyui-teskors-utils       # TSColorMatch, TSPoseDataSmoother, TSVideoCombineNoMetadata (public fork of teskor-hub)
+  - https://github.com/artokun/comfyui-teskors-utils       # TSColorMatch, TSPoseDataSmoother (public fork of teskor-hub; exact origin must be cloned)
   # --- OPTIONAL (only for the muted Upscale4x-RIFE-1080p subgraph) ---
   # - https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler  # SeedVR2* — un-mute the upscale subgraph to use
 
@@ -73,3 +74,7 @@ models:
     local_path: insightface/inswapper_128.onnx
   - url: https://huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/facerestore_models/GPEN-BFR-512.onnx
     local_path: facerestore_models/GPEN-BFR-512.onnx
+
+  # --- SAM3 tracking/masking (REPLACEMENT MODE subgraph; CheckpointLoaderSimple) ---
+  - url: https://huggingface.co/Comfy-Org/sam3.1/resolve/main/checkpoints/sam3.1_multiplex_fp16.safetensors
+    local_path: checkpoints/sam3.1_multiplex_fp16.safetensors

--- a/packs/artokun-flow/pack.yaml
+++ b/packs/artokun-flow/pack.yaml
@@ -25,24 +25,24 @@ sources:
 notes:
   - "AUTHOR'S MAINTAINED PACK — this is the recommended/default WAN Animate
     character-animation pipeline. The TS utility nodes (TSColorMatch temporal color
-    stabilizer, TSPoseDataSmoother pose-jitter smoother, TSVideoCombineNoMetadata) now
-    auto-install from github.com/artokun/comfyui-teskors-utils (a maintained public fork);
-    no public drop-in equivalents exist for the color/pose nodes."
+    stabilizer, TSPoseDataSmoother pose-jitter smoother) now auto-install from
+    github.com/artokun/comfyui-teskors-utils (a maintained public fork); no public
+    drop-in equivalents exist for the color/pose nodes. Final video is saved with
+    VHS_VideoCombine (a proven OUTPUT_NODE) so panel_run(to_node_id) can target it."
   - SAM3 + frame-interpolation + math/mask/post-processing are CORE in recent
     ComfyUI (comfy_extras) — keep ComfyUI updated so SAM3_VideoTrack exists.
+    The SAM3 checkpoint sam3.1_multiplex_fp16.safetensors is installed into
+    models/checkpoints by the manifest (required by REPLACEMENT MODE).
   - Base models download under placeholder names and are saved under the workflow's
     real Kijai filenames (rename-on-download) — same content.
-  - GAPS the gist does NOT cover, source separately. (a) SAM3 checkpoint
-    sam3.1_multiplex_fp16.safetensors in models/checkpoints — ACTIVE, required by
-    the SAM3 subgraph. (b) ReActor inswapper_128.onnx + GPEN-BFR-512.onnx — ReActor
-    auto-fetches these on first use into models/insightface and
-    models/facerestore_models. (c) OPTIONAL upscale only (muted subgraph) —
-    seedvr2_ema_3b_fp8_e4m3fn.safetensors, ema_vae_fp16.safetensors,
-    rife_v4.26.safetensors.
+  - GAPS the gist does NOT cover, source separately. (a) ReActor
+    inswapper_128.onnx + GPEN-BFR-512.onnx — ReActor auto-fetches these on first
+    use into models/insightface and models/facerestore_models. (b) OPTIONAL
+    upscale only (muted subgraph) — seedvr2_ema_3b_fp8_e4m3fn.safetensors,
+    ema_vae_fp16.safetensors, rife_v4.26.safetensors.
   - Bypass the ReActor face-lock node to disable first-frame identity locking.
   - Static-validated (clean lint + UI→API convert; the muted upscale subgraph is
     skipped). Run locally to confirm on your hardware.
 post_install:
-  - Place the SAM3 checkpoint in models/checkpoints/ (see gaps above).
   - Restart ComfyUI (or ComfyUI-Manager -> Install missing custom nodes).
   - Load workflow.json.

--- a/packs/artokun-flow/workflow.json
+++ b/packs/artokun-flow/workflow.json
@@ -1138,7 +1138,7 @@
     },
     {
       "id": 758,
-      "type": "TSVideoCombineNoMetadata",
+      "type": "VHS_VideoCombine",
       "pos": [
         3100,
         280
@@ -1189,23 +1189,28 @@
           "version": "7.7",
           "input_ue_unconnectable": {}
         },
-        "Node name for S&R": "TSVideoCombineNoMetadata",
-        "aux_id": "teskor-hub/comfyui-teskors-utils",
-        "ver": "cba89dd597152e08257e0bac588d59024196d49c"
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "aux_id": "Kosinkadink/ComfyUI-VideoHelperSuite",
+        "ver": "0a75c7958fe320efcb052f1d9f8451fd20c730a8"
       },
-      "widgets_values": [
-        30,
-        0,
-        "wananimate",
-        "video/h264-mp4",
-        false,
-        true,
-        {
+      "widgets_values": {
+        "frame_rate": 30,
+        "loop_count": 0,
+        "filename_prefix": "wananimate",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": false,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
           "hidden": false,
           "paused": false,
           "params": {}
         }
-      ],
+      },
       "color": "#232",
       "bgcolor": "#353"
     },
@@ -5504,7 +5509,7 @@
                 "input_ue_unconnectable": {}
               },
               "Node name for S&R": "TSPoseDataSmoother",
-              "aux_id": "teskor-hub/comfyui-teskors-utils",
+              "aux_id": "artokun/comfyui-teskors-utils",
               "ver": "9c4d0507ccd1f1c5b18fd536f2796e216560ed43"
             },
             "widgets_values": [
@@ -5939,7 +5944,7 @@
                 "input_ue_unconnectable": {}
               },
               "Node name for S&R": "TSColorMatch",
-              "aux_id": "teskor-hub/NEW-UTILS",
+              "aux_id": "artokun/comfyui-teskors-utils",
               "ver": "1e29548a5ff751b73c1a5a2a3f68d20bf2bd8bed"
             },
             "widgets_values": [

--- a/src/__tests__/packs/artokun-flow-sam3-output-node.test.ts
+++ b/src/__tests__/packs/artokun-flow-sam3-output-node.test.ts
@@ -1,0 +1,147 @@
+// #2523 — artokun-flow cannot validate after a clean manifest install:
+// REPLACEMENT MODE's SAM3 subgraph needs sam3.1_multiplex_fp16.safetensors but
+// the manifest never downloaded it, and the only final save node was
+// TSVideoCombineNoMetadata, which the teskor-hub teskors-utils Manager actually
+// installs is not OUTPUT_NODE — so panel_run(to_node_id) refuses it.
+//
+// Pin the SHIPPED pack files apply_manifest / packs:gen consume — not a fixture.
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadManifestFile, resolvePackManifestFile } from "../../services/manifest.js";
+
+const PACK = "artokun-flow";
+const PACK_DIR = join(process.cwd(), "packs", PACK);
+const SAM3 = "sam3.1_multiplex_fp16.safetensors";
+const SAM3_URL =
+  "https://huggingface.co/Comfy-Org/sam3.1/resolve/main/checkpoints/sam3.1_multiplex_fp16.safetensors";
+const SAM3_PATH = `checkpoints/${SAM3}`;
+const ARTOKUN_UTILS = "https://github.com/artokun/comfyui-teskors-utils";
+const TESKOR_HUB = "teskor-hub/comfyui-teskors-utils";
+const OUTPUT_SAVER = "VHS_VideoCombine";
+const INVALID_SAVER = "TSVideoCombineNoMetadata";
+
+type UiNode = {
+  id?: number;
+  type?: string;
+  mode?: number;
+  widgets_values?: unknown;
+  properties?: { aux_id?: string; cnr_id?: string };
+};
+
+type UiSubgraph = { nodes?: UiNode[]; definitions?: { subgraphs?: UiSubgraph[] } };
+type UiWorkflow = UiSubgraph;
+
+function loadUiWorkflow(): UiWorkflow {
+  const file = join(PACK_DIR, "workflow.json");
+  expect(existsSync(file), file).toBe(true);
+  return JSON.parse(readFileSync(file, "utf8")) as UiWorkflow;
+}
+
+function walkNodes(graph: UiSubgraph, out: UiNode[] = []): UiNode[] {
+  if (Array.isArray(graph.nodes)) out.push(...graph.nodes);
+  for (const sub of graph.definitions?.subgraphs ?? []) walkNodes(sub, out);
+  return out;
+}
+
+function workflowText(): string {
+  return readFileSync(join(PACK_DIR, "workflow.json"), "utf8");
+}
+
+function widgetTreeHas(value: unknown, needle: string): boolean {
+  if (typeof value === "string") return value === needle || value.endsWith(`/${needle}`);
+  if (Array.isArray(value)) return value.some((v) => widgetTreeHas(v, needle));
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).some((v) => widgetTreeHas(v, needle));
+  }
+  return false;
+}
+
+describe("artokun-flow ships SAM3 and an OUTPUT_NODE saver (#2523)", () => {
+  it("apply_manifest pack: name still resolves to the shipped manifest", () => {
+    const file = resolvePackManifestFile(PACK);
+    expect(file, "the reported pack must resolve from the running package root").toBeTruthy();
+    expect(file).toMatch(/artokun-flow[\\/]manifest\.ya?ml$/);
+  });
+
+  it("the shipped manifest installs the SAM3 checkpoint REPLACEMENT MODE loads", async () => {
+    const file = resolvePackManifestFile(PACK);
+    expect(file).toBeTruthy();
+    const manifest = await loadManifestFile(file!);
+    const sam3 = manifest.models.find(
+      (m) => m.local_path === SAM3_PATH || m.url === SAM3_URL || m.local_path?.endsWith(SAM3),
+    );
+    expect(sam3, "manifest must download sam3.1_multiplex_fp16.safetensors").toBeTruthy();
+    expect(sam3!.url).toBe(SAM3_URL);
+    expect(sam3!.local_path).toBe(SAM3_PATH);
+  });
+
+  it("REPLACEMENT MODE's CheckpointLoaderSimple still names that SAM3 file", () => {
+    const nodes = walkNodes(loadUiWorkflow());
+    const loaders = nodes.filter(
+      (n) => n.type === "CheckpointLoaderSimple" && widgetTreeHas(n.widgets_values, SAM3),
+    );
+    expect(loaders.length, "SAM3 loader must remain in the shipped graph").toBeGreaterThan(0);
+  });
+
+  it("the root graph saves with an active VHS_VideoCombine, not TSVideoCombineNoMetadata", () => {
+    const text = workflowText();
+    expect(text).not.toContain(`"${INVALID_SAVER}"`);
+    expect(text).toContain(`"${OUTPUT_SAVER}"`);
+    const root = loadUiWorkflow().nodes ?? [];
+    const active = (n: UiNode) => n.mode === 0 || n.mode === undefined;
+    const vhs = root.filter((n) => n.type === OUTPUT_SAVER && active(n));
+    expect(vhs.length, "an active VHS_VideoCombine OUTPUT_NODE saver").toBeGreaterThan(0);
+    expect(vhs.some((n) => n.id === 758), "node 758 is the SAVE VIDEO output").toBe(true);
+    const invalid = walkNodes(loadUiWorkflow()).filter((n) => n.type === INVALID_SAVER);
+    expect(
+      invalid,
+      "TSVideoCombineNoMetadata is not OUTPUT_NODE on the Manager-installed teskor-hub pack",
+    ).toEqual([]);
+    const saver = vhs.find((n) => n.id === 758)!;
+    const widgets = saver.widgets_values as { format?: string; frame_rate?: number } | unknown[];
+    if (Array.isArray(widgets)) {
+      expect(widgets).toContain("video/h264-mp4");
+      expect(widgets).toContain(30);
+    } else {
+      expect(widgets.format).toBe("video/h264-mp4");
+      expect(widgets.frame_rate).toBe(30);
+    }
+  });
+
+  it("the manifest still requests the artokun teskors-utils origin, not teskor-hub", async () => {
+    const file = resolvePackManifestFile(PACK);
+    const manifest = await loadManifestFile(file!);
+    expect(manifest.custom_nodes.join("\n")).toContain(ARTOKUN_UTILS);
+    expect(manifest.custom_nodes.join("\n")).not.toContain(TESKOR_HUB);
+    const raw = readFileSync(file!, "utf8");
+    expect(raw).toContain(ARTOKUN_UTILS);
+    expect(raw).not.toContain(`https://github.com/${TESKOR_HUB}`);
+  });
+
+  it("the shipped workflow stamps TS nodes with the artokun origin, not teskor-hub", () => {
+    const text = workflowText();
+    expect(text).not.toContain(TESKOR_HUB);
+    expect(text).not.toContain("teskor-hub/NEW-UTILS");
+    const tsNodes = walkNodes(loadUiWorkflow()).filter(
+      (n) => n.type === "TSColorMatch" || n.type === "TSPoseDataSmoother",
+    );
+    expect(tsNodes.length, "color match + pose smoother stay in the graph").toBeGreaterThan(0);
+    for (const node of tsNodes) {
+      expect(node.properties?.aux_id, node.type).toBe("artokun/comfyui-teskors-utils");
+    }
+  });
+
+  it("generated installers download SAM3 and clone the artokun origin", () => {
+    for (const name of ["install-windows.bat", "install-runpod.sh"]) {
+      const file = join(PACK_DIR, name);
+      expect(existsSync(file), name).toBe(true);
+      const text = readFileSync(file, "utf8");
+      expect(text, name).toContain(SAM3);
+      expect(text, name).toContain(SAM3_URL);
+      expect(text, name).toContain(ARTOKUN_UTILS);
+      expect(text, name).not.toContain(`https://github.com/${TESKOR_HUB}`);
+    }
+  });
+});

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -380,6 +380,60 @@ describe("applyManifest", () => {
     expect(downloadModelMock).not.toHaveBeenCalled();
   });
 
+  it("does not skip a requested git origin when Manager listed a different author (#2523)", async () => {
+    listInstalledNodesMock.mockResolvedValue([
+      {
+        module: "comfyui-teskors-utils",
+        auxId: "teskor-hub/comfyui-teskors-utils",
+        enabled: true,
+      },
+    ]);
+    installCustomNodeMock.mockResolvedValue({
+      mechanism: "git-clone",
+      message: "cloned artokun/comfyui-teskors-utils",
+    });
+
+    const result = await applyManifest({
+      manifest: {
+        custom_nodes: ["https://github.com/artokun/comfyui-teskors-utils"],
+      },
+    });
+
+    expect(installCustomNodeMock).toHaveBeenCalledTimes(1);
+    expect(installCustomNodeMock.mock.calls[0][0]).toMatchObject({
+      id: "https://github.com/artokun/comfyui-teskors-utils",
+    });
+    expect(result.results[0]).toMatchObject({
+      action: "custom_node",
+      item: "https://github.com/artokun/comfyui-teskors-utils",
+      status: "applied",
+    });
+    expect(result.results[0].status).not.toBe("skipped");
+  });
+
+  it("still skips when Manager listed the requested git origin (#2523)", async () => {
+    listInstalledNodesMock.mockResolvedValue([
+      {
+        module: "comfyui-teskors-utils",
+        auxId: "artokun/comfyui-teskors-utils",
+        enabled: true,
+      },
+    ]);
+
+    const result = await applyManifest({
+      manifest: {
+        custom_nodes: ["https://github.com/artokun/comfyui-teskors-utils"],
+      },
+    });
+
+    expect(installCustomNodeMock).not.toHaveBeenCalled();
+    expect(result.results[0]).toMatchObject({
+      action: "custom_node",
+      item: "https://github.com/artokun/comfyui-teskors-utils",
+      status: "skipped",
+    });
+  });
+
   it("continues after individual failures and reports each item", async () => {
     installCustomNodeMock.mockRejectedValueOnce(new Error("node failed"));
     downloadModelMock.mockResolvedValueOnce("/fake/ComfyUI/models/loras/model.safetensors");

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -922,6 +922,61 @@ describe("node-management service", () => {
       ]);
     });
 
+    it("keeps a correct disk origin when Manager aux_id is stale (#2523)", async () => {
+      // Manager can retain the old alias after the local checkout was corrected.
+      // The disk remote is the stronger witness and must protect the checkout,
+      // including files the user changed locally, from replacement.
+      stubFetch({
+        installedBody: {
+          "comfyui-teskors-utils": {
+            ver: "nightly",
+            aux_id: "teskor-hub/comfyui-teskors-utils",
+            enabled: true,
+          },
+        },
+      });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) {
+          return cloned || !fsCtl.removed.includes(NODE_DIR_UTILS);
+        }
+        return false;
+      });
+      fsCtl.readdirSync = (p) => {
+        const norm = p.replace(/\\/g, "/");
+        return norm.endsWith("/comfyui-teskors-utils")
+          ? ["__init__.py", ".git", "local-change.py"]
+          : [];
+      };
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        const argv = args as string[];
+        if (bin === "git" && argv[0] === "clone") {
+          cloned = true;
+          return "";
+        }
+        if (bin === "git" && argv.includes("get-url")) {
+          return "https://github.com/artokun/comfyui-teskors-utils.git";
+        }
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/artokun/comfyui-teskors-utils",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/already exists in custom_nodes/);
+      expect(fsCtl.removed).not.toContain(NODE_DIR_UTILS);
+      expect(
+        mockedExec.mock.calls.find(
+          (c) => c[0] === "git" && (c[1] as string[])[0] === "clone",
+        ),
+      ).toBeUndefined();
+    });
+
     it("does not treat a Manager listing of teskor-hub as the requested artokun origin (#2523)", async () => {
       // Same substitution, but the on-disk remote cannot be read — aux_id is
       // still enough proof to refuse the Manager hit and clone the URL passed.

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -859,6 +859,121 @@ describe("node-management service", () => {
       expect(cloneEnv?.GIT_ASKPASS).toBe("echo");
     });
 
+    it("replaces a Manager-aliased teskor-hub checkout with the requested artokun origin (#2523)", async () => {
+      // Manager v4 keys from-source installs by bare repo name, so requesting
+      // artokun/comfyui-teskors-utils still clones teskor-hub's repository into
+      // the same folder and reports success. The pack's TS nodes then come from
+      // the wrong fork.
+      stubFetch({
+        installedBody: {
+          "comfyui-teskors-utils": {
+            ver: "nightly",
+            aux_id: "teskor-hub/comfyui-teskors-utils",
+            enabled: true,
+          },
+        },
+      });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) {
+          if (cloned) return true;
+          return !fsCtl.removed.includes(NODE_DIR_UTILS);
+        }
+        return false;
+      });
+      fsCtl.readdirSync = (p) => {
+        const norm = p.replace(/\\/g, "/");
+        return norm.endsWith("/comfyui-teskors-utils") ? ["__init__.py", ".git"] : [];
+      };
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        const argv = args as string[];
+        if (bin === "git" && argv[0] === "clone") {
+          cloned = true;
+          return "";
+        }
+        if (bin === "git" && argv.includes("get-url")) {
+          return "https://github.com/teskor-hub/comfyui-teskors-utils.git";
+        }
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/artokun/comfyui-teskors-utils",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/artokun\/comfyui-teskors-utils/);
+      expect(res.message).toMatch(/teskor-hub\/comfyui-teskors-utils/);
+      expect(fsCtl.removed).toContain(NODE_DIR_UTILS);
+      const cloneCall = mockedExec.mock.calls.find(
+        (c) => c[0] === "git" && (c[1] as string[])[0] === "clone",
+      );
+      expect(cloneCall).toBeDefined();
+      expect(cloneCall![1]).toEqual([
+        "clone",
+        "--depth",
+        "1",
+        "--end-of-options",
+        "https://github.com/artokun/comfyui-teskors-utils",
+        NODE_DIR_UTILS,
+      ]);
+    });
+
+    it("does not treat a Manager listing of teskor-hub as the requested artokun origin (#2523)", async () => {
+      // Same substitution, but the on-disk remote cannot be read — aux_id is
+      // still enough proof to refuse the Manager hit and clone the URL passed.
+      stubFetch({
+        installedBody: {
+          "comfyui-teskors-utils": {
+            ver: "nightly",
+            aux_id: "teskor-hub/comfyui-teskors-utils",
+            enabled: true,
+          },
+        },
+      });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) {
+          return cloned || !fsCtl.removed.includes(NODE_DIR_UTILS);
+        }
+        return false;
+      });
+      fsCtl.readdirSync = (p) => {
+        const norm = p.replace(/\\/g, "/");
+        return norm.endsWith("/comfyui-teskors-utils") ? ["__init__.py", ".git"] : [];
+      };
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        const argv = args as string[];
+        if (bin === "git" && argv[0] === "clone") {
+          cloned = true;
+          return "";
+        }
+        if (bin === "git" && argv.includes("get-url")) {
+          throw Object.assign(new Error("not a git repository"), { status: 128 });
+        }
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/artokun/comfyui-teskors-utils",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(fsCtl.removed).toContain(NODE_DIR_UTILS);
+      const cloneCall = mockedExec.mock.calls.find(
+        (c) => c[0] === "git" && (c[1] as string[])[0] === "clone",
+      );
+      expect((cloneCall![1] as string[]).includes("https://github.com/artokun/comfyui-teskors-utils")).toBe(
+        true,
+      );
+    });
+
     // #463 — a detection failure is allowed to reach a direct clone only after
     // the connected ComfyUI proves that BOTH Manager queue/status dialects are
     // absent. This is distinct from a queue operation's own route-level 404,

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -686,7 +686,10 @@ function nodeAlreadyInstalled(id: string, installed: InstalledNode[]): boolean {
     if (!nameMatch) return false;
     // A git URL that names an owner is not "already installed" when Manager
     // listed a different author's repository under the same bare name.
-    if (wantedOrigin) {
+    // A registry/CNR identity can intentionally point at a differently named
+    // source checkout; only a bare from-source Manager entry's aux_id is the
+    // origin evidence relevant to this pack alias case (#2523).
+    if (wantedOrigin && !node.cnrId) {
       const installedOrigin = gitOwnerRepo(node.auxId);
       if (installedOrigin && installedOrigin !== wantedOrigin) return false;
     }

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -653,9 +653,27 @@ function maybeGitModuleName(value: string): string | undefined {
   return basename(pathPart).replace(/\.git$/i, "").toLowerCase();
 }
 
+/**
+ * `owner/repo` from a git URL or an aux_id (`teskor-hub/comfyui-teskors-utils`).
+ * Used so a Manager listing of a different author is not treated as the
+ * requested origin (#2523).
+ */
+function gitOwnerRepo(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim().replace(/\.git$/i, "").replace(/\/+$/, "");
+  if (!trimmed) return undefined;
+  const hosted = /(?:github\.com|gitlab\.com|bitbucket\.org)[/:]([^/]+)\/([^/#?]+)/i.exec(
+    trimmed,
+  );
+  if (hosted) return `${hosted[1]}/${hosted[2]}`.toLowerCase();
+  const short = /^([^/]+)\/([^/]+)$/.exec(trimmed);
+  return short ? `${short[1]}/${short[2]}`.toLowerCase() : undefined;
+}
+
 function nodeAlreadyInstalled(id: string, installed: InstalledNode[]): boolean {
   const wanted = normalizeId(id);
   const gitModule = maybeGitModuleName(id);
+  const wantedOrigin = gitOwnerRepo(id);
   return installed.some((node) => {
     const candidates = [
       node.module,
@@ -664,7 +682,15 @@ function nodeAlreadyInstalled(id: string, installed: InstalledNode[]): boolean {
     ]
       .filter((v): v is string => Boolean(v))
       .map(normalizeId);
-    return candidates.includes(wanted) || (gitModule ? candidates.includes(gitModule) : false);
+    const nameMatch = candidates.includes(wanted) || (gitModule ? candidates.includes(gitModule) : false);
+    if (!nameMatch) return false;
+    // A git URL that names an owner is not "already installed" when Manager
+    // listed a different author's repository under the same bare name.
+    if (wantedOrigin) {
+      const installedOrigin = gitOwnerRepo(node.auxId);
+      if (installedOrigin && installedOrigin !== wantedOrigin) return false;
+    }
+    return true;
   });
 }
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3735,12 +3735,17 @@ async function cloneCustomNodeFallback(
   // #2523 — Manager v4 resolves a from-source install by BARE REPO NAME and
   // clones the channel/registry URL, so artokun/comfyui-teskors-utils can land
   // as teskor-hub/comfyui-teskors-utils in the same folder. A name hit is not
-  // the requested origin. Replace only when an origin is PROVEN different
-  // (listed aux_id or git remote); unknown origin is left in place.
+  // the requested origin. A verified disk remote is authoritative: stale
+  // Manager metadata must never delete a checkout that already has the right
+  // origin (or any local changes in it). If the disk remote is wrong, replace
+  // it; if the disk remote cannot answer, the Manager aux_id may still prove an
+  // alias replacement is needed.
   const diskOrigin = alreadyPresent ? readGitRemoteOrigin(nodeDir) : undefined;
+  const diskOriginDiffers = gitOriginsDiffer(gitId, diskOrigin);
+  const managerOriginDiffers = gitOriginsDiffer(gitId, opts?.replaceOrigin);
   if (
     alreadyPresent &&
-    (gitOriginsDiffer(gitId, diskOrigin) || gitOriginsDiffer(gitId, opts?.replaceOrigin))
+    (diskOriginDiffers || (!diskOrigin && managerOriginDiffers))
   ) {
     const landed = opts?.replaceOrigin ?? diskOrigin ?? "a different origin";
     try {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3659,6 +3659,12 @@ async function cloneCustomNodeFallback(
     /** Do not re-read the shared saved-default resolver when the caller's
      *  call-scoped target was deliberately unavailable. */
     allowSharedWorkspaceFallback?: boolean;
+    /**
+     * #2523 — Manager listed this pack under a different owner/repo than the
+     * requested git URL (bare-name aliasing). The existing checkout must be
+     * replaced with a clone of `gitId` rather than left in place.
+     */
+    replaceOrigin?: string;
   },
 ): Promise<NodeOpResult> {
   const because =
@@ -3709,7 +3715,7 @@ async function cloneCustomNodeFallback(
   }
 
   const warnings: string[] = [];
-  const alreadyPresent = existsSync(nodeDir);
+  let alreadyPresent = existsSync(nodeDir);
 
   // A directory that is already there but holds nothing but git metadata is NOT
   // a pack — it is the husk an earlier failed install left behind (#900). Without
@@ -3723,6 +3729,34 @@ async function cloneCustomNodeFallback(
         `git metadata — the husk of an install that did not complete, which ComfyUI ` +
         `cannot import and logs an error for on every start. This call did not create ` +
         `it, so it was left untouched. Delete ${nodeDir} by hand and retry the install.`,
+    );
+  }
+
+  // #2523 — Manager v4 resolves a from-source install by BARE REPO NAME and
+  // clones the channel/registry URL, so artokun/comfyui-teskors-utils can land
+  // as teskor-hub/comfyui-teskors-utils in the same folder. A name hit is not
+  // the requested origin. Replace only when an origin is PROVEN different
+  // (listed aux_id or git remote); unknown origin is left in place.
+  const diskOrigin = alreadyPresent ? readGitRemoteOrigin(nodeDir) : undefined;
+  if (
+    alreadyPresent &&
+    (gitOriginsDiffer(gitId, diskOrigin) || gitOriginsDiffer(gitId, opts?.replaceOrigin))
+  ) {
+    const landed = opts?.replaceOrigin ?? diskOrigin ?? "a different origin";
+    try {
+      rmSync(nodeDir, { recursive: true, force: true });
+    } catch (err) {
+      throw new NodeManagementError(
+        `ComfyUI-Manager resolved "${landed}" instead of the requested "${gitId}", ` +
+          `but custom_nodes/${repoName} could not be replaced ` +
+          `(${err instanceof Error ? err.message : String(err)}). ` +
+          `Delete ${nodeDir} by hand and retry the install.`,
+      );
+    }
+    alreadyPresent = false;
+    warnings.push(
+      `ComfyUI-Manager resolved "${landed}" instead of the requested "${gitId}"; ` +
+        `replaced custom_nodes/${repoName} with a direct clone of the requested origin.`,
     );
   }
 
@@ -4388,9 +4422,11 @@ async function installCustomNodeImpl(
     );
     assertInstallTargetStable(targetGeneration, managerBase);
     const listedNode = findInstalledNode(gitId, installed);
+    const originMismatch =
+      listedNode !== undefined && !gitOriginMatchesRequested(gitId, listedNode.auxId);
     /** #2714 — why the Manager's own "installed" verdict was not taken. */
     let uncorroboratedNote: string | undefined;
-    if (listedNode) {
+    if (listedNode && !originMismatch) {
       // The disk is only consulted when it can answer ABOUT THIS SERVER: in
       // remote mode the tree we could read is not the host's, and with no local
       // root captured there is nothing to scan. In both cases the list is the
@@ -4437,6 +4473,8 @@ async function installCustomNodeImpl(
         });
       }
     }
+    const replaceOrigin =
+      originMismatch ? listedNode?.auxId : undefined;
     if (localWriteMismatch) {
       throw new ProcessControlError(
         wrongInstallRefusal(localWriteMismatch, 'install_custom_node (action:"install", git clone)', managerBase),
@@ -4447,10 +4485,20 @@ async function installCustomNodeImpl(
     const clone = () => cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
       refFromVersion,
       allowSharedWorkspaceFallback: cliWorkspace !== undefined,
+      ...(replaceOrigin
+        ? {
+            replaceOrigin,
+            managerRefusalNote:
+              `ComfyUI-Manager installed "${replaceOrigin}" instead of the requested ` +
+              `origin ${gitOwnerRepo(gitId) ?? gitId}`,
+          }
+        : {}),
       // #2714 — the default reason ("not in the ComfyUI-Manager registry") is the
       // wrong explanation when Manager DID list the pack; state what was actually
       // observed instead, so a subsequent refusal from here is not misattributed.
-      ...(uncorroboratedNote ? { managerRefusalNote: uncorroboratedNote } : {}),
+      ...(uncorroboratedNote && !replaceOrigin
+        ? { managerRefusalNote: uncorroboratedNote }
+        : {}),
     });
     // An accepted remote Manager task that resolves no pack still reaches this
     // helper only for its authoritative remote-target refusal; it is not a
@@ -6221,6 +6269,54 @@ function gitInstallChannelNote(channel: string): string {
 function gitUrlOwnerRepo(url: string): string | undefined {
   const m = /[/:]([^/:]+)\/([^/]+?)(?:\.git)?\/*$/.exec(url.trim());
   return m ? `${m[1]}/${m[2]}` : undefined;
+}
+
+/**
+ * `owner/repo` from a git URL, an `aux_id`, or a shorthand `owner/repo` string.
+ * Manager reports git packs as `aux_id: "teskor-hub/comfyui-teskors-utils"` while
+ * a manifest names `https://github.com/artokun/comfyui-teskors-utils` — those must
+ * compare as different origins, not as the same bare repo name (#2523).
+ */
+function gitOwnerRepo(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim().replace(/\.git$/i, "").replace(/\/+$/, "");
+  if (!trimmed) return undefined;
+  const hosted = /(?:github\.com|gitlab\.com|bitbucket\.org)[/:]([^/]+)\/([^/#?]+)/i.exec(
+    trimmed,
+  );
+  if (hosted) return `${hosted[1]}/${hosted[2]}`.toLowerCase();
+  const short = /^([^/]+)\/([^/]+)$/.exec(trimmed);
+  return short ? `${short[1]}/${short[2]}`.toLowerCase() : undefined;
+}
+
+/** True when both values name an owner/repo and those identities differ. */
+function gitOriginsDiffer(wanted: string, other: string | undefined): boolean {
+  const a = gitOwnerRepo(wanted);
+  const b = gitOwnerRepo(other);
+  return Boolean(a && b && a !== b);
+}
+
+/**
+ * A Manager installed-list hit for a git URL is only the requested origin when
+ * `aux_id` names the same owner/repo. Missing aux_id cannot prove a mismatch,
+ * so it is treated as a match (the clone fallback still checks `git remote`).
+ */
+function gitOriginMatchesRequested(gitId: string, auxId: string | undefined): boolean {
+  return !gitOriginsDiffer(gitId, auxId);
+}
+
+function readGitRemoteOrigin(nodeDir: string): string | undefined {
+  try {
+    const out = execFileSync("git", ["-C", nodeDir, "remote", "get-url", "origin"], {
+      encoding: "utf-8",
+      timeout: GIT_CLONE_TIMEOUT,
+      env: nonInteractiveGitEnv(),
+    });
+    const origin = typeof out === "string" ? out.trim() : String(out).trim();
+    return origin || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -4422,8 +4422,13 @@ async function installCustomNodeImpl(
     );
     assertInstallTargetStable(targetGeneration, managerBase);
     const listedNode = findInstalledNode(gitId, installed);
+    // A registry/CNR identity can intentionally point at a differently named
+    // source checkout (the #2714 aux-id alias test); only a bare from-source
+    // Manager entry's aux_id is origin evidence for this pack alias case.
     const originMismatch =
-      listedNode !== undefined && !gitOriginMatchesRequested(gitId, listedNode.auxId);
+      listedNode !== undefined &&
+      !listedNode.cnrId &&
+      !gitOriginMatchesRequested(gitId, listedNode.auxId);
     /** #2714 — why the Manager's own "installed" verdict was not taken. */
     let uncorroboratedNote: string | undefined;
     if (listedNode && !originMismatch) {


### PR DESCRIPTION
## Summary
- The bundled `artokun-flow` pack could not validate after a clean `apply_manifest` install: REPLACEMENT MODE's SAM3 subgraph needs `sam3.1_multiplex_fp16.safetensors`, but the manifest never downloaded it.
- The only final save node was `TSVideoCombineNoMetadata`. On the teskor-hub teskors-utils fork Manager actually installs, that node is not `OUTPUT_NODE`, so `panel_run(to_node_id)` refuses it (`node 758 is not an output node`).
- Manager v4 resolves from-source installs by bare repo name, so `https://github.com/artokun/comfyui-teskors-utils` could land as `teskor-hub/comfyui-teskors-utils`. `apply_manifest` treated that name hit as already-installed and skipped.

Fix:
- Add the official Comfy-Org SAM3 checkpoint to the pack manifest at `checkpoints/sam3.1_multiplex_fp16.safetensors`.
- Replace node 758 with `VHS_VideoCombine` (h264 30fps, a proven OUTPUT_NODE) so `panel_run(to_node_id)` can target it.
- Stamp TS nodes with `artokun/comfyui-teskors-utils`, skip a Manager listing only when `aux_id` matches that origin, and replace a proven-wrong checkout with a direct clone of the requested URL.

## Test plan
- [x] `npx vitest run src/__tests__/packs/artokun-flow-sam3-output-node.test.ts` — shipped manifest downloads SAM3, node 758 is active VHS_VideoCombine, TS nodes stamp the artokun origin, generated installers follow.
- [x] `npx vitest run src/__tests__/services/manifest.test.ts` — apply_manifest does not skip artokun teskors-utils when Manager listed teskor-hub; same origin still skips.
- [x] `npx vitest run src/__tests__/services/node-management.test.ts` — a Manager-aliased teskor-hub checkout is replaced with the requested artokun origin.

Fixes #2523
