### PR TITLE
fix(2530): do not pip-install custom-node deps with an untrusted interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- install_custom_node does not pip-install cloned-node requirements with an untrusted interpreter (Stability Matrix base Python / PEP 668) and does not recommend that same unsafe command (#2530)
+
+
 ## [0.52.164] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1608,6 +1608,9 @@ describe("node-management service", () => {
       expect(res.mechanism).toBe("git-clone");
       // The deps install was REFUSED and the reason is surfaced in the message…
       expect(res.message).toContain("Python dependencies were NOT installed");
+      expect(res.message).toMatch(/PARTIAL install/i);
+      expect(res.message).toMatch(/action:"fix"/);
+      expect(res.message).not.toMatch(/-m pip install/);
       // …and no pip subprocess ran against any interpreter.
       const pipCall = mockedExec.mock.calls.find(
         (c) =>
@@ -1616,6 +1619,61 @@ describe("node-management service", () => {
           (c[1] as string[]).includes(requirements),
       );
       expect(pipCall).toBeUndefined();
+    });
+
+    it("does not recommend the same pip command after a PEP 668 refusal (#2530)", async () => {
+      // Even a pinned COMFYUI_PYTHON can be an externally-managed base interpreter.
+      // Clone still succeeds; the warning must NOT tell the user to re-run the
+      // command PEP 668 just rejected.
+      config.comfyuiPath = undefined;
+      const adopted = "/adopted/ComfyUI";
+      const IS_WIN = process.platform === "win32";
+      const basePy = join(
+        adopted,
+        ".venv",
+        IS_WIN ? "Scripts" : "bin",
+        IS_WIN ? "python.exe" : "python",
+      );
+      process.env.COMFYUI_PYTHON = basePy;
+      const nodeDir = resolve(adopted, "custom_nodes", "comfyui-teskors-utils");
+      const requirements = join(nodeDir, "requirements.txt");
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s === basePy) return true;
+        if (s === requirements) return true;
+        if (s.includes("install.py") || s.includes("cm-cli.py")) return false;
+        if (s.includes(".venv")) return false;
+        if (s.includes("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") {
+          cloned = true;
+          return "";
+        }
+        if (Array.isArray(args) && args.includes("-r")) {
+          throw Object.assign(new Error("Command failed: pip"), {
+            stderr:
+              "error: externally-managed-environment\n" +
+              "This Python installation is managed by uv and should not be modified.\n",
+            stdout: "",
+          });
+        }
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        comfyuiPath: adopted,
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/PEP 668|EXTERNALLY MANAGED/);
+      expect(res.message).toMatch(/action:"fix"/);
+      expect(res.message).toMatch(/Do not re-run pip against that interpreter/);
+      expect(res.message).not.toContain(`${basePy} -m pip install`);
     });
 
     it("full-clones (no --depth) and checks out an explicit ref on fallback", async () => {

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -247,17 +247,37 @@ describe("resolveInstallInterpreter (#651)", () => {
     }
   });
 
+  /** Version + torch probes that agree with the running server (trusted). */
+  function mockTrustedInterpreterProbes(opts?: { version?: string; torch?: string }): void {
+    const version = opts?.version ?? "3.12.12";
+    const torch = opts?.torch ?? "2.13.0";
+    setExecFileResponder((_cmd, args) => {
+      if (args.includes("--version") || args.some((a) => a.includes("sys.version"))) {
+        return { stdout: `Python ${version}\n` };
+      }
+      if (args.includes("pip")) return { stdout: `Name: torch\nVersion: ${torch}\n` };
+      return new Error("nope");
+    });
+  }
+
   it("uses the OS-OBSERVED interpreter when the port owner corroborates the server argv (#401)", async () => {
     const root = await tmpDir();
     try {
       await writeFile(join(root, "main.py"), "", "utf-8");
       await makeVenvPython(root);
-      mockGetSystemStats.mockResolvedValue({ system: { argv: [join(root, "main.py")] } });
+      mockGetSystemStats.mockResolvedValue({
+        system: {
+          argv: [join(root, "main.py")],
+          python_version: "3.12.12",
+          pytorch_version: "2.13.0+cu130",
+        },
+      });
       h.mockLiveInterpreter.mockReturnValue({
         python: "D:/ComfyUI/.venv/Scripts/python.exe",
         source: "process-table",
         pid: 777,
       });
+      mockTrustedInterpreterProbes();
 
       await expect(resolveInstallInterpreter(root)).resolves.toMatchObject({
         python: "D:/ComfyUI/.venv/Scripts/python.exe",
@@ -449,6 +469,114 @@ describe("resolveInstallInterpreter (#651)", () => {
       });
     } finally {
       delete process.env.COMFYUI_PYTHON;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses an observed Stability Matrix BASE interpreter that has no torch while ComfyUI reports pytorch (#2530)", async () => {
+    // The reporter's shape: process-table argv[0] is the uv-managed base CPython
+    // (no torch, PEP 668), while the running ComfyUI imported torch 2.13.0+cu130.
+    // install_comfyui(environment) already sets python_probe_trusted:false; pip
+    // must not target that same interpreter.
+    const root = await tmpDir();
+    try {
+      await writeFile(join(root, "main.py"), "", "utf-8");
+      await makeVenvPython(root);
+      const basePy =
+        "A:/StabilityMatrix-win-x64/Data/Assets/Python/cpython-3.12.12-windows-x86_64-none/python.exe";
+      mockGetSystemStats.mockResolvedValue({
+        system: {
+          argv: [join(root, "main.py")],
+          python_version: "3.12.12",
+          pytorch_version: "2.13.0+cu130",
+        },
+      });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: basePy,
+        source: "process-table",
+        pid: 4242,
+      });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version") || args.some((a) => a.includes("sys.version"))) {
+          return { stdout: "Python 3.12.12\n" };
+        }
+        if (args.includes("pip")) {
+          return Object.assign(new Error("Command failed: exit 1"), {
+            stdout: "",
+            stderr:
+              "WARNING: Package(s) not found: torch, torchvision, torchaudio, xformers, numpy, transformers, diffusers, comfyui-frontend-package\n",
+          });
+        }
+        return new Error("nope");
+      });
+
+      const result = await resolveInstallInterpreter(root);
+
+      expect(result.source).toBe("undetermined");
+      expect(result.python).toBeUndefined();
+      expect(result.reason).toMatch(/none of torch/i);
+      expect(result.reason).toMatch(/2\.13\.0\+cu130/);
+      expect(result.reason).toMatch(/action:"fix"/);
+      expect(result.reason).not.toMatch(/-m pip install/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses an observed interpreter whose torch disagrees with the running ComfyUI (#2530)", async () => {
+    const root = await tmpDir();
+    try {
+      await writeFile(join(root, "main.py"), "", "utf-8");
+      await makeVenvPython(root);
+      mockGetSystemStats.mockResolvedValue({
+        system: {
+          argv: [join(root, "main.py")],
+          python_version: "3.12.12",
+          pytorch_version: "2.13.0+cu130",
+        },
+      });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: "D:/wrong-venv/Scripts/python.exe",
+        source: "process-table",
+        pid: 99,
+      });
+      mockTrustedInterpreterProbes({ version: "3.12.12", torch: "2.4.0" });
+
+      const result = await resolveInstallInterpreter(root);
+      expect(result.source).toBe("undetermined");
+      expect(result.python).toBeUndefined();
+      expect(result.reason).toMatch(/does not match the running ComfyUI pytorch/i);
+      expect(result.reason).not.toMatch(/-m pip install/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("still hands out an observed interpreter when its torch matches the running ComfyUI (#2530)", async () => {
+    const root = await tmpDir();
+    try {
+      await writeFile(join(root, "main.py"), "", "utf-8");
+      await makeVenvPython(root);
+      const venvPy = "D:/ComfyUI/.venv/Scripts/python.exe";
+      mockGetSystemStats.mockResolvedValue({
+        system: {
+          argv: [join(root, "main.py")],
+          python_version: "3.12.12",
+          pytorch_version: "2.13.0+cu130",
+        },
+      });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: venvPy,
+        source: "process-table",
+        pid: 777,
+      });
+      mockTrustedInterpreterProbes({ version: "3.12.12", torch: "2.13.0" });
+
+      await expect(resolveInstallInterpreter(root)).resolves.toMatchObject({
+        python: venvPy,
+        source: "observed",
+      });
+    } finally {
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3011,6 +3011,46 @@ export async function resolvePackPresence(
 }
 
 /**
+ * #2530 — clone succeeded, but the dependency interpreter is unproven. Never
+ * recommend `python -m pip install` against the interpreter we just refused;
+ * that is the Stability Matrix base-python command that PEP 668 already rejected.
+ */
+function depsSkippedUnknownInterpreterWarning(reason: string, packId: string): string {
+  return (
+    `Python dependencies were NOT installed. ${reason} ` +
+    `The pack was cloned but this is a PARTIAL install: the dependency interpreter is unknown. ` +
+    `Do not run pip against an untrusted interpreter. ` +
+    `Use install_custom_node(action:"fix", id:"${packId}") so ComfyUI-Manager can restore/repair ` +
+    `dependencies in the connected environment, or set COMFYUI_PYTHON to the interpreter ` +
+    `ComfyUI actually imports from and retry.`
+  );
+}
+
+function isExternallyManagedPipError(text: string): boolean {
+  return (
+    /^\s*error: externally-managed-environment/im.test(text) ||
+    /interpreter at .+ is externally managed/i.test(text)
+  );
+}
+
+function depsPipFailedWarning(err: unknown, python: string, packId: string): string {
+  const e = err as Error & { stdout?: string | Buffer; stderr?: string | Buffer };
+  const output = `${e.stderr?.toString() ?? ""}\n${e.stdout?.toString() ?? ""}\n${e.message}`;
+  if (isExternallyManagedPipError(output)) {
+    return (
+      `Python dependencies (requirements.txt) failed to install: "${python}" is EXTERNALLY MANAGED ` +
+      `(PEP 668) and must not be modified. Do not re-run pip against that interpreter. ` +
+      `Use install_custom_node(action:"fix", id:"${packId}") so ComfyUI-Manager can restore/repair ` +
+      `the connected environment.`
+    );
+  }
+  return (
+    `Python dependencies (requirements.txt) failed to install (${e.message}); ` +
+    `install them manually with "${python} -m pip install -r requirements.txt".`
+  );
+}
+
+/**
  * Resolve the ComfyUI venv python for installing a cloned node's deps. Prefers
  * the install's own `.venv` (Windows Scripts/ or POSIX bin/), falling back to a
  * bare "python" on PATH. `basePath` is the CALL-SCOPED install root (apply_manifest
@@ -3653,14 +3693,16 @@ async function cloneCustomNodeFallback(
   }
 
   // Best-effort python deps. Don't fail the install if these don't.
+  // #2530 — never pip (or recommend pip) with an interpreter the environment
+  // probe would mark untrusted. resolveInstallInterpreter now shares that
+  // verdict; when it refuses, this is a PARTIAL install and Manager repair is
+  // the next step, not a copy-paste of the same unsafe python -m pip command.
   const requirements = join(nodeDir, "requirements.txt");
   const installScript = join(nodeDir, "install.py");
   if (existsSync(requirements) || existsSync(installScript)) {
     const resolved = await resolveVenvPython(comfyuiBase);
     if (!resolved.python) {
-      warnings.push(
-        `Python dependencies were NOT installed. ${resolved.reason} Set COMFYUI_PYTHON to the interpreter ComfyUI runs with, or restart ComfyUI through this MCP server and retry.`,
-      );
+      warnings.push(depsSkippedUnknownInterpreterWarning(resolved.reason, repoName));
     } else if (existsSync(requirements)) {
       const python = resolved.python;
       try {
@@ -3670,10 +3712,7 @@ async function cloneCustomNodeFallback(
           timeout: COMFY_CLI_TIMEOUT,
         });
       } catch (err) {
-        const e = err as Error;
-        warnings.push(
-          `Python dependencies (requirements.txt) failed to install (${e.message}); install them manually with "${python} -m pip install -r requirements.txt".`,
-        );
+        warnings.push(depsPipFailedWarning(err, python, repoName));
       }
     }
     if (resolved.python && existsSync(installScript)) {

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1731,6 +1731,143 @@ export function torchVersionsAgree(a: string | undefined, b: string | undefined)
   return na.length > 0 && na === nb;
 }
 
+type ObservedInterpreterSource = "launched-by-us" | "process-table";
+
+/**
+ * The same python-version trust verdict `install_comfyui(action:"environment")`
+ * uses for `python_probe_trusted`. Shared so a mutating install cannot pip into
+ * an interpreter the environment probe has already marked untrusted (#2530).
+ */
+function observedPythonTrust(opts: {
+  source: ObservedInterpreterSource;
+  shortVer: string;
+  fullVer: string;
+  runningPython?: string;
+  pid?: number;
+  port?: number;
+}): { trusted: boolean; reason: string } {
+  const { source, shortVer, fullVer, runningPython, pid, port } = opts;
+  if (!runningPython) {
+    if (source === "launched-by-us") {
+      return {
+        trusted: true,
+        reason:
+          `this MCP server launched ComfyUI (PID ${pid}) with this exact ` +
+          `interpreter. The running ComfyUI did not report its own python version, so no ` +
+          `cross-check was possible — none is needed, the interpreter is the one we chose`,
+      };
+    }
+    return {
+      trusted: false,
+      reason:
+        `the observed interpreter (${source}) reports python ${shortVer}, but ` +
+        `the running ComfyUI did not report a python version of its own, so the two could ` +
+        `NOT be compared. That is an unverified match, not a mismatch — refusing to ` +
+        `attribute this interpreter's packages to the server on an unmade comparison`,
+    };
+  }
+  if (!pythonVersionsAgree(fullVer, runningPython)) {
+    return {
+      trusted: false,
+      reason:
+        `the observed interpreter (${source}) reports python ${shortVer}, which ` +
+        `does not match the running ComfyUI python ${runningPython} — ` +
+        `refusing to attribute its packages to the server`,
+    };
+  }
+  return {
+    trusted: true,
+    reason:
+      source === "launched-by-us"
+        ? `this MCP server launched ComfyUI (PID ${pid}) with this exact interpreter`
+        : `the OS reports PID ${pid} (serving port ${port}) is running this interpreter`,
+  };
+}
+
+function torchContradictionOf(
+  probed: { ran: boolean; packages: Record<string, string> },
+  serverTorch: string | undefined,
+): "absent" | "version" | undefined {
+  if (!serverTorch) return undefined;
+  if (probed.ran && !probed.packages.torch) return "absent";
+  if (probed.packages.torch && !torchVersionsAgree(probed.packages.torch, serverTorch)) {
+    return "version";
+  }
+  return undefined;
+}
+
+function torchContradictionReason(
+  kind: "absent" | "version",
+  source: string,
+  torch: string | undefined,
+  serverTorch: string,
+): string {
+  return kind === "absent"
+    ? `the observed interpreter (${source}) has none of torch while ` +
+      `the running ComfyUI reports pytorch ${serverTorch} — this is the base ` +
+      `interpreter, not the venv the server imports from. Refusing to attribute ` +
+      `its packages to the server`
+    : `the observed interpreter (${source}) reports torch ${torch}, ` +
+      `which does not match the running ComfyUI pytorch ${serverTorch} — ` +
+      `refusing to attribute its packages to the server`;
+}
+
+/**
+ * Apply the environment probe's trust rules to an observed install interpreter.
+ * A known-untrusted python (base vs venv, torch mismatch) must not be handed to
+ * pip. Launched-by-us still wins when the interpreter cannot be probed at all —
+ * we chose that path — but a successful probe that contradicts the running
+ * server refuses (#2530).
+ */
+async function corroborateObservedInstallPython(
+  python: string,
+  source: ObservedInterpreterSource,
+  opts: { runningPython?: string; runningTorch?: string; pid?: number },
+): Promise<{ trusted: true } | { trusted: false; reason: string }> {
+  const version =
+    (await probe(python, ["-c", "import sys;print(sys.version)"])) ??
+    (await probe(python, ["--version"]));
+  if (!version) {
+    if (source === "launched-by-us") return { trusted: true };
+    return {
+      trusted: false,
+      reason:
+        `Cannot verify the running server's interpreter "${python}": it did not report a python version, ` +
+        `so it cannot be corroborated against the connected ComfyUI.`,
+    };
+  }
+  const ver = version.replace(/^Python\s+/i, "").replace(/\s+/g, " ").trim();
+  const shortVer = ver.match(/^(\d+(?:\.\d+)*)/)?.[1] ?? ver;
+  const initial = observedPythonTrust({
+    source,
+    shortVer,
+    fullVer: ver,
+    runningPython: opts.runningPython,
+    pid: opts.pid,
+    port: config.resolvedPort,
+  });
+  if (!initial.trusted) return { trusted: false, reason: initial.reason };
+  const probed = await probePipPackages(python, KEY_PACKAGES);
+  const serverTorch = opts.runningTorch?.trim();
+  const contradiction = torchContradictionOf(probed, serverTorch);
+  if (contradiction && serverTorch) {
+    return {
+      trusted: false,
+      reason: torchContradictionReason(contradiction, source, probed.packages.torch, serverTorch),
+    };
+  }
+  return { trusted: true };
+}
+
+function untrustedInstallInterpreterReason(python: string, detail: string): string {
+  return (
+    `Cannot install Python packages with "${python}": ${detail} ` +
+    `Never invoke that interpreter for pip. Use install_custom_node(action:"fix") so ` +
+    `ComfyUI-Manager can restore/repair dependencies in the connected environment, ` +
+    `or set COMFYUI_PYTHON to the interpreter ComfyUI actually imports from.`
+  );
+}
+
 /** A bundle root may contain its actual server in `ComfyUI/`; do not confuse a
  * nested independent checkout with that bundle layout. */
 function targetsLiveInstall(serverRoot: string, requestedRoot: string | undefined): boolean {
@@ -1774,9 +1911,19 @@ export async function resolveInstallInterpreter(
     );
   }
 
-  let system: { argv?: string[]; cwd?: string } | undefined;
+  let system: {
+    argv?: string[];
+    cwd?: string;
+    python_version?: string;
+    pytorch_version?: string;
+  } | undefined;
   try {
-    system = (await getSystemStats()).system as { argv?: string[]; cwd?: string };
+    system = (await getSystemStats()).system as {
+      argv?: string[];
+      cwd?: string;
+      python_version?: string;
+      pytorch_version?: string;
+    };
   } catch {
     return refuse(
       "Cannot verify the running server's interpreter: no local ComfyUI is reachable. " +
@@ -1798,9 +1945,26 @@ export async function resolveInstallInterpreter(
     remote: false,
     serverArgv: system?.argv,
   });
+  const trustLive = async (
+    python: string,
+    source: ObservedInterpreterSource,
+    pid: number,
+  ): Promise<InstallInterpreterResolution | undefined> => {
+    const verdict = await corroborateObservedInstallPython(python, source, {
+      runningPython: system?.python_version,
+      runningTorch: system?.pytorch_version,
+      pid,
+    });
+    if (verdict.trusted) return undefined;
+    return refuse(untrustedInstallInterpreterReason(python, verdict.reason));
+  };
   // A VALIDATED launched-by-us observation (tier 1) is authoritative whenever the
   // live server is the requested install — or argv names no root to contradict it.
+  // Still refuse when the environment probe would mark it untrusted (#2530): a
+  // launched base interpreter with no torch is not the env ComfyUI imports from.
   if (live?.source === "launched-by-us" && (!serverRoot || targetsLiveInstall(serverRoot, root))) {
+    const refused = await trustLive(live.python, live.source, live.pid);
+    if (refused) return refused;
     return {
       python: live.python,
       source: "launched",
@@ -1824,8 +1988,12 @@ export async function resolveInstallInterpreter(
   // A process-table observation (tier 2) is ground truth too, but only once the
   // guards above have tied the live server to the requested install. This strictly
   // ADDS a success source: when nothing observes the interpreter the install still
-  // refuses (#651 fail-closed).
+  // refuses (#651 fail-closed). A torch/python contradiction still untrusts it —
+  // Stability Matrix's uv base python is a common argv[0] that is not the venv
+  // ComfyUI imports from (#2530).
   if (live) {
+    const refused = await trustLive(live.python, live.source, live.pid);
+    if (refused) return refused;
     return {
       python: live.python,
       source: "observed",
@@ -2166,7 +2334,6 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     // Everything that used to live here (sole-candidate-under-a-believed-root,
     // python/torch "fingerprints", ambiguity corroboration) was inference dressed up
     // as proof, and inference is what reported the wrong venv in the first place.
-    const runningPy = running.python_version;
     let trusted = false;
     let reason: string;
 
@@ -2183,41 +2350,19 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
         `we did not launch this ComfyUI and could not read the interpreter of the ` +
         `process serving port ${config.resolvedPort} from the OS${deployed}. Package ` +
         `versions are omitted rather than attributed to the wrong environment`;
-    } else if (!runningPy) {
-      // NOT a mismatch. `pythonVersionsAgree` returns false when EITHER side is missing,
-      // so this used to fall into the branch below and report "does not match the running
-      // ComfyUI python (unreported)" — asserting a disagreement that was never observed.
-      // One verdict, two causes; the message picked the wrong one. Say which happened.
-      if (groundTruth.source === "launched-by-us") {
-        // Nothing to cross-check against, and nothing that needs cross-checking: we
-        // CHOSE this interpreter and spawned the process, and its PID + creation time
-        // still match. Refusing here would be the opposite error — withholding a package
-        // list we genuinely know, because a corroboration we never needed was missing.
-        trusted = true;
-        reason =
-          `this MCP server launched ComfyUI (PID ${groundTruth.pid}) with this exact ` +
-          `interpreter. The running ComfyUI did not report its own python version, so no ` +
-          `cross-check was possible — none is needed, the interpreter is the one we chose`;
-      } else {
-        reason =
-          `the observed interpreter (${groundTruth.source}) reports python ${shortVer}, but ` +
-          `the running ComfyUI did not report a python version of its own, so the two could ` +
-          `NOT be compared. That is an unverified match, not a mismatch — refusing to ` +
-          `attribute this interpreter's packages to the server on an unmade comparison`;
-      }
-    } else if (!pythonVersionsAgree(ver, runningPy)) {
-      // We DID observe the interpreter, yet it disagrees with the running server.
-      // Something is off (a stale PID, a wrapper); report unknown, not a wrong list.
-      reason =
-        `the observed interpreter (${groundTruth.source}) reports python ${shortVer}, which ` +
-        `does not match the running ComfyUI python ${runningPy} — ` +
-        `refusing to attribute its packages to the server`;
     } else {
-      trusted = true;
-      reason =
-        groundTruth.source === "launched-by-us"
-          ? `this MCP server launched ComfyUI (PID ${groundTruth.pid}) with this exact interpreter`
-          : `the OS reports PID ${groundTruth.pid} (serving port ${config.resolvedPort}) is running this interpreter`;
+      // Shared with resolveInstallInterpreter so a mutating pip cannot target an
+      // interpreter this probe has already marked untrusted (#2530).
+      const verdict = observedPythonTrust({
+        source: groundTruth.source,
+        shortVer,
+        fullVer: ver,
+        runningPython: running.python_version,
+        pid: groundTruth.pid,
+        port: config.resolvedPort,
+      });
+      trusted = verdict.trusted;
+      reason = verdict.reason;
     }
 
     local.python_probe_trusted = trusted;
@@ -2236,25 +2381,11 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
       // Homebrew/uv BASE python after the process table lost the venv context
       // (#401 recurrence, 0.52.1). Absence only counts when pip actually answered.
       const serverTorch = running.pytorch_version?.trim();
-      const torchContradiction =
-        serverTorch &&
-        (probed.ran && !pkgs.torch
-          ? "absent"
-          : pkgs.torch && !torchVersionsAgree(pkgs.torch, serverTorch)
-            ? "version"
-            : undefined);
-      if (torchContradiction) {
+      const torchContradiction = torchContradictionOf(probed, serverTorch);
+      if (torchContradiction && serverTorch) {
         trusted = false;
         const observedAs = groundTruth?.source ?? "process-table";
-        reason =
-          torchContradiction === "absent"
-            ? `the observed interpreter (${observedAs}) has none of torch while ` +
-              `the running ComfyUI reports pytorch ${serverTorch} — this is the base ` +
-              `interpreter, not the venv the server imports from. Refusing to attribute ` +
-              `its packages to the server`
-            : `the observed interpreter (${observedAs}) reports torch ${pkgs.torch}, ` +
-              `which does not match the running ComfyUI pytorch ${serverTorch} — ` +
-              `refusing to attribute its packages to the server`;
+        reason = torchContradictionReason(torchContradiction, observedAs, pkgs.torch, serverTorch);
         local.python_probe_trusted = false;
         local.python_probe_reason = reason;
         local.note = [


### PR DESCRIPTION
## Summary

`install_custom_node(action:"install", source:"git", useCmCli:false)` cloned a non-registry pack, then installed `requirements.txt` with a known-untrusted interpreter — Stability Matrix's uv-managed base CPython — after `install_comfyui(action:"environment")` had already set `python_probe_trusted:false` (no torch vs running ComfyUI `2.13.0+cu130`). PEP 668 rejected the write, and the warning recommended the same unsafe `python -m pip install` command.

`resolveInstallInterpreter` now shares the environment probe's python/torch trust verdict. If that interpreter is untrusted, it is never handed to pip. The clone still succeeds as a **partial install**; the message says the dependency interpreter is unknown and offers `install_custom_node(action:"fix")` so ComfyUI-Manager can restore/repair the connected environment.

A PEP 668 pip failure (explicit `COMFYUI_PYTHON` override) likewise refuses to recommend re-running pip against that interpreter.

Fixes #2530

## Test plan

- `npx vitest run src/__tests__/services/workspace-env.test.ts` — 131 passed, 2 skipped
- `npx vitest run src/__tests__/services/node-management.test.ts` — 233 passed
