### PR TITLE
fix(2543): check_runtime does not call env-authenticated paid nodes local/free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- check_runtime does not classify environment-authenticated paid Gemini and WaveSpeed nodes as local/free (#2543)
 - install_comfyui action:"environment" reports the pip-installed ComfyUI-Manager version from a trusted interpreter instead of a disabled custom_nodes/ComfyUI-Manager checkout (#2538)
 
 

--- a/src/__tests__/services/external-service-nodes-not-free.test.ts
+++ b/src/__tests__/services/external-service-nodes-not-free.test.ts
@@ -393,3 +393,198 @@ describe("#2416 ComfyUI-Seed-API BytePlus nodes are not free", () => {
     expect(out.externalProviders).toEqual(["BytePlus"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #2543 — Nicole Social env-auth backends. GEMINI_API_KEY / WAVESPEED_API_KEY
+// live in the environment, never as a workflow input, and api_node is absent,
+// so every generic signal says free while the nodes spend the user's Google
+// Gemini / WaveSpeed balance. The fixtures are the report's own category
+// ("Nicole Social/backends") with no credential widget and no partner marker.
+//
+// The opt-in marker (`external_api_node` / `EXTERNAL_API_NODE`) is the other
+// half of the fix: the next env-only pack can mark itself without a code change.
+// ---------------------------------------------------------------------------
+
+/** The reported Gemini node. No credential input; api_node absent. */
+const NICOLE_GEMINI = def({
+  name: "NicoleGeminiGenerate",
+  display_name: "Nicole Gemini Generate",
+  category: "Nicole Social/backends",
+  python_module: "custom_nodes.nicole-social",
+  input: { required: { prompt: ["STRING", {}] } },
+});
+
+/** The reported WaveSpeed node. Same pack, same hole. */
+const NICOLE_WAVESPEED = def({
+  name: "NicoleWaveSpeedGenerate",
+  display_name: "Nicole WaveSpeed Generate",
+  category: "Nicole Social/backends",
+  python_module: "custom_nodes.nicole-social",
+  input: { required: { prompt: ["STRING", {}] } },
+});
+
+const KJNODES = def({
+  name: "INTConstant",
+  category: "KJNodes",
+  python_module: "custom_nodes.ComfyUI-KJNodes",
+  input: { required: { value: ["INT", {}] } },
+});
+
+/** A merely similar "gemini" category — must stay free until marked. */
+const LOCAL_GEMINI_TAGGER = def({
+  name: "LocalGeminiTagger",
+  category: "gemini/caption",
+  python_module: "custom_nodes.comfyui-local-gemini-tools",
+  input: { required: { image: ["IMAGE", {}] } },
+});
+
+/** chengzeyi/Comfy-WaveSpeed is a LOCAL optimizer, not the hosted WaveSpeed API. */
+const WAVESPEED_LOCAL_CACHE = def({
+  name: "ApplyFirstBlockCache",
+  category: "wavespeed",
+  python_module: "custom_nodes.Comfy-WaveSpeed",
+  input: { required: { model: ["MODEL", {}] } },
+});
+
+/** Official Comfy partner Gemini — stays isApiNode, not the external list. */
+const PARTNER_GEMINI = def({
+  name: "GeminiNode",
+  category: "api node/image/Gemini",
+  api_node: true,
+});
+
+describe("#2543 env-authenticated Gemini/WaveSpeed nodes are not free", () => {
+  it("THE REPORTED GRAPH: Nicole Social backends are no longer local/free", async () => {
+    // Exact unfixed verdict from #2543: runtime:"local", usesApiNodes:false,
+    // guidance "Local-GPU / free — every node runs on the user's own GPU, no paid credits."
+    const out = await runtimeOf(
+      ["PreviewImage", "NicoleGeminiGenerate", "NicoleWaveSpeedGenerate", "ImpactMakeImageBatch"],
+      {
+        PreviewImage: CORE_PREVIEW,
+        NicoleGeminiGenerate: NICOLE_GEMINI,
+        NicoleWaveSpeedGenerate: NICOLE_WAVESPEED,
+        ImpactMakeImageBatch: IMPACT,
+      },
+    );
+
+    expect(out.runtime).toBe("mixed");
+    expect(out.usesApiNodes).toBe(true);
+    expect(out.externalApiNodes).toEqual(["NicoleGeminiGenerate", "NicoleWaveSpeedGenerate"]);
+    expect(out.externalProviders).toEqual(["Google Gemini", "WaveSpeed"]);
+    expect(out.apiNodes).toEqual([]);
+    expect(out.unknownNodes).toEqual([]);
+  });
+
+  it("an all-external Nicole Social graph reads `api`, not `mixed`", async () => {
+    const out = await runtimeOf(["NicoleGeminiGenerate"], { NicoleGeminiGenerate: NICOLE_GEMINI });
+    expect(out.runtime).toBe("api");
+    expect(out.usesApiNodes).toBe(true);
+    expect(out.externalProviders).toEqual(["Google Gemini", "WaveSpeed"]);
+  });
+
+  it("the category prefix matches even when the pack directory is renamed", async () => {
+    const renamed = def({
+      ...NICOLE_WAVESPEED,
+      python_module: "custom_nodes.my-nicole-fork",
+    } as Partial<ComfyUINodeDef>);
+    expect(isExternalServiceNode(renamed)).toBe(true);
+    const out = await runtimeOf(["NicoleWaveSpeedGenerate"], { NicoleWaveSpeedGenerate: renamed });
+    expect(out.runtime).toBe("api");
+    expect(out.externalProviders).toEqual(["Google Gemini", "WaveSpeed"]);
+  });
+
+  it("a merely SIMILAR category is not swept in", async () => {
+    const other = def({
+      name: "NicoleSocialExtrasMasker",
+      category: "Nicole Social Extras/Mask",
+      python_module: "custom_nodes.nicole-ai-extras",
+      input: { required: { image: ["IMAGE", {}] } },
+    });
+    const out = await runtimeOf(["NicoleSocialExtrasMasker"], { NicoleSocialExtrasMasker: other });
+    expect(out.runtime).toBe("local");
+    expect(out.usesApiNodes).toBe(false);
+    expect(out.externalProviders).toBeUndefined();
+  });
+
+  it("a generic `gemini` category is not treated as paid", async () => {
+    expect(isExternalServiceNode(LOCAL_GEMINI_TAGGER)).toBe(false);
+    const out = await runtimeOf(["LocalGeminiTagger", "KSampler"], {
+      LocalGeminiTagger: LOCAL_GEMINI_TAGGER,
+      KSampler: CORE_SAMPLER,
+    });
+    expect(out.runtime).toBe("local");
+    expect(out.usesApiNodes).toBe(false);
+  });
+
+  it("Impact Pack, KJNodes, and Comfy-WaveSpeed's local optimizer stay free", async () => {
+    expect(isExternalServiceNode(IMPACT)).toBe(false);
+    expect(isExternalServiceNode(KJNODES)).toBe(false);
+    expect(isExternalServiceNode(WAVESPEED_LOCAL_CACHE)).toBe(false);
+    const out = await runtimeOf(["ImpactMakeImageBatch", "INTConstant", "ApplyFirstBlockCache"], {
+      ImpactMakeImageBatch: IMPACT,
+      INTConstant: KJNODES,
+      ApplyFirstBlockCache: WAVESPEED_LOCAL_CACHE,
+    });
+    expect(out.runtime).toBe("local");
+    expect(out.usesApiNodes).toBe(false);
+    expect(out.externalApiNodes).toEqual([]);
+  });
+
+  it("official Comfy partner Gemini stays in apiNodes, not the external list", async () => {
+    expect(isApiNode(PARTNER_GEMINI)).toBe(true);
+    expect(isExternalServiceNode(PARTNER_GEMINI)).toBe(false);
+    const out = await runtimeOf(["GeminiNode"], { GeminiNode: PARTNER_GEMINI });
+    expect(out.apiNodes).toEqual(["GeminiNode"]);
+    expect(out.externalApiNodes).toEqual([]);
+    expect(out.runtime).toBe("api");
+  });
+
+  it("an explicit external_api_node marker is enough (no widget, no pack entry)", async () => {
+    const marked = def({
+      name: "EnvOnlyPaidBackend",
+      category: "misc/backends",
+      python_module: "custom_nodes.some-unlisted-env-auth-pack",
+      external_api_node: true,
+      external_api_provider: "Acme",
+      input: { required: { prompt: ["STRING", {}] } },
+    });
+    expect(isExternalServiceNode(marked)).toBe(true);
+    expect(isApiNode(marked)).toBe(false);
+    const out = await runtimeOf(["EnvOnlyPaidBackend"], { EnvOnlyPaidBackend: marked });
+    expect(out.runtime).toBe("api");
+    expect(out.usesApiNodes).toBe(true);
+    expect(out.externalApiNodes).toEqual(["EnvOnlyPaidBackend"]);
+    expect(out.externalProviders).toEqual(["Acme"]);
+    expect(out.apiNodes).toEqual([]);
+  });
+
+  it("EXTERNAL_API_NODE as a string names the provider without a companion field", async () => {
+    const marked = def({
+      name: "EnvOnlyStringMarker",
+      category: "misc",
+      python_module: "custom_nodes.another-unlisted-pack",
+      EXTERNAL_API_NODE: "CloudVendor",
+      input: { required: { prompt: ["STRING", {}] } },
+    });
+    expect(isExternalServiceNode(marked)).toBe(true);
+    const out = await runtimeOf(["EnvOnlyStringMarker"], { EnvOnlyStringMarker: marked });
+    expect(out.runtime).toBe("api");
+    expect(out.externalProviders).toEqual(["CloudVendor"]);
+    expect(out.apiNodes).toEqual([]);
+  });
+
+  it("a boolean marker without a provider still is not local/free", async () => {
+    const marked = def({
+      name: "EnvOnlyUnnamed",
+      category: "misc",
+      python_module: "custom_nodes.unnamed-env-auth-pack",
+      external_api_node: true,
+      input: { required: { prompt: ["STRING", {}] } },
+    });
+    const out = await runtimeOf(["EnvOnlyUnnamed"], { EnvOnlyUnnamed: marked });
+    expect(out.runtime).toBe("api");
+    expect(out.usesApiNodes).toBe(true);
+    expect(out.externalApiNodes).toEqual(["EnvOnlyUnnamed"]);
+    expect(out.externalProviders).toBeUndefined();
+  });
+});

--- a/src/comfyui/types.ts
+++ b/src/comfyui/types.ts
@@ -26,6 +26,19 @@ export interface ComfyUINodeDef {
    * with "api node/" (e.g. "api node/image/BFL").
    */
   api_node?: boolean;
+  /**
+   * #2543 — opt-in for third-party nodes that bill a paid external service
+   * from environment-only credentials (no api_key widget, no Comfy `api_node`).
+   * Packs may set the class attribute `EXTERNAL_API_NODE` (boolean, or a string
+   * naming the provider). Honored when present on /object_info so the next
+   * env-only pack does not need a code change here.
+   */
+  external_api_node?: boolean | string;
+  /** Python class-attr spelling of `external_api_node`, if a serializer dumps it. */
+  EXTERNAL_API_NODE?: boolean | string;
+  /** Optional provider when `external_api_node` is a boolean. */
+  external_api_provider?: string;
+  EXTERNAL_API_PROVIDER?: string;
   deprecated?: boolean;
   experimental?: boolean;
 }

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -91,9 +91,11 @@ export function isApiNode(def: ComfyUINodeDef): boolean {
  *    Shipping just this would have closed #1483 with the reporter's own graph still
  *    reported as free.
  *
- * So it takes both, and they cover different populations: the registry catches packs whose
- * nodes advertise nothing at all, the credential signal catches packs nobody has
- * enumerated yet (49 classes on the measured install — Novita, Gemini, joyCaption…).
+ * So it takes three signals, and they cover different populations: the registry catches
+ * packs whose nodes advertise nothing at all, the credential signal catches packs nobody
+ * has enumerated yet (49 classes on the measured install — Novita, Gemini, joyCaption…),
+ * and an explicit `external_api_node` / `EXTERNAL_API_NODE` opt-in on the node def lets
+ * the next env-only pack mark itself without a code change here (#2543).
  *
  * DELIBERATELY SEPARATE FROM `isApiNode`, not folded into it: that predicate also drives
  * `listApiNodes` and the 3D-generation picker, which enumerate COMFY PARTNER nodes and
@@ -169,6 +171,32 @@ const EXTERNAL_SERVICE_PACKS: readonly ExternalServicePack[] = [
     localCategoryPrefixes: ["seed/video"],
     provider: "BytePlus",
   },
+  // #2543 — Nicole Social env-auth backends (the report's own category is
+  // "Nicole Social/backends"). GEMINI_API_KEY / WAVESPEED_API_KEY live in the
+  // environment, never as workflow inputs, and api_node is absent — so every
+  // generic signal says free while the nodes spend the user's Google Gemini /
+  // WaveSpeed balance. The category prefix carries the match through a directory
+  // rename the way the fal and PoYo entries do.
+  //
+  // Two entries so a graph that uses the pack names BOTH providers rather than a
+  // slash-joined string. They share the match on purpose: /object_info does not
+  // distinguish which env var a class reads. Deliberately NOT a generic "gemini"
+  // / "wavespeed" match — that is the keyword-regex hole #1483 refused, and it
+  // would flag local packs (Impact, KJNodes, Comfy-WaveSpeed's local optimizer)
+  // plus any merely similar category. Official Comfy partner Gemini nodes stay
+  // isApiNode (`api_node: true`) and never enter this list.
+  {
+    module: "nicole-social",
+    categoryPrefixes: ["nicole social"],
+    provider: "Google Gemini",
+  },
+  {
+    module: "nicole-social",
+    categoryPrefixes: ["nicole social"],
+    provider: "WaveSpeed",
+  },
+  { module: "nicole_social", provider: "Google Gemini" },
+  { module: "nicole_social", provider: "WaveSpeed" },
 ];
 
 /**
@@ -216,30 +244,86 @@ function packMatches(pack: ExternalServicePack, category: string, pythonModule: 
 }
 
 /**
- * Which known paid pack does this node belong to, if any — or null.
+ * Every known paid pack this node belongs to — empty if none.
  *
- * EVERY matching entry is considered, and a single one that does NOT exempt the node wins
+ * EVERY matching entry is considered, and any one that does NOT exempt the node counts
  * (codex P1). Returning on the first match let `ComfyUI-fal-API-Flux` bind to the broader
  * `comfyui-fal-api` entry and inherit ITS `FAL/Utils` exemption, so a paid Flux node in
  * that category answered "free" while the stricter entry written for that very pack was
  * never reached. Resolving toward PAID is also the correct direction for a money guard:
  * disagreement between two entries is not evidence of free.
+ *
+ * #2543 — a pack that hosts more than one vendor (Nicole Social bills Google Gemini AND
+ * WaveSpeed from the same category) contributes every distinct provider, so guidance can
+ * name both balances rather than the first entry's alone.
  */
-function externalServicePackFor(def: ComfyUINodeDef): ExternalServicePack | null {
+function matchingPaidPacks(def: ComfyUINodeDef): ExternalServicePack[] {
   const category = (def.category ?? "").toLowerCase();
   const pythonModule = (def.python_module ?? "").toLowerCase();
-  let exemptedBy: ExternalServicePack | null = null;
+  const paid: ExternalServicePack[] = [];
   for (const pack of EXTERNAL_SERVICE_PACKS) {
     if (!packMatches(pack, category, pythonModule)) continue;
     const exempt = pack.localCategoryPrefixes?.some(
       (p) => category === p || category.startsWith(`${p}/`),
     );
-    if (!exempt) return pack;
-    exemptedBy = pack;
+    if (!exempt) paid.push(pack);
   }
-  // Matched only packs that call this one of their own local helpers.
-  void exemptedBy;
-  return null;
+  return paid;
+}
+
+function externalServicePackFor(def: ComfyUINodeDef): ExternalServicePack | null {
+  return matchingPaidPacks(def)[0] ?? null;
+}
+
+type ExternalApiFields = {
+  external_api_node?: unknown;
+  EXTERNAL_API_NODE?: unknown;
+  externalApiNode?: unknown;
+  external_api_provider?: unknown;
+  EXTERNAL_API_PROVIDER?: unknown;
+  externalApiProvider?: unknown;
+};
+
+function markerValue(value: unknown): { marked: boolean; provider: string | null } {
+  if (value === true) return { marked: true, provider: null };
+  if (typeof value === "string") {
+    const s = value.trim();
+    if (!s) return { marked: false, provider: null };
+    if (s.toLowerCase() === "true") return { marked: true, provider: null };
+    if (s.toLowerCase() === "false") return { marked: false, provider: null };
+    return { marked: true, provider: s };
+  }
+  return { marked: false, provider: null };
+}
+
+function namedProvider(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const s = value.trim();
+  return s.length > 0 ? s : null;
+}
+
+/**
+ * #2543 — explicit opt-in on the node def. Env-only packs cannot put a credential
+ * widget on the workflow just to satisfy classification; they set EXTERNAL_API_NODE
+ * (optionally with a provider) instead. Absence is not evidence of free — the
+ * enumerated registry and credential-input catch still apply.
+ */
+function externalApiMark(def: ComfyUINodeDef): { marked: boolean; provider: string | null } {
+  const rec = def as ComfyUINodeDef & ExternalApiFields;
+  let marked = false;
+  let provider: string | null = null;
+  for (const value of [rec.external_api_node, rec.EXTERNAL_API_NODE, rec.externalApiNode]) {
+    const parsed = markerValue(value);
+    if (!parsed.marked) continue;
+    marked = true;
+    if (parsed.provider) provider = parsed.provider;
+  }
+  if (!marked) return { marked: false, provider: null };
+  for (const value of [rec.external_api_provider, rec.EXTERNAL_API_PROVIDER, rec.externalApiProvider]) {
+    const named = namedProvider(value);
+    if (named) provider = named;
+  }
+  return { marked, provider };
 }
 
 /**
@@ -249,16 +333,28 @@ function externalServicePackFor(def: ComfyUINodeDef): ExternalServicePack | null
  */
 export function isExternalServiceNode(def: ComfyUINodeDef): boolean {
   if (isApiNode(def)) return false;
+  if (externalApiMark(def).marked) return true;
   if (externalServicePackFor(def)) return true;
   // The general catch: a node that asks for a service credential cannot be CONFIRMED free,
   // whichever pack it came from.
   return declaresCredentialInput(def);
 }
 
-/** The provider that bills for `def`, when a known pack identifies one. */
+/** Distinct providers that bill for `def`, when a marker or known pack names them. */
+function externalServiceProviders(def: ComfyUINodeDef): string[] {
+  if (isApiNode(def)) return [];
+  const mark = externalApiMark(def);
+  if (mark.provider) return [mark.provider];
+  const named: string[] = [];
+  for (const pack of matchingPaidPacks(def)) {
+    if (!named.includes(pack.provider)) named.push(pack.provider);
+  }
+  return named;
+}
+
+/** The provider that bills for `def`, when a known pack or marker identifies one. */
 export function externalServiceProvider(def: ComfyUINodeDef): string | null {
-  if (isApiNode(def)) return null;
-  return externalServicePackFor(def)?.provider ?? null;
+  return externalServiceProviders(def)[0] ?? null;
 }
 
 export interface ApiNodeSummary {
@@ -492,8 +588,9 @@ export async function checkWorkflowRuntime(
     // money just the same, so it must reach the same verdict.
     else if (isExternalServiceNode(def)) {
       externalApiNodes.push(ct);
-      const provider = externalServiceProvider(def);
-      if (provider && !externalProviders.includes(provider)) externalProviders.push(provider);
+      for (const provider of externalServiceProviders(def)) {
+        if (!externalProviders.includes(provider)) externalProviders.push(provider);
+      }
     }
   }
   const paidNodes = [...apiNodes, ...externalApiNodes];


### PR DESCRIPTION
## Summary

`list_packs(action:"check_runtime")` classified a workflow containing custom nodes that make paid Google Gemini and WaveSpeed API calls as `runtime:"local"` with guidance "Local-GPU / free". The nodes read `GEMINI_API_KEY` / `WAVESPEED_API_KEY` from the environment, so `/object_info` exposes neither `api_node:true` nor a credential widget. `checkWorkflowRuntime` had no signal.

**Root cause**: the same hole as #1483 / #1855 / #2416 — env-only third-party packs cannot be seen by the partner marker or the credential-input catch, and this pack was not in `EXTERNAL_SERVICE_PACKS`. A keyword regex over "gemini" categories is the wrong fix (#1483): it misses packs that do not put the vendor in the category, and it would flag local helpers.

**Fix**: follow the established classifier, do not invent a new one.

1. Honor an explicit `/object_info` opt-in (`external_api_node` / `EXTERNAL_API_NODE`, optional provider) so the next env-only pack does not need a code change and does not need a credential widget.
2. Enumerate the reported Nicole Social pack (module + category prefix `"nicole social"`) and name both providers (`Google Gemini`, `WaveSpeed`) in `externalProviders` / guidance.

Official Comfy partner Gemini nodes stay `isApiNode`. Impact Pack, KJNodes, Comfy-WaveSpeed's local optimizer, and a generic `gemini` category stay free.

## Test plan

- `npx vitest run src/__tests__/services/external-service-nodes-not-free.test.ts src/__tests__/services/api-nodes.test.ts` (63 passed: 30 + 33)

Fixes #2543
