### PR TITLE
fix(2533): write enclosing subgraph for promoted unet_name/clip_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- panel_set_widget writes promoted unet_name/clip_name and labelled prompt rails on the enclosing subgraph instead of the link-driven inner (#2533)
 - install_custom_node does not pip-install cloned-node requirements with an untrusted interpreter (Stability Matrix base Python / PEP 668) and does not recommend that same unsafe command (#2530)
 
 

--- a/src/__tests__/orchestrator/promoted-link-driven-write.test.ts
+++ b/src/__tests__/orchestrator/promoted-link-driven-write.test.ts
@@ -321,3 +321,571 @@ describe("panel_set_widget promoted link-driven inner misroute (#2500)", () => {
     expect(h.serializeForQueue().value_2).toBe(5);
   });
 });
+
+// #2533 — remaining reports after #2500's PrimitiveInt value_2/value_3 path:
+// a labelled PrimitiveString `value` (prompt) and MiniMax COMBO rails
+// (unet_name/clip_name) still succeed on the link-driven inner while the
+// enclosing subgraph widget stays at its initial serialized value.
+
+const KREA_TAB = "wf:krea-turbo";
+const KREA_CONTAINER_ID = 12;
+const KREA_INNER_ID = 131;
+const KREA_WORKFLOW_UUID = "workflow-krea-turbo";
+const KREA_ROOT_GRAPH = "graph:workflow-krea-turbo-root";
+const KREA_CHILD_GRAPH = "graph:workflow-krea-turbo-container-12";
+const KREA_OLD_PROMPT = "a cat";
+const KREA_NEW_PROMPT = "a red bicycle at dusk";
+const MINIMAX_TAB = "wf:minimax-music";
+const MINIMAX_CONTAINER_ID = 37;
+const MINIMAX_UNET_INNER_ID = 6;
+const MINIMAX_CLIP_INNER_ID = 8;
+const MINIMAX_WORKFLOW_UUID = "workflow-minimax-music";
+const MINIMAX_ROOT_GRAPH = "graph:workflow-minimax-music-root";
+const MINIMAX_CHILD_GRAPH = "graph:workflow-minimax-music-container-37";
+const MINIMAX_OLD_UNET = "music_fp16.safetensors";
+const MINIMAX_NEW_UNET = "music_fp8.safetensors";
+const MINIMAX_OLD_CLIP = "clip_fp16.safetensors";
+const MINIMAX_NEW_CLIP = "clip_fp8.safetensors";
+
+function linkDrivenWarning(widget: string): string {
+  return (
+    "The write SUCCEEDED and was verified, but it will NOT change the render: " +
+    `widget ${widget} on inner node is link-driven from promoted input. ` +
+    "Set the enclosing subgraph node instead. The container was not written."
+  );
+}
+
+function promotedStringTerminal(hostWidget: string, innerWidget: string, innerNodeId: number) {
+  return {
+    widget: hostWidget,
+    parent_rail: { authoritative: true, widget: hostWidget === "prompt" ? "value" : hostWidget },
+    immediate_node_id: innerNodeId,
+    immediate_widget: innerWidget,
+    terminal_node_id: innerNodeId,
+    terminal_node_type: "PrimitiveString",
+    terminal_widget: innerWidget,
+    terminal_inputs: [{ name: innerWidget, type: "STRING" }],
+    chain_depth: 0,
+  };
+}
+
+function kreaHarness() {
+  const calls: Array<Record<string, unknown>> = [];
+  const containerWidgets: Record<string, string> = { value: KREA_OLD_PROMPT };
+  const innerWidgets: Record<string, string> = { value: KREA_OLD_PROMPT };
+  let inSubgraph = false;
+  let currentGraphIdentity = KREA_ROOT_GRAPH;
+  const connectionIdentity = { generation: 1, tabSessionId: "browser-tab-krea" };
+  let observedPromotedScope: {
+    known: true;
+    scope: "root" | "subgraph";
+    ownerNodeId: string | null;
+    workflowUuid: string;
+    graphIdentity: string;
+  } = {
+    known: true,
+    scope: "root",
+    ownerNodeId: null,
+    workflowUuid: KREA_WORKFLOW_UUID,
+    graphIdentity: KREA_ROOT_GRAPH,
+  };
+
+  const currentViewing = () => ({
+    scope: inSubgraph ? "subgraph" : "root",
+    ...(inSubgraph ? { owner_node_id: KREA_CONTAINER_ID } : {}),
+    graph_identity: currentGraphIdentity,
+    workflow_uuid: KREA_WORKFLOW_UUID,
+  });
+
+  const rememberViewing = (value: Record<string, unknown>) => {
+    const viewing = value.viewing;
+    if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return value;
+    const identity = viewing as Record<string, unknown>;
+    if (identity.scope !== "root" && identity.scope !== "subgraph") return value;
+    observedPromotedScope = {
+      known: true,
+      scope: identity.scope,
+      ownerNodeId: identity.owner_node_id == null ? null : String(identity.owner_node_id),
+      workflowUuid: KREA_WORKFLOW_UUID,
+      graphIdentity: typeof identity.graph_identity === "string"
+        ? identity.graph_identity
+        : currentGraphIdentity,
+    };
+    return value;
+  };
+
+  const innerNode = {
+    id: KREA_INNER_ID,
+    type: "PrimitiveString",
+    node_identity: `node-incarnation:test:${KREA_INNER_ID}`,
+    widgets: { value: innerWidgets.value },
+    inputs: [{ name: "value", type: "STRING" }],
+  };
+
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      if (cmd.cmd === "graph_set_widget") {
+        const nodeId = Number(cmd.node_id);
+        const widget = String(cmd.widget);
+        const value = String(cmd.value);
+        if (nodeId === KREA_CONTAINER_ID && (widget === "value" || widget === "prompt")) {
+          containerWidgets.value = value;
+          if (widget === "prompt") containerWidgets.prompt = value;
+          return { set: { node_id: nodeId, widget, previous: KREA_OLD_PROMPT, value } };
+        }
+        if (nodeId === KREA_INNER_ID && (widget === "value" || widget === "prompt")) {
+          innerWidgets.value = value;
+          return {
+            set: { node_id: nodeId, widget, previous: KREA_OLD_PROMPT, value },
+            warning: linkDrivenWarning(widget),
+          };
+        }
+        throw new Error(`unexpected graph_set_widget ${nodeId} ${widget}`);
+      }
+      if (cmd.cmd === "graph_get_subgraph") {
+        if (String(cmd.node_id) !== String(KREA_CONTAINER_ID)) {
+          throw new Error(`Node ${cmd.node_id} (OrdinaryNode) is not a subgraph`);
+        }
+        return rememberViewing({
+          subgraph_of: {
+            node_id: KREA_CONTAINER_ID,
+            title: "Text to Image (Krea-2 Turbo)",
+            graph_identity: KREA_CHILD_GRAPH,
+          },
+          node_count: 1,
+          nodes: [{ ...innerNode, widgets: { value: innerWidgets.value } }],
+          promoted_terminals: [
+            promotedStringTerminal("prompt", "value", KREA_INNER_ID),
+          ],
+          viewing: currentViewing(),
+        });
+      }
+      if (cmd.cmd === "graph_enter_subgraph") {
+        inSubgraph = true;
+        currentGraphIdentity = KREA_CHILD_GRAPH;
+        return { scope: "subgraph", node_id: cmd.node_id };
+      }
+      if (cmd.cmd === "graph_exit_subgraph") {
+        inSubgraph = false;
+        currentGraphIdentity = KREA_ROOT_GRAPH;
+        return { scope: "root" };
+      }
+      if (cmd.cmd === "graph_query") {
+        const wantId = Array.isArray(cmd.ids) && cmd.ids.length ? String(cmd.ids[0]) : null;
+        if (inSubgraph && wantId === String(KREA_INNER_ID)) {
+          return rememberViewing({
+            nodes: [{ id: innerNode.id, type: innerNode.type, node_identity: innerNode.node_identity }],
+            viewing: currentViewing(),
+          });
+        }
+        return rememberViewing({
+          nodes: [
+            {
+              id: KREA_CONTAINER_ID,
+              type: "SubgraphNode",
+              is_subgraph: true,
+              node_identity: "node-incarnation:test:12",
+              widgets: { ...containerWidgets },
+            },
+          ],
+          viewing: currentViewing(),
+        });
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: KREA_TAB, title: "krea", connected_at: 0 }],
+    resolveActiveTabId: () => KREA_TAB,
+    tabCanMutateGraph: () => true,
+    tabConnectionIdentity: () => connectionIdentity,
+    promotedScopeFor: () => observedPromotedScope,
+    tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedNodeIdentityFenceCapability: () => true,
+    tabExpectedScopeGraphIdentityFenceCapability: () => true,
+    tabPromotedTerminalWitnessCapability: () => true,
+    tabPromotedParentRailFenceCapability: () => true,
+    tabReceiverResolvable: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    workflowUuidFor: () => ({ known: true, uuid: KREA_WORKFLOW_UUID }),
+  } as PanelToolCtx["bridge"];
+
+  return {
+    b,
+    calls,
+    containerWidgets,
+    innerWidgets,
+    serializeForQueue: () => ({ value: containerWidgets.value }),
+    viewing: () => observedPromotedScope,
+    get inSubgraph() {
+      return inSubgraph;
+    },
+  };
+}
+
+async function runKreaSetWidget(widget: "prompt" | "value") {
+  const h = kreaHarness();
+  const ctx = makePanelToolCtx(h.b, KREA_TAB, new WorkflowTargetStore());
+  const setDef = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  const queryDef = buildPanelToolDefs().find((d) => d.name === "panel_query_graph");
+  if (!setDef || !queryDef) throw new Error("panel tools are not registered");
+  const written: ToolResult = await setDef.handler(
+    { node_id: KREA_CONTAINER_ID, widget, value: KREA_NEW_PROMPT } as never,
+    ctx,
+  );
+  const queried: ToolResult = await queryDef.handler(
+    { ids: [KREA_CONTAINER_ID], fields: "detail", limit: 1 } as never,
+    ctx,
+  );
+  return { h, written, queried };
+}
+
+describe("panel_set_widget promoted STRING prompt/value (#2533)", () => {
+  it.each(["prompt", "value"] as const)(
+    "writes the enclosing subgraph when the caller addresses the labelled STRING as %s",
+    async (widget) => {
+      const { h, written, queried } = await runKreaSetWidget(widget);
+
+      expect(written.isError === true).toBe(false);
+      expect(textOf(written)).not.toMatch(/will NOT change the render|The container was not written/);
+      expect(h.calls.map((call) => call.cmd)).not.toContain("graph_enter_subgraph");
+      expect(h.inSubgraph).toBe(false);
+      expect(h.viewing().scope).toBe("root");
+
+      const writes = h.calls.filter((call) => call.cmd === "graph_set_widget");
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toEqual(
+        expect.objectContaining({ node_id: KREA_CONTAINER_ID, value: KREA_NEW_PROMPT }),
+      );
+      expect(writes.some((call) => Number(call.node_id) === KREA_INNER_ID)).toBe(false);
+
+      expect(h.serializeForQueue()).toEqual({ value: KREA_NEW_PROMPT });
+
+      const detail = parseJson(queried);
+      const nodes = detail?.nodes as Array<Record<string, unknown>> | undefined;
+      expect(nodes?.[0]).toMatchObject({
+        id: KREA_CONTAINER_ID,
+        widgets: expect.objectContaining({ value: KREA_NEW_PROMPT }),
+      });
+    },
+  );
+});
+
+function minimaxHarness() {
+  const calls: Array<Record<string, unknown>> = [];
+  const containerWidgets: Record<string, string> = {
+    unet_name: MINIMAX_OLD_UNET,
+    clip_name: MINIMAX_OLD_CLIP,
+  };
+  const innerWidgets: Record<number, Record<string, string>> = {
+    [MINIMAX_UNET_INNER_ID]: { unet_name: MINIMAX_OLD_UNET },
+    [MINIMAX_CLIP_INNER_ID]: { clip_name: MINIMAX_OLD_CLIP },
+  };
+  let inSubgraph = false;
+  let currentGraphIdentity = MINIMAX_ROOT_GRAPH;
+  const connectionIdentity = { generation: 1, tabSessionId: "browser-tab-minimax" };
+  let observedPromotedScope: {
+    known: true;
+    scope: "root" | "subgraph";
+    ownerNodeId: string | null;
+    workflowUuid: string;
+    graphIdentity: string;
+  } = {
+    known: true,
+    scope: "root",
+    ownerNodeId: null,
+    workflowUuid: MINIMAX_WORKFLOW_UUID,
+    graphIdentity: MINIMAX_ROOT_GRAPH,
+  };
+
+  const currentViewing = () => ({
+    scope: inSubgraph ? "subgraph" : "root",
+    ...(inSubgraph ? { owner_node_id: MINIMAX_CONTAINER_ID } : {}),
+    graph_identity: currentGraphIdentity,
+    workflow_uuid: MINIMAX_WORKFLOW_UUID,
+  });
+
+  const rememberViewing = (value: Record<string, unknown>) => {
+    const viewing = value.viewing;
+    if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return value;
+    const identity = viewing as Record<string, unknown>;
+    if (identity.scope !== "root" && identity.scope !== "subgraph") return value;
+    observedPromotedScope = {
+      known: true,
+      scope: identity.scope,
+      ownerNodeId: identity.owner_node_id == null ? null : String(identity.owner_node_id),
+      workflowUuid: MINIMAX_WORKFLOW_UUID,
+      graphIdentity: typeof identity.graph_identity === "string"
+        ? identity.graph_identity
+        : currentGraphIdentity,
+    };
+    return value;
+  };
+
+  const innerNodes = [
+    {
+      id: MINIMAX_UNET_INNER_ID,
+      type: "UNETLoader",
+      node_identity: `node-incarnation:test:${MINIMAX_UNET_INNER_ID}`,
+      widgets: { unet_name: MINIMAX_OLD_UNET, weight_dtype: "default" },
+      inputs: [
+        { name: "unet_name", type: "COMBO" },
+        { name: "weight_dtype", type: "COMBO" },
+      ],
+    },
+    {
+      id: MINIMAX_CLIP_INNER_ID,
+      type: "CLIPLoader",
+      node_identity: `node-incarnation:test:${MINIMAX_CLIP_INNER_ID}`,
+      widgets: { clip_name: MINIMAX_OLD_CLIP, type: "stable_diffusion" },
+      inputs: [
+        { name: "clip_name", type: "COMBO" },
+        { name: "type", type: "COMBO" },
+      ],
+    },
+  ];
+
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      if (cmd.cmd === "graph_set_widget") {
+        const nodeId = Number(cmd.node_id);
+        const widget = String(cmd.widget);
+        const value = String(cmd.value);
+        if (nodeId === MINIMAX_CONTAINER_ID && (widget === "unet_name" || widget === "clip_name")) {
+          const previous = containerWidgets[widget];
+          containerWidgets[widget] = value;
+          return { set: { node_id: nodeId, widget, previous, value } };
+        }
+        if (nodeId === MINIMAX_UNET_INNER_ID && widget === "unet_name") {
+          innerWidgets[nodeId].unet_name = value;
+          return {
+            set: { node_id: nodeId, widget, previous: MINIMAX_OLD_UNET, value },
+            warning: linkDrivenWarning(widget),
+          };
+        }
+        if (nodeId === MINIMAX_CLIP_INNER_ID && widget === "clip_name") {
+          innerWidgets[nodeId].clip_name = value;
+          return {
+            set: { node_id: nodeId, widget, previous: MINIMAX_OLD_CLIP, value },
+            warning: linkDrivenWarning(widget),
+          };
+        }
+        throw new Error(`unexpected graph_set_widget ${nodeId} ${widget}`);
+      }
+      if (cmd.cmd === "graph_get_subgraph") {
+        if (String(cmd.node_id) !== String(MINIMAX_CONTAINER_ID)) {
+          throw new Error(`Node ${cmd.node_id} (OrdinaryNode) is not a subgraph`);
+        }
+        return rememberViewing({
+          subgraph_of: {
+            node_id: MINIMAX_CONTAINER_ID,
+            title: "audio_minimax_music_3",
+            graph_identity: MINIMAX_CHILD_GRAPH,
+          },
+          node_count: innerNodes.length,
+          nodes: innerNodes.map((node) => ({
+            ...node,
+            widgets: { ...node.widgets, ...innerWidgets[node.id] },
+          })),
+          promoted_terminals: [
+            {
+              widget: "unet_name",
+              parent_rail: { authoritative: true, widget: "unet_name" },
+              immediate_node_id: MINIMAX_UNET_INNER_ID,
+              immediate_widget: "unet_name",
+              terminal_node_id: MINIMAX_UNET_INNER_ID,
+              terminal_node_type: "UNETLoader",
+              terminal_widget: "unet_name",
+              terminal_inputs: [
+                { name: "unet_name", type: "COMBO" },
+                { name: "weight_dtype", type: "COMBO" },
+              ],
+              chain_depth: 0,
+            },
+            {
+              widget: "clip_name",
+              parent_rail: { authoritative: true, widget: "clip_name" },
+              immediate_node_id: MINIMAX_CLIP_INNER_ID,
+              immediate_widget: "clip_name",
+              terminal_node_id: MINIMAX_CLIP_INNER_ID,
+              terminal_node_type: "CLIPLoader",
+              terminal_widget: "clip_name",
+              terminal_inputs: [
+                { name: "clip_name", type: "COMBO" },
+                { name: "type", type: "COMBO" },
+              ],
+              chain_depth: 0,
+            },
+          ],
+          viewing: currentViewing(),
+        });
+      }
+      if (cmd.cmd === "graph_enter_subgraph") {
+        inSubgraph = true;
+        currentGraphIdentity = MINIMAX_CHILD_GRAPH;
+        return { scope: "subgraph", node_id: cmd.node_id };
+      }
+      if (cmd.cmd === "graph_exit_subgraph") {
+        inSubgraph = false;
+        currentGraphIdentity = MINIMAX_ROOT_GRAPH;
+        return { scope: "root" };
+      }
+      if (cmd.cmd === "graph_query") {
+        const wantId = Array.isArray(cmd.ids) && cmd.ids.length ? String(cmd.ids[0]) : null;
+        if (inSubgraph && wantId) {
+          const node = innerNodes.find((candidate) => String(candidate.id) === wantId);
+          if (node) {
+            return rememberViewing({
+              nodes: [{ id: node.id, type: node.type, node_identity: node.node_identity }],
+              viewing: currentViewing(),
+            });
+          }
+        }
+        return rememberViewing({
+          nodes: [
+            {
+              id: MINIMAX_CONTAINER_ID,
+              type: "SubgraphNode",
+              is_subgraph: true,
+              node_identity: "node-incarnation:test:37",
+              widgets: { ...containerWidgets },
+            },
+          ],
+          viewing: currentViewing(),
+        });
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: MINIMAX_TAB, title: "minimax", connected_at: 0 }],
+    resolveActiveTabId: () => MINIMAX_TAB,
+    tabCanMutateGraph: () => true,
+    tabConnectionIdentity: () => connectionIdentity,
+    promotedScopeFor: () => observedPromotedScope,
+    tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedNodeIdentityFenceCapability: () => true,
+    tabExpectedScopeGraphIdentityFenceCapability: () => true,
+    tabPromotedTerminalWitnessCapability: () => true,
+    tabPromotedParentRailFenceCapability: () => true,
+    tabReceiverResolvable: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    workflowUuidFor: () => ({ known: true, uuid: MINIMAX_WORKFLOW_UUID }),
+  } as PanelToolCtx["bridge"];
+
+  return {
+    b,
+    calls,
+    containerWidgets,
+    innerWidgets,
+    serializeForQueue: () => ({ ...containerWidgets }),
+    viewing: () => observedPromotedScope,
+    get inSubgraph() {
+      return inSubgraph;
+    },
+  };
+}
+
+async function runMinimaxSetWidget(widget: "unet_name" | "clip_name", value: string) {
+  const h = minimaxHarness();
+  const ctx = makePanelToolCtx(h.b, MINIMAX_TAB, new WorkflowTargetStore());
+  const setDef = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  const queryDef = buildPanelToolDefs().find((d) => d.name === "panel_query_graph");
+  if (!setDef || !queryDef) throw new Error("panel tools are not registered");
+  const written: ToolResult = await setDef.handler(
+    { node_id: MINIMAX_CONTAINER_ID, widget, value } as never,
+    ctx,
+  );
+  const queried: ToolResult = await queryDef.handler(
+    { ids: [MINIMAX_CONTAINER_ID], fields: "detail", limit: 1 } as never,
+    ctx,
+  );
+  return { h, written, queried };
+}
+
+describe("panel_set_widget promoted unet_name/clip_name (#2533)", () => {
+  it("writes unet_name on the enclosing MiniMax container so queue serialization leaves the fp16 default", async () => {
+    const { h, written, queried } = await runMinimaxSetWidget("unet_name", MINIMAX_NEW_UNET);
+
+    expect(written.isError === true).toBe(false);
+    expect(textOf(written)).not.toMatch(/will NOT change the render|The container was not written/);
+    expect(h.calls.map((call) => call.cmd)).not.toContain("graph_enter_subgraph");
+    expect(h.inSubgraph).toBe(false);
+    expect(h.viewing().scope).toBe("root");
+
+    const writes = h.calls.filter((call) => call.cmd === "graph_set_widget");
+    expect(writes).toEqual([
+      expect.objectContaining({
+        node_id: MINIMAX_CONTAINER_ID,
+        widget: "unet_name",
+        value: MINIMAX_NEW_UNET,
+      }),
+    ]);
+    expect(writes.some((call) => Number(call.node_id) === MINIMAX_UNET_INNER_ID)).toBe(false);
+
+    expect(h.containerWidgets.unet_name).toBe(MINIMAX_NEW_UNET);
+    expect(h.containerWidgets.clip_name).toBe(MINIMAX_OLD_CLIP);
+    expect(h.serializeForQueue()).toEqual({
+      unet_name: MINIMAX_NEW_UNET,
+      clip_name: MINIMAX_OLD_CLIP,
+    });
+
+    const detail = parseJson(queried);
+    const nodes = detail?.nodes as Array<Record<string, unknown>> | undefined;
+    expect(nodes?.[0]).toMatchObject({
+      id: MINIMAX_CONTAINER_ID,
+      widgets: { unet_name: MINIMAX_NEW_UNET, clip_name: MINIMAX_OLD_CLIP },
+    });
+  });
+
+  it("writes clip_name on the enclosing MiniMax container so the parent rail is not left at the fp16 clip", async () => {
+    const { h, written, queried } = await runMinimaxSetWidget("clip_name", MINIMAX_NEW_CLIP);
+
+    expect(written.isError === true).toBe(false);
+    expect(h.calls.map((call) => call.cmd)).not.toContain("graph_enter_subgraph");
+    expect(h.inSubgraph).toBe(false);
+
+    const writes = h.calls.filter((call) => call.cmd === "graph_set_widget");
+    expect(writes).toEqual([
+      expect.objectContaining({
+        node_id: MINIMAX_CONTAINER_ID,
+        widget: "clip_name",
+        value: MINIMAX_NEW_CLIP,
+      }),
+    ]);
+    expect(writes.some((call) => Number(call.node_id) === MINIMAX_CLIP_INNER_ID)).toBe(false);
+
+    expect(h.containerWidgets).toEqual({
+      unet_name: MINIMAX_OLD_UNET,
+      clip_name: MINIMAX_NEW_CLIP,
+    });
+    expect(h.serializeForQueue()).toEqual({
+      unet_name: MINIMAX_OLD_UNET,
+      clip_name: MINIMAX_NEW_CLIP,
+    });
+
+    const detail = parseJson(queried);
+    const nodes = detail?.nodes as Array<Record<string, unknown>> | undefined;
+    expect(nodes?.[0]).toMatchObject({
+      id: MINIMAX_CONTAINER_ID,
+      widgets: { unet_name: MINIMAX_OLD_UNET, clip_name: MINIMAX_NEW_CLIP },
+    });
+  });
+
+  it("fails closed on the reported misroute: an inner UNETLoader write leaves container unet_name at fp16", async () => {
+    const h = minimaxHarness();
+    await h.b.send({
+      cmd: "graph_set_widget",
+      node_id: MINIMAX_UNET_INNER_ID,
+      widget: "unet_name",
+      value: MINIMAX_NEW_UNET,
+    });
+    expect(h.innerWidgets[MINIMAX_UNET_INNER_ID].unet_name).toBe(MINIMAX_NEW_UNET);
+    expect(h.containerWidgets.unet_name).toBe(MINIMAX_OLD_UNET);
+    expect(h.serializeForQueue().unet_name).toBe(MINIMAX_OLD_UNET);
+  });
+});

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -1181,13 +1181,12 @@ describe("panel_set_widget promoted subgraph input routing (#2488)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(mutations).toBe(1);
-    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
-      expect.objectContaining({ node_id: 78, widget: "frame_counts", value: 49 }),
-      expect.objectContaining({ node_id: 12, widget: "length", value: 49 }),
-    ]);
-    expect(text).toMatch(/link-driven/);
-    expect(text).toMatch(/enclosing subgraph node 78/);
+    expect(mutations).toBe(0);
+    expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+    expect(
+      calls.some((call) => call.cmd === "graph_set_widget" && Number(call.node_id) === 12),
+    ).toBe(false);
+    expect(text).toMatch(/enclosing subgraph widget on node 78/);
     expect(text).not.toMatch(/Applied via the validated promoted inner widget/);
   });
 });
