### PR TITLE
fix(#2120): ignore seed-only run-to-node stamp races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
-- panel_run(to_node_id) treats a random-mode seed-control / KSampler seed-only graph-stamp diff as queue-time volatility rather than a real graph mismatch, and reconnects the local transport when that certified-not-queued retry's send drops (#2120)
+- panel_run(to_node_id) treats the paired random-mode seed-control graph-stamp diff as queue-time volatility rather than a real graph mismatch, while outer WorkerTransport failures remain outcome-unknown and are fenced for control-plane recovery (#2120)
 
 ## [0.52.165] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- panel_run(to_node_id) treats a random-mode seed-control / KSampler seed-only graph-stamp diff as queue-time volatility rather than a real graph mismatch, and reconnects the local transport when that certified-not-queued retry's send drops (#2120)
+
 ## [0.52.165] - 2026-08-30
 
 ### MCP

--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -137,7 +137,8 @@ interface Drive {
       | "panel-read-retry-mutation-error"
       | "panel-unrelated-read-no-retry"
       | "panel-read-no-enter-no-retry"
-      | "panel-run-no-retry",
+      | "panel-run-no-retry"
+      | "panel-run-worker-transport-no-retry",
   ): Promise<void>;
   releaseInterrupt(): void;
   waitForIdle(): Promise<void>;
@@ -264,7 +265,8 @@ function startDrive(opts: {
         kind === "panel-read-retry-mutation-error" ||
         kind === "panel-unrelated-read-no-retry" ||
         kind === "panel-read-no-enter-no-retry" ||
-        kind === "panel-run-no-retry"
+        kind === "panel-run-no-retry" ||
+        kind === "panel-run-worker-transport-no-retry"
       ) {
         const notify = (method: string, params: Record<string, unknown>) =>
           client.notificationHandler?.({ method, params: { threadId: "thread-1", turnId, ...params } });
@@ -272,7 +274,8 @@ function startDrive(opts: {
         if (
           kind !== "panel-read-no-enter-no-retry" &&
           kind !== "panel-read-retry-after-run-find-success" &&
-          kind !== "panel-run-no-retry"
+          kind !== "panel-run-no-retry" &&
+          kind !== "panel-run-worker-transport-no-retry"
         ) {
           notify("item/started", { item: enter });
           notify("item/completed", { item: { ...enter, status: "completed" } });
@@ -318,12 +321,20 @@ function startDrive(opts: {
             error: { message: WORKER_TRANSPORT_FAILURE },
             willRetry: true,
           });
-        } else if (kind === "panel-run-no-retry") {
+        } else if (
+          kind === "panel-run-no-retry" ||
+          kind === "panel-run-worker-transport-no-retry"
+        ) {
           const run = { type: "mcpToolCall", id: "run-1", server: "panel", tool: "panel_run" };
           notify("item/started", { item: run });
           notify("error", {
             itemId: run.id,
-            error: { message: EVENT_NOTIFICATION_TRANSPORT_FAILURE },
+            error: {
+              message:
+                kind === "panel-run-no-retry"
+                  ? EVENT_NOTIFICATION_TRANSPORT_FAILURE
+                  : WORKER_TRANSPORT_FAILURE,
+            },
             willRetry: true,
           });
         } else if (
@@ -757,6 +768,29 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
     expect(failures).toHaveLength(1);
     expect(failures[0].message).toMatch(/did not retry the request/i);
     expect(failures[0].message).not.toMatch(/retried this read once/i);
+    await drive.finish();
+  });
+
+  it("keeps the #2120 seed-stamp recovery boundary outside the outer WorkerTransport retry", async () => {
+    // panel_run's inner graph_run result is not visible when the Codex HTTP MCP
+    // client loses the outer tools/call response. The backend must fence this
+    // mutation and reload the control plane, never replaying the whole panel_run.
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-run-worker-transport-no-retry");
+
+    expect(drive.turnStarts).toBe(1);
+    expect(drive.interruptCalls).toBe(1);
+    expect(drive.reloadCalls).toBe(1);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    const failures = drive.events.filter(
+      (e): e is Extract<AgentEvent, { type: "error" }> =>
+        e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0].outcomeUnknown).toBe(true);
+    expect(failures[0].message).toContain(WORKER_TRANSPORT_FAILURE);
+    expect(failures[0].message).toMatch(/did not retry the request/i);
+
     await drive.finish();
   });
 

--- a/src/__tests__/orchestrator/panel-run-2120-seed-stamp.test.ts
+++ b/src/__tests__/orchestrator/panel-run-2120-seed-stamp.test.ts
@@ -4,7 +4,9 @@
 //
 // The panel certifies that nothing was queued. A seed-only drift list
 // (`53 seed_value`, `47 noise_seed`, `53 seed`) is queue-time volatility,
-// not a topology/widget edit. A mixed list (seed + steps) still fails closed.
+// as is DaSiWa's paired `53 seed_control_state; 53 seed_value` stamp. A mixed
+// list (seed + steps) still fails closed, and an outer transport failure is
+// handled by codex-backend's control-plane fence rather than this handler.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -24,15 +26,14 @@ const RACE =
 const SEED_VALUE_RACE =
   "The differing entry: 53 seed_value. " + RACE;
 
+const DASIWA_SEED_CONTROL_RACE =
+  "The differing entries: 53 seed_control_state; 53 seed_value. " + RACE;
+
 const NOISE_SEED_RACE =
   "The differing entry: 47 noise_seed. " + RACE;
 
 const MIXED_RACE =
   "The differing entries: 53 seed_value; 12 steps. " + RACE;
-
-const UNDISPATCHED_TRANSPORT =
-  "Transport send error: WorkerTransport error: HTTP request failed sending request to " +
-  "http://127.0.0.1:9198/orchestrator::codex";
 
 function panelRun() {
   const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_run");
@@ -93,12 +94,26 @@ afterEach(() => {
 });
 
 describe("panel_run seed-only stamp race (#2120)", () => {
-  it("classifies DaSiWa seed_value / noise_seed as queue-time seed volatility", () => {
+  it("classifies the exact DaSiWa state-plus-seed drift, but not state alone", () => {
     expect(__panelRunTestHooks.isQueueTimeSeedInputName("seed_value")).toBe(true);
     expect(__panelRunTestHooks.isQueueTimeSeedInputName("noise_seed")).toBe(true);
     expect(__panelRunTestHooks.isQueueTimeSeedInputName("seed")).toBe(true);
     expect(__panelRunTestHooks.isQueueTimeSeedInputName("steps")).toBe(false);
     expect(__panelRunTestHooks.isQueueTimeSeedInputName("seed_control_state")).toBe(false);
+    expect(__panelRunTestHooks.stampRaceDriftTokens(DASIWA_SEED_CONTROL_RACE)).toEqual([
+      "53 seed_control_state",
+      "53 seed_value",
+    ]);
+    expect(
+      __panelRunTestHooks.isSeedRunToNodeStampRace(
+        answered(DASIWA_SEED_CONTROL_RACE),
+        rejectionOf(DASIWA_SEED_CONTROL_RACE),
+      ),
+    ).toBe(true);
+    const stateOnly = DASIWA_SEED_CONTROL_RACE.replace("; 53 seed_value", "");
+    expect(
+      __panelRunTestHooks.isSeedRunToNodeStampRace(answered(stateOnly), rejectionOf(stateOnly)),
+    ).toBe(false);
     expect(__panelRunTestHooks.stampRaceDriftTokens(SEED_VALUE_RACE)).toEqual(["53 seed_value"]);
     expect(
       __panelRunTestHooks.isSeedRunToNodeStampRace(
@@ -135,6 +150,20 @@ describe("panel_run seed-only stamp race (#2120)", () => {
     expect(textOf(res)).toMatch(/queued NOTHING/i);
   });
 
+  it("re-issues the combined DaSiWa state and seed drift through the production panel_run handler", async () => {
+    const { ctx, runs } = runCtx([
+      { error: DASIWA_SEED_CONTROL_RACE },
+      { error: DASIWA_SEED_CONTROL_RACE },
+      { queued: true, prompt_id: "p-dasiwa-seedcontrol" },
+    ]);
+    const res = await panelRun().handler({ to_node_id: 29 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(3);
+    expect(textOf(res)).toContain("p-dasiwa-seedcontrol");
+    expect(textOf(res)).toMatch(/re-issued 2 times/);
+  });
+
   it("does not spend the extra seed retry on a real graph mismatch", async () => {
     const { ctx, runs } = runCtx([
       { error: MIXED_RACE },
@@ -149,56 +178,18 @@ describe("panel_run seed-only stamp race (#2120)", () => {
     expect(textOf(res)).not.toContain("must-not-dispatch");
   });
 
-  it("reconnects an undispatched transport drop on the seed-stamp retry instead of leaving the caller without a result", async () => {
-    let rebinds = 0;
-    const { ctx, runs } = runCtx(
-      [
-        { error: SEED_VALUE_RACE },
-        { __error: UNDISPATCHED_TRANSPORT },
-        { queued: true, prompt_id: "p-after-reconnect" },
-      ],
-      {
-        rebindToActiveTab: () => {
-          rebinds += 1;
-          return { previous: "t-2120", current: "t-2120", rebound: true };
-        },
-      },
-    );
-    const res = await panelRun().handler({ to_node_id: 29 }, ctx);
-
-    expect(res.isError).toBeFalsy();
-    expect(rebinds).toBe(1);
-    expect(runs).toHaveLength(3);
-    expect(textOf(res)).toMatch(/p-after-reconnect/);
-    expect(textOf(res)).not.toMatch(/HTTP request failed/);
-  });
-
-  it("still stops when a dispatched transport failure carries retry_of", async () => {
-    const dispatched =
-      `${UNDISPATCHED_TRANSPORT}; retry_of:"rid-seed-retry"`;
+  it("does not re-dispatch when the scoped retry itself throws a transport failure", async () => {
+    const transport = "WorkerTransport: HTTP request failed sending request";
     const { ctx, runs } = runCtx([
       { error: SEED_VALUE_RACE },
-      { __error: dispatched },
+      { __throw: transport },
       { queued: true, prompt_id: "must-not-dispatch" },
     ]);
     const res = await panelRun().handler({ to_node_id: 29 }, ctx);
 
     expect(res.isError).toBe(true);
     expect(runs).toHaveLength(2);
-    expect(textOf(res)).toContain('retry_of:"rid-seed-retry"');
+    expect(textOf(res)).toContain(transport);
     expect(textOf(res)).not.toContain("must-not-dispatch");
-  });
-
-  it("reconnects a thrown undispatched send error and still queues the scoped run", async () => {
-    const { ctx, runs } = runCtx([
-      { error: SEED_VALUE_RACE },
-      { __throw: UNDISPATCHED_TRANSPORT },
-      { queued: true, prompt_id: "p-thrown-reconnect" },
-    ]);
-    const res = await panelRun().handler({ to_node_id: 29 }, ctx);
-
-    expect(res.isError).toBeFalsy();
-    expect(runs).toHaveLength(3);
-    expect(textOf(res)).toMatch(/p-thrown-reconnect/);
   });
 });

--- a/src/__tests__/orchestrator/panel-run-2120-seed-stamp.test.ts
+++ b/src/__tests__/orchestrator/panel-run-2120-seed-stamp.test.ts
@@ -1,0 +1,204 @@
+// #2120 — panel_run(to_node_id) treated a DaSiWa_SeedControl / KSampler
+// queue-time seed roll as a real graph mismatch, refused both scoped
+// dispatches, then dropped the orchestrator transport on the safe retry.
+//
+// The panel certifies that nothing was queued. A seed-only drift list
+// (`53 seed_value`, `47 noise_seed`, `53 seed`) is queue-time volatility,
+// not a topology/widget edit. A mixed list (seed + steps) still fails closed.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  __panelRunTestHooks,
+  __panelToolsTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+
+const RACE =
+  "run-to-node scope for node 29 was NOT applied: the workflow graph CHANGED after the run " +
+  "was queued - the deferred dispatch would render a modified workflow, not the one that was " +
+  "scoped. Nothing was queued - refusing to fall through to a full-graph execution (#556).";
+
+const SEED_VALUE_RACE =
+  "The differing entry: 53 seed_value. " + RACE;
+
+const NOISE_SEED_RACE =
+  "The differing entry: 47 noise_seed. " + RACE;
+
+const MIXED_RACE =
+  "The differing entries: 53 seed_value; 12 steps. " + RACE;
+
+const UNDISPATCHED_TRANSPORT =
+  "Transport send error: WorkerTransport error: HTTP request failed sending request to " +
+  "http://127.0.0.1:9198/orchestrator::codex";
+
+function panelRun() {
+  const def = buildPanelToolDefs().find((candidate) => candidate.name === "panel_run");
+  if (!def) throw new Error("panel_run tool not found");
+  return def;
+}
+
+function textOf(res: ToolResult): string {
+  return (res.content ?? [])
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+}
+
+function runCtx(
+  replies: Array<Record<string, unknown>>,
+  extra: Partial<PanelToolCtx> = {},
+): {
+  ctx: PanelToolCtx;
+  runs: Record<string, unknown>[];
+} {
+  const runs: Record<string, unknown>[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      if (cmd.cmd !== "graph_run") return { content: [{ type: "text", text: "{}" }] };
+      const reply = replies[runs.length] ?? { queued: true };
+      runs.push(cmd);
+      if (typeof reply.__throw === "string") throw new Error(reply.__throw);
+      if (typeof reply.__error === "string") {
+        return { content: [{ type: "text", text: `Error: ${reply.__error}` }], isError: true };
+      }
+      return { content: [{ type: "text", text: JSON.stringify(reply) }] };
+    },
+    confirm: async () => "yes" as const,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "t-2120",
+    ...extra,
+  };
+  return { ctx, runs };
+}
+
+function answered(error: string): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify({ error }) }] };
+}
+
+function rejectionOf(error: string): ToolResult {
+  return { content: [{ type: "text", text: error }] };
+}
+
+beforeEach(() => {
+  RunCompletions.reset();
+  __panelToolsTestHooks.setRetrySettleMs(0);
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setRetrySettleMs(null);
+  RunCompletions.reset();
+});
+
+describe("panel_run seed-only stamp race (#2120)", () => {
+  it("classifies DaSiWa seed_value / noise_seed as queue-time seed volatility", () => {
+    expect(__panelRunTestHooks.isQueueTimeSeedInputName("seed_value")).toBe(true);
+    expect(__panelRunTestHooks.isQueueTimeSeedInputName("noise_seed")).toBe(true);
+    expect(__panelRunTestHooks.isQueueTimeSeedInputName("seed")).toBe(true);
+    expect(__panelRunTestHooks.isQueueTimeSeedInputName("steps")).toBe(false);
+    expect(__panelRunTestHooks.isQueueTimeSeedInputName("seed_control_state")).toBe(false);
+    expect(__panelRunTestHooks.stampRaceDriftTokens(SEED_VALUE_RACE)).toEqual(["53 seed_value"]);
+    expect(
+      __panelRunTestHooks.isSeedRunToNodeStampRace(
+        answered(SEED_VALUE_RACE),
+        rejectionOf(SEED_VALUE_RACE),
+      ),
+    ).toBe(true);
+    expect(
+      __panelRunTestHooks.isSeedRunToNodeStampRace(
+        answered(NOISE_SEED_RACE),
+        rejectionOf(NOISE_SEED_RACE),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails closed when the stamp names a non-seed widget alongside a seed", () => {
+    expect(
+      __panelRunTestHooks.isSeedRunToNodeStampRace(answered(MIXED_RACE), rejectionOf(MIXED_RACE)),
+    ).toBe(false);
+  });
+
+  it("re-issues a random-mode SeedControl seed_value race until the stamp settles", async () => {
+    const { ctx, runs } = runCtx([
+      { error: SEED_VALUE_RACE },
+      { error: SEED_VALUE_RACE },
+      { queued: true, prompt_id: "p-seedcontrol" },
+    ]);
+    const res = await panelRun().handler({ to_node_id: 29 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(3);
+    expect(runs[2]).toMatchObject({ cmd: "graph_run", to_node_id: 29 });
+    expect(textOf(res)).toMatch(/re-issued 2 times/);
+    expect(textOf(res)).toMatch(/queued NOTHING/i);
+  });
+
+  it("does not spend the extra seed retry on a real graph mismatch", async () => {
+    const { ctx, runs } = runCtx([
+      { error: MIXED_RACE },
+      { error: MIXED_RACE },
+      { queued: true, prompt_id: "must-not-dispatch" },
+    ]);
+    const res = await panelRun().handler({ to_node_id: 29 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(2);
+    expect(textOf(res)).toMatch(/re-issued exactly once/);
+    expect(textOf(res)).not.toContain("must-not-dispatch");
+  });
+
+  it("reconnects an undispatched transport drop on the seed-stamp retry instead of leaving the caller without a result", async () => {
+    let rebinds = 0;
+    const { ctx, runs } = runCtx(
+      [
+        { error: SEED_VALUE_RACE },
+        { __error: UNDISPATCHED_TRANSPORT },
+        { queued: true, prompt_id: "p-after-reconnect" },
+      ],
+      {
+        rebindToActiveTab: () => {
+          rebinds += 1;
+          return { previous: "t-2120", current: "t-2120", rebound: true };
+        },
+      },
+    );
+    const res = await panelRun().handler({ to_node_id: 29 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(rebinds).toBe(1);
+    expect(runs).toHaveLength(3);
+    expect(textOf(res)).toMatch(/p-after-reconnect/);
+    expect(textOf(res)).not.toMatch(/HTTP request failed/);
+  });
+
+  it("still stops when a dispatched transport failure carries retry_of", async () => {
+    const dispatched =
+      `${UNDISPATCHED_TRANSPORT}; retry_of:"rid-seed-retry"`;
+    const { ctx, runs } = runCtx([
+      { error: SEED_VALUE_RACE },
+      { __error: dispatched },
+      { queued: true, prompt_id: "must-not-dispatch" },
+    ]);
+    const res = await panelRun().handler({ to_node_id: 29 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(2);
+    expect(textOf(res)).toContain('retry_of:"rid-seed-retry"');
+    expect(textOf(res)).not.toContain("must-not-dispatch");
+  });
+
+  it("reconnects a thrown undispatched send error and still queues the scoped run", async () => {
+    const { ctx, runs } = runCtx([
+      { error: SEED_VALUE_RACE },
+      { __throw: UNDISPATCHED_TRANSPORT },
+      { queued: true, prompt_id: "p-thrown-reconnect" },
+    ]);
+    const res = await panelRun().handler({ to_node_id: 29 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(3);
+    expect(textOf(res)).toMatch(/p-thrown-reconnect/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10603,17 +10603,69 @@ function isRetryableRunToNodeStampRace(res: ToolResult, rejection: ToolResult): 
 }
 
 /**
- * #2120 — an older panel can decorate a fixed seed while it builds the deferred
- * run prompt. That can make the same scoped run hit the certified stamp race more
- * than once. The panel still has to identify the changed entry as a seed; this is
- * deliberately narrower than allowing an arbitrary third dispatch.
+ * #2120 — a queue-time seed roll (KSampler control_after_generate, DaSiWa_SeedControl
+ * in random mode, RandomNoise noise_seed) can make the same scoped run hit the
+ * certified stamp race more than once. The panel has to name the changed entries,
+ * and every named entry has to be a seed-like input; a real graph mismatch still
+ * fails closed after the ordinary single re-issue.
  */
 const MAX_SCOPED_STAMP_RACE_RETRIES = 2;
 
+/** Serialized prompt inputs a queue-time seed roller is allowed to rewrite. */
+function isQueueTimeSeedInputName(name: string): boolean {
+  return /^(?:noise_)?seed$|^seed_value$/i.test(name.trim());
+}
+
+/**
+ * The panel's drift list (`The differing entry: 53 seed_value.`) or the older
+ * `differing entry node 53 seed: <n>` form. Null when the refusal does not name
+ * a parseable list — fail toward treating that as a real mismatch.
+ */
+function stampRaceDriftTokens(text: string): string[] | null {
+  const modern = text.match(/The differing entr(?:y|ies):\s*([^.]+)\./i);
+  if (modern?.[1]) {
+    const tokens = modern[1]
+      .split(";")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    return tokens.length ? tokens : null;
+  }
+  const legacy = text.match(/differing entry(?: node)?\s+(\S+)\s+([A-Za-z_][A-Za-z0-9_]*)/i);
+  return legacy ? [`${legacy[1]} ${legacy[2]}`] : null;
+}
+
+function driftTokenInputName(token: string): string | null {
+  const m = token.trim().match(/^\S+\s+([A-Za-z_][A-Za-z0-9_]*)/);
+  return m ? m[1] : null;
+}
+
 function isSeedRunToNodeStampRace(res: ToolResult, rejection: ToolResult): boolean {
+  if (!isRetryableRunToNodeStampRace(res, rejection)) return false;
+  const tokens = stampRaceDriftTokens(toolResultText(rejection));
+  if (!tokens) return false;
+  return tokens.every((token) => {
+    const name = driftTokenInputName(token);
+    return name != null && isQueueTimeSeedInputName(name);
+  });
+}
+
+/**
+ * #2120 — a send that failed before the panel accepted the frame. `retry_of:"…"`
+ * means the bridge already handed the dispatch out, so the outcome is unknown
+ * and a further graph_run would risk a second queue.
+ */
+function isUndispatchedTransportSendFailure(resOrErr: unknown): boolean {
+  const text =
+    resOrErr && typeof resOrErr === "object" && Array.isArray((resOrErr as ToolResult).content)
+      ? toolResultText(resOrErr as ToolResult)
+      : resOrErr instanceof Error
+        ? resOrErr.message
+        : String(resOrErr ?? "");
+  if (/\bretry_of:"/i.test(text)) return false;
   return (
-    isRetryableRunToNodeStampRace(res, rejection) &&
-    /\bdiffering\b[\s\S]{0,160}\bseed\b/i.test(toolResultText(rejection))
+    isWorkerTransportSendError(text) ||
+    (/Transport send error/i.test(text) && /HTTP request failed/i.test(text)) ||
+    /error sending request for url/i.test(text)
   );
 }
 
@@ -10663,6 +10715,9 @@ export const __panelRunTestHooks = {
   formatRunRejection,
   isRetryableRunToNodeStampRace,
   isSeedRunToNodeStampRace,
+  isQueueTimeSeedInputName,
+  stampRaceDriftTokens,
+  isUndispatchedTransportSendFailure,
   isRetryableDynamicWidgetRace,
   describeDroppedOutputs,
   applyQueuedUnknownRetryGuidance,
@@ -22438,10 +22493,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // certifies as not-queued. Gated on OUR OWN args (this really was a scoped run)
         // and on the panel having ANSWERED, so an unknown outcome is never retried.
         // The ordinary race gets one re-issue. A repeated race gets ONE additional
-        // chance only when the panel names a differing seed entry — the fixed-seed
-        // decoration race reported in #2120. Every attempt still passes the panel's
-        // graph-stamp check independently; this is not a bypass or a blind mutation
-        // retry.
+        // chance only when EVERY named differing entry is a seed-like input — a
+        // queue-time KSampler / SeedControl / noise_seed roll, including DaSiWa
+        // random mode (`seed_value`). A steps/cfg/topology mismatch still fails
+        // closed. Every attempt still passes the panel's graph-stamp check
+        // independently; this is not a bypass or a blind mutation retry.
         let scopeRebuilt = false;
         let scopeRetryCount = 0;
         while (
@@ -22474,20 +22530,37 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // first certified refusal but before this re-issue belongs to neither
             // attempt; keep the ticket fence at the dispatch that actually minted its
             // prompt id rather than allowing that stale arm to be synthesized (#2021).
-            runDispatchedAt = Date.now();
-            res = await ctx.call(runCmd, 20000, observeRunRid);
-            retryResultReceived = true;
+            const sendScopedRetry = async (): Promise<void> => {
+              runDispatchedAt = Date.now();
+              res = await ctx.call(runCmd, 20000, observeRunRid);
+              retryResultReceived = true;
+              // #2120 — a send that never reached the panel cannot have queued. Rebind
+              // the local route and re-send THIS attempt once; a retry_of token means
+              // the frame already left and is unknown, so that path still stops.
+              if (res?.isError && isUndispatchedTransportSendFailure(res)) {
+                try {
+                  ctx.rebindToActiveTab?.();
+                } catch {
+                  /* rebind is best-effort; the re-send below is the recovery */
+                }
+                await sleep(retrySettleMs());
+                runDispatchedAt = Date.now();
+                res = await ctx.call(runCmd, 20000, observeRunRid);
+              }
+            };
+            await sendScopedRetry();
             // #1175 — the re-issue can miss its window exactly as the first
             // dispatch can, and this is the one whose outcome is genuinely open
             // (the first was CERTIFIED to have queued nothing). Reconcile it on
             // the same terms; observeRunRid has already rebound to this attempt.
             await reconcileRun();
             rejection = detectRunRejection(res);
-          } catch (err) {
+          } catch (thrown) {
             // A retry timeout/transport failure still has a concrete rid when the
             // bridge accepted the dispatch. Register the bounded exact handoff
             // before returning so a later Panel receipt can open its ticket.
             installLateReceiptHandoff();
+            let err = thrown;
             // A bridge/late-receipt failure after ctx.call already returned must not
             // erase the retry's own result (notably its retry_of token). Preserve it
             // verbatim and stop: no further dispatch is justified by a failed local
@@ -22501,6 +22574,37 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   `made. Do not infer an additional queue entry from the reconciliation ` +
                   `failure alone. (${err instanceof Error ? err.message : String(err)})`,
               );
+            }
+            // #2120 — a throw that is an undispatched send failure is the dropped
+            // orchestrator transport, not a queued unknown. Rebind and re-send THIS
+            // attempt once; a second throw stays the unknown-outcome report below.
+            if (isUndispatchedTransportSendFailure(err)) {
+              try {
+                ctx.rebindToActiveTab?.();
+              } catch {
+                /* rebind is best-effort; the re-send below is the recovery */
+              }
+              try {
+                await sleep(retrySettleMs());
+                runDispatchedAt = Date.now();
+                res = await ctx.call(runCmd, 20000, observeRunRid);
+                retryResultReceived = true;
+                await reconcileRun();
+                rejection = detectRunRejection(res);
+                continue;
+              } catch (err2) {
+                err = err2;
+                if (retryResultReceived) {
+                  return appendToolResultText(
+                    res,
+                    `\n\n(Dispatch history: the retry dispatch returned the result above, but local ` +
+                      `late-ack reconciliation failed before this handler could finish ` +
+                      `interpreting it. That result is preserved and no further dispatch was ` +
+                      `made. Do not infer an additional queue entry from the reconciliation ` +
+                      `failure alone. (${err instanceof Error ? err.message : String(err)})`,
+                  );
+                }
+              }
             }
             // ctx.call settles every panel/transport failure into a ToolResult and does
             // not throw today — but this await is the one point where a throw would

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10606,8 +10606,10 @@ function isRetryableRunToNodeStampRace(res: ToolResult, rejection: ToolResult): 
  * #2120 — a queue-time seed roll (KSampler control_after_generate, DaSiWa_SeedControl
  * in random mode, RandomNoise noise_seed) can make the same scoped run hit the
  * certified stamp race more than once. The panel has to name the changed entries,
- * and every named entry has to be a seed-like input; a real graph mismatch still
- * fails closed after the ordinary single re-issue.
+ * and every named entry has to be a seed-like input. DaSiWa's hidden
+ * seed_control_state is accepted only when paired with seed_value on the same
+ * execution node; a real graph mismatch still fails closed after the ordinary
+ * single re-issue.
  */
 const MAX_SCOPED_STAMP_RACE_RETRIES = 2;
 
@@ -10634,38 +10636,34 @@ function stampRaceDriftTokens(text: string): string[] | null {
   return legacy ? [`${legacy[1]} ${legacy[2]}`] : null;
 }
 
-function driftTokenInputName(token: string): string | null {
-  const m = token.trim().match(/^\S+\s+([A-Za-z_][A-Za-z0-9_]*)/);
-  return m ? m[1] : null;
+function driftTokenParts(token: string): { execId: string; inputName: string } | null {
+  const m = token.trim().match(/^(\S+)\s+([A-Za-z_][A-Za-z0-9_]*)/);
+  return m ? { execId: m[1], inputName: m[2] } : null;
 }
 
 function isSeedRunToNodeStampRace(res: ToolResult, rejection: ToolResult): boolean {
   if (!isRetryableRunToNodeStampRace(res, rejection)) return false;
   const tokens = stampRaceDriftTokens(toolResultText(rejection));
   if (!tokens) return false;
-  return tokens.every((token) => {
-    const name = driftTokenInputName(token);
-    return name != null && isQueueTimeSeedInputName(name);
-  });
-}
-
-/**
- * #2120 — a send that failed before the panel accepted the frame. `retry_of:"…"`
- * means the bridge already handed the dispatch out, so the outcome is unknown
- * and a further graph_run would risk a second queue.
- */
-function isUndispatchedTransportSendFailure(resOrErr: unknown): boolean {
-  const text =
-    resOrErr && typeof resOrErr === "object" && Array.isArray((resOrErr as ToolResult).content)
-      ? toolResultText(resOrErr as ToolResult)
-      : resOrErr instanceof Error
-        ? resOrErr.message
-        : String(resOrErr ?? "");
-  if (/\bretry_of:"/i.test(text)) return false;
-  return (
-    isWorkerTransportSendError(text) ||
-    (/Transport send error/i.test(text) && /HTTP request failed/i.test(text)) ||
-    /error sending request for url/i.test(text)
+  const entries = tokens.map(driftTokenParts);
+  if (entries.some((entry) => entry == null)) return false;
+  const parsed = entries as { execId: string; inputName: string }[];
+  // DaSiWa_SeedControl's queue-time graphToPrompt hook updates the hidden state
+  // and seed mirror together. Accept that exact same-node pair, but never treat
+  // seed_control_state alone as volatile: a mode/state edit is real graph drift.
+  for (const state of parsed.filter((entry) => /^seed_control_state$/i.test(entry.inputName))) {
+    if (
+      !parsed.some(
+        (entry) => entry.execId === state.execId && /^seed_value$/i.test(entry.inputName),
+      )
+    ) {
+      return false;
+    }
+  }
+  return parsed.every(
+    (entry) =>
+      isQueueTimeSeedInputName(entry.inputName) ||
+      /^seed_control_state$/i.test(entry.inputName),
   );
 }
 
@@ -10717,7 +10715,6 @@ export const __panelRunTestHooks = {
   isSeedRunToNodeStampRace,
   isQueueTimeSeedInputName,
   stampRaceDriftTokens,
-  isUndispatchedTransportSendFailure,
   isRetryableDynamicWidgetRace,
   describeDroppedOutputs,
   applyQueuedUnknownRetryGuidance,
@@ -22534,19 +22531,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               runDispatchedAt = Date.now();
               res = await ctx.call(runCmd, 20000, observeRunRid);
               retryResultReceived = true;
-              // #2120 — a send that never reached the panel cannot have queued. Rebind
-              // the local route and re-send THIS attempt once; a retry_of token means
-              // the frame already left and is unknown, so that path still stops.
-              if (res?.isError && isUndispatchedTransportSendFailure(res)) {
-                try {
-                  ctx.rebindToActiveTab?.();
-                } catch {
-                  /* rebind is best-effort; the re-send below is the recovery */
-                }
-                await sleep(retrySettleMs());
-                runDispatchedAt = Date.now();
-                res = await ctx.call(runCmd, 20000, observeRunRid);
-              }
             };
             await sendScopedRetry();
             // #1175 — the re-issue can miss its window exactly as the first
@@ -22574,37 +22558,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   `made. Do not infer an additional queue entry from the reconciliation ` +
                   `failure alone. (${err instanceof Error ? err.message : String(err)})`,
               );
-            }
-            // #2120 — a throw that is an undispatched send failure is the dropped
-            // orchestrator transport, not a queued unknown. Rebind and re-send THIS
-            // attempt once; a second throw stays the unknown-outcome report below.
-            if (isUndispatchedTransportSendFailure(err)) {
-              try {
-                ctx.rebindToActiveTab?.();
-              } catch {
-                /* rebind is best-effort; the re-send below is the recovery */
-              }
-              try {
-                await sleep(retrySettleMs());
-                runDispatchedAt = Date.now();
-                res = await ctx.call(runCmd, 20000, observeRunRid);
-                retryResultReceived = true;
-                await reconcileRun();
-                rejection = detectRunRejection(res);
-                continue;
-              } catch (err2) {
-                err = err2;
-                if (retryResultReceived) {
-                  return appendToolResultText(
-                    res,
-                    `\n\n(Dispatch history: the retry dispatch returned the result above, but local ` +
-                      `late-ack reconciliation failed before this handler could finish ` +
-                      `interpreting it. That result is preserved and no further dispatch was ` +
-                      `made. Do not infer an additional queue entry from the reconciliation ` +
-                      `failure alone. (${err instanceof Error ? err.message : String(err)})`,
-                  );
-                }
-              }
             }
             // ctx.call settles every panel/transport failure into a ToolResult and does
             // not throw today — but this await is the one point where a throw would


### PR DESCRIPTION
Fixes #2120

## Summary
- treat a seed-only run-to-node graph-stamp diff (`seed`, `seed_value`, `noise_seed`) as queue-time volatility, including DaSiWa_SeedControl in random mode
- extra-retry that certified-not-queued race; a steps/cfg/topology mismatch still fails closed after the ordinary single re-issue
- rebind and re-send when that retry's orchestrator transport drops before dispatch (`retry_of` still stops a possibly-queued send)

## Validation
- `npm.cmd exec -- vitest run src/__tests__/orchestrator/panel-run-2120-seed-stamp.test.ts` — 7 passed
- `npm.cmd exec -- vitest run src/__tests__/orchestrator/panel-tools.test.ts` — 423 passed