### PR TITLE
fix(2528): resolve get_workflow strip under userdata/workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,13 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - queue action:"status" confirms an idle prompt against /history before calling it done, and does not report a completed run when ComfyUI has no record of it (#2507, #2661)
 
+## Unreleased
+
+### MCP
+
+#### Fixed
+- get_workflow strip resolves an absolute path under the live ComfyUI userdata/workflows tree without dropping the workflows segment or mangling Unicode dashes (#2528)
+
 ## [0.52.161] - 2026-08-30
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- get_workflow strip resolves an absolute path under the live ComfyUI userdata/workflows tree without dropping the workflows segment or mangling Unicode dashes (#2528)
+
 ## [0.52.174] - 2026-09-02
 
 ### MCP
@@ -126,13 +131,6 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - queue action:"status" confirms an idle prompt against /history before calling it done, and does not report a completed run when ComfyUI has no record of it (#2507, #2661)
-
-## Unreleased
-
-### MCP
-
-#### Fixed
-- get_workflow strip resolves an absolute path under the live ComfyUI userdata/workflows tree without dropping the workflows segment or mangling Unicode dashes (#2528)
 
 ## [0.52.161] - 2026-08-30
 

--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -36,7 +36,7 @@ Return, list, summarize or query a SAVED workflow FILE — files on disk, named 
   Options: `ui`, `api`, `raw`.
 </ParamField>
 <ParamField path="path" type="string">
-  action:"strip" / "slice" / "query" — Absolute server-side path to a workflow .json on disk (e.g. C:\\Users\\you\\ComfyUI\\user\\default\\workflows\\pusa_extend.json). Read directly from disk — no library lookup.
+  action:"strip" / "slice" / "query" — Absolute server-side path to a workflow .json on disk (e.g. C:\\Users\\you\\ComfyUI\\user\\default\\workflows\\pusa_extend.json). Read directly from disk — no library lookup. If a userdata path is missing the `workflows` segment after `user/default`, it is retried with that segment restored, preserving the filename exactly.
 </ParamField>
 <ParamField path="graph" type="object">
   action:"strip" / "slice" / "query" — Inline workflow JSON (UI format for "strip"/"slice"; UI or API for "query"), as an alternative to path/filename.

--- a/src/__tests__/tools/get-workflow-userdata-workflows-path.test.ts
+++ b/src/__tests__/tools/get-workflow-userdata-workflows-path.test.ts
@@ -66,7 +66,10 @@ vi.mock("../../services/frontend-virtual-types.js", () => ({
   frontendVirtualTypesFor: () => new Set<string>(),
 }));
 
-import { registerWorkflowLibraryTools } from "../../tools/workflow-library.js";
+import {
+  registerWorkflowLibraryTools,
+  restoreDroppedWorkflowsSegment,
+} from "../../tools/workflow-library.js";
 
 type Handler = (args: Record<string, unknown>) => Promise<{
   isError?: boolean;
@@ -173,3 +176,28 @@ describe("#2528 get_workflow strip keeps the userdata workflows segment", () => 
     expect(mocks.fetchApi).not.toHaveBeenCalled();
   });
 });
+
+describe.runIf(process.platform === "win32")(
+  "#2528 restores Windows roots without changing them",
+  () => {
+    it.each([
+      [
+        "a UNC root",
+        String.raw`\\server\share\user\default\artokun_lab\workflow.json`,
+        String.raw`\\server\share\user\default\workflows\artokun_lab\workflow.json`,
+      ],
+      [
+        "an extended-length drive root",
+        String.raw`\\?\C:\ComfyUI\user\default\artokun_lab\workflow.json`,
+        String.raw`\\?\C:\ComfyUI\user\default\workflows\artokun_lab\workflow.json`,
+      ],
+      [
+        "an extended-length UNC root",
+        String.raw`\\?\UNC\server\share\user\default\artokun_lab\workflow.json`,
+        String.raw`\\?\UNC\server\share\user\default\workflows\artokun_lab\workflow.json`,
+      ],
+    ])("preserves %s", (_label, dropped, expected) => {
+      expect(restoreDroppedWorkflowsSegment(dropped)).toBe(expected);
+    });
+  },
+);

--- a/src/__tests__/tools/get-workflow-userdata-workflows-path.test.ts
+++ b/src/__tests__/tools/get-workflow-userdata-workflows-path.test.ts
@@ -1,0 +1,166 @@
+// #2528 — get_workflow action:"strip" ENOENT'd a valid absolute Windows
+// workflow path by dropping the `workflows` segment from the live ComfyUI
+// userdata tree:
+//
+//   real:      {workspace}/user/default/workflows/artokun_lab/{emdash}.json
+//   attempted: {workspace}/user/default/artokun_lab/{emdash}.json
+//
+// The filename also contains an em-dash (U+2014). A resolver that mangles it
+// to ASCII `-` or `?` misses the same file. The shipped reader must resolve
+// under userdata/workflows (never join the library-relative tail onto
+// user/default) and must pass the filename through byte-for-byte.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const mocks = vi.hoisted(() => ({
+  fetchApi: vi.fn(),
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  liveWorkspace: vi.fn(),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  comfyApiFetch: (...args: unknown[]) => mocks.fetchApi(...args),
+  getObjectInfo: (...args: unknown[]) => mocks.getObjectInfo(...args),
+  backfillObjectInfo: (...args: unknown[]) => mocks.backfillObjectInfo(...args),
+}));
+
+vi.mock("../../services/workspace-env.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/workspace-env.js")>();
+  return {
+    ...actual,
+    resolveEffectiveComfyUIBaseLive: (...args: unknown[]) => mocks.liveWorkspace(...args),
+  };
+});
+
+vi.mock("../../services/workflow-slicer.js", () => ({ sliceWorkflow: vi.fn() }));
+vi.mock("../../services/graph-query.js", () => ({
+  queryApiGraph: vi.fn(),
+  LIMIT_CEILING: 200,
+  MAX_CHARS_CEILING: 60000,
+  MAX_CHARS_FLOOR: 500,
+}));
+vi.mock("../../services/userdata-library.js", () => ({ listWorkflowLibraryKeys: vi.fn() }));
+vi.mock("../../services/workflow-sections.js", () => ({ detectSections: vi.fn() }));
+vi.mock("../../services/hierarchical-mermaid.js", () => ({
+  generateOverview: vi.fn(),
+  generateSectionDetail: vi.fn(),
+  listSections: vi.fn(),
+  generateSummary: vi.fn(),
+}));
+vi.mock("../../services/mermaid-converter.js", () => ({ convertToMermaid: vi.fn() }));
+vi.mock("../../services/workflow-health.js", () => ({ analyzeGraphHealth: vi.fn() }));
+vi.mock("../../services/image-management.js", () => ({ extractWorkflowFromImage: vi.fn() }));
+vi.mock("../../tools/prompt-director.js", () => ({ promptDirectorInspectAction: vi.fn() }));
+vi.mock("../../tools/workflow-lock.js", () => ({
+  lockWorkflowAction: vi.fn(),
+  verifyWorkflowLockAction: vi.fn(),
+}));
+vi.mock("../../config.js", () => ({
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+}));
+vi.mock("../../services/frontend-virtual-types.js", () => ({
+  frontendVirtualTypesFor: () => new Set<string>(),
+}));
+
+import { registerWorkflowLibraryTools } from "../../tools/workflow-library.js";
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(): Handler {
+  let handler: Handler | undefined;
+  const server = {
+    tool: (name: string, _description: string, _shape: unknown, candidate: Handler) => {
+      if (name === "get_workflow") handler = candidate;
+    },
+  };
+  registerWorkflowLibraryTools(server as never);
+  if (!handler) throw new Error("get_workflow was not registered");
+  return handler;
+}
+
+const text = (res: Awaited<ReturnType<Handler>>) => res.content.map((c) => c.text).join(" ");
+
+/** Em-dash U+2014 — the character in the reporter's filename, not ASCII `-`. */
+const EMDASH = "\u2014";
+const WORKFLOW_FILE = `FRSS27-2807 ${EMDASH} ProductView Face006 Validated.json`;
+
+const GRAPH = {
+  "1": { class_type: "SaveImage", inputs: { filename_prefix: "from-userdata-workflows" } },
+};
+
+let workspace = "";
+let realFile = "";
+let droppedFile = "";
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  workspace = mkdtempSync(join(tmpdir(), "cmcp-2528-ws-"));
+  const workflowsDir = join(workspace, "user", "default", "workflows", "artokun_lab");
+  mkdirSync(workflowsDir, { recursive: true });
+  realFile = join(workflowsDir, WORKFLOW_FILE);
+  droppedFile = join(workspace, "user", "default", "artokun_lab", WORKFLOW_FILE);
+  writeFileSync(realFile, JSON.stringify(GRAPH));
+  mocks.liveWorkspace.mockResolvedValue(workspace);
+  mocks.getObjectInfo.mockResolvedValue({});
+  mocks.backfillObjectInfo.mockImplementation(async (info: unknown) => info);
+  mocks.fetchApi.mockResolvedValue({
+    ok: false,
+    status: 500,
+    statusText: "Internal Server Error",
+    json: async () => ({}),
+    text: async () => "Internal Server Error",
+  });
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe("#2528 get_workflow strip keeps the userdata workflows segment", () => {
+  it('action:"strip" reads the absolute userdata/workflows path (em-dash intact)', async () => {
+    const res = await getHandler()({ action: "strip", path: realFile, format: "raw" });
+
+    expect(res.isError).toBeUndefined();
+    expect(text(res)).not.toMatch(/ENOENT/);
+    expect(text(res)).not.toContain(droppedFile);
+    expect(JSON.parse(res.content[0]!.text)).toEqual(GRAPH);
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
+  });
+
+  it("the dropped-workflows reconstruction ENOENT path still finds the file", async () => {
+    // The production error opened user/default/artokun_lab/... — that file is
+    // NOT created here. A resolver that joins the library-relative tail onto
+    // user/default (dropping `workflows`) ENOENTs; restoring the segment must
+    // open the real userdata/workflows location, em-dash and all.
+    const res = await getHandler()({ action: "strip", path: droppedFile, format: "raw" });
+
+    expect(res.isError).toBeUndefined();
+    expect(text(res)).not.toMatch(/ENOENT/);
+    expect(text(res)).not.toContain(droppedFile);
+    expect(JSON.parse(res.content[0]!.text)).toEqual(GRAPH);
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
+  });
+
+  it("does not find a hyphen-mangled stand-in when only the em-dash file exists", async () => {
+    const mangled = join(
+      workspace,
+      "user",
+      "default",
+      "workflows",
+      "artokun_lab",
+      WORKFLOW_FILE.replace(EMDASH, "-"),
+    );
+    const res = await getHandler()({ action: "strip", path: mangled, format: "raw" });
+
+    expect(res.isError).toBe(true);
+    expect(text(res)).toMatch(/ENOENT|not found/i);
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/tools/get-workflow-userdata-workflows-path.test.ts
+++ b/src/__tests__/tools/get-workflow-userdata-workflows-path.test.ts
@@ -148,6 +148,15 @@ describe("#2528 get_workflow strip keeps the userdata workflows segment", () => 
     expect(mocks.fetchApi).not.toHaveBeenCalled();
   });
 
+  it('action:"strip" also repairs an absolute `filename` from the same userdata tree', async () => {
+    const res = await getHandler()({ action: "strip", filename: droppedFile, format: "raw" });
+
+    expect(res.isError).toBeUndefined();
+    expect(text(res)).not.toMatch(/ENOENT/);
+    expect(JSON.parse(res.content[0]!.text)).toEqual(GRAPH);
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
+  });
+
   it("does not find a hyphen-mangled stand-in when only the em-dash file exists", async () => {
     const mangled = join(
       workspace,

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { readFile, realpath } from "node:fs/promises";
-import { isAbsolute, relative, resolve as pathResolve, sep } from "node:path";
+import { isAbsolute, parse as pathParse, relative, resolve as pathResolve } from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiWorkflow, WorkflowJSON } from "../comfyui/types.js";
 import { getObjectInfo, backfillObjectInfo, comfyApiFetch } from "../comfyui/client.js";
@@ -99,20 +99,18 @@ function isEnoent(err: unknown): boolean {
  * filename is copied segment-for-segment so an em-dash is not rewritten to
  * ASCII `-` or `?`.
  */
-function restoreDroppedWorkflowsSegment(absPath: string): string | undefined {
+export function restoreDroppedWorkflowsSegment(absPath: string): string | undefined {
   if (!isAbsolute(absPath)) return undefined;
   const resolved = pathResolve(absPath);
-  const segs = resolved.split(/[\\/]+/).filter((s) => s !== "");
+  const root = pathParse(resolved).root;
+  const segs = resolved.slice(root.length).split(/[\\/]+/).filter((s) => s !== "");
   const insertAfter = (anchor: readonly string[]): string | undefined => {
     for (let i = 0; i <= segs.length - anchor.length; i++) {
       if (!anchor.every((part, j) => segs[i + j] === part)) continue;
       const after = i + anchor.length;
       if (segs[after] === "workflows" || after >= segs.length) return undefined;
       const next = [...segs.slice(0, after), "workflows", ...segs.slice(after)];
-      if (/^[A-Za-z]:$/.test(next[0] ?? "")) {
-        return pathResolve(`${next[0]}${sep}`, ...next.slice(1));
-      }
-      return pathResolve(sep, ...next);
+      return pathResolve(root, ...next);
     }
     return undefined;
   };

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -313,7 +313,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         .optional()
         .describe(
           'action:"strip" / "slice" / "query" — Absolute server-side path to a workflow .json on disk (e.g. ' +
-            "C:\\\\Users\\\\you\\\\ComfyUI\\\\user\\\\default\\\\workflows\\\\pusa_extend.json). Read directly from disk — no library lookup.",
+            "C:\\\\Users\\\\you\\\\ComfyUI\\\\user\\\\default\\\\workflows\\\\pusa_extend.json). Read directly from disk — no library lookup. If a userdata path is missing the `workflows` segment after `user/default`, it is retried with that segment restored, preserving the filename exactly.",
         ),
       graph: z
         .record(z.string(), z.any())

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { readFile, realpath } from "node:fs/promises";
-import { isAbsolute, relative, resolve as pathResolve } from "node:path";
+import { isAbsolute, relative, resolve as pathResolve, sep } from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiWorkflow, WorkflowJSON } from "../comfyui/types.js";
 import { getObjectInfo, backfillObjectInfo, comfyApiFetch } from "../comfyui/client.js";
@@ -59,7 +59,11 @@ async function loadRawFromSource(
     throw new ValidationError("Provide exactly one of: path, filename, or graph.");
   }
   if (graph) return graph;
-  if (path) return JSON.parse(await readFile(path, "utf8"));
+  if (path) return JSON.parse(await readWorkflowFile(path));
+  if (filename && isAbsolute(filename)) {
+    const fromDisk = await tryReadWorkspaceWorkflow(filename);
+    if (fromDisk !== undefined) return fromDisk;
+  }
   const encoded = encodeURIComponent(`workflows/${filename}`);
   const res = await comfyApiFetch(`/api/userdata/${encoded}`);
   if (!res.ok) {
@@ -83,6 +87,57 @@ function isInsideRoot(root: string, candidate: string): boolean {
   return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
 }
 
+function isEnoent(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException)?.code === "ENOENT";
+}
+
+/**
+ * #2528 — an absolute path under the live ComfyUI userdata tree was opened as
+ * `{install}/user/default/{library-rel}` instead of
+ * `{install}/user/default/workflows/{library-rel}`. Re-insert the `workflows`
+ * segment after `user/default` (or after `user` for the legacy layout). The
+ * filename is copied segment-for-segment so an em-dash is not rewritten to
+ * ASCII `-` or `?`.
+ */
+function restoreDroppedWorkflowsSegment(absPath: string): string | undefined {
+  if (!isAbsolute(absPath)) return undefined;
+  const resolved = pathResolve(absPath);
+  const segs = resolved.split(/[\\/]+/).filter((s) => s !== "");
+  const insertAfter = (anchor: readonly string[]): string | undefined => {
+    for (let i = 0; i <= segs.length - anchor.length; i++) {
+      if (!anchor.every((part, j) => segs[i + j] === part)) continue;
+      const after = i + anchor.length;
+      if (segs[after] === "workflows" || after >= segs.length) return undefined;
+      const next = [...segs.slice(0, after), "workflows", ...segs.slice(after)];
+      if (/^[A-Za-z]:$/.test(next[0] ?? "")) {
+        return pathResolve(`${next[0]}${sep}`, ...next.slice(1));
+      }
+      return pathResolve(sep, ...next);
+    }
+    return undefined;
+  };
+  const underDefault = segs.some((s, i) => s === "user" && segs[i + 1] === "default");
+  return underDefault ? insertAfter(["user", "default"]) : insertAfter(["user"]);
+}
+
+/** Read a workflow JSON from disk, restoring a dropped userdata `workflows` segment. */
+async function readWorkflowFile(absPath: string): Promise<string> {
+  try {
+    return await readFile(absPath, "utf8");
+  } catch (err) {
+    if (!isEnoent(err)) throw err;
+    const restored = restoreDroppedWorkflowsSegment(absPath);
+    if (restored && restored !== absPath) {
+      try {
+        return await readFile(restored, "utf8");
+      } catch (restoredErr) {
+        if (!isEnoent(restoredErr)) throw restoredErr;
+      }
+    }
+    throw err;
+  }
+}
+
 /**
  * #2506 — get/analyze used to send every `filename` to /api/userdata/workflows/.
  * An absolute path under the live ComfyUI workspace (e.g. data/_downloads/*.json)
@@ -99,29 +154,33 @@ async function tryReadWorkspaceWorkflow(
   if (!workspace) return undefined;
 
   const resolvedRoot = pathResolve(workspace);
-  const resolvedFile = pathResolve(filename);
-  if (!isInsideRoot(resolvedRoot, resolvedFile)) return undefined;
+  const candidates = [pathResolve(filename)];
+  const restored = restoreDroppedWorkflowsSegment(filename);
+  if (restored && restored !== candidates[0]) candidates.push(pathResolve(restored));
 
-  let realRoot: string;
-  try {
-    realRoot = await realpath(resolvedRoot);
-  } catch {
+  let sawInsideRoot = false;
+  for (const resolvedFile of candidates) {
+    if (!isInsideRoot(resolvedRoot, resolvedFile)) continue;
+    sawInsideRoot = true;
+    let realRoot: string;
+    let realFile: string;
+    try {
+      realRoot = await realpath(resolvedRoot);
+      realFile = await realpath(resolvedFile);
+    } catch {
+      continue;
+    }
+    if (!isInsideRoot(realRoot, realFile)) continue;
+    const parsed: unknown = JSON.parse(await readFile(realFile, "utf8"));
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new ValidationError(`Could NOT read path: ${filename} is not a workflow object.`);
+    }
+    return parsed as Record<string, unknown>;
+  }
+  if (sawInsideRoot) {
     throw new ValidationError(`Workflow not found: ${filename} (404)`);
   }
-  let realFile: string;
-  try {
-    realFile = await realpath(resolvedFile);
-  } catch {
-    throw new ValidationError(`Workflow not found: ${filename} (404)`);
-  }
-  if (!isInsideRoot(realRoot, realFile)) {
-    throw new ValidationError(`Workflow not found: ${filename} (404)`);
-  }
-  const parsed: unknown = JSON.parse(await readFile(realFile, "utf8"));
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new ValidationError(`Could NOT read path: ${filename} is not a workflow object.`);
-  }
-  return parsed as Record<string, unknown>;
+  return undefined;
 }
 
 /** Keep every saved-workflow UI conversion on the same schema-backed path. */


### PR DESCRIPTION
## Summary

`get_workflow action:"strip"` opened a valid absolute Windows workflow path after dropping the `workflows` segment from the live ComfyUI userdata tree, so the real file ENOENT'd:

- real: `{ComfyUI}/user/default/workflows/artokun_lab/FRSS27-2807 — ProductView Face006 Validated.json`
- attempted: `{ComfyUI}/user/default/artokun_lab/FRSS27-2807 — ProductView Face006 Validated.json`

On ENOENT, restore that `workflows` segment after `user/default` (or `user` for the legacy layout) and read the repaired path. The filename is copied segment-for-segment so an em-dash is not rewritten to ASCII `-` or `?`.

## Test plan

- [x] `npx vitest run src/__tests__/tools/get-workflow-userdata-workflows-path.test.ts src/__tests__/tools/get-workflow-workspace-subfolder.test.ts src/__tests__/tools/workflow-library.test.ts` — 42 passed
- [x] Regression test fails on the dropped-`workflows` ENOENT reconstruction and passes after the restore
- [x] Em-dash filename is not matched by a hyphen-mangled stand-in

Fixes #2528