@@ -1272,6 +1271,183 @@ describe("panel_set_widget promoted Primitive value misroute (#2500)", () => {
       calls.some((call) => call.cmd === "graph_set_widget" && Number(call.node_id) === 198),
     ).toBe(false);
     expect(text).not.toMatch(/Applied via the validated promoted inner widget/);
+  });
+});
+
+/** #2533 — Krea-2 Turbo promoted STRING (`value`, labelled `prompt`). Both
+ * caller names must resolve to the same inner PrimitiveString.value, and the
+ * enclosing subgraph widget is the durable store. */
+const KREA_PROMPT_PROMOTED_SUBGRAPH = {
+  subgraph_of: { node_id: 12, title: "Text to Image (Krea-2 Turbo)" },
+  node_count: 1,
+  nodes: [
+    {
+      id: 131,
+      type: "PrimitiveString",
+      widgets: { value: "a cat" },
+      inputs: [{ name: "value", type: "STRING" }],
+    },
+  ],
+  promoted_terminals: [
+    {
+      widget: "prompt",
+      parent_rail: { authoritative: true, widget: "value" },
+      immediate_node_id: 131,
+      immediate_widget: "value",
+      terminal_node_id: 131,
+      terminal_node_type: "PrimitiveString",
+      terminal_widget: "value",
+      terminal_inputs: [{ name: "value", type: "STRING" }],
+      chain_depth: 0,
+    },
+  ],
+};
+
+/** #2533 — MiniMax audio_minimax_music_3. Root container 37 has authoritative
+ * unet_name/clip_name rails; the inners are ordinary COMBO widgets that are
+ * live inputs, not Primitive* value. */
+const MINIMAX_MUSIC_PROMOTED_SUBGRAPH = {
+  subgraph_of: { node_id: 37, title: "audio_minimax_music_3" },
+  node_count: 2,
+  nodes: [
+    {
+      id: 6,
+      type: "UNETLoader",
+      widgets: { unet_name: "music_fp16.safetensors", weight_dtype: "default" },
+      inputs: [
+        { name: "unet_name", type: "COMBO" },
+        { name: "weight_dtype", type: "COMBO" },
+      ],
+    },
+    {
+      id: 8,
+      type: "CLIPLoader",
+      widgets: { clip_name: "clip_fp16.safetensors", type: "stable_diffusion" },
+      inputs: [
+        { name: "clip_name", type: "COMBO" },
+        { name: "type", type: "COMBO" },
+      ],
+    },
+  ],
+  promoted_terminals: [
+    {
+      widget: "unet_name",
+      parent_rail: { authoritative: true, widget: "unet_name" },
+      immediate_node_id: 6,
+      immediate_widget: "unet_name",
+      terminal_node_id: 6,
+      terminal_node_type: "UNETLoader",
+      terminal_widget: "unet_name",
+      terminal_inputs: [
+        { name: "unet_name", type: "COMBO" },
+        { name: "weight_dtype", type: "COMBO" },
+      ],
+      chain_depth: 0,
+    },
+    {
+      widget: "clip_name",
+      parent_rail: { authoritative: true, widget: "clip_name" },
+      immediate_node_id: 8,
+      immediate_widget: "clip_name",
+      terminal_node_id: 8,
+      terminal_node_type: "CLIPLoader",
+      terminal_widget: "clip_name",
+      terminal_inputs: [
+        { name: "clip_name", type: "COMBO" },
+        { name: "type", type: "COMBO" },
+      ],
+      chain_depth: 0,
+    },
+  ],
+};
+
+describe("panel_set_widget promoted STRING prompt/value (#2533)", () => {
+  const hostDetail = {
+    text:
+      '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+      '{"id":12,"type":"SubgraphNode","is_subgraph":true}',
+  };
+
+  it.each(["prompt", "value"] as const)(
+    "writes the enclosing subgraph when the labelled STRING is addressed as %s",
+    async (widget) => {
+      const { text, isError, calls, mutations } = await setWidget(
+        { node_id: 12, widget, value: "a red bicycle at dusk" },
+        {
+          ownerNodeId: 12,
+          firstWrite: "ok",
+          promotedTerminalWitnesses: true,
+          promotedDetail: hostDetail,
+          subgraph: KREA_PROMPT_PROMOTED_SUBGRAPH,
+        },
+      );
+
+      expect(isError).toBe(false);
+      expect(mutations).toBe(1);
+      expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+      expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+        expect.objectContaining({ node_id: 12, widget: "value", value: "a red bicycle at dusk" }),
+      ]);
+      expect(calls.some((call) => Number(call.node_id) === 131)).toBe(false);
+      expect(text).toMatch(/enclosing subgraph node 12 widget "value"/);
+      expect(text).not.toMatch(/will NOT change the render|The container was not written/);
+    },
+  );
+});
+
+describe("panel_set_widget promoted MiniMax unet_name/clip_name (#2533)", () => {
+  const hostDetail = {
+    text:
+      '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+      '{"id":37,"type":"SubgraphNode","is_subgraph":true}',
+  };
+
+  it("writes unet_name on the enclosing container instead of inner UNETLoader 6", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 37, widget: "unet_name", value: "music_fp8.safetensors" },
+      {
+        ownerNodeId: 37,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: hostDetail,
+        subgraph: MINIMAX_MUSIC_PROMOTED_SUBGRAPH,
+        innerWriteLinkDriven: true,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 37, widget: "unet_name", value: "music_fp8.safetensors" }),
+    ]);
+    expect(calls.some((call) => Number(call.node_id) === 6)).toBe(false);
+    expect(text).toMatch(/enclosing subgraph node 37 widget "unet_name"/);
+    expect(text).not.toMatch(/will NOT change the render|The container was not written/);
+  });
+
+  it("writes clip_name on the enclosing container instead of inner CLIPLoader 8", async () => {
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 37, widget: "clip_name", value: "clip_fp8.safetensors" },
+      {
+        ownerNodeId: 37,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: hostDetail,
+        subgraph: MINIMAX_MUSIC_PROMOTED_SUBGRAPH,
+        innerWriteLinkDriven: true,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 37, widget: "clip_name", value: "clip_fp8.safetensors" }),
+    ]);
+    expect(calls.some((call) => Number(call.node_id) === 8)).toBe(false);
+    expect(text).toMatch(/enclosing subgraph node 37 widget "clip_name"/);
+    expect(text).not.toMatch(/will NOT change the render|The container was not written/);
   });
 });
 
