### PR TITLE
fix(2671): a Windows updater that cannot reach npm or git says so, and says what to do

### DIFF
--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -2141,6 +2141,25 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     ).toBe(false);
   });
 
+  it("#2671 r3 what the REMOTE says can never make us diagnose an ownership refusal", () => {
+    // codex gate r3. `git fetch` relays server text verbatim on `remote:`
+    // lines, so a remote could put the advice string in front of us and have
+    // its own auth failure re-reported as an ownership problem — complete with
+    // our advice to grant a trust exception it has no business asking for.
+    const dir = "C:\\comfy\\custom_nodes\\comfyui-agent-panel";
+    const hostile =
+      `git fetch --quiet in ${dir} failed: ` +
+      `remote: run: git config --global --add safe.directory /tmp/anything\n` +
+      `remote: detected dubious ownership in repository\n` +
+      `fatal: Authentication failed for 'https://example.invalid/x.git/'`;
+    expect(isGitOwnershipRefusal(hostile, dir)).toBe(false);
+    // Control: identical text on git's OWN lines still classifies, so the
+    // filter is dropping the remote channel and not the pattern.
+    expect(
+      isGitOwnershipRefusal(hostile.replace(/^remote: /gm, ""), dir),
+    ).toBe(true);
+  });
+
   it("locally-AHEAD checkout (HEAD ≠ upstream): NOT 'at tip', throws unverifiable", async () => {
     const h = makeDeps({
       comfyuiPath: COMFY,

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -2103,6 +2103,44 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(isGitOwnershipRefusal("error: invalid key: safe.directory")).toBe(false);
   });
 
+  it("#2671 r2 the CHECKOUT PATH cannot spoof the predicate, in either direction", () => {
+    // codex gate r2. runGit embeds the panel dir in every message, so a path
+    // containing the words would match a bare substring test and rob a real
+    // failure of its own correct diagnosis.
+    const spoofDir = "C:\\work\\dubious ownership\\panel";
+    expect(
+      isGitOwnershipRefusal(
+        `git status --porcelain in ${spoofDir} failed: fatal: not a git repository`,
+        spoofDir,
+      ),
+    ).toBe(false);
+    // Without the dir the same message DOES match — which is what proves the
+    // removal, not some other property, is doing the work.
+    expect(
+      isGitOwnershipRefusal(
+        `git status --porcelain in ${spoofDir} failed: fatal: not a git repository`,
+      ),
+    ).toBe(true);
+    // The direction that actually matters: a REAL refusal inside that same
+    // adversarial directory must still classify. Stripping the path must not
+    // disarm detection — git's advice line survives it.
+    expect(
+      isGitOwnershipRefusal(
+        `git rev-parse in ${spoofDir} failed: fatal: detected dubious ownership in repository at '${spoofDir}'\n` +
+          `To add an exception for this directory, call:\n\n` +
+          `\tgit config --global --add safe.directory ${spoofDir}`,
+        spoofDir,
+      ),
+    ).toBe(true);
+    // git prints forward slashes even when we hold backslashes.
+    expect(
+      isGitOwnershipRefusal(
+        `fatal: not a git repository at 'C:/work/dubious ownership/panel'`,
+        spoofDir,
+      ),
+    ).toBe(false);
+  });
+
   it("locally-AHEAD checkout (HEAD ≠ upstream): NOT 'at tip', throws unverifiable", async () => {
     const h = makeDeps({
       comfyuiPath: COMFY,

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -45,6 +45,7 @@ import {
   isProvenQuiescentQueue,
   classifyManagerTaskRecord,
   describeManagerTaskVerdict,
+  gitOwnershipRefusalMessage,
   isGitOwnershipRefusal,
   PanelInstallError,
   PANEL_REGISTRY_ID,
@@ -2139,6 +2140,23 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
         spoofDir,
       ),
     ).toBe(false);
+  });
+
+  it("#2671 r4 the take-ownership remedy names a command the platform HAS", () => {
+    // codex gate r4. This refusal is not Windows-only — on Linux it fires
+    // routinely for a panel dir left root-owned by an install run under sudo —
+    // and `takeown` does not exist there. Naming an unrunnable command is the
+    // same defect the whole message exists to remove.
+    const dir = "/home/me/ComfyUI/custom_nodes/comfyui-agent-panel";
+    const win = gitOwnershipRefusalMessage("C:\\comfy\\panel", "manager no-op", "win32");
+    expect(win).toContain('takeown /f "C:\\comfy\\panel" /r /d y');
+    expect(win).not.toContain("chown");
+
+    const posix = gitOwnershipRefusalMessage(dir, "manager no-op", "linux");
+    expect(posix).toContain(`sudo chown -R "$(id -un)" "${dir}"`);
+    expect(posix).not.toContain("takeown");
+    // The scoped git remedy is platform-independent and must survive on both.
+    for (const m of [win, posix]) expect(m).toContain("--add safe.directory");
   });
 
   it("#2671 r3 what the REMOTE says can never make us diagnose an ownership refusal", () => {

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -2092,6 +2092,15 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     // Unrelated git failures must stay unclassified.
     expect(isGitOwnershipRefusal("fatal: not a git repository")).toBe(false);
     expect(isGitOwnershipRefusal("error: Your local changes would be overwritten")).toBe(false);
+    // codex gate r1 — the bare key was too loose. A checkout under a directory
+    // literally NAMED `safe.directory`, or a config error naming the key, must
+    // keep its own diagnosis rather than be rewritten as an ownership refusal.
+    expect(
+      isGitOwnershipRefusal(
+        "fatal: not a git repository: 'C:/comfy/safe.directory/custom_nodes/panel'",
+      ),
+    ).toBe(false);
+    expect(isGitOwnershipRefusal("error: invalid key: safe.directory")).toBe(false);
   });
 
   it("locally-AHEAD checkout (HEAD ≠ upstream): NOT 'at tip', throws unverifiable", async () => {

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -2089,7 +2089,20 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
       "Um eine Ausnahme für dieses Verzeichnis hinzuzufügen, rufen Sie auf:\n\n" +
       "\tgit config --global --add safe.directory C:/comfy/panel";
     expect(isGitOwnershipRefusal(translated)).toBe(true);
-    expect(isGitOwnershipRefusal("fatal: detected dubious ownership in repository")).toBe(true);
+    expect(
+      isGitOwnershipRefusal(
+        "fatal: detected dubious ownership in repository at 'C:/comfy/panel'\n" +
+          "To add an exception for this directory, call:\n\n" +
+          "\tgit config --global --add safe.directory C:/comfy/panel",
+      ),
+    ).toBe(true);
+    // The PROSE on its own is deliberately NOT a signal (codex gate r5). It is
+    // the half of git's message that translation removes, so it never covered a
+    // case the command did not — while being spoofable by any repo-derived
+    // string that lands in a gate message. Measured on git 2.54.0: the advice
+    // line accompanies the fatal for status, fetch, rev-parse, merge, log and
+    // ls-files, and in a bare repo, so dropping it costs no real detection.
+    expect(isGitOwnershipRefusal("fatal: detected dubious ownership in repository")).toBe(false);
     // Unrelated git failures must stay unclassified.
     expect(isGitOwnershipRefusal("fatal: not a git repository")).toBe(false);
     expect(isGitOwnershipRefusal("error: Your local changes would be overwritten")).toBe(false);
@@ -2108,7 +2121,10 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     // codex gate r2. runGit embeds the panel dir in every message, so a path
     // containing the words would match a bare substring test and rob a real
     // failure of its own correct diagnosis.
-    const spoofDir = "C:\\work\\dubious ownership\\panel";
+    // The path has to carry the full advice COMMAND to be a spoof at all now
+    // (r5 tightened the anchor), so that is what an adversarial checkout dir
+    // looks like here.
+    const spoofDir = "C:\\work\\git config --global --add safe.directory\\panel";
     expect(
       isGitOwnershipRefusal(
         `git status --porcelain in ${spoofDir} failed: fatal: not a git repository`,
@@ -2136,10 +2152,50 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     // git prints forward slashes even when we hold backslashes.
     expect(
       isGitOwnershipRefusal(
-        `fatal: not a git repository at 'C:/work/dubious ownership/panel'`,
+        `fatal: not a git repository at '${spoofDir.replace(/\\/g, "/")}'`,
         spoofDir,
       ),
     ).toBe(false);
+  });
+
+  it("#2671 r5 a repo FILENAME cannot spoof the predicate, and l10n still cannot disarm it", () => {
+    // codex gate r5. The cleanliness gate prints `git status --porcelain`
+    // verbatim, so filenames from the user's own checkout land in the message.
+    // A file named "--add safe.directory" turned a dirty-checkout refusal into
+    // an ownership diagnosis, with a remedy for a problem they do not have.
+    const dir = "C:\\comfy\\custom_nodes\\comfyui-agent-panel";
+    expect(
+      isGitOwnershipRefusal(
+        `Refusing the panel update git fallback: the panel repo at ${dir} has ` +
+          `UNCOMMITTED changes or untracked files (git status --porcelain):\n` +
+          `?? --add safe.directory\n M src/panel.js`,
+        dir,
+      ),
+    ).toBe(false);
+    // Nor via a file named for the prose, which is why the prose alternative
+    // was dropped rather than merely anchored.
+    expect(
+      isGitOwnershipRefusal(`?? detected dubious ownership in repository`, dir),
+    ).toBe(false);
+
+    // The direction that must NOT regress: git's real advice still classifies,
+    // in English and under a translated catalog. Both live in the same
+    // translatable string, so the command surviving is the whole point.
+    const advice = `\tgit config --global --add safe.directory ${dir}`;
+    expect(
+      isGitOwnershipRefusal(
+        `fatal: detected dubious ownership in repository at '${dir}'\n` +
+          `To add an exception for this directory, call:\n\n${advice}`,
+        dir,
+      ),
+    ).toBe(true);
+    expect(
+      isGitOwnershipRefusal(
+        `fatal: Unsichere Besitzverhältnisse im Repository unter '${dir}' entdeckt\n` +
+          `Um eine Ausnahme für dieses Verzeichnis hinzuzufügen, rufen Sie auf:\n\n${advice}`,
+        dir,
+      ),
+    ).toBe(true);
   });
 
   it("#2671 r4 the take-ownership remedy names a command the platform HAS", () => {
@@ -2165,16 +2221,24 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     // its own auth failure re-reported as an ownership problem — complete with
     // our advice to grant a trust exception it has no business asking for.
     const dir = "C:\\comfy\\custom_nodes\\comfyui-agent-panel";
+    const relayed = `run: git config --global --add safe.directory /tmp/anything`;
     const hostile =
       `git fetch --quiet in ${dir} failed: ` +
-      `remote: run: git config --global --add safe.directory /tmp/anything\n` +
+      // Note this first one is NOT at a line start — runGit's prefix precedes
+      // it — which is exactly why the filter excises to end-of-line rather
+      // than dropping whole lines.
+      `remote: ${relayed}\n` +
       `remote: detected dubious ownership in repository\n` +
       `fatal: Authentication failed for 'https://example.invalid/x.git/'`;
     expect(isGitOwnershipRefusal(hostile, dir)).toBe(false);
-    // Control: identical text on git's OWN lines still classifies, so the
-    // filter is dropping the remote channel and not the pattern.
+    // Control: the SAME advice text on a line git itself wrote still
+    // classifies, so the filter is dropping the remote channel, not the
+    // pattern.
     expect(
-      isGitOwnershipRefusal(hostile.replace(/^remote: /gm, ""), dir),
+      isGitOwnershipRefusal(
+        `git fetch --quiet in ${dir} failed: fatal: detected dubious ownership\n\t${relayed}`,
+        dir,
+      ),
     ).toBe(true);
   });
 

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -45,6 +45,7 @@ import {
   isProvenQuiescentQueue,
   classifyManagerTaskRecord,
   describeManagerTaskVerdict,
+  isGitOwnershipRefusal,
   PanelInstallError,
   PANEL_REGISTRY_ID,
   PANEL_VERSION,
@@ -1997,6 +1998,100 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
       PanelInstallError,
     );
     expect(h.gitPulls).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // #2671 — a git OWNERSHIP refusal is its own cause, not the gate's
+  // -------------------------------------------------------------------------
+
+  /**
+   * git's real refusal, captured on Windows from
+   * `GIT_TEST_ASSUME_DIFFERENT_OWNER=1 git rev-parse --show-toplevel` (exit
+   * 128), wrapped exactly as panel-installer's runGit wraps it. Every git
+   * subcommand in the fallback produces this same fatal, which is why the gate
+   * that reports it says nothing about the cause.
+   */
+  const ownershipStderr = (gitArgs: string, atDir: string) =>
+    `git ${gitArgs} in ${atDir} failed: fatal: detected dubious ownership in repository at '${atDir}'\n` +
+    `To add an exception for this directory, call:\n\n` +
+    `\tgit config --global --add safe.directory ${atDir}`;
+
+  it("#2671 ownership refusal at the worktree-root gate names OWNERSHIP, not a broken gitdir", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: LEGACY_NOOP,
+      gitRootError: ownershipStderr("rev-parse --show-toplevel", dir),
+      onGitPull: () => "Updating d806619..675ace8\nFast-forward",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+
+    // The real cause, and the exact scoped remediation with the path QUOTED
+    // (git's own advice line leaves it bare, which breaks on a path with a space).
+    expect(msg).toMatch(/owned by a DIFFERENT account/);
+    expect(msg).toContain(`git config --global --add safe.directory "${dir}"`);
+    // It must also kill the dead end: retrying `git pull` by hand fails identically.
+    expect(msg).toMatch(/git pull.*would use|will not work either/s);
+    // And it must NOT keep the gate's misdiagnosis, which asserts a cause
+    // (an unprovable/copied worktree root) that is false here.
+    expect(msg).not.toMatch(/could not prove .* is the panel repo's worktree root/);
+    // Nothing was mutated.
+    expect(h.gitPulls).toEqual([]);
+  });
+
+  it("#2671 the SAME classification fires from a later gate — it is not pinned to gate order", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: LEGACY_NOOP,
+      onGitPull: () => "Updating d806619..675ace8\nFast-forward",
+    });
+    // Worktree-root and cleanliness gates pass; the refusal surfaces at the
+    // fetch/upstream gate instead, whose own wording blames the upstream.
+    h.deps.gitUpstreamRev = () => {
+      throw new Error(ownershipStderr("rev-parse @{upstream}", dir));
+    };
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/owned by a DIFFERENT account/);
+    expect(msg).toContain(`git config --global --add safe.directory "${dir}"`);
+    expect(h.gitPulls).toEqual([]);
+  });
+
+  it("#2671 a NON-ownership git failure keeps its own gate-specific diagnosis", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: LEGACY_NOOP,
+      gitRootError: "fatal: not a git repository (or any of the parent directories): .git",
+      onGitPull: () => "Updating d806619..675ace8\nFast-forward",
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    const msg = String(err?.message ?? err);
+    // The control: the re-map must not swallow everything it catches.
+    expect(msg).toMatch(/worktree root/);
+    expect(msg).not.toMatch(/owned by a DIFFERENT account/);
+  });
+
+  it("#2671 the ownership predicate anchors on the config key, which l10n keeps verbatim", () => {
+    // git wraps the whole advice in ONE translatable string, so the prose
+    // "dubious ownership" is gone under a translated catalog while the command
+    // token survives. Anchoring on the prose alone would misclassify there.
+    const translated =
+      "fatal: Unsichere Besitzverhältnisse im Repository unter 'C:/comfy/panel' entdeckt\n" +
+      "Um eine Ausnahme für dieses Verzeichnis hinzuzufügen, rufen Sie auf:\n\n" +
+      "\tgit config --global --add safe.directory C:/comfy/panel";
+    expect(isGitOwnershipRefusal(translated)).toBe(true);
+    expect(isGitOwnershipRefusal("fatal: detected dubious ownership in repository")).toBe(true);
+    // Unrelated git failures must stay unclassified.
+    expect(isGitOwnershipRefusal("fatal: not a git repository")).toBe(false);
+    expect(isGitOwnershipRefusal("error: Your local changes would be overwritten")).toBe(false);
   });
 
   it("locally-AHEAD checkout (HEAD ≠ upstream): NOT 'at tip', throws unverifiable", async () => {

--- a/src/__tests__/services/self-update.test.ts
+++ b/src/__tests__/services/self-update.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -10,6 +10,7 @@ import {
   compareSemver,
   detectInstallMode,
   isNewer,
+  resolveNpmLauncher,
   runSelfUpdate,
   selfUpdateStatus,
   SelfUpdateError,
@@ -50,6 +51,7 @@ function makeDeps(opts: {
   npmOk?: boolean; // result of runNpm
   npmStderr?: string; // npm failure output (diagnostics must survive, #912)
   npmStdout?: string;
+  npmMissing?: boolean; // #2671: npm could not be LOCATED at all
   platform?: string; // injected platform (the deferred path is Windows-only)
   scheduleOk?: boolean; // whether scheduleDeferredUpdate reports a launch
   registryThrows?: boolean;
@@ -91,7 +93,12 @@ function makeDeps(opts: {
       const ok = opts.npmOk ?? true;
       return ok
         ? { ok }
-        : { ok, stderr: opts.npmStderr ?? "", stdout: opts.npmStdout ?? "" };
+        : {
+            ok,
+            stderr: opts.npmStderr ?? "",
+            stdout: opts.npmStdout ?? "",
+            ...(opts.npmMissing ? { npmMissing: true } : {}),
+          };
     },
     platform: opts.platform ? () => opts.platform! : undefined,
     scheduleDeferredUpdate: async (o) => {
@@ -948,5 +955,223 @@ describe("selfUpdateStatus and the empty-version guard (#1136 review)", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2671 — self-update must not die because npm is not on THIS process's PATH
+// ---------------------------------------------------------------------------
+
+describe("#2671 — locating npm", () => {
+  // The reporter's host: comfyui-mcp launched by something that never puts the
+  // Node directory on PATH, so `npm.cmd` resolves to nothing and Windows says
+  // "'npm.cmd' is not recognized as an internal or external command".
+  const WIN_NODE_DIR = "C:\\Program Files\\nodejs";
+  const WIN_NODE = join(WIN_NODE_DIR, "node.exe");
+  const WIN_NPM_CLI = join(WIN_NODE_DIR, "node_modules", "npm", "bin", "npm-cli.js");
+  const WIN_SHIM = join(WIN_NODE_DIR, "npm.cmd");
+
+  it("PATH hit keeps the pre-#2671 invocation byte-for-byte (bare shim, shell on)", () => {
+    const got = resolveNpmLauncher({
+      platform: "win32",
+      pathEnv: `C:\\Windows\\system32;${WIN_NODE_DIR}`,
+      execPath: WIN_NODE,
+      exists: (p) => p === WIN_SHIM,
+    });
+    // The bare name, NOT an absolute path: on every host where this already
+    // worked, nothing about the spawn changes.
+    expect(got).toEqual({ file: "npm.cmd", prefixArgs: [], shell: true, source: "path" });
+  });
+
+  it("PATH miss falls back to the npm beside the RUNNING node binary", () => {
+    const got = resolveNpmLauncher({
+      platform: "win32",
+      pathEnv: "C:\\Windows\\system32;C:\\Python311\\Scripts", // no node dir
+      execPath: WIN_NODE,
+      exists: (p) => p === WIN_NPM_CLI,
+    });
+    expect(got?.source).toBe("node-adjacent");
+    // Spawns node with npm's own JS — no shell, so the space in
+    // "C:\Program Files" needs no quoting and cannot split the command.
+    expect(got?.file).toBe(WIN_NODE);
+    expect(got?.shell).toBe(false);
+    expect(got?.prefixArgs).toEqual([WIN_NPM_CLI]);
+  });
+
+  it("POSIX resolves npm through the <prefix>/lib layout, not the Windows one", () => {
+    const cli = join("/usr/local/bin", "..", "lib", "node_modules", "npm", "bin", "npm-cli.js");
+    const got = resolveNpmLauncher({
+      platform: "linux",
+      pathEnv: "/usr/bin:/bin",
+      execPath: "/usr/local/bin/node",
+      exists: (p) => p === cli,
+    });
+    expect(got?.source).toBe("node-adjacent");
+    expect(got?.shell).toBe(false); // never a shell off Windows
+    expect(got?.prefixArgs).toEqual([resolve(cli)]);
+  });
+
+  it("npm nowhere → undefined (callers still get one last-resort bare attempt)", () => {
+    expect(
+      resolveNpmLauncher({
+        platform: "win32",
+        pathEnv: "C:\\Windows\\system32",
+        execPath: WIN_NODE,
+        exists: () => false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("an empty PATH entry never becomes a resolution; a quoted one still does", () => {
+    // An empty entry means "the current directory" to cmd.exe. Picking npm up
+    // from wherever ComfyUI happens to be running is not something we do.
+    expect(
+      resolveNpmLauncher({
+        platform: "win32",
+        pathEnv: ";;  ;",
+        execPath: WIN_NODE,
+        exists: (p) => p === join(".", "npm.cmd") || p === "npm.cmd",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveNpmLauncher({
+        platform: "win32",
+        pathEnv: `"${WIN_NODE_DIR}"`,
+        execPath: WIN_NODE,
+        exists: (p) => p === WIN_SHIM,
+      })?.source,
+    ).toBe("path");
+  });
+
+  it("a PATH probe that THROWS does not abort the resolution", () => {
+    const got = resolveNpmLauncher({
+      platform: "win32",
+      pathEnv: "\\\\dead-share\\x;C:\\Windows\\system32",
+      execPath: WIN_NODE,
+      exists: (p) => {
+        if (p.startsWith("\\\\dead-share")) throw new Error("EPERM");
+        return p === WIN_NPM_CLI;
+      },
+    });
+    expect(got?.source).toBe("node-adjacent");
+  });
+});
+
+describe("#2671 — an unfindable npm is reported as such, not as a failed update", () => {
+  it("reports npm-not-found with the command to run by hand (global)", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.52.139",
+      latest: "0.52.165",
+      npmOk: false,
+      npmMissing: true,
+      npmStderr:
+        "'npm.cmd' is not recognized as an internal or external command,\noperable program or batch file.",
+      platform: "win32",
+    });
+    const res = await runSelfUpdate(h.deps);
+    expect(res.action).toBe("unavailable");
+    // A distinct reason from "npm-failed": npm never ran, so it rendered no
+    // verdict on the update at all.
+    expect(res.reason).toBe("npm-not-found");
+    expect(res.note).toMatch(/npm could not be found/);
+    // The user must be told what to actually DO, and that nothing changed.
+    expect(res.note).toContain(`npm i -g ${PACKAGE_NAME}@latest`);
+    expect(res.note).toMatch(/nothing was changed/);
+    expect(res.note).toMatch(/nodejs\.org/);
+    // The raw launcher failure still travels, so a misclassification can never
+    // hide evidence from the user.
+    expect(res.note).toContain("is not recognized");
+    // The old note claimed npm had rejected the update. It had not.
+    expect(res.note).not.toMatch(/npm update to 0\.52\.165 failed/);
+  });
+
+  it("a LOCAL install is told WHERE to run the command", async () => {
+    const h = makeDeps({
+      packageDir: LOCAL_DIR,
+      currentVersion: "0.52.139",
+      latest: "0.52.165",
+      existing: [join(LOCAL_PROJECT, "package.json")],
+      npmOk: false,
+      npmMissing: true,
+      platform: "win32",
+    });
+    const res = await runSelfUpdate(h.deps);
+    expect(res.reason).toBe("npm-not-found");
+    expect(res.note).toContain(`npm i ${PACKAGE_NAME}@latest`);
+    expect(res.note).toContain(LOCAL_PROJECT);
+  });
+
+  it("EBUSY OUTRANKS the not-found probe — npm plainly ran, so the deferred helper still fires", async () => {
+    // The ordering guard. `npmMissing` only says our own PATH/node-adjacent
+    // probe found nothing; an EBUSY in the output is positive proof npm
+    // executed anyway. Trusting the probe over that proof would strand every
+    // Windows user whose shell resolves npm in a way we cannot see, by
+    // skipping the helper that is the ONLY way an in-place Windows update
+    // ever lands.
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.52.139",
+      latest: "0.52.165",
+      npmOk: false,
+      npmMissing: true,
+      npmStderr: "npm error code EBUSY\nnpm error EBUSY: resource busy or locked",
+      platform: "win32",
+      scheduleOk: true,
+    });
+    const res = await runSelfUpdate(h.deps);
+    expect(res.action).toBe("scheduled");
+    expect(res.reason).toBe("locked-by-running-process");
+    expect(h.scheduleCalls).toHaveLength(1);
+  });
+
+  it("a normal npm failure is untouched by the new branch", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.19.1",
+      latest: "0.20.0",
+      npmOk: false, // npmMissing NOT set — npm ran and said no
+      npmStderr: "npm error code E404",
+      platform: "linux",
+    });
+    const res = await runSelfUpdate(h.deps);
+    expect(res.reason).toBe("npm-failed");
+    expect(res.note).toContain("npm update to 0.20.0 failed");
+    expect(res.note).not.toMatch(/npm could not be found/);
+  });
+});
+
+describe("#2671 — the DEFERRED helper must launch the same npm the caller resolved", () => {
+  const OPTS = {
+    mode: "global" as const,
+    packageDir: "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\comfyui-mcp",
+    to: "0.52.165",
+  };
+
+  it("a node-adjacent launcher is quoted, so 'Program Files' survives the space", () => {
+    const script = buildDeferredUpdateScript(
+      {
+        ...OPTS,
+        npm: {
+          file: "C:\\Program Files\\nodejs\\node.exe",
+          prefixArgs: ["C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js"],
+          shell: false,
+          source: "node-adjacent",
+        },
+      },
+      "C:\\tmp\\log.txt",
+    );
+    expect(script).toContain(
+      "& 'C:\\Program Files\\nodejs\\node.exe' " +
+        "'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js' i -g",
+    );
+    // The bare shim would have failed for exactly the reason the in-process
+    // attempt did — silently, into a log nobody opens.
+    expect(script).not.toContain("& npm.cmd ");
+  });
+
+  it("with no resolved launcher the historical bare shim is kept", () => {
+    const script = buildDeferredUpdateScript(OPTS, "C:\\tmp\\log.txt");
+    expect(script).toContain("& npm.cmd i -g");
   });
 });

--- a/src/__tests__/services/self-update.test.ts
+++ b/src/__tests__/services/self-update.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -13,6 +13,8 @@ import {
   deferredUpdateScriptFor,
   isNewer,
   resolveNpmLauncher,
+  runNpmResolved,
+  type NpmLauncher,
   runSelfUpdate,
   selfUpdateStatus,
   SelfUpdateError,
@@ -1010,7 +1012,11 @@ describe("#2671 — locating npm", () => {
     });
     expect(got?.source).toBe("node-adjacent");
     expect(got?.shell).toBe(false); // never a shell off Windows
-    expect(got?.prefixArgs).toEqual([resolve(cli)]);
+    // `join` already normalized the ".."; no host-cwd `resolve` is involved,
+    // which is what lets the win32 case above evaluate correctly on a POSIX runner.
+    expect(got?.prefixArgs).toEqual([cli]);
+    // `join` collapsed the "..", so nothing downstream has to.
+    expect(got?.prefixArgs[0]).not.toContain("..");
   });
 
   it("npm nowhere → undefined (callers still get one last-resort bare attempt)", () => {
@@ -1188,15 +1194,24 @@ describe("#2671 — the scheduler's script carries THIS process's npm resolution
   const psq = (s: string) => `'${s.replace(/'/g, "''")}'`;
 
   it("defaults npm in when the caller supplies none", () => {
-    // Guard against a vacuous assertion: if npm were unresolvable on the host
-    // running this suite, the check below would pass on an empty premise.
-    // Anything running vitest was itself installed with npm, so this holds.
     const resolved = currentNpmLauncher();
-    expect(resolved).toBeDefined();
-
-    const script = deferredUpdateScriptFor(OPTS, LOG);
-    const expected = [resolved!.file, ...resolved!.prefixArgs].map(psq).join(" ");
-    expect(script).toContain(`& ${expected} i -g ${PACKAGE_NAME}@latest`);
+    // The composition itself, which holds on any host: the seam must default
+    // the launcher rather than pass opts through untouched.
+    expect(deferredUpdateScriptFor(OPTS, LOG)).toBe(
+      buildDeferredUpdateScript({ ...OPTS, npm: resolved }, LOG),
+    );
+    // And where npm IS resolvable — every host this repo builds on, since it
+    // installs with npm — pin the rendered call too, so the assertion above
+    // cannot pass merely because both sides resolved to nothing. Skipping
+    // rather than asserting `toBeDefined` keeps a pnpm/yarn-only or
+    // npm-less-Node host from going red for an environmental reason (codex
+    // gate r1).
+    if (resolved) {
+      const expected = [resolved.file, ...resolved.prefixArgs].map(psq).join(" ");
+      expect(deferredUpdateScriptFor(OPTS, LOG)).toContain(
+        `& ${expected} i -g ${PACKAGE_NAME}@latest`,
+      );
+    }
   });
 
   it("an explicitly supplied launcher is not overwritten by the default", () => {
@@ -1213,5 +1228,143 @@ describe("#2671 — the scheduler's script carries THIS process's npm resolution
       LOG,
     );
     expect(script).toContain("& 'X:\\node\\node.exe' 'X:\\node\\npm-cli.js' i -g");
+  });
+});
+
+describe("#2671 r1 — npmMissing must never be claimed about a run that happened", () => {
+  // codex gate r1. `npmMissing` used to be set from "our probe found nothing
+  // AND execFile reported an error", but on the last-resort bare-name attempt
+  // an error is equally consistent with npm running and returning E404. The
+  // user then got "npm could not be found — install Node.js" for a registry
+  // problem. defaultRunNpm now asks the SHELL before making that claim; these
+  // pin the CLASSIFIER's half of the contract, that a run npm demonstrably
+  // performed is never relabelled.
+
+  it("an npm-level failure reported WITHOUT the missing flag stays npm-failed", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.52.139",
+      latest: "0.52.165",
+      npmOk: false,
+      // The exact shape the old code mislabelled: our probe found no npm, but
+      // the bare-name attempt reached npm and npm answered.
+      npmStderr: "npm error code E404\nnpm error 404 Not Found - GET https://registry.npmjs.org/comfyui-mcp",
+      platform: "win32",
+    });
+    const res = await runSelfUpdate(h.deps);
+    expect(res.reason).toBe("npm-failed");
+    expect(res.note).not.toMatch(/npm could not be found/);
+    expect(res.note).not.toMatch(/nodejs\.org/); // no install-Node remediation
+    expect(res.note).toContain("404 Not Found");
+  });
+
+  it("defaultRunNpm reports no missing flag on a host where npm IS resolvable", async () => {
+    // Drives the REAL defaultRunNpm (not the harness fake) against the real
+    // shell, with a deliberately failing npm subcommand. npm exists here, so
+    // whatever else happens the not-found flag must stay off.
+    const res = await defaultDeps.runNpm(["run", "comfyui-mcp-no-such-script-2671"]);
+    expect(res.ok).toBe(false); // the command really did fail
+    expect(res.npmMissing).toBeUndefined(); // ...but not because npm is absent
+  }, 60_000);
+});
+
+describe("#2671 r1 — the last-resort attempt only claims 'missing' on the shell's word", () => {
+  const FAIL = { ok: false, stdout: "", stderr: "npm error code E404" };
+  const okRes = { ok: true, stdout: "", stderr: "" };
+
+  function io(over: {
+    launcher?: NpmLauncher | undefined;
+    spawnResult?: { ok: boolean; stdout?: string; stderr?: string };
+    shellResolves?: boolean | undefined;
+    calls?: Array<{ file: string; args: string[]; shell: boolean }>;
+    probes?: number[];
+  }) {
+    return {
+      platform: "win32",
+      launcher: over.launcher,
+      spawn: async (file: string, args: string[], shell: boolean) => {
+        over.calls?.push({ file, args, shell });
+        return over.spawnResult ?? FAIL;
+      },
+      shellResolvesNpm: async () => {
+        over.probes?.push(1);
+        return over.shellResolves;
+      },
+    };
+  }
+
+  it("a resolved launcher is run as-is and NEVER probed or flagged", async () => {
+    const calls: Array<{ file: string; args: string[]; shell: boolean }> = [];
+    const probes: number[] = [];
+    const res = await runNpmResolved(
+      io({
+        launcher: {
+          file: "C:\\Program Files\\nodejs\\node.exe",
+          prefixArgs: ["C:\\Program Files\\nodejs\\npm-cli.js"],
+          shell: false,
+          source: "node-adjacent",
+        },
+        calls,
+        probes,
+      }),
+      ["i", "-g", "x"],
+    );
+    expect(res.npmMissing).toBeUndefined();
+    expect(calls).toEqual([
+      {
+        file: "C:\\Program Files\\nodejs\\node.exe",
+        args: ["C:\\Program Files\\nodejs\\npm-cli.js", "i", "-g", "x"],
+        shell: false,
+      },
+    ]);
+    expect(probes).toHaveLength(0); // holding a launcher, nothing to ask
+  });
+
+  it("THE REGRESSION: unresolved launcher + npm ran and said E404 → npm-failed, not missing", async () => {
+    // The exact shape codex caught. Our probe found no npm, the bare-name
+    // attempt reached npm anyway, npm returned 404. Reporting "npm could not
+    // be found" here sends the user to install Node.js over a registry error.
+    const res = await runNpmResolved(
+      io({ launcher: undefined, shellResolves: true }),
+      ["i", "-g", "x"],
+    );
+    expect(res.ok).toBe(false);
+    expect(res.npmMissing).toBeUndefined();
+    expect(res.stderr).toContain("E404");
+  });
+
+  it("unresolved launcher + the shell cannot resolve npm either → missing", async () => {
+    const res = await runNpmResolved(
+      io({ launcher: undefined, shellResolves: false }),
+      ["i", "-g", "x"],
+    );
+    expect(res.npmMissing).toBe(true);
+  });
+
+  it("an UNANSWERABLE probe does not become a claim", async () => {
+    // `where`/`sh` itself failed to launch. That says nothing about npm, so the
+    // not-found claim stays unmade rather than being guessed at.
+    const res = await runNpmResolved(
+      io({ launcher: undefined, shellResolves: undefined }),
+      ["i", "-g", "x"],
+    );
+    expect(res.npmMissing).toBeUndefined();
+  });
+
+  it("a SUCCESSFUL last-resort attempt is never probed at all", async () => {
+    const probes: number[] = [];
+    const res = await runNpmResolved(
+      io({ launcher: undefined, spawnResult: okRes, shellResolves: false, probes }),
+      ["i", "-g", "x"],
+    );
+    expect(res.ok).toBe(true);
+    expect(res.npmMissing).toBeUndefined();
+    expect(probes).toHaveLength(0); // it worked; there is nothing to diagnose
+  });
+
+  it("the last-resort attempt is the pre-#2671 invocation, unchanged", async () => {
+    const calls: Array<{ file: string; args: string[]; shell: boolean }> = [];
+    await runNpmResolved(io({ launcher: undefined, shellResolves: true, calls }), ["i", "-g", "x"]);
+    expect(calls).toEqual([{ file: "npm.cmd", args: ["i", "-g", "x"], shell: true }]);
   });
 });

--- a/src/__tests__/services/self-update.test.ts
+++ b/src/__tests__/services/self-update.test.ts
@@ -14,6 +14,7 @@ import {
   isNewer,
   resolveNpmLauncher,
   runNpmResolved,
+  shellCanResolveNpm,
   type NpmLauncher,
   runSelfUpdate,
   selfUpdateStatus,
@@ -1366,5 +1367,86 @@ describe("#2671 r1 — the last-resort attempt only claims 'missing' on the shel
     const calls: Array<{ file: string; args: string[]; shell: boolean }> = [];
     await runNpmResolved(io({ launcher: undefined, shellResolves: true, calls }), ["i", "-g", "x"]);
     expect(calls).toEqual([{ file: "npm.cmd", args: ["i", "-g", "x"], shell: true }]);
+  });
+});
+
+describe("#2671 r2 — the shell probe must answer only what it actually knows", () => {
+  // codex gate r2. These pin the DISCRIMINATOR against execFile's real error
+  // shapes, measured on Windows rather than assumed:
+  //   found           -> err === null
+  //   exit 1 (no npm) -> { code: 1,       killed: false }   the only real "no"
+  //   spawn failure   -> { code: "ENOENT"               }   a STRING code
+  //   timeout kill    -> { code: null,    killed: true  }
+  // The first draft answered "cannot tell" from a child.on("error") listener,
+  // which never wins: execFile's own error handler invokes the callback first,
+  // so the promise was already settled `false` and BOTH non-answers became
+  // "npm is not installed".
+  // These drive the REAL shellCanResolveNpm against REAL child processes. An
+  // earlier draft re-implemented the classification inside the test; reverting
+  // the discriminator to `!err` left all of it green, which is the whole reason
+  // the probe command is injectable now.
+  const isWin = process.platform === "win32";
+
+  it("a command that IS resolvable answers yes", async () => {
+    const res = await shellCanResolveNpm(
+      isWin
+        ? { file: "where", args: ["where.exe"] }
+        : { file: "sh", args: ["-c", "command -v sh"] },
+    );
+    expect(res).toBe(true);
+  }, 60_000);
+
+  it("a command that is genuinely absent answers NO — a real exit code", async () => {
+    const res = await shellCanResolveNpm(
+      isWin
+        ? { file: "where", args: ["definitely-no-such-command-2671"] }
+        : { file: "sh", args: ["-c", "command -v definitely-no-such-command-2671"] },
+    );
+    expect(res).toBe(false);
+  }, 60_000);
+
+  it("a probe that cannot SPAWN answers cannot-tell, not 'npm is missing'", async () => {
+    // ENOENT arrives with a STRING code. Reading it as a failed lookup is what
+    // would send a user with a broken `where` off to reinstall Node.
+    const res = await shellCanResolveNpm({ file: "no-such-binary-2671-probe", args: [] });
+    expect(res).toBeUndefined();
+  }, 60_000);
+
+  it("a probe we KILL on timeout answers cannot-tell", async () => {
+    const res = await shellCanResolveNpm(
+      isWin
+        ? { file: "ping", args: ["-n", "30", "127.0.0.1"], timeoutMs: 700 }
+        : { file: "sleep", args: ["30"], timeoutMs: 700 },
+    );
+    expect(res).toBeUndefined();
+  }, 60_000);
+});
+
+describe("#2671 r2 — the PATH scan must not block on a dead network share", () => {
+  it("a UNC PATH entry is never stat'ed", () => {
+    // codex gate r2: `exists` is synchronous and a dead share blocks for the
+    // SMB timeout, inside a module contracted to never block startup.
+    const probed: string[] = [];
+    const got = resolveNpmLauncher({
+      platform: "win32",
+      pathEnv: "\\\\fileserver\\tools\\node;//other/share;C:\\Program Files\\nodejs",
+      execPath: "C:\\Program Files\\nodejs\\node.exe",
+      exists: (p) => {
+        probed.push(p);
+        return p === join("C:\\Program Files\\nodejs", "npm.cmd");
+      },
+    });
+    expect(got?.source).toBe("path"); // the local entry after them still works
+    expect(probed.some((p) => p.startsWith("\\\\") || p.startsWith("//"))).toBe(false);
+  });
+
+  it("a UNC entry is still walked on POSIX, where a leading // is just a path", () => {
+    const got = resolveNpmLauncher({
+      platform: "linux",
+      pathEnv: "//net/tools:/usr/bin",
+      execPath: "/usr/local/bin/node",
+      exists: (p) => p === join("//net/tools", "npm"),
+    });
+    expect(got?.source).toBe("path");
   });
 });

--- a/src/__tests__/services/self-update.test.ts
+++ b/src/__tests__/services/self-update.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { join } from "node:path";
+import { join, posix as posixPath, win32 as winPath } from "node:path";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -971,10 +971,13 @@ describe("#2671 — locating npm", () => {
   // The reporter's host: comfyui-mcp launched by something that never puts the
   // Node directory on PATH, so `npm.cmd` resolves to nothing and Windows says
   // "'npm.cmd' is not recognized as an internal or external command".
+  // Windows fixtures are built with the WIN32 path flavour, not the host's, so
+  // these cases assert real Windows behaviour on the ubuntu-latest CI legs too
+  // (codex gate r3 — with host-native joins they passed only on Windows).
   const WIN_NODE_DIR = "C:\\Program Files\\nodejs";
-  const WIN_NODE = join(WIN_NODE_DIR, "node.exe");
-  const WIN_NPM_CLI = join(WIN_NODE_DIR, "node_modules", "npm", "bin", "npm-cli.js");
-  const WIN_SHIM = join(WIN_NODE_DIR, "npm.cmd");
+  const WIN_NODE = winPath.join(WIN_NODE_DIR, "node.exe");
+  const WIN_NPM_CLI = winPath.join(WIN_NODE_DIR, "node_modules", "npm", "bin", "npm-cli.js");
+  const WIN_SHIM = winPath.join(WIN_NODE_DIR, "npm.cmd");
 
   it("PATH hit keeps the pre-#2671 invocation byte-for-byte (bare shim, shell on)", () => {
     const got = resolveNpmLauncher({
@@ -1004,7 +1007,7 @@ describe("#2671 — locating npm", () => {
   });
 
   it("POSIX resolves npm through the <prefix>/lib layout, not the Windows one", () => {
-    const cli = join("/usr/local/bin", "..", "lib", "node_modules", "npm", "bin", "npm-cli.js");
+    const cli = posixPath.join("/usr/local/bin", "..", "lib", "node_modules", "npm", "bin", "npm-cli.js");
     const got = resolveNpmLauncher({
       platform: "linux",
       pathEnv: "/usr/bin:/bin",
@@ -1039,7 +1042,7 @@ describe("#2671 — locating npm", () => {
         platform: "win32",
         pathEnv: ";;  ;",
         execPath: WIN_NODE,
-        exists: (p) => p === join(".", "npm.cmd") || p === "npm.cmd",
+        exists: (p) => p === winPath.join(".", "npm.cmd") || p === "npm.cmd",
       }),
     ).toBeUndefined();
     expect(
@@ -1433,7 +1436,7 @@ describe("#2671 r2 — the PATH scan must not block on a dead network share", ()
       execPath: "C:\\Program Files\\nodejs\\node.exe",
       exists: (p) => {
         probed.push(p);
-        return p === join("C:\\Program Files\\nodejs", "npm.cmd");
+        return p === winPath.join("C:\\Program Files\\nodejs", "npm.cmd");
       },
     });
     expect(got?.source).toBe("path"); // the local entry after them still works
@@ -1445,7 +1448,7 @@ describe("#2671 r2 — the PATH scan must not block on a dead network share", ()
       platform: "linux",
       pathEnv: "//net/tools:/usr/bin",
       execPath: "/usr/local/bin/node",
-      exists: (p) => p === join("//net/tools", "npm"),
+      exists: (p) => p === posixPath.join("//net/tools", "npm"),
     });
     expect(got?.source).toBe("path");
   });

--- a/src/__tests__/services/self-update.test.ts
+++ b/src/__tests__/services/self-update.test.ts
@@ -9,6 +9,8 @@ import {
   checkAndSelfUpdate,
   compareSemver,
   detectInstallMode,
+  currentNpmLauncher,
+  deferredUpdateScriptFor,
   isNewer,
   resolveNpmLauncher,
   runSelfUpdate,
@@ -1173,5 +1175,43 @@ describe("#2671 — the DEFERRED helper must launch the same npm the caller reso
   it("with no resolved launcher the historical bare shim is kept", () => {
     const script = buildDeferredUpdateScript(OPTS, "C:\\tmp\\log.txt");
     expect(script).toContain("& npm.cmd i -g");
+  });
+});
+
+describe("#2671 — the scheduler's script carries THIS process's npm resolution", () => {
+  const OPTS = {
+    mode: "global" as const,
+    packageDir: "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\comfyui-mcp",
+    to: "0.52.165",
+  };
+  const LOG = "C:\\tmp\\log.txt";
+  const psq = (s: string) => `'${s.replace(/'/g, "''")}'`;
+
+  it("defaults npm in when the caller supplies none", () => {
+    // Guard against a vacuous assertion: if npm were unresolvable on the host
+    // running this suite, the check below would pass on an empty premise.
+    // Anything running vitest was itself installed with npm, so this holds.
+    const resolved = currentNpmLauncher();
+    expect(resolved).toBeDefined();
+
+    const script = deferredUpdateScriptFor(OPTS, LOG);
+    const expected = [resolved!.file, ...resolved!.prefixArgs].map(psq).join(" ");
+    expect(script).toContain(`& ${expected} i -g ${PACKAGE_NAME}@latest`);
+  });
+
+  it("an explicitly supplied launcher is not overwritten by the default", () => {
+    const script = deferredUpdateScriptFor(
+      {
+        ...OPTS,
+        npm: {
+          file: "X:\\node\\node.exe",
+          prefixArgs: ["X:\\node\\npm-cli.js"],
+          shell: false,
+          source: "node-adjacent",
+        },
+      },
+      LOG,
+    );
+    expect(script).toContain("& 'X:\\node\\node.exe' 'X:\\node\\npm-cli.js' i -g");
   });
 });

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -540,14 +540,37 @@ function runGit(dir: string, args: string[], timeoutMs: number): string {
  * lose its own correct diagnosis. The two-token command form cannot collide
  * with a path.
  *
+ * That fixed one instance of a CLASS, though (codex gate r2): every gate
+ * message embeds the panel dir, so any substring predicate can be spoofed by a
+ * checkout path containing the words — `C:\work\dubious ownership\panel` would
+ * have matched the prose alternative. So the known directory is REMOVED from
+ * the haystack before testing, which retires the collision class by
+ * construction rather than by making each pattern individually unspoofable.
+ * A genuine refusal in such a directory still classifies, because git's advice
+ * line survives the removal.
+ *
  * DIAGNOSTIC ONLY. This classification never authorizes a mutation — it
  * rewrites a message and nothing else. comfyui-mcp deliberately does not add
  * the safe.directory exception itself: that is the user's security decision.
  */
 const GIT_OWNERSHIP_REFUSAL_RE = /--add\s+safe\.directory|dubious ownership/i;
 
-export function isGitOwnershipRefusal(message: string): boolean {
-  return GIT_OWNERSHIP_REFUSAL_RE.test(message);
+/** Every rendering of `dir` that could appear in git's or a gate's message. */
+function pathVariants(dir: string): string[] {
+  const variants = new Set([dir, dir.replace(/\\/g, "/"), dir.replace(/\//g, "\\")]);
+  return [...variants].filter(Boolean);
+}
+
+export function isGitOwnershipRefusal(message: string, dir?: string): boolean {
+  let haystack = message;
+  if (dir) {
+    for (const v of pathVariants(dir)) {
+      // Windows paths are case-insensitive, and git may echo a different case
+      // than we hold.
+      haystack = haystack.replace(new RegExp(v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gi"), "");
+    }
+  }
+  return GIT_OWNERSHIP_REFUSAL_RE.test(haystack);
 }
 
 /**
@@ -2986,7 +3009,7 @@ async function updateViaGitCheckoutFallback(
     return await updateViaGitCheckoutFallbackInner(opts);
   } catch (err) {
     const raw = err instanceof Error ? err.message : String(err);
-    if (!isGitOwnershipRefusal(raw)) throw err;
+    if (!isGitOwnershipRefusal(raw, opts.dir)) throw err;
     throw new PanelInstallError(gitOwnershipRefusalMessage(opts.dir, opts.managerReason));
   }
 }

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -529,17 +529,22 @@ function runGit(dir: string, args: string[], timeoutMs: number): string {
  * those readings is WRONG here — the repo is fine, and the "update it manually
  * with git pull" remedy they prescribe fails with the same fatal.
  *
- * Anchored on `safe.directory` FIRST: git's whole message is one translatable
- * string, but the config key inside it is a literal command token that
- * translations keep verbatim, whereas the prose "dubious ownership" is
- * translated wherever git's l10n catalogs are installed. The prose alternative
- * is kept as a second chance, not as the primary signal.
+ * Anchored on the remediation COMMAND git prints, `--add safe.directory`, not
+ * on the prose "dubious ownership": git's whole message is one translatable
+ * string, so the prose is gone under a translated catalog while the command
+ * inside it stays verbatim. The prose is kept only as a second chance.
+ *
+ * The bare key `safe.directory` would have been too loose (codex gate r1): a
+ * checkout living under a directory literally named `safe.directory`, or a
+ * config error naming the key, would be rewritten as an ownership refusal and
+ * lose its own correct diagnosis. The two-token command form cannot collide
+ * with a path.
  *
  * DIAGNOSTIC ONLY. This classification never authorizes a mutation — it
  * rewrites a message and nothing else. comfyui-mcp deliberately does not add
  * the safe.directory exception itself: that is the user's security decision.
  */
-const GIT_OWNERSHIP_REFUSAL_RE = /safe\.directory|dubious ownership/i;
+const GIT_OWNERSHIP_REFUSAL_RE = /--add\s+safe\.directory|dubious ownership/i;
 
 export function isGitOwnershipRefusal(message: string): boolean {
   return GIT_OWNERSHIP_REFUSAL_RE.test(message);

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -517,6 +517,68 @@ function runGit(dir: string, args: string[], timeoutMs: number): string {
 }
 
 /**
+ * #2671 — git's refusal to operate on a repository whose on-disk owner is not
+ * the account running us ("detected dubious ownership"). It is NOT a broken
+ * checkout: git exits 128 on EVERY subcommand, verified locally against
+ * `GIT_TEST_ASSUME_DIFFERENT_OWNER=1` for rev-parse, status, fetch and
+ * rev-parse @{upstream} — all four produce the identical fatal.
+ *
+ * That is what makes it worth naming. Each gate in the fallback catches its own
+ * git failure and narrates a cause specific to that gate ("could not prove the
+ * worktree root", "could not confirm the repo is clean"), and every one of
+ * those readings is WRONG here — the repo is fine, and the "update it manually
+ * with git pull" remedy they prescribe fails with the same fatal.
+ *
+ * Anchored on `safe.directory` FIRST: git's whole message is one translatable
+ * string, but the config key inside it is a literal command token that
+ * translations keep verbatim, whereas the prose "dubious ownership" is
+ * translated wherever git's l10n catalogs are installed. The prose alternative
+ * is kept as a second chance, not as the primary signal.
+ *
+ * DIAGNOSTIC ONLY. This classification never authorizes a mutation — it
+ * rewrites a message and nothing else. comfyui-mcp deliberately does not add
+ * the safe.directory exception itself: that is the user's security decision.
+ */
+const GIT_OWNERSHIP_REFUSAL_RE = /safe\.directory|dubious ownership/i;
+
+export function isGitOwnershipRefusal(message: string): boolean {
+  return GIT_OWNERSHIP_REFUSAL_RE.test(message);
+}
+
+/**
+ * The self-contained, actionable replacement for whichever gate happened to
+ * catch an ownership refusal first (#2671). Names the real cause, the exact
+ * scoped remediation, and why we will not apply it on the user's behalf.
+ *
+ * It deliberately does NOT relay the caught message as a "git said" tail. By
+ * the time a gate throws, git's fatal is nested inside that gate's own
+ * narration — the very misdiagnosis this replaces — so quoting it would put
+ * "could not prove … is the panel repo's worktree root" back in front of the
+ * user. Git's actual advice is not lost: it is reproduced below, and with the
+ * directory QUOTED, which git's own line omits (it breaks on a path with a
+ * space, and the default ComfyUI layouts have several).
+ */
+export function gitOwnershipRefusalMessage(dir: string, managerReason: string): string {
+  return (
+    `Panel update did NOT apply: ${managerReason}, and the git fallback is ` +
+    `REFUSED: git will not touch the panel checkout at ${dir} because that ` +
+    `directory is owned by a DIFFERENT account than the one running ComfyUI. ` +
+    `The checkout is not damaged and nothing was changed — but every git ` +
+    `command there fails this way, including the "git pull" a manual retry ` +
+    `would use, so retrying by hand as this same user will not work either.\n` +
+    `Pick ONE of these; comfyui-mcp will not do either for you, because both ` +
+    `hand git back the right to run config-controlled hooks out of that ` +
+    `directory and that is your call to make:\n` +
+    `  1. Trust just this one checkout, then retry the update:\n` +
+    `       git config --global --add safe.directory "${dir}"\n` +
+    `  2. Or, if the directory should not belong to another account at all, ` +
+    `take ownership back from an ELEVATED terminal:\n` +
+    `       takeown /f "${dir}" /r /d y\n` +
+    `Either way, RESTART ComfyUI afterwards.`
+  );
+}
+
+/**
  * `git status --porcelain` in the panel's checkout — the #724 fallback's
  * CLEANLINESS gate. Empty output = clean; anything else (modified tracked
  * files, staged changes, untracked files) means the fallback must REFUSE:
@@ -2901,7 +2963,30 @@ function assertSwapTreeCorroborated(
   );
 }
 
-async function updateViaGitCheckoutFallback(opts: {
+/**
+ * #2671 — re-map an ownership refusal onto its real cause, wherever in the
+ * fallback it surfaced.
+ *
+ * Deliberately wrapped at the FUNCTION boundary rather than patched into the
+ * gate that happens to run first today. Every git call in the body refuses
+ * identically under this condition, so which gate reports it is an artefact of
+ * gate ORDER; pinning the classification to one of them would silently stop
+ * working the day the gates are reordered. Non-ownership failures fall through
+ * untouched — their own gate-specific diagnosis is the right one.
+ */
+async function updateViaGitCheckoutFallback(
+  opts: Parameters<typeof updateViaGitCheckoutFallbackInner>[0],
+): Promise<PanelActionResult> {
+  try {
+    return await updateViaGitCheckoutFallbackInner(opts);
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err);
+    if (!isGitOwnershipRefusal(raw)) throw err;
+    throw new PanelInstallError(gitOwnershipRefusalMessage(opts.dir, opts.managerReason));
+  }
+}
+
+async function updateViaGitCheckoutFallbackInner(opts: {
   deps: PanelInstallerDeps;
   dir: string;
   previousVersion?: string;

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -596,8 +596,25 @@ export function isGitOwnershipRefusal(message: string, dir?: string): boolean {
  * user. Git's actual advice is not lost: it is reproduced below, and with the
  * directory QUOTED, which git's own line omits (it breaks on a path with a
  * space, and the default ComfyUI layouts have several).
+ *
+ * The take-ownership remedy is PLATFORM-SPECIFIC (codex gate r4). This refusal
+ * is not a Windows-only condition — on Linux it fires routinely for a panel dir
+ * left owned by root because ComfyUI was installed under sudo — and handing
+ * those users `takeown` names a command their system does not have. Naming a
+ * remedy that cannot run is the same defect this whole message replaces.
  */
-export function gitOwnershipRefusalMessage(dir: string, managerReason: string): string {
+export function gitOwnershipRefusalMessage(
+  dir: string,
+  managerReason: string,
+  platform: string = process.platform,
+): string {
+  const takeOwnership =
+    platform === "win32"
+      ? `take ownership back from an ELEVATED terminal:\n` +
+        `       takeown /f "${dir}" /r /d y`
+      : `take ownership back (it is commonly root-owned after an install run ` +
+        `under sudo):\n` +
+        `       sudo chown -R "$(id -un)" "${dir}"`;
   return (
     `Panel update did NOT apply: ${managerReason}, and the git fallback is ` +
     `REFUSED: git will not touch the panel checkout at ${dir} because that ` +
@@ -611,8 +628,7 @@ export function gitOwnershipRefusalMessage(dir: string, managerReason: string): 
     `  1. Trust just this one checkout, then retry the update:\n` +
     `       git config --global --add safe.directory "${dir}"\n` +
     `  2. Or, if the directory should not belong to another account at all, ` +
-    `take ownership back from an ELEVATED terminal:\n` +
-    `       takeown /f "${dir}" /r /d y\n` +
+    `${takeOwnership}\n` +
     `Either way, RESTART ComfyUI afterwards.`
   );
 }

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -562,7 +562,18 @@ function pathVariants(dir: string): string[] {
 }
 
 export function isGitOwnershipRefusal(message: string, dir?: string): boolean {
-  let haystack = message;
+  // Drop everything the REMOTE said (codex gate r3). `git fetch` relays server
+  // text verbatim on `remote:` lines, so a remote could put "--add
+  // safe.directory" in front of us and turn its own auth failure into a
+  // fabricated ownership diagnosis — one that tells the user to grant a trust
+  // exception it has no business asking for. Text an external party controls
+  // must never drive a local classification.
+  //
+  // Excised from the marker to end-of-line rather than by dropping whole
+  // lines: runGit prefixes the stderr with `git <args> in <dir> failed: `, so
+  // the FIRST relayed line does not begin at a line start. Git's own messages
+  // never contain "remote:" except when relaying, so nothing local is lost.
+  let haystack = message.replace(/\bremote:.*$/gim, "");
   if (dir) {
     for (const v of pathVariants(dir)) {
       // Windows paths are case-insensitive, and git may echo a different case

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -529,31 +529,33 @@ function runGit(dir: string, args: string[], timeoutMs: number): string {
  * those readings is WRONG here — the repo is fine, and the "update it manually
  * with git pull" remedy they prescribe fails with the same fatal.
  *
- * Anchored on the remediation COMMAND git prints, `--add safe.directory`, not
- * on the prose "dubious ownership": git's whole message is one translatable
- * string, so the prose is gone under a translated catalog while the command
- * inside it stays verbatim. The prose is kept only as a second chance.
+ * Anchored on the whole remediation COMMAND git prints — `git config …
+ * --add safe.directory` on one line — and NOT on the prose "detected dubious
+ * ownership". Git wraps the entire message in one translatable string, so under
+ * a translated catalog the prose is gone while the command inside it stays
+ * verbatim. The command anchor therefore covers every case the prose would
+ * have, and the prose alternative was pure spoofing surface, so it is gone.
  *
- * The bare key `safe.directory` would have been too loose (codex gate r1): a
- * checkout living under a directory literally named `safe.directory`, or a
- * config error naming the key, would be rewritten as an ownership refusal and
- * lose its own correct diagnosis. The two-token command form cannot collide
- * with a path.
+ * That the advice is ALWAYS printed is measured, not assumed (git 2.54.0): the
+ * line appears for status, fetch, rev-parse, rev-parse @{upstream}, merge, log
+ * and ls-files, and in a bare repository too. It is part of the same die()
+ * string as the fatal, not a separately suppressible advice hint.
  *
- * That fixed one instance of a CLASS, though (codex gate r2): every gate
- * message embeds the panel dir, so any substring predicate can be spoofed by a
- * checkout path containing the words — `C:\work\dubious ownership\panel` would
- * have matched the prose alternative. So the known directory is REMOVED from
- * the haystack before testing, which retires the collision class by
- * construction rather than by making each pattern individually unspoofable.
- * A genuine refusal in such a directory still classifies, because git's advice
- * line survives the removal.
+ * The predicate got here by three tightenings, each closing a way REPO-DERIVED
+ * TEXT could spoof it — every gate message embeds strings the user controls:
+ *   r1 — the bare key `safe.directory` matched a directory NAMED that.
+ *   r2 — the panel dir is embedded in every gate message, so any pattern could
+ *        be spoofed by the checkout path. The dir is stripped before testing.
+ *   r3 — `git fetch` relays server text on `remote:` lines. Excised too.
+ *   r5 — the dirty-checkout gate embeds arbitrary FILENAMES from `git status
+ *        --porcelain`, so a file named `--add safe.directory` reclassified a
+ *        dirty checkout as an ownership refusal. Hence the full command anchor.
  *
  * DIAGNOSTIC ONLY. This classification never authorizes a mutation — it
  * rewrites a message and nothing else. comfyui-mcp deliberately does not add
  * the safe.directory exception itself: that is the user's security decision.
  */
-const GIT_OWNERSHIP_REFUSAL_RE = /--add\s+safe\.directory|dubious ownership/i;
+const GIT_OWNERSHIP_REFUSAL_RE = /\bgit\s+config\b[^\n]*--add\s+safe\.directory/i;
 
 /** Every rendering of `dir` that could appear in git's or a gate's message. */
 function pathVariants(dir: string): string[] {

--- a/src/services/self-update.ts
+++ b/src/services/self-update.ts
@@ -30,7 +30,7 @@
 import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { execFile, spawn } from "node:child_process";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { fileURLToPath } from "node:url";
 import { unreachableHostMessage } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -486,6 +486,15 @@ export function resolveNpmLauncher(io: {
 }): NpmLauncher | undefined {
   const isWin = io.platform === "win32";
   const shim = npmShimName(io.platform);
+  // Path arithmetic must follow the INJECTED platform, never the host's (codex
+  // gate r3). Host-native `dirname` on a Windows execPath evaluated from Linux
+  // returns "." — there is no "/" in it — so the node-adjacent candidate
+  // silently collapses to a bare relative path and the launcher is missed. In
+  // production io.platform IS process.platform, so this is the native flavour
+  // and nothing changes; it only makes the seam mean what it says. Choosing the
+  // FLAVOUR retires the class, where the r1 fix (dropping one `resolve()`)
+  // removed a single instance of it.
+  const P = isWin ? pathWin32 : pathPosix;
 
   const pathSep = isWin ? ";" : ":";
   for (const raw of (io.pathEnv ?? "").split(pathSep)) {
@@ -501,7 +510,7 @@ export function resolveNpmLauncher(io: {
     // walk is the shell's problem and already bounded by NPM_TIMEOUT_MS.
     if (isWin && /^[\\/]{2}/.test(entry)) continue;
     try {
-      if (io.exists(join(entry, shim))) {
+      if (io.exists(P.join(entry, shim))) {
         return { file: shim, prefixArgs: [], shell: isWin, source: "path" };
       }
     } catch {
@@ -509,19 +518,17 @@ export function resolveNpmLauncher(io: {
     }
   }
 
-  // `join` normalizes the ".." itself, and `io.execPath` is always absolute, so
-  // there is nothing left for a `resolve()` to do here. Calling one would be
-  // worse than redundant: it resolves against the HOST's cwd and separator
-  // rules, so a Windows layout evaluated on a POSIX runner (which is exactly
-  // what the injected `platform` exists for) would come back cwd-prefixed.
-  const nodeDir = dirname(io.execPath);
+  // `P.join` normalizes the ".." itself and `io.execPath` is always absolute, so
+  // there is nothing left for a `resolve()` to do — and calling one would be
+  // actively wrong, since it resolves against the HOST's cwd (codex gate r1).
+  const nodeDir = P.dirname(io.execPath);
   const cliCandidates = isWin
     ? // Windows: node.exe and node_modules/ sit in the same directory.
-      [join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js")]
+      [P.join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js")]
     : // POSIX: <prefix>/bin/node alongside <prefix>/lib/node_modules/npm.
       [
-        join(nodeDir, "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
-        join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js"),
+        P.join(nodeDir, "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+        P.join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js"),
       ];
   for (const cli of cliCandidates) {
     try {

--- a/src/services/self-update.ts
+++ b/src/services/self-update.ts
@@ -349,6 +349,20 @@ export function buildDeferredUpdateScript(opts: DeferredUpdateOpts, logPath: str
 }
 
 /**
+ * The helper script the scheduler actually writes: #2671's npm resolution
+ * DEFAULTED in for this process when the caller supplied none.
+ *
+ * Exported as its own seam because the defaulting is the entire fix on this
+ * exit, and it is invisible to a test of buildDeferredUpdateScript alone — that
+ * one is handed a launcher and can only prove it renders one. Resolving at this
+ * single choke point also means both scheduler callers inherit it rather than
+ * each having to remember.
+ */
+export function deferredUpdateScriptFor(opts: DeferredUpdateOpts, logPath: string): string {
+  return buildDeferredUpdateScript({ ...opts, npm: opts.npm ?? currentNpmLauncher() }, logPath);
+}
+
+/**
  * Launch the detached helper. Resolves true only when the script was written
  * AND powershell actually spawned — a false here must surface as "not
  * scheduled", never as a claimed scheduled update. Never throws.
@@ -376,14 +390,7 @@ async function defaultScheduleDeferredUpdate(opts: DeferredUpdateOpts): Promise<
       }
     }
     const scriptPath = join(dir, `comfyui-mcp-self-update-${process.pid}-${Date.now()}.ps1`);
-    // #2671 — resolve npm HERE, the single choke point every scheduler caller
-    // passes through, rather than at each of them. `opts.npm` stays injectable
-    // for tests; production always gets this process's own resolution.
-    writeFileSync(
-      scriptPath,
-      buildDeferredUpdateScript({ ...opts, npm: opts.npm ?? currentNpmLauncher() }, logPath),
-      "utf-8",
-    );
+    writeFileSync(scriptPath, deferredUpdateScriptFor(opts, logPath), "utf-8");
     const spawned = await new Promise<boolean>((resolveP) => {
       const child = spawn(
         "powershell.exe",
@@ -522,7 +529,7 @@ export function resolveNpmLauncher(io: {
 }
 
 /** Resolve the npm launcher for THIS process. */
-function currentNpmLauncher(): NpmLauncher | undefined {
+export function currentNpmLauncher(): NpmLauncher | undefined {
   return resolveNpmLauncher({
     platform: process.platform,
     pathEnv: process.env.PATH ?? process.env.Path,

--- a/src/services/self-update.ts
+++ b/src/services/self-update.ts
@@ -493,6 +493,13 @@ export function resolveNpmLauncher(io: {
     // not somewhere we are willing to pick an npm up from.
     const entry = raw.trim().replace(/^"(.*)"$/, "$1");
     if (!entry) continue;
+    // Never stat a UNC path (codex gate r2). `exists` is synchronous, and a
+    // dead network share blocks on the SMB timeout — tens of seconds — inside
+    // a module whose whole contract is that it can be fired and forgotten from
+    // startup without blocking. Reach is not lost: npm genuinely living only on
+    // a share is still found by the last-resort bare-name spawn, whose own PATH
+    // walk is the shell's problem and already bounded by NPM_TIMEOUT_MS.
+    if (isWin && /^[\\/]{2}/.test(entry)) continue;
     try {
       if (io.exists(join(entry, shim))) {
         return { file: shim, prefixArgs: [], shell: isWin, source: "path" };
@@ -581,26 +588,42 @@ function spawnNpm(
  * remediation for a problem they do not have.
  *
  * `where`/`command -v` answer with an EXIT CODE, so this is a structured
- * question, not a match on cmd.exe's localized "is not recognized". A probe
- * that cannot be spawned at all answers `undefined` — cannot tell — and callers
- * must not read that as "missing".
+ * question, not a match on cmd.exe's localized "is not recognized". Only a real
+ * exit code is an ANSWER; a probe that could not run, or that we killed on
+ * timeout, returns `undefined` — cannot tell — and callers must not read that
+ * as "missing".
+ *
+ * Discriminating on `err.code` being a NUMBER is measured, not assumed (codex
+ * gate r2). execFile reports all four outcomes through the same callback:
+ *   found            -> err === null
+ *   exit 1 (no npm)  -> { code: 1,        killed: false }
+ *   spawn failure    -> { code: "ENOENT"                }   (a STRING)
+ *   timeout kill     -> { code: null,     killed: true  }
+ * An earlier draft answered `undefined` from a `child.on("error")` listener,
+ * which never fires in time: execFile's own internal error handler invokes the
+ * callback FIRST, so the promise was already settled as `false`. Both failure
+ * modes silently became "npm is not installed".
  */
-async function shellCanResolveNpm(): Promise<boolean | undefined> {
+export async function shellCanResolveNpm(
+  // Injectable so a test can drive the REAL discriminator against real spawn
+  // failures and real timeouts. A test that re-implements the classification
+  // locally proves only that the test agrees with itself: the first draft of
+  // these tests did exactly that, and reverting the discriminator left every
+  // one of them green.
+  probe?: { file: string; args: string[]; timeoutMs?: number },
+): Promise<boolean | undefined> {
   const isWin = process.platform === "win32";
-  const [file, probeArgs] = isWin
-    ? ["where", [npmShimName("win32")]]
-    : ["sh", ["-c", "command -v npm"]];
+  const { file, args, timeoutMs } = probe ?? {
+    file: isWin ? "where" : "sh",
+    args: isWin ? [npmShimName("win32")] : ["-c", "command -v npm"],
+  };
   return new Promise((resolveP) => {
     try {
-      const child = execFile(
-        file,
-        probeArgs,
-        { timeout: 15_000, windowsHide: true },
-        (err) => resolveP(!err),
-      );
-      // The probe itself never launched (no `where`, no `sh`) — that says
-      // nothing about npm.
-      child.on("error", () => resolveP(undefined));
+      execFile(file, args, { timeout: timeoutMs ?? 15_000, windowsHide: true }, (err) => {
+        if (!err) return resolveP(true);
+        const e = err as NodeJS.ErrnoException & { killed?: boolean };
+        resolveP(typeof e.code === "number" && !e.killed ? false : undefined);
+      });
     } catch {
       resolveP(undefined);
     }

--- a/src/services/self-update.ts
+++ b/src/services/self-update.ts
@@ -502,6 +502,11 @@ export function resolveNpmLauncher(io: {
     }
   }
 
+  // `join` normalizes the ".." itself, and `io.execPath` is always absolute, so
+  // there is nothing left for a `resolve()` to do here. Calling one would be
+  // worse than redundant: it resolves against the HOST's cwd and separator
+  // rules, so a Windows layout evaluated on a POSIX runner (which is exactly
+  // what the injected `platform` exists for) would come back cwd-prefixed.
   const nodeDir = dirname(io.execPath);
   const cliCandidates = isWin
     ? // Windows: node.exe and node_modules/ sit in the same directory.
@@ -516,7 +521,7 @@ export function resolveNpmLauncher(io: {
       if (io.exists(cli)) {
         return {
           file: io.execPath,
-          prefixArgs: [resolve(cli)],
+          prefixArgs: [cli],
           shell: false,
           source: "node-adjacent",
         };
@@ -538,43 +543,129 @@ export function currentNpmLauncher(): NpmLauncher | undefined {
   });
 }
 
+/** One npm spawn. Resolves and never throws; `ok` is a clean exit. */
+function spawnNpm(
+  file: string,
+  spawnArgs: string[],
+  useShell: boolean,
+  cwd?: string,
+): Promise<{ ok: boolean; stdout?: string; stderr?: string }> {
+  return new Promise((resolveP) => {
+    try {
+      // SAFE: every npm arg is a hard-coded constant (no interpolation of user
+      // input), so the shell path has no injection surface. `prefixArgs` is
+      // only ever populated on the shell:false node path.
+      const child = execFile(
+        file,
+        spawnArgs,
+        { cwd, timeout: NPM_TIMEOUT_MS, windowsHide: true, shell: useShell },
+        (err, stdout, stderr) =>
+          resolveP({ ok: !err, stdout: String(stdout ?? ""), stderr: String(stderr ?? "") }),
+      );
+      child.on("error", () => resolveP({ ok: false }));
+    } catch {
+      resolveP({ ok: false });
+    }
+  });
+}
+
+/**
+ * Ask the SHELL — not our own PATH scan — whether it can resolve npm at all
+ * (#2671, codex gate r1).
+ *
+ * This exists to keep "npm could not be found" from being asserted about a run
+ * that plainly happened. `resolveNpmLauncher` failing means only that OUR probe
+ * found nothing; the bare-name last resort still goes through cmd.exe/sh, whose
+ * resolver is not ours. If that attempt then fails because npm returned E404 or
+ * the registry timed out, calling it "npm is not installed" hands the user
+ * remediation for a problem they do not have.
+ *
+ * `where`/`command -v` answer with an EXIT CODE, so this is a structured
+ * question, not a match on cmd.exe's localized "is not recognized". A probe
+ * that cannot be spawned at all answers `undefined` — cannot tell — and callers
+ * must not read that as "missing".
+ */
+async function shellCanResolveNpm(): Promise<boolean | undefined> {
+  const isWin = process.platform === "win32";
+  const [file, probeArgs] = isWin
+    ? ["where", [npmShimName("win32")]]
+    : ["sh", ["-c", "command -v npm"]];
+  return new Promise((resolveP) => {
+    try {
+      const child = execFile(
+        file,
+        probeArgs,
+        { timeout: 15_000, windowsHide: true },
+        (err) => resolveP(!err),
+      );
+      // The probe itself never launched (no `where`, no `sh`) — that says
+      // nothing about npm.
+      child.on("error", () => resolveP(undefined));
+    } catch {
+      resolveP(undefined);
+    }
+  });
+}
+
+/**
+ * The npm-running decision, over injected IO (#2671).
+ *
+ * Split out from `defaultRunNpm` so the unresolved-launcher branch is
+ * reachable from a test: on any machine that can run this suite npm IS
+ * resolvable, so the interesting path — the one the reporter hit — would
+ * otherwise never execute under test and its guard could not be pinned.
+ */
+export async function runNpmResolved(
+  io: {
+    platform: string;
+    launcher: NpmLauncher | undefined;
+    spawn: (
+      file: string,
+      spawnArgs: string[],
+      useShell: boolean,
+      cwd?: string,
+    ) => Promise<{ ok: boolean; stdout?: string; stderr?: string }>;
+    shellResolvesNpm: () => Promise<boolean | undefined>;
+  },
+  args: string[],
+  cwd?: string,
+): Promise<{ ok: boolean; stdout?: string; stderr?: string; npmMissing?: boolean }> {
+  const { launcher } = io;
+  if (launcher) {
+    // Resolved: run it and report npm's own verdict. Never `npmMissing` — we
+    // are holding the launcher.
+    return io.spawn(launcher.file, [...launcher.prefixArgs, ...args], launcher.shell, cwd);
+  }
+
+  // LAST RESORT (#2671): npm is nowhere WE can see it, but our PATH scan is not
+  // the shell's resolver, so make the pre-#2671 bare-name attempt rather than
+  // turning a failed probe into a hard refusal. This is why the change can only
+  // add reach.
+  const res = await io.spawn(npmShimName(io.platform), args, io.platform === "win32", cwd);
+  if (res.ok) return res;
+
+  // It failed, and we could not locate npm. Only NOW is it worth asking whether
+  // npm exists at all — and the answer has to come from the SHELL, because this
+  // failure is equally consistent with "npm ran and said no" (codex gate r1).
+  // Anything other than a definite no leaves the claim unmade.
+  const resolvable = await io.shellResolvesNpm();
+  return resolvable === false ? { ...res, npmMissing: true } : res;
+}
+
 function defaultRunNpm(
   args: string[],
   cwd?: string,
 ): Promise<{ ok: boolean; stdout?: string; stderr?: string; npmMissing?: boolean }> {
-  return new Promise((resolveP) => {
-    const isWin = process.platform === "win32";
-    const launcher = currentNpmLauncher();
-    // LAST RESORT (#2671): when npm is nowhere we can see it, still make the
-    // pre-#2671 bare-name attempt. Our PATH scan is not cmd.exe's resolver, so
-    // an exotic host where the shell would have found npm must not be turned
-    // into a hard refusal by a failed probe. `npmMissing` is then reported only
-    // if that attempt ALSO fails, which makes this strictly additive.
-    const cmd = launcher?.file ?? npmShimName(process.platform);
-    const spawnArgs = [...(launcher?.prefixArgs ?? []), ...args];
-    // SAFE: every npm arg is a hard-coded constant (no interpolation of user
-    // input), so the shell path has no injection surface. `prefixArgs` is only
-    // ever populated on the shell:false node path.
-    const useShell = launcher ? launcher.shell : isWin;
-    const missing = launcher === undefined ? { npmMissing: true } : {};
-    try {
-      const child = execFile(
-        cmd,
-        spawnArgs,
-        { cwd, timeout: NPM_TIMEOUT_MS, windowsHide: true, shell: useShell },
-        (err, stdout, stderr) =>
-          resolveP({
-            ok: !err,
-            stdout: String(stdout ?? ""),
-            stderr: String(stderr ?? ""),
-            ...(err ? missing : {}),
-          }),
-      );
-      child.on("error", () => resolveP({ ok: false, ...missing }));
-    } catch {
-      resolveP({ ok: false, ...missing });
-    }
-  });
+  return runNpmResolved(
+    {
+      platform: process.platform,
+      launcher: currentNpmLauncher(),
+      spawn: spawnNpm,
+      shellResolvesNpm: shellCanResolveNpm,
+    },
+    args,
+    cwd,
+  );
 }
 
 export const defaultDeps: SelfUpdateDeps = {

--- a/src/services/self-update.ts
+++ b/src/services/self-update.ts
@@ -76,8 +76,11 @@ export interface SelfUpdateResult {
    *   - "locked-by-running-process" — npm failed because THIS process holds its
    *     own files open (Windows keeps sharp's libvips DLL mapped, #912).
    *   - "npm-failed" — npm failed for some other reason (see `note` for the tail).
+   *   - "npm-not-found" — npm could not be LOCATED at all (#2671), so the
+   *     failure says nothing about the update itself. Distinct from
+   *     "npm-failed": that one is npm's verdict, this one is npm never running.
    */
-  reason?: "locked-by-running-process" | "npm-failed";
+  reason?: "locked-by-running-process" | "npm-failed" | "npm-not-found";
   /** Human-facing note (reconnect instruction, reason, etc.). */
   note?: string;
 }
@@ -113,7 +116,19 @@ export interface SelfUpdateDeps {
   runNpm: (
     args: string[],
     cwd?: string,
-  ) => Promise<{ ok: boolean; stdout?: string; stderr?: string }>;
+  ) => Promise<{
+    ok: boolean;
+    stdout?: string;
+    stderr?: string;
+    /**
+     * #2671 — true only when npm could not be LOCATED (neither on PATH nor
+     * beside the running node binary) AND the last-resort bare-name spawn also
+     * failed. A STRUCTURED signal on purpose: the alternative is matching
+     * cmd.exe's "is not recognized as an internal or external command", which
+     * is localized and would misclassify on every non-English Windows.
+     */
+    npmMissing?: boolean;
+  }>;
   /** Process platform — injectable so the Windows-only deferred path is testable. */
   platform?: () => string;
   /**
@@ -207,6 +222,14 @@ export interface DeferredUpdateOpts {
   packageDir: string;
   /** Version the helper should land (for the log line; it installs @latest). */
   to: string;
+  /**
+   * #2671 — how the helper must launch npm. The helper inherits the SAME PATH
+   * this process has, so when npm was only reachable beside the node binary,
+   * a helper hard-coded to bare `npm.cmd` fails exactly as the in-process run
+   * would have — silently, into a log the user never opens. Undefined keeps
+   * the historical bare-shim call.
+   */
+  npm?: NpmLauncher;
 }
 
 /** Where the helper writes its log (named in user-facing notes). */
@@ -270,6 +293,14 @@ export function buildDeferredUpdateScript(opts: DeferredUpdateOpts, logPath: str
   // abort the helper, never let npm run in whatever directory it inherited
   // (codex gate r1). Empty for global installs (npm -g has no cwd dependence).
   const cwd = opts.mode === "local" && opts.projectRoot ? opts.projectRoot : "";
+  // #2671 — call the SAME npm the in-process attempt resolved. A node-adjacent
+  // launcher becomes `& '<node.exe>' '<npm-cli.js>' …`; both are psLiteral'd, so
+  // the default `C:\Program Files\nodejs` path survives its space. With no
+  // resolved launcher we keep the historical bare shim, which is still right
+  // whenever PATH carries npm by the time the helper actually runs.
+  const npmCall = opts.npm
+    ? [opts.npm.file, ...opts.npm.prefixArgs].map(psLiteral).join(" ")
+    : "npm.cmd";
   return [
     `# comfyui-mcp deferred self-update helper (#912). Log: ${logPath}`,
     `$ErrorActionPreference = 'Continue'`,
@@ -302,7 +333,7 @@ export function buildDeferredUpdateScript(opts: DeferredUpdateOpts, logPath: str
     `    }`,
     `  }`,
     `  if ($aborted) { break }`,
-    `  & npm.cmd ${npmArgs} *>> $log`,
+    `  & ${npmCall} ${npmArgs} *>> $log`,
     `  if ($LASTEXITCODE -eq 0) { $ok = $true } else { Start-Sleep -Seconds 10 }`,
     `}`,
     `if ($aborted) {`,
@@ -345,7 +376,14 @@ async function defaultScheduleDeferredUpdate(opts: DeferredUpdateOpts): Promise<
       }
     }
     const scriptPath = join(dir, `comfyui-mcp-self-update-${process.pid}-${Date.now()}.ps1`);
-    writeFileSync(scriptPath, buildDeferredUpdateScript(opts, logPath), "utf-8");
+    // #2671 — resolve npm HERE, the single choke point every scheduler caller
+    // passes through, rather than at each of them. `opts.npm` stays injectable
+    // for tests; production always gets this process's own resolution.
+    writeFileSync(
+      scriptPath,
+      buildDeferredUpdateScript({ ...opts, npm: opts.npm ?? currentNpmLauncher() }, logPath),
+      "utf-8",
+    );
     const spawned = await new Promise<boolean>((resolveP) => {
       const child = spawn(
         "powershell.exe",
@@ -380,27 +418,154 @@ export function deferredUpdateLogPath(): string {
   return join(tmpdir(), HELPER_LOG_NAME);
 }
 
+// ---------------------------------------------------------------------------
+// #2671 — locating npm
+// ---------------------------------------------------------------------------
+
+/**
+ * How to LAUNCH npm (#2671).
+ *
+ * npm used to be resolved as the bare name `npm.cmd`/`npm` through the
+ * inherited PATH, so an orchestrator started by a launcher that does not put
+ * the Node directory on PATH — ComfyUI Desktop, a Python venv, a service
+ * wrapper — could never self-update: Windows answered `'npm.cmd' is not
+ * recognized as an internal or external command` and the note relayed that
+ * verbatim, leaving the user to remediate by hand.
+ *
+ * npm is not actually absent in that case. It ships NEXT TO the `node` binary
+ * that is running this very process, and `process.execPath` is an absolute
+ * path we always have, PATH or no PATH.
+ */
+export interface NpmLauncher {
+  /** Executable to spawn. */
+  file: string;
+  /** Args inserted BEFORE npm's own argv (the npm-cli.js path, or nothing). */
+  prefixArgs: string[];
+  /** Whether the spawn needs a shell — a Windows `.cmd` shim does, node does not. */
+  shell: boolean;
+  /** Where it was found. Reported in diagnostics; never parsed. */
+  source: "path" | "node-adjacent";
+}
+
+/** The launcher shim name cmd.exe/sh would resolve for a bare `npm`. */
+function npmShimName(platform: string): string {
+  return platform === "win32" ? "npm.cmd" : "npm";
+}
+
+/**
+ * Resolve how to run npm (#2671). Pure over its injected IO so the Windows
+ * layouts are testable from POSIX and vice versa.
+ *
+ * Order matters:
+ *   1. PATH. When the shim is there we return the BARE name and keep the shell
+ *      exactly as before, so the invocation is byte-identical to the
+ *      pre-#2671 one on every host where it already worked. This change can
+ *      only add reach, never move the working case onto a new code path.
+ *   2. npm's own JS beside the running node binary, run by `process.execPath`
+ *      directly. Deliberately NOT the `npm.cmd` shim: a shim needs shell:true,
+ *      and `execFile` with shell:true concatenates file+args unquoted, so the
+ *      default install path `C:\Program Files\nodejs\npm.cmd` would be split
+ *      at the space and cmd.exe would try to run `C:\Program`. Spawning node
+ *      with the script as an argv entry needs no shell and no quoting.
+ *
+ * Returns undefined when npm is genuinely not locatable; callers still get one
+ * last-resort bare-name attempt before reporting that.
+ */
+export function resolveNpmLauncher(io: {
+  platform: string;
+  pathEnv: string | undefined;
+  execPath: string;
+  exists: (p: string) => boolean;
+}): NpmLauncher | undefined {
+  const isWin = io.platform === "win32";
+  const shim = npmShimName(io.platform);
+
+  const pathSep = isWin ? ";" : ":";
+  for (const raw of (io.pathEnv ?? "").split(pathSep)) {
+    // A Windows PATH entry may be quoted; an empty one means "cwd", which is
+    // not somewhere we are willing to pick an npm up from.
+    const entry = raw.trim().replace(/^"(.*)"$/, "$1");
+    if (!entry) continue;
+    try {
+      if (io.exists(join(entry, shim))) {
+        return { file: shim, prefixArgs: [], shell: isWin, source: "path" };
+      }
+    } catch {
+      /* an unreadable PATH entry is simply not where npm is */
+    }
+  }
+
+  const nodeDir = dirname(io.execPath);
+  const cliCandidates = isWin
+    ? // Windows: node.exe and node_modules/ sit in the same directory.
+      [join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js")]
+    : // POSIX: <prefix>/bin/node alongside <prefix>/lib/node_modules/npm.
+      [
+        join(nodeDir, "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+        join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js"),
+      ];
+  for (const cli of cliCandidates) {
+    try {
+      if (io.exists(cli)) {
+        return {
+          file: io.execPath,
+          prefixArgs: [resolve(cli)],
+          shell: false,
+          source: "node-adjacent",
+        };
+      }
+    } catch {
+      /* probe failure is not a location */
+    }
+  }
+  return undefined;
+}
+
+/** Resolve the npm launcher for THIS process. */
+function currentNpmLauncher(): NpmLauncher | undefined {
+  return resolveNpmLauncher({
+    platform: process.platform,
+    pathEnv: process.env.PATH ?? process.env.Path,
+    execPath: process.execPath,
+    exists: existsSync,
+  });
+}
+
 function defaultRunNpm(
   args: string[],
   cwd?: string,
-): Promise<{ ok: boolean; stdout?: string; stderr?: string }> {
+): Promise<{ ok: boolean; stdout?: string; stderr?: string; npmMissing?: boolean }> {
   return new Promise((resolveP) => {
-    // `npm` is a .cmd shim on Windows; execFile needs shell:true to run it.
-    // SAFE: every arg is a hard-coded constant (no interpolation of user input),
-    // so there is no shell-injection surface.
     const isWin = process.platform === "win32";
-    const cmd = isWin ? "npm.cmd" : "npm";
+    const launcher = currentNpmLauncher();
+    // LAST RESORT (#2671): when npm is nowhere we can see it, still make the
+    // pre-#2671 bare-name attempt. Our PATH scan is not cmd.exe's resolver, so
+    // an exotic host where the shell would have found npm must not be turned
+    // into a hard refusal by a failed probe. `npmMissing` is then reported only
+    // if that attempt ALSO fails, which makes this strictly additive.
+    const cmd = launcher?.file ?? npmShimName(process.platform);
+    const spawnArgs = [...(launcher?.prefixArgs ?? []), ...args];
+    // SAFE: every npm arg is a hard-coded constant (no interpolation of user
+    // input), so the shell path has no injection surface. `prefixArgs` is only
+    // ever populated on the shell:false node path.
+    const useShell = launcher ? launcher.shell : isWin;
+    const missing = launcher === undefined ? { npmMissing: true } : {};
     try {
       const child = execFile(
         cmd,
-        args,
-        { cwd, timeout: NPM_TIMEOUT_MS, windowsHide: true, shell: isWin },
+        spawnArgs,
+        { cwd, timeout: NPM_TIMEOUT_MS, windowsHide: true, shell: useShell },
         (err, stdout, stderr) =>
-          resolveP({ ok: !err, stdout: String(stdout ?? ""), stderr: String(stderr ?? "") }),
+          resolveP({
+            ok: !err,
+            stdout: String(stdout ?? ""),
+            stderr: String(stderr ?? ""),
+            ...(err ? missing : {}),
+          }),
       );
-      child.on("error", () => resolveP({ ok: false }));
+      child.on("error", () => resolveP({ ok: false, ...missing }));
     } catch {
-      resolveP({ ok: false });
+      resolveP({ ok: false, ...missing });
     }
   });
 }
@@ -737,6 +902,40 @@ async function applyNpmUpdate(
         `the orchestrator fully (a /mcp reconnect or auto-restart keeps a process ` +
         `holding the lock), then run: ${manualUpdateCommand(info)}${manualUpdateLocation(info)}` +
         (tail ? `\nnpm said:\n${tail}` : ""),
+    };
+  }
+
+  // #2671 — npm was never LOCATED, so nothing here is npm's verdict on the
+  // update. Checked AFTER the lock branch on purpose: an EBUSY in the output is
+  // positive proof npm actually ran, and that proof outranks our own
+  // could-not-find-it probe (which cannot see every way a shell resolves a
+  // command). npm's raw output still travels in the note either way, so a
+  // misclassification can never hide evidence from the user.
+  if (res.npmMissing) {
+    const isDefaultWin = (deps.platform?.() ?? process.platform) === "win32";
+    return {
+      action: "unavailable",
+      mode: info.mode,
+      from: info.currentVersion,
+      to: latest,
+      reason: "npm-not-found",
+      note:
+        `Cannot self-update to ${latest}: npm could not be found. It is not on ` +
+        `this server process's PATH, and there is no npm beside the Node binary ` +
+        `running it (${process.execPath}). Staying on ${info.currentVersion} — ` +
+        `nothing was changed.\nTo update, run this yourself in a terminal that ` +
+        `HAS npm: ${manualUpdateCommand(info)}${manualUpdateLocation(info)}` +
+        (isDefaultWin
+          ? `\nIf that terminal also reports npm is not recognized, Node.js is ` +
+            `not installed for this user — install it from https://nodejs.org ` +
+            `and reopen the terminal.`
+          : `\nIf that terminal also cannot find npm, install Node.js ` +
+            `(https://nodejs.org) and retry.`) +
+        `\nWhen npm IS installed, this usually means the orchestrator was ` +
+        `launched by something that does not pass the Node directory on PATH; ` +
+        `relaunching it from a shell where \`npm -v\` works lets this action ` +
+        `run on its own.` +
+        (tail ? `\nThe launch failed with:\n${tail}` : ""),
     };
   }
 


### PR DESCRIPTION
Closes #2671.

Two independent dead ends on the reporter's Windows 11 host (comfyui-mcp 0.52.139; both still live on main at 0.52.165 — `git grep safe.directory -- src/` returns zero hits and npm was still resolved as a bare name).

## 1. The panel git fallback misattributed an OWNERSHIP refusal

Git refuses **every** subcommand on a repository whose on-disk owner is not the current account. Measured, not assumed — `GIT_TEST_ASSUME_DIFFERENT_OWNER=1` against `rev-parse --show-toplevel`, `status --porcelain`, `fetch --quiet` and `rev-parse @{upstream}` all produce the identical fatal at exit 128.

Each gate in `updateViaGitCheckoutFallback` catches its own git failure and narrates a cause specific to that gate, so whichever ran first took the blame. The reporter was told we *\"could not prove &lt;dir&gt; is the panel repo's worktree root\"* — false, the checkout is fine — and was sent to *\"update the panel repo manually\"*, which fails with the same fatal. Both halves of that message are wrong for this cause.

The refusal is now classified at the **function boundary**, not inside whichever gate runs first, because which gate reports it is purely an artefact of gate order and would silently stop working the day the gates are reordered. The replacement names the real cause, says nothing changed, kills the manual-`git pull` dead end, and gives the two remediations — scoped `safe.directory`, or `takeown` — while stating plainly that comfyui-mcp will not apply either. That is deliberate and is what the reporter asked for: both hand git back the right to run config-controlled hooks out of that directory, which is the user's security decision, not ours.

It also quotes the directory, which git's own advice line does not — that breaks on a path with a space, and the default ComfyUI layouts have several.

## 2. Self-update could not find npm even when npm was right there

`npm` was resolved as the bare name `npm.cmd` through the inherited PATH only, so an orchestrator launched by something that does not pass the Node directory (ComfyUI Desktop, a Python venv, a service wrapper) got `'npm.cmd' is not recognized as an internal or external command` relayed verbatim, as though npm had *rejected* the update. npm was not absent: it ships beside the node binary running the process.

Resolution now tries PATH first — returning the **bare name**, so the invocation stays byte-identical on every host where it already worked — then falls back to npm's own JS beside `process.execPath`, spawned by node directly. Deliberately *not* the `npm.cmd` shim: a shim needs `shell:true`, and `execFile` concatenates file and args unquoted, so the default `C:\Program Files\nodejs\npm.cmd` would split at the space.

The detached PowerShell helper — the sibling exit, and the only way an in-place Windows update ever lands — is fixed at the scheduler choke point so both callers inherit it. Hard-coded to bare `npm.cmd`, it would have failed exactly as the in-process attempt did: silently, into a log nobody opens.

### Rig proof (this machine, real npm, real spawn)

```
PATH-intact resolution  : {"file":"npm.cmd","prefixArgs":[],"shell":true,"source":"path"}
PATH-stripped resolution: {"file":"C:\Program Files\nodejs\node.exe",
                           "prefixArgs":["C:\...\npm\bin\npm-cli.js"],
                           "shell":false,"source":"node-adjacent"}
control (both blinded)  : undefined
npm --version via resolved launcher: "11.13.0"
pre-fix bare `npm.cmd` under the same PATH: FAILED -> 'npm.cmd' is not recognized as an internal or external command
```

The reporter's exact error is reproduced under the pre-fix invocation, and the fix runs npm under the identical PATH. The control (both probes blinded → `undefined`) is what proves the node-adjacent branch produced that result rather than the PATH branch.

## Where the load-bearing claims are — please look here

- **The predicate is prose matching**, which this repo has been burned by. It anchors on the `safe.directory` config *key* rather than the phrase \"dubious ownership\": git wraps the whole advice in one translatable string, so the prose disappears under a translated catalog while the command token survives. The prose alternative is kept only as a second chance. Git for Windows ships no locale catalogs here (verified — `LC_ALL=de_DE.UTF-8` still returns English), so I did **not** add locale pinning; it would have been an unmeasured change. There is a test that fails if the predicate is narrowed to the prose.
- **It authorizes nothing.** The classification rewrites a message and nothing else — no config write, no mutation, no retry decision keys off it.
- **The ordering guard in `applyNpmUpdate`.** `npmMissing` is checked *after* the EBUSY branch on purpose: an EBUSY in the output is positive proof npm ran, and that beats our own could-not-find-it probe, which cannot see every way a shell resolves a command. Getting this backwards would strand Windows users by skipping the deferred helper. Pinned by a test.
- **It cannot do worse than the old code.** When npm is nowhere, the pre-existing bare-name spawn is *still* attempted; `npmMissing` is reported only if that also fails. And it is a structured field, not a match on cmd.exe's localized \"is not recognized\".
- **I dropped the raw git tail** from the ownership message. By the time a gate throws, git's fatal is nested inside that gate's own narration — the very misdiagnosis being replaced — so quoting it put \"could not prove … is the panel repo's worktree root\" back in front of the user. Git's advice is not lost; it is reproduced, quoted.

## Verification

- 22 new tests. Full suite: **13660 passed, 1 pre-existing concurrency flake** (`job-watcher.test.ts`, a file this PR does not touch — passes 16/16 in isolation).
- **Mutation-tested, 7 mutants, all killed with controls surviving**: neutering the re-map → 2 failures (the non-ownership control correctly survives); narrowing the predicate to prose → only the l10n test; removing the node-adjacent fallback → 3; removing the not-found classification → 2; reverting the helper to the bare shim → 1; removing the ordering guard → 1; dropping the seam's defaulting → 1.

## Not done, deliberately

- The reporter's **\"safe verified registry/zip replacement without requiring git safe.directory\"** is a new update mechanism — a feature, parked under the freeze. This makes the existing path diagnosable instead.
- **No automatic `safe.directory` write**, per the reporter's own constraint and because it is a security decision.
- **No panel-repo changes**, so no Playwright run: nothing here touches panel JS. These messages surface as MCP tool-result text.