### PR TITLE
fix(2538): prefer pip Manager version over disabled legacy custom_nodes folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- install_comfyui action:"environment" reports the pip-installed ComfyUI-Manager version from a trusted interpreter instead of a disabled custom_nodes/ComfyUI-Manager checkout (#2538)
+
+
 ## [0.52.163] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -760,6 +760,7 @@ describe("getEnvironment", () => {
       expect(env.local.code_path).toBe(codeRoot);
       expect(env.local.code_path_source).toBe("env");
       expect(env.local.git).toEqual({ rev: "abc123", branch: "main" });
+      // No trusted interpreter, so no pip Manager version — custom_nodes is fallback (#2538).
       expect(env.local.comfyui_manager_version).toBe("3.41");
       expect(env.local.note).toMatch(/Split install/);
     } finally {
@@ -961,6 +962,8 @@ describe("getEnvironment", () => {
       });
 
       const env = await getEnvironment();
+      // Offline / untrusted probe: no pip package list, so the custom_nodes
+      // checkout is the fallback — not a claim that this is the live Manager (#2538).
       expect(env.local.comfyui_manager_version).toBe("3.10.1");
       expect(env.local.git).toEqual({ rev: "abc1234", branch: "master" });
     } finally {
@@ -996,6 +999,126 @@ describe("getEnvironment", () => {
       devices: [],
     });
   }