@@ -3051,6 +3227,65 @@ describe("promotedInnerWidgetIsLinkDriven (#2500)", () => {
         "model.prompt",
       ),
     ).toBe(false);
+  });
+
+  it("detects a PrimitiveString whose value widget is a live STRING input (#2533)", () => {
+    expect(
+      promotedInnerWidgetIsLinkDriven(
+        {
+          id: 131,
+          type: "PrimitiveString",
+          widgets: { value: "a cat" },
+          inputs: [{ name: "value", type: "STRING" }],
+        },
+        "value",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a UNETLoader unet_name live input only when the parent rail is authoritative (#2533)", () => {
+    const inner = {
+      id: 6,
+      type: "UNETLoader",
+      widgets: { unet_name: "music_fp16.safetensors", weight_dtype: "default" },
+      inputs: [
+        { name: "unet_name", type: "COMBO" },
+        { name: "weight_dtype", type: "COMBO" },
+      ],
+    };
+    const terminal = {
+      nodeId: 6,
+      nodeType: "UNETLoader",
+      widget: "unet_name",
+      inputs: [
+        { name: "unet_name", type: "COMBO" },
+        { name: "weight_dtype", type: "COMBO" },
+      ],
+      chainDepth: 0,
+    };
+    expect(promotedInnerWidgetIsLinkDriven(inner, "unet_name", terminal)).toBe(false);
+    expect(
+      promotedInnerWidgetIsLinkDriven(inner, "unet_name", terminal, {
+        authoritative: true as const,
+        widget: "unet_name",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects a CLIPLoader clip_name live input only when the parent rail is authoritative (#2533)", () => {
+    const inner = {
+      id: 8,
+      type: "CLIPLoader",
+      widgets: { clip_name: "clip_fp16.safetensors" },
+      inputs: [{ name: "clip_name", type: "COMBO" }],
+    };
+    expect(promotedInnerWidgetIsLinkDriven(inner, "clip_name")).toBe(false);
+    expect(
+      promotedInnerWidgetIsLinkDriven(inner, "clip_name", undefined, {
+        authoritative: true as const,
+        widget: "clip_name",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7961,7 +7961,9 @@ const PROMOTED_PRIMITIVE_INNER_TYPES = new Set([
  * Same-name proxyWidgets promotions keep the inner write so #2314's known-bad
  * live probe still runs before any container mutation.
  * #2500 — a Primitive* `value` that exists as a live input is driven by the
- * promoted rail even when the parent-rail witness is missing; write the host. */
+ * promoted rail even when the parent-rail witness is missing; write the host.
+ * #2533 — an authoritative parent rail whose inner widget is a live input
+ * (unet_name, clip_name, labelled prompt) is the same store; write the host. */
 function shouldWritePromotedHostFirst(plan: PromotedWritePlan): boolean {
   if (plan.innerLinkDriven) return true;
   if (!plan.inner.parentRail) return false;
@@ -8640,7 +8642,12 @@ async function preparePromotedWidgetWrite(
     ...(outerNodeIdentity ? { outerNodeIdentity } : {}),
     inner,
     innerNodeType,
-    innerLinkDriven: promotedInnerWidgetIsLinkDriven(innerNode, inner.widget, inner.terminal),
+    innerLinkDriven: promotedInnerWidgetIsLinkDriven(
+      innerNode,
+      inner.widget,
+      inner.terminal,
+      inner.parentRail,
+    ),
     ...(inner.terminal ? { terminal: inner.terminal } : {}),
     scope,
     binding: {
@@ -20629,11 +20636,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             const afterMappingError = currentPromotedBindingError(ctx, plan.binding);
             if (afterMappingError) return promotedWriteRefusal(args.widget as string, afterMappingError);
 
-            // #2500 — a link-driven inner Primitive (duration/value_2, fps/value_3)
-            // accepts a write and warns that rendering still reads the enclosing
-            // subgraph widget. Write that container first, at the caller's current
-            // graph, and do not enter the inner scope. This is the #1655 fallback
-            // path when the #2488 host-rail write already contradicted.
+            // #2500/#2533 — a link-driven inner (Primitive value, or a same-name
+            // COMBO/STRING live input with an authoritative parent rail) accepts
+            // a write and warns that rendering still reads the enclosing subgraph
+            // widget. Write that container first, at the caller's current graph,
+            // and do not enter the inner scope. This is the #1655 fallback path
+            // when the #2488 host-rail write already contradicted.
             if (plan.innerLinkDriven) {
               if (plan.terminal) {
                 const terminalBlocked = refuseKnownBadPromotedTerminal(plan.terminal);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7948,6 +7948,21 @@ function promotedHostAppliedNote(plan: PromotedWritePlan): string {
   );
 }
 
+/** #2514 — an enclosing-subgraph host write is the parent-authoritative
+ * receipt. Advertise parent_widget_synced even when we never entered the
+ * inner scope (#2500/#2533 host-first), matching the remapped-inner path. */
+function promotedHostWriteReceipt(res: ToolResult, plan: PromotedWritePlan): ToolResult {
+  const payload = parseToolResultJson(res);
+  const note = promotedHostAppliedNote(plan);
+  if (!payload) return appendToolResultText(res, note);
+  const shaped = shapeParentAuthoritativePromotedWrite(payload, {
+    nodeId: plan.outerNodeId,
+    widget: plan.hostWidget,
+    synced: true,
+  });
+  return appendToolResultText(rewriteToolResultJson(res, shaped), note);
+}
+
 const PROMOTED_PRIMITIVE_INNER_TYPES = new Set([
   "PrimitiveInt",
   "PrimitiveFloat",
@@ -20686,7 +20701,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 ctx,
                 plan.outerNodeId,
               );
-              return appendToolResultText(persisted, promotedHostAppliedNote(plan));
+              return promotedHostWriteReceipt(persisted, plan);
             }
 
             const enter = await ctx.call(
@@ -20992,7 +21007,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 ctx,
                 promotedPlan.outerNodeId,
               );
-              return appendToolResultText(persisted, promotedHostAppliedNote(promotedPlan));
+              return promotedHostWriteReceipt(persisted, promotedPlan);
             }
             const hostRefusal = parseContradictoryPromotedWidgetRefusal(
               textOfToolResult(hostWritten),
@@ -21031,7 +21046,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   ctx,
                   promotedPlan.outerNodeId,
                 );
-                return appendToolResultText(persisted, promotedHostAppliedNote(remapPlan));
+                return promotedHostWriteReceipt(persisted, remapPlan);
               }
               if (
                 !parseContradictoryPromotedWidgetRefusal(

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -344,28 +344,47 @@ function primitiveNodeType(innerNode: Record<string, unknown> | null | undefined
   return terminal?.nodeType ?? null;
 }
 
+function innerHasNamedInput(
+  innerNode: Record<string, unknown> | null | undefined,
+  widget: string,
+  terminal?: PromotedTerminalWitness,
+): boolean {
+  const wanted = widget.toLowerCase();
+  if (isRecord(innerNode) && Array.isArray(innerNode.inputs)) {
+    for (const raw of innerNode.inputs) {
+      const name = inputName(raw);
+      if (name && name.toLowerCase() === wanted) return true;
+    }
+  }
+  return terminal?.inputs.some((input) => input.name.toLowerCase() === wanted) === true;
+}
+
 /**
  * #2500 — a Primitive* `value` widget that exists as a live input is driven by
  * the subgraph's promoted rail. Writing that inner widget reports success and
  * leaves the enclosing container (the value that serializes and renders)
  * unchanged. The enclosing subgraph widget is the write target. Converted
- * widgets on ordinary nodes (dynamic-combo children, etc.) are not this shape.
+ * widgets on ordinary nodes (dynamic-combo children, etc.) are not this shape
+ * unless an authoritative parent rail proves the inner input is that rail.
+ * #2533 — same-name COMBO/STRING rails (unet_name, clip_name, labelled prompt)
+ * with a parent-rail witness are the same store: the inner widget is live and
+ * the container is what serializes. Incomplete own-entries (#2393) omit the
+ * rail and keep the inner COMBO write.
  */
 export function promotedInnerWidgetIsLinkDriven(
   innerNode: Record<string, unknown> | null | undefined,
   innerWidget: string,
   terminal?: PromotedTerminalWitness,
+  parentRail?: PromotedParentRailWitness,
 ): boolean {
-  if (innerWidget.toLowerCase() !== "value") return false;
-  const nodeType = primitiveNodeType(innerNode, terminal);
-  if (!nodeType || !PRIMITIVE_NODE_TYPE_RE.test(nodeType)) return false;
-  if (isRecord(innerNode) && Array.isArray(innerNode.inputs)) {
-    for (const raw of innerNode.inputs) {
-      const name = inputName(raw);
-      if (name && name.toLowerCase() === "value") return true;
+  if (innerWidget.toLowerCase() === "value") {
+    const nodeType = primitiveNodeType(innerNode, terminal);
+    if (nodeType && PRIMITIVE_NODE_TYPE_RE.test(nodeType) && innerHasNamedInput(innerNode, "value", terminal)) {
+      return true;
     }
   }
-  return terminal?.inputs.some((input) => input.name.toLowerCase() === "value") === true;
+  if (!parentRail) return false;
+  return innerHasNamedInput(innerNode, innerWidget, terminal);
 }
 
 function innerNodeId(node: Record<string, unknown>): number | string | null {


### PR DESCRIPTION
## Summary
#2500 already writes the enclosing subgraph for Primitive* `value` rails. Tests for the remaining #2533 fixtures show labelled PrimitiveString `prompt`/`value` is covered by that path. MiniMax `audio_minimax_music_3` `unet_name`/`clip_name` is not: those same-name COMBO live inputs have an authoritative parent rail, so the write entered inner node 6, reported success, and left the container at the fp16 default.

`promotedInnerWidgetIsLinkDriven` now treats a live inner input as link-driven when the parent-rail witness is present. Incomplete own-entries (#2393) still omit the rail and write the inner COMBO.

## Test plan
- `npx vitest run src/__tests__/orchestrator/promoted-link-driven-write.test.ts src/__tests__/orchestrator/promoted-widget.test.ts`
- 204 passed (8 link-driven-write + 196 promoted-widget). #2500 duration/fps cases stay green. Prompt/value STRING already passed on 8a27341; unet_name/clip_name failed until this host write.

Fixes #2533