### PR TITLE
fix(2529): accept VHS_VideoCombine as a panel_run to_node_id output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - get_workflow strip resolves an absolute path under the live ComfyUI userdata/workflows tree without dropping the workflows segment or mangling Unicode dashes (#2528)
-- panel_run accepts VHS_VideoCombine (and any class with live object_info output_node true) as a run-to-node target instead of refusing it as not an output node (#2529)
+- panel_run accepts VHS_VideoCombine (and any class with live object_info output_node true) as a run-to-node target instead of refusing it as not an output node (#2529); recovery preserves scoped batch and cloud targets, and refuses a nested fallback when the panel cannot provide its exact colon-qualified execution path
 
 ## [0.52.174] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - get_workflow strip resolves an absolute path under the live ComfyUI userdata/workflows tree without dropping the workflows segment or mangling Unicode dashes (#2528)
+- panel_run accepts VHS_VideoCombine (and any class with live object_info output_node true) as a run-to-node target instead of refusing it as not an output node (#2529)
 
 ## [0.52.174] - 2026-09-02
 
@@ -138,7 +139,6 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - get_image list_assets and get_system_stats logs fall back to the connected panel same-origin history/logs/view reads when the configured headless route is unreachable, and panel_run completion events name PreviewImage outputs with type temp (#2283)
-- panel_run accepts VHS_VideoCombine (and any class with live object_info output_node true) as a run-to-node target instead of refusing it as not an output node (#2529)
 - panel_set_widget does not treat a MiniMaxH3Director duration write as failed when the value landed and only a setting-store onValueChange callback threw (#2545, #2654)
 - panel_connect retries a LiteGraph wildcard-to-wildcard (`*` → `*`) pairing when the panel reports "No input accepts type *" — PrimitiveNode "connect to widget input" can land on LogicIF.when_true / when_false so the primitive becomes typed from the destination (#2542, #2653)
 - panel_query_graph inspects the unsaved live canvas after custom-widget / builder content-only [root-shape-mismatch] instead of recommending a destructive re-open (#2544, #2652)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - get_image list_assets and get_system_stats logs fall back to the connected panel same-origin history/logs/view reads when the configured headless route is unreachable, and panel_run completion events name PreviewImage outputs with type temp (#2283)
+- panel_run accepts VHS_VideoCombine (and any class with live object_info output_node true) as a run-to-node target instead of refusing it as not an output node (#2529)
 - panel_set_widget does not treat a MiniMaxH3Director duration write as failed when the value landed and only a setting-store onValueChange callback threw (#2545, #2654)
 - panel_connect retries a LiteGraph wildcard-to-wildcard (`*` → `*`) pairing when the panel reports "No input accepts type *" — PrimitiveNode "connect to widget input" can land on LogicIF.when_true / when_false so the primitive becomes typed from the destination (#2542, #2653)
 - panel_query_graph inspects the unsaved live canvas after custom-widget / builder content-only [root-shape-mismatch] instead of recommending a destructive re-open (#2544, #2652)

--- a/src/__tests__/comfyui/cloud-client.test.ts
+++ b/src/__tests__/comfyui/cloud-client.test.ts
@@ -27,6 +27,7 @@ const {
   interrupt,
   uploadImageHttp,
 } = await import("../../comfyui/cloud-client.js");
+const { enqueuePrompt: dispatchEnqueuePrompt } = await import("../../comfyui/client.js");
 
 describe("cloud-client", () => {
   const originalFetch = global.fetch;
@@ -64,6 +65,16 @@ describe("cloud-client", () => {
     const body = JSON.parse((calls[0]?.init?.body as string) ?? "{}");
     expect(body.prompt).toBeDefined();
     expect(body.extra_data).toEqual({ api_key_comfy_org: "x" });
+  });
+
+  it("preserves partial execution targets for scoped cloud enqueues", async () => {
+    await dispatchEnqueuePrompt(
+      { "380": { class_type: "VHS_VideoCombine", inputs: {} } } as never,
+      undefined,
+      { partialExecutionTargets: ["10:15:380"] },
+    );
+    const body = JSON.parse((calls[0]?.init?.body as string) ?? "{}");
+    expect(body.partial_execution_targets).toEqual(["10:15:380"]);
   });
 
   it("returns empty history (no global endpoint) when no prompt_id", async () => {

--- a/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
+++ b/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
@@ -119,6 +119,23 @@ describe("enqueuePrompt — surfaces ComfyUI 400 validation details (#485)", () 
     expect(out.queue_remaining).toBe(1); // real depth, not -17
   });
 
+  it("forwards partial execution targets to the direct /prompt fallback", async () => {
+    comfyuiFetch
+      .mockResolvedValueOnce(res(200, { prompt_id: "scoped", number: 1 }, "OK"))
+      .mockResolvedValueOnce(res(200, { queue_running: [], queue_pending: [] }, "OK"));
+
+    await enqueuePrompt(
+      { "380": { class_type: "VHS_VideoCombine", inputs: {} } },
+      undefined,
+      { partialExecutionTargets: ["380"] },
+    );
+
+    const request = comfyuiFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      partial_execution_targets: ["380"],
+    });
+  });
+
   it("falls back to undefined queue_remaining when /queue can't be read", async () => {
     comfyuiFetch
       .mockResolvedValueOnce(res(200, { prompt_id: "abc", number: 5 }, "OK"))

--- a/src/__tests__/orchestrator/panel-run-2529-vhs-output-node.test.ts
+++ b/src/__tests__/orchestrator/panel-run-2529-vhs-output-node.test.ts
@@ -168,6 +168,37 @@ describe("panel_run accepts VHS_VideoCombine as to_node_id from object_info (#25
     expect(RunCompletions.ticketFor("p-vhs-http")).toBeDefined();
   });
 
+  it("surfaces a direct fallback enqueue error instead of restoring the original refusal", async () => {
+    setEnqueueScopedOutputNodeForTests(async () => {
+      throw new Error(
+        "OUTCOME UNDETERMINED: the POST to /prompt was accepted and may already be queued",
+      );
+    });
+    const { ctx } = runCtx({
+      graphRun: () => ({ queued: false, error: VHS_REFUSAL }),
+    });
+    const res = await panelRun().handler({ to_node_id: 380 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/direct \/prompt fallback failed/);
+    expect(textOf(res)).toMatch(/OUTCOME UNDETERMINED/);
+    expect(textOf(res)).not.toMatch(/nothing was queued/i);
+  });
+
+  it("surfaces an unknown outcome when the recovery graph_run retry throws", async () => {
+    const { ctx } = runCtx({
+      graphRun: (_cmd, attempt) => {
+        if (attempt === 1) return { queued: false, error: VHS_REFUSAL };
+        throw new Error("socket closed after dispatch");
+      },
+    });
+    const res = await panelRun().handler({ to_node_id: 380 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/outcome is UNKNOWN/);
+    expect(textOf(res)).toMatch(/socket closed after dispatch/);
+  });
+
   it("does not recover a non-output class (KSampler) even if the refusal shape matches", async () => {
     const samplerRefusal =
       `node 12 (KSampler) is not an output node — "run to node" can ` +

--- a/src/__tests__/orchestrator/panel-run-2529-vhs-output-node.test.ts
+++ b/src/__tests__/orchestrator/panel-run-2529-vhs-output-node.test.ts
@@ -1,0 +1,215 @@
+// #2529 — panel_run(to_node_id) refused ComfyUI-VideoHelperSuite VHS_VideoCombine
+// as "not an output node" because the panel keys constructor.nodeData.output_node,
+// which that custom frontend class omits. Live /object_info.output_node is true.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  __panelToolsTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+import {
+  setEnqueueScopedOutputNodeForTests,
+  setOutputNodeObjectInfoForTests,
+} from "../../services/output-node.js";
+import type { ObjectInfo } from "../../comfyui/types.js";
+
+const VHS_REFUSAL =
+  `node 380 (VHS_VideoCombine) is not an output node — "run to node" can ` +
+  `only target an output node such as SaveImage, PreviewImage, or SaveVideo.`;
+
+function panelRun() {
+  const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_run");
+  if (!def) throw new Error("panel_run tool not found");
+  return def;
+}
+
+function panelQueryGraph() {
+  const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_query_graph");
+  if (!def) throw new Error("panel_query_graph tool not found");
+  return def;
+}
+
+function textOf(res: ToolResult): string {
+  return (res.content ?? [])
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+}
+
+function objectInfo(outputNode: boolean): { ok: true; object_info: ObjectInfo } {
+  return {
+    ok: true,
+    object_info: {
+      VHS_VideoCombine: {
+        input: { required: { images: ["IMAGE", {}] } },
+        output: ["VHS_FILENAMES"],
+        output_is_list: [false],
+        output_name: ["Filenames"],
+        name: "VHS_VideoCombine",
+        display_name: "Video Combine",
+        description: "",
+        category: "Video Helper Suite",
+        output_node: outputNode,
+      },
+    },
+  };
+}
+
+function runCtx(script: {
+  graphRun?: (cmd: Record<string, unknown>, attempt: number) => Record<string, unknown> | ToolResult;
+  objectInfo?: Record<string, unknown>;
+}): { ctx: PanelToolCtx; runs: Record<string, unknown>[] } {
+  const runs: Record<string, unknown>[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      if (cmd.cmd === "graph_get_object_info") {
+        return {
+          content: [{ type: "text", text: JSON.stringify(script.objectInfo ?? objectInfo(true)) }],
+        };
+      }
+      if (cmd.cmd === "graph_query") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                total: 1,
+                shown: 1,
+                text: JSON.stringify({ id: 380, type: "VHS_VideoCombine" }),
+                nodes: [{ id: 380, type: "VHS_VideoCombine" }],
+              }),
+            },
+          ],
+        };
+      }
+      if (cmd.cmd !== "graph_run") {
+        return { content: [{ type: "text", text: "{}" }] };
+      }
+      runs.push(cmd);
+      const reply = script.graphRun
+        ? script.graphRun(cmd, runs.length)
+        : { queued: false, error: VHS_REFUSAL };
+      if ("content" in reply) return reply as ToolResult;
+      return { content: [{ type: "text", text: JSON.stringify(reply) }] };
+    },
+    confirm: async () => "yes" as const,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "t-2529",
+  };
+  return { ctx, runs };
+}
+
+beforeEach(() => {
+  RunCompletions.reset();
+  __panelToolsTestHooks.setRetrySettleMs(0);
+  setOutputNodeObjectInfoForTests(undefined);
+  setEnqueueScopedOutputNodeForTests(null);
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setRetrySettleMs(null);
+  setOutputNodeObjectInfoForTests(undefined);
+  setEnqueueScopedOutputNodeForTests(null);
+  RunCompletions.reset();
+});
+
+describe("panel_run accepts VHS_VideoCombine as to_node_id from object_info (#2529)", () => {
+  it("FAILS closed when object_info does not mark the class as an output node", async () => {
+    const { ctx, runs } = runCtx({ objectInfo: objectInfo(false) });
+    const res = await panelRun().handler({ to_node_id: 380 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/not an output node/);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.output_node).toBeUndefined();
+  });
+
+  it("re-issues graph_run with output_node:true once object_info says OUTPUT_NODE", async () => {
+    const { ctx, runs } = runCtx({
+      graphRun: (cmd, attempt) => {
+        if (attempt === 1) return { queued: false, error: VHS_REFUSAL };
+        expect(cmd.output_node).toBe(true);
+        expect(cmd.to_node_id).toBe(380);
+        return { queued: true, prompt_id: "p-vhs-retry" };
+      },
+    });
+    const res = await panelRun().handler({ to_node_id: 380 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(2);
+    expect(runs[1]).toMatchObject({
+      cmd: "graph_run",
+      to_node_id: 380,
+      output_node: true,
+    });
+    expect(textOf(res)).toMatch(/p-vhs-retry/);
+    expect(RunCompletions.ticketFor("p-vhs-retry")).toBeDefined();
+  });
+
+  it("falls back to /prompt partial_execution_targets when the panel still refuses", async () => {
+    const enqueued: Array<{ targets: string[] }> = [];
+    setEnqueueScopedOutputNodeForTests(async (_workflow, targets) => {
+      enqueued.push({ targets });
+      return { prompt_id: "p-vhs-http" };
+    });
+    const { ctx, runs } = runCtx({
+      graphRun: () => ({ queued: false, error: VHS_REFUSAL }),
+    });
+    const res = await panelRun().handler({ to_node_id: 380 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs.length).toBeGreaterThanOrEqual(2);
+    expect(enqueued).toEqual([{ targets: ["380"] }]);
+    expect(textOf(res)).toMatch(/p-vhs-http/);
+    expect(textOf(res)).toMatch(/output_node_source/);
+    expect(RunCompletions.ticketFor("p-vhs-http")).toBeDefined();
+  });
+
+  it("does not recover a non-output class (KSampler) even if the refusal shape matches", async () => {
+    const samplerRefusal =
+      `node 12 (KSampler) is not an output node — "run to node" can ` +
+      `only target an output node such as SaveImage, PreviewImage, or SaveVideo.`;
+    const { ctx, runs } = runCtx({
+      objectInfo: {
+        ok: true,
+        object_info: {
+          KSampler: {
+            input: { required: {} },
+            output: ["LATENT"],
+            output_is_list: [false],
+            output_name: ["LATENT"],
+            name: "KSampler",
+            display_name: "KSampler",
+            description: "",
+            category: "sampling",
+            output_node: false,
+          },
+        },
+      },
+      graphRun: () => ({ queued: false, error: samplerRefusal }),
+    });
+    const res = await panelRun().handler({ to_node_id: 12 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/not an output node/);
+    expect(runs).toHaveLength(1);
+  });
+});
+
+describe("panel_query_graph stamps is_output from object_info (#2529)", () => {
+  it("adds is_output:true on VHS_VideoCombine when object_info.output_node is true", async () => {
+    setOutputNodeObjectInfoForTests(objectInfo(true).object_info);
+    const { ctx } = runCtx({});
+    const res = await panelQueryGraph().handler({ ids: [380], fields: "detail" }, ctx);
+    const payload = JSON.parse(textOf(res)) as {
+      nodes?: Array<{ type?: string; is_output?: boolean }>;
+    };
+    expect(payload.nodes?.[0]).toMatchObject({
+      type: "VHS_VideoCombine",
+      is_output: true,
+    });
+  });
+});

--- a/src/__tests__/orchestrator/panel-run-2529-vhs-output-node.test.ts
+++ b/src/__tests__/orchestrator/panel-run-2529-vhs-output-node.test.ts
@@ -15,10 +15,12 @@ import {
   setOutputNodeObjectInfoForTests,
 } from "../../services/output-node.js";
 import type { ObjectInfo } from "../../comfyui/types.js";
+import { getComfyUIBaseUrl } from "../../config.js";
 
 const VHS_REFUSAL =
   `node 380 (VHS_VideoCombine) is not an output node — "run to node" can ` +
   `only target an output node such as SaveImage, PreviewImage, or SaveVideo.`;
+const WORKFLOW_UUID = "11111111-1111-4111-8111-111111111111";
 
 function panelRun() {
   const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_run");
@@ -61,6 +63,9 @@ function objectInfo(outputNode: boolean): { ok: true; object_info: ObjectInfo } 
 function runCtx(script: {
   graphRun?: (cmd: Record<string, unknown>, attempt: number) => Record<string, unknown> | ToolResult;
   objectInfo?: Record<string, unknown>;
+  viewing?: Record<string, unknown>;
+  serializedWorkflow?: Record<string, unknown>;
+  observedOrigin?: string;
 }): { ctx: PanelToolCtx; runs: Record<string, unknown>[] } {
   const runs: Record<string, unknown>[] = [];
   const ctx: PanelToolCtx = {
@@ -76,10 +81,28 @@ function runCtx(script: {
             {
               type: "text",
               text: JSON.stringify({
+                viewing: script.viewing ?? { scope: "root", workflow_uuid: WORKFLOW_UUID },
                 total: 1,
                 shown: 1,
                 text: JSON.stringify({ id: 380, type: "VHS_VideoCombine" }),
                 nodes: [{ id: 380, type: "VHS_VideoCombine" }],
+              }),
+            },
+          ],
+        };
+      }
+      if (cmd.cmd === "graph_serialize") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                workflow: script.serializedWorkflow ?? {
+                  nodes: [{ id: 380, type: "VHS_VideoCombine" }],
+                  links: [],
+                  extra: { comfyui_mcp: { workflow_uuid: WORKFLOW_UUID } },
+                },
+                node_count: 1,
               }),
             },
           ],
@@ -96,7 +119,9 @@ function runCtx(script: {
       return { content: [{ type: "text", text: JSON.stringify(reply) }] };
     },
     confirm: async () => "yes" as const,
-    bridge: {} as PanelToolCtx["bridge"],
+    bridge: {
+      tabServerOrigin: () => script.observedOrigin ?? getComfyUIBaseUrl(),
+    } as PanelToolCtx["bridge"],
     tabId: "t-2529",
   };
   return { ctx, runs };
@@ -168,6 +193,75 @@ describe("panel_run accepts VHS_VideoCombine as to_node_id from object_info (#25
     expect(RunCompletions.ticketFor("p-vhs-http")).toBeDefined();
   });
 
+  it("does not invent a numeric target for a nested node when the panel still refuses", async () => {
+    const enqueued: string[][] = [];
+    setEnqueueScopedOutputNodeForTests(async (_workflow, targets) => {
+      enqueued.push(targets);
+      return { prompt_id: "must-not-queue" };
+    });
+    const { ctx } = runCtx({
+      viewing: {
+        scope: "subgraph",
+        owner_node_id: 10,
+        workflow_uuid: WORKFLOW_UUID,
+      },
+      serializedWorkflow: {
+        nodes: [{ id: 10, type: "Subgraph" }],
+        links: [],
+        extra: { comfyui_mcp: { workflow_uuid: WORKFLOW_UUID } },
+        definitions: { subgraphs: [{ id: "subgraph-10", nodes: [], links: [] }] },
+      },
+      graphRun: () => ({ queued: false, error: VHS_REFUSAL }),
+    });
+    const res = await panelRun().handler({ to_node_id: 380 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/exact colon-qualified NodeExecutionId/);
+    expect(textOf(res)).toMatch(/No fallback prompt was sent/);
+    expect(enqueued).toEqual([]);
+  });
+
+  it("preserves batch_count and tickets every scoped fallback prompt", async () => {
+    const enqueued: Array<{ targets: string[]; batchCount: number }> = [];
+    setEnqueueScopedOutputNodeForTests(async (_workflow, targets, batchCount) => {
+      enqueued.push({ targets, batchCount });
+      return {
+        prompt_id: "p-vhs-batch-1",
+        prompt_ids: ["p-vhs-batch-1", "p-vhs-batch-2", "p-vhs-batch-3"],
+      };
+    });
+    const { ctx } = runCtx({
+      graphRun: () => ({ queued: false, error: VHS_REFUSAL }),
+    });
+    const res = await panelRun().handler({ to_node_id: 380, batch_count: 3 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(enqueued).toEqual([{ targets: ["380"], batchCount: 3 }]);
+    expect(textOf(res)).toMatch(/p-vhs-batch-1/);
+    expect(textOf(res)).toMatch(/p-vhs-batch-2/);
+    expect(textOf(res)).toMatch(/p-vhs-batch-3/);
+    expect(RunCompletions.ticketFor("p-vhs-batch-1")).toBeDefined();
+    expect(RunCompletions.ticketFor("p-vhs-batch-2")).toBeDefined();
+    expect(RunCompletions.ticketFor("p-vhs-batch-3")).toBeDefined();
+  });
+
+  it("fails closed when the panel and serialized workflow identities disagree", async () => {
+    const enqueued: string[][] = [];
+    setEnqueueScopedOutputNodeForTests(async (_workflow, targets) => {
+      enqueued.push(targets);
+      return { prompt_id: "must-not-queue" };
+    });
+    const { ctx } = runCtx({
+      viewing: { scope: "root", workflow_uuid: "22222222-2222-4222-8222-222222222222" },
+      graphRun: () => ({ queued: false, error: VHS_REFUSAL }),
+    });
+    const res = await panelRun().handler({ to_node_id: 380 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/same workflow identity/);
+    expect(enqueued).toEqual([]);
+  });
+
   it("surfaces a direct fallback enqueue error instead of restoring the original refusal", async () => {
     setEnqueueScopedOutputNodeForTests(async () => {
       throw new Error(
@@ -233,6 +327,19 @@ describe("panel_run accepts VHS_VideoCombine as to_node_id from object_info (#25
 describe("panel_query_graph stamps is_output from object_info (#2529)", () => {
   it("adds is_output:true on VHS_VideoCombine when object_info.output_node is true", async () => {
     setOutputNodeObjectInfoForTests(objectInfo(true).object_info);
+    const { ctx } = runCtx({});
+    const res = await panelQueryGraph().handler({ ids: [380], fields: "detail" }, ctx);
+    const payload = JSON.parse(textOf(res)) as {
+      nodes?: Array<{ type?: string; is_output?: boolean }>;
+    };
+    expect(payload.nodes?.[0]).toMatchObject({
+      type: "VHS_VideoCombine",
+      is_output: true,
+    });
+  });
+
+  it("refreshes object_info through the panel when the headless cache is cold", async () => {
+    setOutputNodeObjectInfoForTests(undefined);
     const { ctx } = runCtx({});
     const res = await panelQueryGraph().handler({ ids: [380], fields: "detail" }, ctx);
     const payload = JSON.parse(textOf(res)) as {

--- a/src/__tests__/services/output-node.test.ts
+++ b/src/__tests__/services/output-node.test.ts
@@ -1,0 +1,85 @@
+// #2529 — VHS_VideoCombine (and any class with object_info.output_node) is a
+// terminal output. Classification must follow live /object_info, not a name list.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  isOutputNodeType,
+  parseNotOutputNodeRefusal,
+  setOutputNodeObjectInfoForTests,
+  stampOutputNodeFlags,
+} from "../../services/output-node.js";
+import type { ObjectInfo } from "../../comfyui/types.js";
+
+const VHS_REFUSAL =
+  `node 380 (VHS_VideoCombine) is not an output node — "run to node" can ` +
+  `only target an output node such as SaveImage, PreviewImage, or SaveVideo.`;
+
+function def(outputNode: boolean): ObjectInfo[string] {
+  return {
+    input: { required: {} },
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    name: "x",
+    display_name: "x",
+    description: "",
+    category: "video",
+    output_node: outputNode,
+  };
+}
+
+afterEach(() => {
+  setOutputNodeObjectInfoForTests(undefined);
+});
+
+describe("output-node classification from object_info (#2529)", () => {
+  it("treats VHS_VideoCombine as an output only when object_info.output_node is true", () => {
+    expect(isOutputNodeType("VHS_VideoCombine", undefined)).toBe(false);
+    expect(isOutputNodeType("VHS_VideoCombine", {})).toBe(false);
+    expect(
+      isOutputNodeType("VHS_VideoCombine", { VHS_VideoCombine: def(false) }),
+    ).toBe(false);
+    expect(
+      isOutputNodeType("VHS_VideoCombine", { VHS_VideoCombine: def(true) }),
+    ).toBe(true);
+  });
+
+  it("does not hardcode VHS_VideoCombine — an unknown OUTPUT_NODE class is accepted too", () => {
+    expect(
+      isOutputNodeType("SomeCustomSave", { SomeCustomSave: def(true) }),
+    ).toBe(true);
+    expect(isOutputNodeType("SaveImage", { SaveImage: def(false) })).toBe(false);
+  });
+
+  it("parses the panel's not-an-output-node refusal", () => {
+    expect(parseNotOutputNodeRefusal(VHS_REFUSAL)).toEqual({
+      nodeId: 380,
+      classType: "VHS_VideoCombine",
+    });
+    expect(parseNotOutputNodeRefusal("node 8 is not an output node")).toBeNull();
+    expect(parseNotOutputNodeRefusal("prompt_no_outputs")).toBeNull();
+  });
+
+  it("stamps is_output:true on query rows from object_info, not from the class name", () => {
+    const payload = {
+      text: JSON.stringify({ id: 380, type: "VHS_VideoCombine" }),
+      nodes: [
+        { id: 380, type: "VHS_VideoCombine" },
+        { id: 1, type: "KSampler" },
+      ],
+    };
+    const stamped = stampOutputNodeFlags(payload, {
+      VHS_VideoCombine: def(true),
+      KSampler: def(false),
+    });
+    expect(stamped.nodes).toEqual([
+      { id: 380, type: "VHS_VideoCombine", is_output: true },
+      { id: 1, type: "KSampler" },
+    ]);
+    expect(JSON.parse(String(stamped.text))).toMatchObject({
+      id: 380,
+      type: "VHS_VideoCombine",
+      is_output: true,
+    });
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -415,6 +415,11 @@ let objectInfoInflight: Promise<ObjectInfo> | null = null;
 // stale value (codex WS-3 finding #1).
 let objectInfoEpoch = 0;
 
+/** Fresh `/object_info` snapshot, or null when the cache is empty or expired. */
+export function peekObjectInfoCache(): ObjectInfo | null {
+  return objectInfoCacheFresh() ? objectInfoCache : null;
+}
+
 function objectInfoCacheFresh(): boolean {
   if (objectInfoCache === null) return false;
   const age = Date.now() - objectInfoCachedAt;
@@ -778,7 +783,7 @@ function describeRejectedOutputs(nodeErrors: unknown): string | undefined {
 export async function enqueuePrompt(
   workflow: Record<string, unknown>,
   extraData?: Record<string, unknown>,
-  opts?: { front?: boolean },
+  opts?: { front?: boolean; partialExecutionTargets?: readonly string[] },
 ): Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }> {
   if (isCloudMode()) return cloudClient.enqueuePrompt(workflow, extraData);
 
@@ -799,6 +804,9 @@ export async function enqueuePrompt(
       client_id: "comfyui-mcp",
       ...(extraData ? { extra_data: extraData } : {}),
       ...(opts?.front ? { front: true } : {}),
+      ...(opts?.partialExecutionTargets?.length
+        ? { partial_execution_targets: [...opts.partialExecutionTargets] }
+        : {}),
     }),
   });
   if (!res.ok) {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -785,7 +785,7 @@ export async function enqueuePrompt(
   extraData?: Record<string, unknown>,
   opts?: { front?: boolean; partialExecutionTargets?: readonly string[] },
 ): Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }> {
-  if (isCloudMode()) return cloudClient.enqueuePrompt(workflow, extraData);
+  if (isCloudMode()) return cloudClient.enqueuePrompt(workflow, extraData, opts);
 
   // POST /prompt directly (rather than the SDK's _enqueue_prompt) for two
   // reasons: (1) the SDK does not forward `extra_data` — how comfy.org API-node

--- a/src/comfyui/cloud-client.ts
+++ b/src/comfyui/cloud-client.ts
@@ -118,11 +118,15 @@ export interface CloudJobStatus {
 export async function enqueuePrompt(
   workflow: Record<string, unknown>,
   extraData?: Record<string, unknown>,
+  opts?: { partialExecutionTargets?: readonly string[] },
 ): Promise<{ prompt_id: string; queue_remaining?: number }> {
   logger.info("Cloud: submitting workflow to Comfy Cloud");
   const body: Record<string, unknown> = { prompt: workflow };
   if (extraData && Object.keys(extraData).length > 0) {
     body.extra_data = extraData;
+  }
+  if (opts?.partialExecutionTargets?.length) {
+    body.partial_execution_targets = [...opts.partialExecutionTargets];
   }
   const res = await cloudFetch("/api/prompt", {
     method: "POST",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -20809,50 +20809,50 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       async (args: A, ctx) =>
         stampOutputNodeFlagsOnToolResult(
           projectFindNodesReply(
-          withTruncationHints(
-            await ctx.call({
-              cmd: "graph_find_nodes",
-              query: args.query,
-              type: args.type,
-              title: args.title,
-              input: args.input,
-              output: args.output,
-              widget: args.widget,
-              widget_value: args.widget_value,
-              is_output: args.is_output,
-              is_subgraph: args.is_subgraph,
-              mode: args.mode,
-              limit: args.limit,
-            }),
-            [
-            {
-              flag: "truncated",
-              key: "truncation_hint",
-              // #809 (defect 2): the scan STOPS at the cap, so `count` is not a match
-              // total and the absent matches are not "no more matches".
-              //
-              // The wording is deliberately "may be incomplete", not "there ARE more"
-              // (codex gate): this orchestrator ships ahead of the panel, and a panel
-              // build older than the matching panel PR sets `truncated` on an EXACT-cap
-              // result that dropped nothing. Asserting more exist would manufacture the
-              // very false alarm this issue is removing. A current panel supplies its own
-              // precise hint and the rider defers to it.
-              text: (p) => {
-                const inForce =
-                  typeof args.limit === "number" ? args.limit : FIND_NODES_DEFAULT_LIMIT;
-                const raise =
-                  inForce >= FIND_NODES_LIMIT_CEILING
-                    ? `\`limit\` is already at its ceiling of ${FIND_NODES_LIMIT_CEILING}, so narrow with \`type\`/\`title\`/\`widget_value\` instead`
-                    : `Raise \`limit\` up to ${FIND_NODES_LIMIT_CEILING}, or narrow with \`type\`/\`title\`/\`widget_value\``;
-                return (
-                  `The scan reached \`limit\`=${inForce} at ${replyCount(p, "matches") ?? "the cap"} match(es), so this result MAY be incomplete — ` +
-                  `treat it as "not proof a node is absent" rather than as the full match set. ${raise}.`
-                );
-              },
-            },
-            ],
-          ),
-          args.fields,
+            withTruncationHints(
+              await ctx.call({
+                cmd: "graph_find_nodes",
+                query: args.query,
+                type: args.type,
+                title: args.title,
+                input: args.input,
+                output: args.output,
+                widget: args.widget,
+                widget_value: args.widget_value,
+                is_output: args.is_output,
+                is_subgraph: args.is_subgraph,
+                mode: args.mode,
+                limit: args.limit,
+              }),
+              [
+                {
+                  flag: "truncated",
+                  key: "truncation_hint",
+                  // #809 (defect 2): the scan STOPS at the cap, so `count` is not a match
+                  // total and the absent matches are not "no more matches".
+                  //
+                  // The wording is deliberately "may be incomplete", not "there ARE more"
+                  // (codex gate): this orchestrator ships ahead of the panel, and a panel
+                  // build older than the matching panel PR sets `truncated` on an EXACT-cap
+                  // result that dropped nothing. Asserting more exist would manufacture the
+                  // very false alarm this issue is removing. A current panel supplies its own
+                  // precise hint and the rider defers to it.
+                  text: (p) => {
+                    const inForce =
+                      typeof args.limit === "number" ? args.limit : FIND_NODES_DEFAULT_LIMIT;
+                    const raise =
+                      inForce >= FIND_NODES_LIMIT_CEILING
+                        ? `\`limit\` is already at its ceiling of ${FIND_NODES_LIMIT_CEILING}, so narrow with \`type\`/\`title\`/\`widget_value\` instead`
+                        : `Raise \`limit\` up to ${FIND_NODES_LIMIT_CEILING}, or narrow with \`type\`/\`title\`/\`widget_value\``;
+                    return (
+                      `The scan reached \`limit\`=${inForce} at ${replyCount(p, "matches") ?? "the cap"} match(es), so this result MAY be incomplete — ` +
+                      `treat it as "not proof a node is absent" rather than as the full match set. ${raise}.`
+                    );
+                  },
+                },
+              ],
+            ),
+            args.fields,
           ),
           outputNodeObjectInfoNow(),
         ),

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -464,7 +464,7 @@ import {
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
 import type { ObjectInfo } from "../comfyui/types.js";
 import {
-  outputNodeObjectInfoNow,
+  outputNodeObjectInfoForPanel,
   recoverOutputNodeScopedRun,
   stampOutputNodeFlagsOnToolResult,
 } from "../services/output-node.js";
@@ -20481,8 +20481,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           return fail(contentOnlyRootShapeReadNote(toolResultText(panelReply)));
         }
         rememberLiveRootViewing(ctx, parseToolResultJson(panelReply)?.viewing);
+        const outputNodeObjectInfo = await outputNodeObjectInfoForPanel(
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+          panelReply,
+        );
         return fitQueryGraphReply(
-          stampOutputNodeFlagsOnToolResult(panelReply, outputNodeObjectInfoNow()),
+          stampOutputNodeFlagsOnToolResult(panelReply, outputNodeObjectInfo),
           args.max_chars,
           widgetMaxChars.note ?? legacyWidgetMaxCharsNote(panelReply, widgetMaxChars.value),
         );
@@ -20806,9 +20810,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             `Projection: 'compact' (default) keeps id/type/title/mode/is_output/is_subgraph and the matched_on reasons; 'ids' returns bare ids; 'detail' is the full node summary with every widget, socket and the node description. The reply echoes the projection it applied.`,
           ),
       },
-      async (args: A, ctx) =>
-        stampOutputNodeFlagsOnToolResult(
-          projectFindNodesReply(
+      async (args: A, ctx) => {
+        const findReply = projectFindNodesReply(
             withTruncationHints(
               await ctx.call({
                 cmd: "graph_find_nodes",
@@ -20853,9 +20856,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               ],
             ),
             args.fields,
-          ),
-          outputNodeObjectInfoNow(),
-        ),
+          );
+        const outputNodeObjectInfo = await outputNodeObjectInfoForPanel(
+          (cmd, timeoutMs) => ctx.call(cmd, timeoutMs),
+          findReply,
+        );
+        return stampOutputNodeFlagsOnToolResult(findReply, outputNodeObjectInfo);
+      },
     ),
     def(
       "panel_add_node",
@@ -23105,7 +23112,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_run",
-      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). On success it confirms the run was queued; if ComfyUI REFUSES the prompt (validation failure on either channel — per-node node_errors OR a top-level error like a missing node type) it returns a FAILURE with that rejection detail, never a false 'queued'. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, VHS_VideoCombine, or any class whose live /object_info has output_node:true) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. The output node may be NESTED inside a subgraph — just pass its id (resolved in the scope you're currently viewing, then anywhere in the workflow); the tool builds the nested execution path for you. Omit it to run the whole graph. DUPLICATE FENCE (#862): if a render this session cannot account for is already in flight (after a reconnect this is usually YOUR earlier render still running — the queue record does not survive a restart), the run is REFUSED before anything is queued and the in-flight prompt is named; inspect queue (action:'list') first, then pass allow_duplicate:true once you have decided it is fine to run behind what is there — a scoped to_node_id preview after a reconnect is the ordinary case for it, a deliberate sweep/batch the other. Use this so the render runs on THEIR canvas and they see the result.",
+      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). On success it confirms the run was queued; if ComfyUI REFUSES the prompt (validation failure on either channel — per-node node_errors OR a top-level error like a missing node type) it returns a FAILURE with that rejection detail, never a false 'queued'. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, VHS_VideoCombine, or any class whose live /object_info has output_node:true) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. The output node may be NESTED inside a subgraph — just pass its id (resolved in the scope you're currently viewing, then anywhere in the workflow); the connected panel builds the exact nested execution path for you. If a legacy panel still refuses this class, recovery uses /prompt only for an identity-proven root target and FAILS CLOSED rather than guessing a numeric target for a nested execution path. Omit it to run the whole graph. DUPLICATE FENCE (#862): if a render this session cannot account for is already in flight (after a reconnect this is usually YOUR earlier render still running — the queue record does not survive a restart), the run is REFUSED before anything is queued and the in-flight prompt is named; inspect queue (action:'list') first, then pass allow_duplicate:true once you have decided it is fine to run behind what is there — a scoped to_node_id preview after a reconnect is the ordinary case for it, a deliberate sweep/batch the other. Use this so the render runs on THEIR canvas and they see the result.",
       {
         batch_count: z
           .number()
@@ -23519,6 +23526,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 cmd,
                 timeoutMs,
                 cmd.cmd === "graph_run" ? observeRunRid : undefined,
+              ),
+            // The direct fallback is allowed only when the panel's server-observed
+            // origin proves the configured headless target (cloud uses its scoped
+            // cloud payload instead). A missing or contradictory origin fails closed.
+            directFallbackAllowed:
+              isCloudMode() ||
+              sameHttpBase(
+                ctx.bridge?.tabServerOrigin?.(ctx.tabId),
+                getComfyUIBaseUrl(),
               ),
           });
           if (recovered) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -464,6 +464,11 @@ import {
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
 import type { ObjectInfo } from "../comfyui/types.js";
 import {
+  outputNodeObjectInfoNow,
+  recoverOutputNodeScopedRun,
+  stampOutputNodeFlagsOnToolResult,
+} from "../services/output-node.js";
+import {
   captureComfyUITargetFence,
   restartComfyUI,
   preflightLocalRestart,
@@ -20477,7 +20482,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         }
         rememberLiveRootViewing(ctx, parseToolResultJson(panelReply)?.viewing);
         return fitQueryGraphReply(
-          panelReply,
+          stampOutputNodeFlagsOnToolResult(panelReply, outputNodeObjectInfoNow()),
           args.max_chars,
           widgetMaxChars.note ?? legacyWidgetMaxCharsNote(panelReply, widgetMaxChars.value),
         );
@@ -20802,7 +20807,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           ),
       },
       async (args: A, ctx) =>
-        projectFindNodesReply(
+        stampOutputNodeFlagsOnToolResult(
+          projectFindNodesReply(
           withTruncationHints(
             await ctx.call({
               cmd: "graph_find_nodes",
@@ -20847,6 +20853,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             ],
           ),
           args.fields,
+          ),
+          outputNodeObjectInfoNow(),
         ),
     ),
     def(
@@ -23097,7 +23105,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_run",
-      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). On success it confirms the run was queued; if ComfyUI REFUSES the prompt (validation failure on either channel — per-node node_errors OR a top-level error like a missing node type) it returns a FAILURE with that rejection detail, never a false 'queued'. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, …) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. The output node may be NESTED inside a subgraph — just pass its id (resolved in the scope you're currently viewing, then anywhere in the workflow); the tool builds the nested execution path for you. Omit it to run the whole graph. DUPLICATE FENCE (#862): if a render this session cannot account for is already in flight (after a reconnect this is usually YOUR earlier render still running — the queue record does not survive a restart), the run is REFUSED before anything is queued and the in-flight prompt is named; inspect queue (action:'list') first, then pass allow_duplicate:true once you have decided it is fine to run behind what is there — a scoped to_node_id preview after a reconnect is the ordinary case for it, a deliberate sweep/batch the other. Use this so the render runs on THEIR canvas and they see the result.",
+      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). On success it confirms the run was queued; if ComfyUI REFUSES the prompt (validation failure on either channel — per-node node_errors OR a top-level error like a missing node type) it returns a FAILURE with that rejection detail, never a false 'queued'. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, VHS_VideoCombine, or any class whose live /object_info has output_node:true) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. The output node may be NESTED inside a subgraph — just pass its id (resolved in the scope you're currently viewing, then anywhere in the workflow); the tool builds the nested execution path for you. Omit it to run the whole graph. DUPLICATE FENCE (#862): if a render this session cannot account for is already in flight (after a reconnect this is usually YOUR earlier render still running — the queue record does not survive a restart), the run is REFUSED before anything is queued and the in-flight prompt is named; inspect queue (action:'list') first, then pass allow_duplicate:true once you have decided it is fine to run behind what is there — a scoped to_node_id preview after a reconnect is the ordinary case for it, a deliberate sweep/batch the other. Use this so the render runs on THEIR canvas and they see the result.",
       {
         batch_count: z
           .number()
@@ -23495,6 +23503,28 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 `nothing. Do NOT re-run blindly: check the queue (action:"list") or ` +
                 `get_history before deciding. (${err instanceof Error ? err.message : String(err)})`,
             );
+          }
+        }
+        // #2529 — the panel refuses run-to-node when constructor.nodeData.output_node
+        // is missing, even for classes whose live /object_info OUTPUT_NODE is true
+        // (VHS_VideoCombine). Consult that metadata and recover before surfacing.
+        if (rejection && typeof args.to_node_id === "number") {
+          const recovered = await recoverOutputNodeScopedRun({
+            toNodeId: args.to_node_id,
+            res,
+            rejection,
+            batchCount: typeof args.batch_count === "number" ? args.batch_count : undefined,
+            call: (cmd, timeoutMs) =>
+              ctx.call(
+                cmd,
+                timeoutMs,
+                cmd.cmd === "graph_run" ? observeRunRid : undefined,
+              ),
+          });
+          if (recovered) {
+            res = recovered as ToolResult;
+            await reconcileRun();
+            rejection = detectRunRejection(res);
           }
         }
         if (rejection) {

--- a/src/services/output-node.ts
+++ b/src/services/output-node.ts
@@ -126,17 +126,16 @@ function stampNode(node: Record<string, unknown>, objectInfo: ObjectInfo): void 
   if (isOutputNodeType(classType, objectInfo)) node.is_output = true;
 }
 
-function stampValue(value: unknown, objectInfo: ObjectInfo, depth: number): unknown {
-  if (depth > 8 || value == null) return value;
+function stampValue(value: unknown, objectInfo: ObjectInfo, depth: number): void {
+  if (depth > 8 || value == null) return;
   if (Array.isArray(value)) {
     for (const item of value) stampValue(item, objectInfo, depth + 1);
-    return value;
+    return;
   }
   const rec = asRecord(value);
-  if (!rec) return value;
+  if (!rec) return;
   stampNode(rec, objectInfo);
   for (const nested of Object.values(rec)) stampValue(nested, objectInfo, depth + 1);
-  return rec;
 }
 
 function stampJsonLines(text: string, objectInfo: ObjectInfo): string {

--- a/src/services/output-node.ts
+++ b/src/services/output-node.ts
@@ -1,0 +1,333 @@
+/**
+ * #2529 — terminal-output classification from live `/object_info` `output_node`.
+ *
+ * ComfyUI's backend executes any class with `OUTPUT_NODE = True`. The panel's
+ * run-to-node guard keys `node.constructor.nodeData.output_node` instead, which
+ * is missing on some custom frontend classes (VHS_VideoCombine) even when the
+ * backend metadata is true. Classify from object_info — never a name list.
+ */
+
+import type { ObjectInfo, UiWorkflow, WorkflowJSON } from "../comfyui/types.js";
+import { enqueuePrompt, peekObjectInfoCache } from "../comfyui/client.js";
+import { convertUiToApi, isUiFormat } from "./workflow-converter.js";
+
+export const NOT_OUTPUT_NODE_RE =
+  /node\s+(\d+)\s+\(([^)]+)\)\s+is not an output node/i;
+
+export type NotOutputNodeRefusal = {
+  nodeId: number;
+  classType: string;
+};
+
+export type ToolResultLike = {
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "image"; data: string; mimeType: string }
+  >;
+  isError?: boolean;
+};
+
+type GraphCall = (
+  cmd: Record<string, unknown>,
+  timeoutMs?: number,
+) => Promise<ToolResultLike>;
+
+let objectInfoOverride: ObjectInfo | null | undefined;
+let enqueueScopedOutputNodeOverride:
+  | ((
+      workflow: WorkflowJSON,
+      targets: string[],
+    ) => Promise<{ prompt_id: string }>)
+  | null = null;
+
+/** Test seam: overlay / recovery object_info without a live ComfyUI. */
+export function setOutputNodeObjectInfoForTests(
+  info: ObjectInfo | null | undefined,
+): void {
+  objectInfoOverride = info;
+}
+
+/** Test seam: HTTP `/prompt` fallback without posting to a real ComfyUI. */
+export function setEnqueueScopedOutputNodeForTests(
+  fn:
+    | ((
+        workflow: WorkflowJSON,
+        targets: string[],
+      ) => Promise<{ prompt_id: string }>)
+    | null,
+): void {
+  enqueueScopedOutputNodeOverride = fn;
+}
+
+export function outputNodeObjectInfoNow(): ObjectInfo | null {
+  if (objectInfoOverride !== undefined) return objectInfoOverride;
+  return peekObjectInfoCache();
+}
+
+export function isOutputNodeType(
+  classType: string,
+  objectInfo: ObjectInfo | null | undefined,
+): boolean {
+  if (!classType || !objectInfo) return false;
+  return objectInfo[classType]?.output_node === true;
+}
+
+export function toolResultText(res: ToolResultLike): string {
+  return (res.content ?? [])
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+export function parseToolResultJson(
+  res: ToolResultLike,
+): Record<string, unknown> | null {
+  const text = res.content.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    return asRecord(JSON.parse(text));
+  } catch {
+    return null;
+  }
+}
+
+export function parseNotOutputNodeRefusal(
+  source: string | ToolResultLike,
+): NotOutputNodeRefusal | null {
+  const text = typeof source === "string" ? source : toolResultText(source);
+  const m = text.match(NOT_OUTPUT_NODE_RE);
+  if (!m) return null;
+  const nodeId = Number(m[1]);
+  const classType = m[2]?.trim() ?? "";
+  if (!Number.isInteger(nodeId) || !classType) return null;
+  return { nodeId, classType };
+}
+
+function nodeClassType(node: Record<string, unknown>): string | null {
+  if (typeof node.type === "string" && node.type) return node.type;
+  if (typeof node.class_type === "string" && node.class_type) return node.class_type;
+  return null;
+}
+
+function stampNode(node: Record<string, unknown>, objectInfo: ObjectInfo): void {
+  const classType = nodeClassType(node);
+  if (!classType) return;
+  if (isOutputNodeType(classType, objectInfo)) node.is_output = true;
+}
+
+function stampValue(value: unknown, objectInfo: ObjectInfo, depth: number): unknown {
+  if (depth > 8 || value == null) return value;
+  if (Array.isArray(value)) {
+    for (const item of value) stampValue(item, objectInfo, depth + 1);
+    return value;
+  }
+  const rec = asRecord(value);
+  if (!rec) return value;
+  stampNode(rec, objectInfo);
+  for (const nested of Object.values(rec)) stampValue(nested, objectInfo, depth + 1);
+  return rec;
+}
+
+function stampJsonLines(text: string, objectInfo: ObjectInfo): string {
+  const lines = text.split("\n");
+  let changed = false;
+  const out = lines.map((line) => {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) return line;
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      const rec = asRecord(parsed);
+      if (!rec) return line;
+      const before = rec.is_output;
+      stampNode(rec, objectInfo);
+      if (rec.is_output === before) return line;
+      changed = true;
+      return JSON.stringify(rec);
+    } catch {
+      return line;
+    }
+  });
+  return changed ? out.join("\n") : text;
+}
+
+/**
+ * Add `is_output:true` on live-graph rows whose class has `output_node:true`
+ * in object_info. Does not invent `is_output:false`.
+ */
+export function stampOutputNodeFlags(
+  payload: Record<string, unknown>,
+  objectInfo: ObjectInfo | null | undefined,
+): Record<string, unknown> {
+  if (!objectInfo) return payload;
+  stampValue(payload, objectInfo, 0);
+  if (typeof payload.text === "string") {
+    payload.text = stampJsonLines(payload.text, objectInfo);
+  }
+  return payload;
+}
+
+export function stampOutputNodeFlagsOnToolResult<T extends ToolResultLike>(
+  res: T,
+  objectInfo: ObjectInfo | null | undefined,
+): T {
+  if (!objectInfo || res.isError) return res;
+  const payload = parseToolResultJson(res);
+  if (!payload) return res;
+  const stamped = stampOutputNodeFlags(payload, objectInfo);
+  const idx = res.content.findIndex((c) => c.type === "text");
+  if (idx < 0) return res;
+  return {
+    ...res,
+    content: res.content.map((c, i) =>
+      i === idx && c.type === "text"
+        ? { ...c, text: JSON.stringify(stamped, null, 2) }
+        : c,
+    ),
+  };
+}
+
+function objectInfoFromReply(reply: unknown): ObjectInfo | null {
+  const rec = asRecord(reply);
+  if (!rec) return null;
+  const info = rec.object_info ?? rec;
+  const map = asRecord(info);
+  if (!map) return null;
+  for (const def of Object.values(map)) {
+    const node = asRecord(def);
+    if (node && ("input" in node || "output" in node || "output_node" in node)) {
+      return map as ObjectInfo;
+    }
+  }
+  return null;
+}
+
+async function fetchPanelObjectInfo(call: GraphCall): Promise<ObjectInfo | null> {
+  if (objectInfoOverride !== undefined) return objectInfoOverride;
+  try {
+    const reply = await call({ cmd: "graph_get_object_info" }, 90_000);
+    if (reply.isError) return null;
+    return objectInfoFromReply(parseToolResultJson(reply));
+  } catch {
+    return null;
+  }
+}
+
+function uiWorkflowFromSerialize(payload: Record<string, unknown> | null): UiWorkflow | null {
+  if (!payload) return null;
+  const inner = payload.workflow ?? payload;
+  return isUiFormat(inner) ? inner : null;
+}
+
+async function enqueueConvertedScopedRun(
+  toNodeId: number,
+  classType: string,
+  objectInfo: ObjectInfo,
+  call: GraphCall,
+): Promise<{ prompt_id: string } | null> {
+  const targetId = String(toNodeId);
+  const targets = [targetId];
+  if (enqueueScopedOutputNodeOverride) {
+    return enqueueScopedOutputNodeOverride(
+      { [targetId]: { class_type: classType, inputs: {} } },
+      targets,
+    );
+  }
+  const serialized = await call({ cmd: "graph_serialize" }, 8000);
+  if (serialized.isError) return null;
+  const ui = uiWorkflowFromSerialize(parseToolResultJson(serialized));
+  if (!ui) return null;
+  const converted = convertUiToApi(ui, objectInfo);
+  if (!converted.workflow[targetId]) return null;
+  return enqueuePrompt(converted.workflow, undefined, {
+    partialExecutionTargets: targets,
+  });
+}
+
+function queuedToolResult(
+  promptId: string,
+  toNodeId: number,
+  classType: string,
+): ToolResultLike {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            queued: true,
+            prompt_id: promptId,
+            to_node_id: toNodeId,
+            ran_to_node: toNodeId,
+            output_node_source: "object_info",
+            output_node_class: classType,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+/**
+ * When the panel refuses a scoped run as "not an output node", consult live
+ * object_info. If that class is `output_node:true`, retry graph_run (newer
+ * panels can honor `output_node:true`) and fall back to `/prompt` with
+ * `partial_execution_targets` — the field ComfyUI itself uses for run-to-node.
+ */
+export async function recoverOutputNodeScopedRun(opts: {
+  toNodeId: number;
+  res: ToolResultLike;
+  rejection: ToolResultLike;
+  batchCount?: number;
+  call: GraphCall;
+}): Promise<ToolResultLike | null> {
+  const parsed =
+    parseNotOutputNodeRefusal(opts.rejection) ??
+    parseNotOutputNodeRefusal(opts.res);
+  if (!parsed || parsed.nodeId !== opts.toNodeId) return null;
+
+  const objectInfo = await fetchPanelObjectInfo(opts.call);
+  if (!isOutputNodeType(parsed.classType, objectInfo) || !objectInfo) return null;
+
+  const retry = await opts.call(
+    {
+      cmd: "graph_run",
+      batch_count: opts.batchCount,
+      to_node_id: opts.toNodeId,
+      output_node: true,
+    },
+    20_000,
+  );
+  const retryParsed = parseToolResultJson(retry);
+  if (
+    !retry.isError &&
+    retryParsed?.queued !== false &&
+    (retryParsed?.queued === true || typeof retryParsed?.prompt_id === "string")
+  ) {
+    return retry;
+  }
+  if (!parseNotOutputNodeRefusal(retry)) {
+    // A different failure (validation, transport) — surface it rather than
+    // enqueueing a second prompt.
+    return retry;
+  }
+
+  try {
+    const enqueued = await enqueueConvertedScopedRun(
+      opts.toNodeId,
+      parsed.classType,
+      objectInfo,
+      opts.call,
+    );
+    if (!enqueued?.prompt_id) return null;
+    return queuedToolResult(enqueued.prompt_id, opts.toNodeId, parsed.classType);
+  } catch {
+    return null;
+  }
+}

--- a/src/services/output-node.ts
+++ b/src/services/output-node.ts
@@ -34,16 +34,25 @@ type GraphCall = (
 
 type ScopedEnqueueResult = {
   prompt_id: string;
+  prompt_ids?: string[];
   queue_remaining?: number;
   rejectedOutputs?: string;
 };
 
+type ScopedEnqueueOutcome =
+  | { result: ScopedEnqueueResult }
+  | { refusal: string }
+  | null;
+
+type ScopedEnqueueOverride = (
+  workflow: WorkflowJSON,
+  targets: string[],
+  batchCount: number,
+) => Promise<ScopedEnqueueResult>;
+
 let objectInfoOverride: ObjectInfo | null | undefined;
 let enqueueScopedOutputNodeOverride:
-  | ((
-      workflow: WorkflowJSON,
-      targets: string[],
-    ) => Promise<{ prompt_id: string }>)
+  | ScopedEnqueueOverride
   | null = null;
 
 /** Test seam: overlay / recovery object_info without a live ComfyUI. */
@@ -55,12 +64,7 @@ export function setOutputNodeObjectInfoForTests(
 
 /** Test seam: HTTP `/prompt` fallback without posting to a real ComfyUI. */
 export function setEnqueueScopedOutputNodeForTests(
-  fn:
-    | ((
-        workflow: WorkflowJSON,
-        targets: string[],
-      ) => Promise<{ prompt_id: string }>)
-    | null,
+  fn: ScopedEnqueueOverride | null,
 ): void {
   enqueueScopedOutputNodeOverride = fn;
 }
@@ -114,9 +118,11 @@ export function parseNotOutputNodeRefusal(
   return { nodeId, classType };
 }
 
-function nodeClassType(node: Record<string, unknown>): string | null {
-  if (typeof node.type === "string" && node.type) return node.type;
-  if (typeof node.class_type === "string" && node.class_type) return node.class_type;
+function nodeClassType(node: unknown): string | null {
+  const record = asRecord(node);
+  if (!record) return null;
+  if (typeof record.type === "string" && record.type) return record.type;
+  if (typeof record.class_type === "string" && record.class_type) return record.class_type;
   return null;
 }
 
@@ -222,10 +228,115 @@ async function fetchPanelObjectInfo(call: GraphCall): Promise<ObjectInfo | null>
   }
 }
 
+function containsUnstampedNode(value: unknown, depth = 0): boolean {
+  if (depth > 8 || value == null) return false;
+  if (Array.isArray(value)) return value.some((item) => containsUnstampedNode(item, depth + 1));
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed.startsWith("{")) return false;
+    try {
+      return containsUnstampedNode(JSON.parse(trimmed) as unknown, depth + 1);
+    } catch {
+      return false;
+    }
+  }
+  const record = asRecord(value);
+  if (!record) return false;
+  if (nodeClassType(record) && !("is_output" in record)) return true;
+  return Object.values(record).some((nested) => containsUnstampedNode(nested, depth + 1));
+}
+
+/** Use the fresh headless cache, or refresh the panel only when its reply has
+ * node rows whose output classification is absent. */
+export async function outputNodeObjectInfoForPanel(
+  call: GraphCall,
+  source?: ToolResultLike,
+): Promise<ObjectInfo | null> {
+  if (!source || source.isError || !containsUnstampedNode(parseToolResultJson(source))) return null;
+  return outputNodeObjectInfoNow() ?? fetchPanelObjectInfo(call);
+}
+
 function uiWorkflowFromSerialize(payload: Record<string, unknown> | null): UiWorkflow | null {
   if (!payload) return null;
   const inner = payload.workflow ?? payload;
   return isUiFormat(inner) ? inner : null;
+}
+
+function workflowUuidFromUi(ui: UiWorkflow): string | null {
+  const extra = asRecord(ui.extra);
+  const metadata = asRecord(extra?.comfyui_mcp);
+  const uuid = metadata?.workflow_uuid;
+  return typeof uuid === "string" && uuid.length > 0 ? uuid : null;
+}
+
+function scopedFallbackRefusal(reason: string): { refusal: string } {
+  return { refusal: reason };
+}
+
+function rootScopedFallbackWitness(
+  payload: Record<string, unknown> | null,
+  ui: UiWorkflow,
+  toNodeId: number,
+  classType: string,
+): { targetId: string } | { refusal: string } {
+  const viewing = asRecord(payload?.viewing);
+  if (viewing?.scope === "subgraph") {
+    return scopedFallbackRefusal(
+      `the panel reports the target is in a subgraph, but its exact colon-qualified ` +
+        `NodeExecutionId is not exposed to MCP; the panel retry must perform this nested run`,
+    );
+  }
+  if (viewing?.scope !== "root") {
+    return scopedFallbackRefusal(
+      `the panel did not provide a root viewing-scope witness, so the workflow target is ` +
+        `unproven`,
+    );
+  }
+
+  const panelUuid = viewing.workflow_uuid;
+  const serializedUuid = workflowUuidFromUi(ui);
+  if (
+    typeof panelUuid !== "string" ||
+    panelUuid.length === 0 ||
+    serializedUuid === null ||
+    panelUuid !== serializedUuid
+  ) {
+    return scopedFallbackRefusal(
+      `the panel graph and serialized workflow did not carry the same workflow identity; ` +
+        `no fallback prompt was sent`,
+    );
+  }
+
+  const targetId = String(toNodeId);
+  const rootNode = ui.nodes.find(
+    (node) => String(node.id) === targetId && nodeClassType(node) === classType,
+  );
+  if (!rootNode) {
+    return scopedFallbackRefusal(
+      `node ${targetId} is not present as the requested class on the serialized root ` +
+        `graph; an exact scoped target could not be proven`,
+    );
+  }
+
+  const queriedNodes = payload?.nodes;
+  if (
+    !Array.isArray(queriedNodes) ||
+    !queriedNodes.some((raw) => {
+      const node = asRecord(raw);
+      return node !== null && String(node.id) === targetId && nodeClassType(node) === classType;
+    })
+  ) {
+    return scopedFallbackRefusal(
+      `the panel's current root query did not return node ${targetId} as ` +
+        `${classType}; the target may have moved or changed`,
+    );
+  }
+  return { targetId };
+}
+
+function normalizedBatchCount(batchCount: number | undefined): number {
+  if (typeof batchCount !== "number" || !Number.isFinite(batchCount)) return 1;
+  return Math.max(1, Math.min(100, Math.floor(batchCount)));
 }
 
 async function enqueueConvertedScopedRun(
@@ -233,24 +344,84 @@ async function enqueueConvertedScopedRun(
   classType: string,
   objectInfo: ObjectInfo,
   call: GraphCall,
-): Promise<ScopedEnqueueResult | null> {
-  const targetId = String(toNodeId);
-  const targets = [targetId];
-  if (enqueueScopedOutputNodeOverride) {
-    return enqueueScopedOutputNodeOverride(
-      { [targetId]: { class_type: classType, inputs: {} } },
-      targets,
+  batchCount: number | undefined,
+  directFallbackAllowed: boolean,
+): Promise<ScopedEnqueueOutcome> {
+  if (!directFallbackAllowed) {
+    return scopedFallbackRefusal(
+      `the panel's server-observed origin was not proven to be the configured ComfyUI ` +
+        `target; direct /prompt fallback is disabled to prevent cross-instance queueing`,
     );
   }
+
   const serialized = await call({ cmd: "graph_serialize" }, 8000);
   if (serialized.isError) return null;
   const ui = uiWorkflowFromSerialize(parseToolResultJson(serialized));
   if (!ui) return null;
+  const queried = await call(
+    { cmd: "graph_query", ids: [toNodeId], fields: "detail", limit: 1 },
+    8000,
+  );
+  if (queried.isError) return null;
+  const witness = rootScopedFallbackWitness(
+    parseToolResultJson(queried),
+    ui,
+    toNodeId,
+    classType,
+  );
+  if ("refusal" in witness) return witness;
+
+  const targets = [witness.targetId];
   const converted = convertUiToApi(ui, objectInfo);
-  if (!converted.workflow[targetId]) return null;
-  return enqueuePrompt(converted.workflow, undefined, {
-    partialExecutionTargets: targets,
-  });
+  if (!converted.workflow[witness.targetId]) {
+    return scopedFallbackRefusal(
+      `the converted workflow did not contain root target ${witness.targetId}; ` +
+        `no unscoped prompt was sent`,
+    );
+  }
+
+  const count = normalizedBatchCount(batchCount);
+  if (enqueueScopedOutputNodeOverride) {
+    return {
+      result: await enqueueScopedOutputNodeOverride(converted.workflow, targets, count),
+    };
+  }
+
+  const results: ScopedEnqueueResult[] = [];
+  try {
+    for (let i = 0; i < count; i += 1) {
+      results.push(
+        await enqueuePrompt(converted.workflow, undefined, {
+          partialExecutionTargets: targets,
+        }),
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `${message} Direct scoped fallback had already accepted ${results.length} of ` +
+        `${count} requested batch run(s); do not blindly re-submit before checking ` +
+        `queue/history.`,
+    );
+  }
+
+  return {
+    result: {
+      prompt_id: results[0].prompt_id,
+      ...(results.length > 1
+        ? { prompt_ids: results.map((entry) => entry.prompt_id) }
+        : {}),
+      queue_remaining: results.at(-1)?.queue_remaining,
+      ...(results.some((entry) => entry.rejectedOutputs)
+        ? {
+            rejectedOutputs: results
+              .map((entry) => entry.rejectedOutputs)
+              .filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+              .join("\n"),
+          }
+        : {}),
+    },
+  };
 }
 
 function queuedToolResult(
@@ -266,6 +437,9 @@ function queuedToolResult(
           {
             queued: true,
             prompt_id: enqueued.prompt_id,
+            ...(enqueued.prompt_ids && enqueued.prompt_ids.length > 1
+              ? { prompt_ids: enqueued.prompt_ids }
+              : {}),
             to_node_id: toNodeId,
             ran_to_node: toNodeId,
             output_node_source: "object_info",
@@ -297,6 +471,7 @@ export async function recoverOutputNodeScopedRun(opts: {
   rejection: ToolResultLike;
   batchCount?: number;
   call: GraphCall;
+  directFallbackAllowed?: boolean;
 }): Promise<ToolResultLike | null> {
   const parsed =
     parseNotOutputNodeRefusal(opts.rejection) ??
@@ -353,9 +528,26 @@ export async function recoverOutputNodeScopedRun(opts: {
       parsed.classType,
       objectInfo,
       opts.call,
+      opts.batchCount,
+      opts.directFallbackAllowed === true,
     );
-    if (!enqueued?.prompt_id) return null;
-    return queuedToolResult(enqueued, opts.toNodeId, parsed.classType);
+    if (!enqueued) return null;
+    if ("refusal" in enqueued) {
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Error: panel_run recognized ${parsed.classType} as an OUTPUT_NODE from ` +
+              `the connected panel's object_info, but refused the direct /prompt fallback: ` +
+              `${enqueued.refusal}. No fallback prompt was sent.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    if (!enqueued.result?.prompt_id) return null;
+    return queuedToolResult(enqueued.result, opts.toNodeId, parsed.classType);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {

--- a/src/services/output-node.ts
+++ b/src/services/output-node.ts
@@ -32,6 +32,12 @@ type GraphCall = (
   timeoutMs?: number,
 ) => Promise<ToolResultLike>;
 
+type ScopedEnqueueResult = {
+  prompt_id: string;
+  queue_remaining?: number;
+  rejectedOutputs?: string;
+};
+
 let objectInfoOverride: ObjectInfo | null | undefined;
 let enqueueScopedOutputNodeOverride:
   | ((
@@ -228,7 +234,7 @@ async function enqueueConvertedScopedRun(
   classType: string,
   objectInfo: ObjectInfo,
   call: GraphCall,
-): Promise<{ prompt_id: string } | null> {
+): Promise<ScopedEnqueueResult | null> {
   const targetId = String(toNodeId);
   const targets = [targetId];
   if (enqueueScopedOutputNodeOverride) {
@@ -249,7 +255,7 @@ async function enqueueConvertedScopedRun(
 }
 
 function queuedToolResult(
-  promptId: string,
+  enqueued: ScopedEnqueueResult,
   toNodeId: number,
   classType: string,
 ): ToolResultLike {
@@ -260,11 +266,17 @@ function queuedToolResult(
         text: JSON.stringify(
           {
             queued: true,
-            prompt_id: promptId,
+            prompt_id: enqueued.prompt_id,
             to_node_id: toNodeId,
             ran_to_node: toNodeId,
             output_node_source: "object_info",
             output_node_class: classType,
+            ...(enqueued.queue_remaining === undefined
+              ? {}
+              : { queue_remaining: enqueued.queue_remaining }),
+            ...(enqueued.rejectedOutputs
+              ? { rejected_outputs: enqueued.rejectedOutputs }
+              : {}),
           },
           null,
           2,
@@ -295,15 +307,33 @@ export async function recoverOutputNodeScopedRun(opts: {
   const objectInfo = await fetchPanelObjectInfo(opts.call);
   if (!isOutputNodeType(parsed.classType, objectInfo) || !objectInfo) return null;
 
-  const retry = await opts.call(
-    {
-      cmd: "graph_run",
-      batch_count: opts.batchCount,
-      to_node_id: opts.toNodeId,
-      output_node: true,
-    },
-    20_000,
-  );
+  let retry: ToolResultLike;
+  try {
+    retry = await opts.call(
+      {
+        cmd: "graph_run",
+        batch_count: opts.batchCount,
+        to_node_id: opts.toNodeId,
+        output_node: true,
+      },
+      20_000,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            `Error: panel_run's OUTPUT_NODE recovery retry for ${parsed.classType} ` +
+            `failed before a reply could be read; its outcome is UNKNOWN and it may ` +
+            `have queued a render. Check queue (action:"list") or get_history before ` +
+            `re-submitting. (${message})`,
+        },
+      ],
+      isError: true,
+    };
+  }
   const retryParsed = parseToolResultJson(retry);
   if (
     !retry.isError &&
@@ -326,8 +356,20 @@ export async function recoverOutputNodeScopedRun(opts: {
       opts.call,
     );
     if (!enqueued?.prompt_id) return null;
-    return queuedToolResult(enqueued.prompt_id, opts.toNodeId, parsed.classType);
-  } catch {
-    return null;
+    return queuedToolResult(enqueued, opts.toNodeId, parsed.classType);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            `Error: panel_run recovered ${parsed.classType} as an OUTPUT_NODE from ` +
+            `the connected panel's object_info, but the direct /prompt fallback failed: ` +
+            `${message}`,
+        },
+      ],
+      isError: true,
+    };
   }
 }


### PR DESCRIPTION
## Summary
``panel_run({to_node_id})`` refused ComfyUI-VideoHelperSuite ``VHS_VideoCombine`` as \"not an output node\" even though it is the terminal saving node (``OUTPUT_NODE = True``) in packs like wan-longer-videos-i2v. The panel keys ``constructor.nodeData.output_node``, which that custom frontend class omits; ``panel_query_graph`` therefore also skipped ``is_output:true``.

This classifies terminal outputs from live ``/object_info`` ``output_node`` metadata (not a hardcoded name list). On a scoped-run refusal:
1. consult ``graph_get_object_info``
2. if ``output_node:true``, retry ``graph_run`` with that proof
3. if the panel still refuses, enqueue via ``/prompt`` with ``partial_execution_targets`` — the field ComfyUI itself uses for run-to-node

``panel_query_graph`` / ``panel_find_nodes`` stamp ``is_output:true`` from the same metadata.

## Test plan
- ``npx vitest run src/__tests__/services/output-node.test.ts src/__tests__/orchestrator/panel-run-2529-vhs-output-node.test.ts --maxWorkers=4``
- 9 passed (4 helper + 5 panel_run/query)

Fixes #2529