+
+  async function writeLegacyManager(install: string, version: string): Promise<void> {
+    await mkdir(join(install, "custom_nodes", "ComfyUI-Manager"), { recursive: true });
+    await writeFile(
+      join(install, "custom_nodes", "ComfyUI-Manager", "pyproject.toml"),
+      `[project]\nname = "comfyui-manager"\nversion = "${version}"\n`,
+      "utf-8",
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // #2538 — a leftover custom_nodes/ComfyUI-Manager checkout is not the live
+  // Manager when ComfyUI --enable-manager serves the pip package instead.
+  // -------------------------------------------------------------------------
+
+  it("prefers a trusted pip comfyui-manager over a leftover custom_nodes checkout (#2538)", async () => {
+    const dir = await tmpDir();
+    const exe = await stageWorkspace(dir);
+    const install = join(dir, "ComfyUI");
+    await writeLegacyManager(install, "3.41");
+    try {
+      statsReachable("3.12.11");
+      h.mockLiveInterpreter.mockReturnValue({
+        python: exe,
+        source: "launched-by-us",
+        pid: 4242,
+      });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.12.11\n" };
+        if (args.includes("pip")) {
+          const records = ["Name: torch\nVersion: 2.5.0"];
+          // Only emit the pip Manager if the probe actually asked for it — otherwise
+          // this would pass on a KEY_PACKAGES list that still ignores comfyui-manager.
+          if (args.includes("comfyui-manager") || args.includes("comfyui_manager")) {
+            records.push("Name: comfyui-manager\nVersion: 4.2.2");
+          }
+          return { stdout: `${records.join("\n---\n")}\n` };
+        }
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages?.["comfyui-manager"]).toBe("4.2.2");
+      expect(env.local.comfyui_manager_version).toBe("4.2.2");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to custom_nodes when a trusted probe has no pip comfyui-manager (#2538)", async () => {
+    const dir = await tmpDir();
+    const exe = await stageWorkspace(dir);
+    const install = join(dir, "ComfyUI");
+    await writeLegacyManager(install, "3.41");
+    try {
+      statsReachable("3.12.11");
+      h.mockLiveInterpreter.mockReturnValue({
+        python: exe,
+        source: "launched-by-us",
+        pid: 4242,
+      });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.12.11\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages?.["comfyui-manager"]).toBeUndefined();
+      expect(env.local.comfyui_manager_version).toBe("3.41");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not invent a pip Manager version after a trusted probe is withdrawn (#2538)", async () => {
+    const dir = await tmpDir();
+    const exe = await stageWorkspace(dir);
+    const install = join(dir, "ComfyUI");
+    await writeLegacyManager(install, "3.41");
+    try {
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.12.11",
+          comfyui_version: "0.27.1",
+          pytorch_version: "2.9.0",
+          embedded_python: false,
+          argv: [],
+        },
+        devices: [],
+      });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: exe,
+        source: "process-table",
+        pid: 99,
+      });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.12.11\n" };
+        if (args.includes("pip")) {
+          const records = ["Name: torch\nVersion: 1.0.0"];
+          if (args.includes("comfyui-manager") || args.includes("comfyui_manager")) {
+            records.push("Name: comfyui-manager\nVersion: 4.2.2");
+          }
+          return { stdout: `${records.join("\n---\n")}\n` };
+        }
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      // Fail-closed: a withdrawn probe's pip 4.2.2 must not be reported as live.
+      expect(env.local.comfyui_manager_version).toBe("3.41");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 
   it("reports UNKNOWN (never a package list) when the interpreter was not observed", async () => {
     const dir = await tmpDir();

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1917,7 +1917,10 @@ async function probeGitRev(
   return { rev, branch };
 }
 
-/** Read ComfyUI-Manager version from its local install if present. */
+/** Read ComfyUI-Manager version from a custom_nodes checkout.
+ *  Fallback only — ComfyUI with --enable-manager serves the pip package and
+ *  disables this folder ("Blocked by policy"), so a live version must come
+ *  from a trusted interpreter probe first (#2538). */
 async function readManagerVersion(
   workspacePath: string,
 ): Promise<string | undefined> {
@@ -1991,6 +1994,8 @@ export interface EnvironmentInfo {
      *  "we couldn't determine it" apart from "we determined it's absent" (#401). */
     python_probe_reason?: string;
     git?: { rev?: string; branch?: string };
+    /** Live Manager version: trusted pip `comfyui-manager` when observed,
+     *  else a custom_nodes checkout (unverified when the pip probe is not). */
     comfyui_manager_version?: string;
     packages?: Record<string, string>;
     note?: string;
@@ -2006,6 +2011,9 @@ const KEY_PACKAGES = [
   "transformers",
   "diffusers",
   "comfyui-frontend-package",
+  // pip Manager (ComfyUI --enable-manager). Must outrank a leftover
+  // custom_nodes/ComfyUI-Manager checkout that core has blocked (#2538).
+  "comfyui-manager",
 ];
 
 export async function getEnvironment(): Promise<EnvironmentInfo> {
@@ -2307,11 +2315,19 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
   // Manager lives under custom_nodes/, which --base-directory runtimes scan
   // from the data/base root (#1770). Fall back to the checkout only when no
   // data root is known (legacy layout next to main.py).
+  //
+  // A trusted pip `comfyui-manager` is the live Manager when ComfyUI is
+  // started with --enable-manager: core then blocks custom_nodes/ComfyUI-Manager
+  // ("Blocked by policy") and the leftover 3.x folder is not what HTTP serves
+  // (#2538). An untrusted probe must not invent that pip version.
   const managerRoot = localRoot ?? codeRoot;
-  if (managerRoot) {
-    const managerVersion = await readManagerVersion(managerRoot);
-    if (managerVersion) local.comfyui_manager_version = managerVersion;
-  }
+  const pipManager =
+    local.python_probe_trusted === true
+      ? (local.packages?.["comfyui-manager"] ?? local.packages?.["comfyui_manager"])
+      : undefined;
+  const managerVersion =
+    pipManager ?? (managerRoot ? await readManagerVersion(managerRoot) : undefined);
+  if (managerVersion) local.comfyui_manager_version = managerVersion;
 
   return { running_instance: running, local };
 }


### PR DESCRIPTION
## Summary

`install_comfyui` action:"environment" reported `local.comfyui_manager_version` from a leftover `custom_nodes/ComfyUI-Manager` checkout (3.41) even when ComfyUI was started with `--enable-manager` and the live Manager was the pip package (4.2.2). Core logs that folder as "Blocked by policy"; the env probe still treated it as the running Manager.

## Fix

- Probe `comfyui-manager` with the other `KEY_PACKAGES`.
- When `python_probe_trusted` is true, prefer `local.packages["comfyui-manager"]`.
- When the probe is untrusted, do not invent a pip version — keep the custom_nodes reading as fallback.

Fixes #2538
