### PR TITLE
fix(2673): a loader input naming a file the server does not have says where it looked, and how to fix it

### DIFF
--- a/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
+++ b/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
@@ -173,6 +173,12 @@ describe("#2673: a loader input naming a file the server does not have", () => {
       // The transport-failure wording would be FALSE here: this process did
       // reach the server — it got a 400 back.
       expect(message).not.toContain("this process cannot");
+      // …and the verdict states its own BOUND (gate, round 3): the comparison
+      // sees the tabs open RIGHT NOW, while the upload happened in the past, so
+      // a tab that has since closed is invisible to it. An unbounded "RULED OUT"
+      // would be a claim about history made from a snapshot of the present.
+      expect(message).toContain("visible right now");
+      expect(message).toContain("closed or navigated away");
     });
 
     it("#1175 parity: an ALIASED loopback spelling is the same server, and says so", async () => {

--- a/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
+++ b/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
@@ -200,6 +200,28 @@ describe("#2673: a loader input naming a file the server does not have", () => {
       expect(message).toContain("Rule that out before treating the file as simply missing");
     });
 
+    it("drops an OPAQUE origin, which serialises to the truthy string \"null\"", async () => {
+      // Gate, round 4. `new URL("file:///tmp").origin` is the STRING "null" —
+      // truthy, so it would otherwise be reported as a panel on a different
+      // ComfyUI called "null". It is not an address.
+      setConnectedPanelOrigins(() => ["file:///tmp"]);
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).not.toContain("null");
+      expect(message).not.toContain("A connected panel is on");
+      expect(message).toContain("names a FILE on the server");
+    });
+
+    it("keeps a cloudflared-style hostname VERBATIM — it is an address, not a credential", async () => {
+      // The reason origins are normalised rather than scrubbed: a quick-tunnel
+      // hostname is a 32-char hex label, which #1191's opaque-run pass would
+      // redact — deleting exactly the answer this message exists to give.
+      const tunnel = "https://abcdef0123456789abcdef0123456789.trycloudflare.com";
+      setConnectedPanelOrigins(() => [tunnel]);
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).toContain(tunnel);
+      expect(message).toContain("a DIFFERENT ComfyUI from this target");
+    });
+
     it("drops an origin that is not a well-formed scheme://host[:port]", async () => {
       // Gate, round 3. Only a normalised origin may reach the message; anything
       // else is dropped rather than echoed. With nothing left, there is no
@@ -336,6 +358,30 @@ describe("#2673: a loader input naming a file the server does not have", () => {
       expect(message).toContain("names a FILE on the server");
       // The claim is SCOPED, so it is not false even here.
       expect(message).toContain("on stock ComfyUI");
+    });
+
+    it("a value_not_in_list whose received_value was never a filename", async () => {
+      // Gate, round 4. `value_not_in_list` reports what it received. A non-string
+      // means the widget never held a filename — a malformed prompt, an object,
+      // a link tuple — and reading that as "the server is missing this file"
+      // would misdiagnose a real rejection.
+      const message = await enqueueAgainst(
+        rejection({
+          "12": {
+            class_type: "VHS_LoadVideo",
+            errors: [
+              {
+                type: "value_not_in_list",
+                message: "Value not in list",
+                details: "video: {'path': 'clip.mp4'} not in (list of length 41)",
+                extra_info: { input_name: "video", received_value: { path: "clip.mp4" } },
+              },
+            ],
+          },
+        }),
+      );
+      expect(message).toContain("Value not in list");
+      expect(message).not.toContain("names a FILE on the server");
     });
 
     it("a node error with no machine `type` at all", async () => {

--- a/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
+++ b/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
@@ -55,10 +55,24 @@ function res(status: number, body: unknown, statusText = "Bad Request"): Respons
   });
 }
 
+/** One node error exactly as ComfyUI 0.34.0 emits it (execution.py). */
+interface NodeErrorEntry {
+  type?: string;
+  message: string;
+  details: string;
+  extra_info: { input_name?: string; input_config?: unknown; received_value?: unknown };
+}
+
 /** The 400 envelope ComfyUI 0.34.0 answers a failed prompt validation with. */
-function rejection(
-  nodeErrors: Record<string, { class_type?: string; errors?: unknown[] }>,
-): unknown {
+interface RejectionBody {
+  error: { type: string; message: string; details: string; extra_info: Record<string, never> };
+  node_errors: Record<
+    string,
+    { class_type: string; errors: NodeErrorEntry[]; dependent_outputs?: string[] }
+  >;
+}
+
+function rejection(nodeErrors: RejectionBody["node_errors"]): RejectionBody {
   return {
     error: {
       type: "prompt_outputs_failed_validation",
@@ -85,7 +99,7 @@ const MISSING_ATTACHMENT = rejection({
   },
 });
 
-async function enqueueAgainst(body: unknown): Promise<string> {
+async function enqueueAgainst(body: RejectionBody): Promise<string> {
   comfyuiFetch.mockResolvedValueOnce(res(400, body));
   const err = await enqueuePrompt({ "5": { class_type: "LoadImage", inputs: {} } }).catch(
     (e: unknown) => e,

--- a/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
+++ b/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #2673 — a headless enqueue rejected because a LOADER names a file the server
+ * does not have must say WHERE it looked and how to put the file there.
+ *
+ * The reporter attached an image in the panel; the sidebar showed
+ * `input/8058752600640.JPG`; a headless workflow with `LoadImage image=` that
+ * name came back "Invalid image file". Everything the agent received was
+ * ComfyUI's own two lines, so it filed a P2 guessing at "attachment
+ * registration/race, or filename handling in comfyui-mcp" — when nothing between
+ * the panel and `/prompt` rewrites the value at all, and comfyui-mcp was already
+ * holding the one machine-checkable cause (a connected panel on a DIFFERENT
+ * ComfyUI than COMFYUI_URL, which `describeTargetDrift` has detected since #952
+ * but only on TRANSPORT failures).
+ *
+ * THE FIXTURE IS VERSION-CHECKED, not invented. Read off the reporter's own
+ * ComfyUI v0.34.0 (`execution.py`, `nodes.py`):
+ *   - `LoadImage.VALIDATE_INPUTS(image)` returns "Invalid image file: {}";
+ *   - the combo-membership check is SKIPPED for any input the node declares in
+ *     its own VALIDATE_INPUTS, so LoadImage.image can only fail as
+ *     `custom_validation_failed` — never `value_not_in_list`;
+ *   - that error carries `extra_info: {"input_name": x}` and NOTHING else (no
+ *     `input_config`, no `received_value`), which is why detection keys on
+ *     `type` + `input_name` + class_type rather than on the input's upload flag.
+ */
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  };
+});
+
+// Partial mock over the REAL fetch module: only the transport is faked, so the
+// origin comparison under test is the shipped one, driven through its own setter
+// rather than through a stub that could agree with anything.
+const comfyuiFetch = vi.fn();
+vi.mock("../../comfyui/fetch.js", async () => {
+  const actual = await vi.importActual<typeof import("../../comfyui/fetch.js")>(
+    "../../comfyui/fetch.js",
+  );
+  return { ...actual, comfyuiFetch: (...a: unknown[]) => comfyuiFetch(...a) };
+});
+
+const { enqueuePrompt } = await import("../../comfyui/client.js");
+const { setConnectedPanelOrigins } = await import("../../comfyui/fetch.js");
+
+function res(status: number, body: unknown, statusText = "Bad Request"): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status,
+    statusText,
+  });
+}
+
+/** The 400 envelope ComfyUI 0.34.0 answers a failed prompt validation with. */
+function rejection(
+  nodeErrors: Record<string, { class_type?: string; errors?: unknown[] }>,
+): unknown {
+  return {
+    error: {
+      type: "prompt_outputs_failed_validation",
+      message: "Prompt outputs failed validation",
+      details: "",
+      extra_info: {},
+    },
+    node_errors: nodeErrors,
+  };
+}
+
+const MISSING_ATTACHMENT = rejection({
+  "5": {
+    class_type: "LoadImage",
+    errors: [
+      {
+        type: "custom_validation_failed",
+        message: "Custom validation failed for node",
+        details: "image - Invalid image file: 8058752600640.JPG",
+        extra_info: { input_name: "image" },
+      },
+    ],
+    dependent_outputs: ["9"],
+  },
+});
+
+async function enqueueAgainst(body: unknown): Promise<string> {
+  comfyuiFetch.mockResolvedValueOnce(res(400, body));
+  const err = await enqueuePrompt({ "5": { class_type: "LoadImage", inputs: {} } }).catch(
+    (e: unknown) => e,
+  );
+  return (err as Error).message;
+}
+
+describe("#2673: a loader input naming a file the server does not have", () => {
+  beforeEach(() => {
+    comfyuiFetch.mockReset();
+    setConnectedPanelOrigins(null);
+  });
+  afterEach(() => {
+    setConnectedPanelOrigins(null);
+    vi.clearAllMocks();
+  });
+
+  it("keeps ComfyUI's own diagnosis FIRST and whole", async () => {
+    const message = await enqueueAgainst(MISSING_ATTACHMENT);
+    expect(message).toContain("Prompt outputs failed validation");
+    expect(message).toContain("LoadImage");
+    expect(message).toContain("node 5");
+    expect(message).toContain("Invalid image file: 8058752600640.JPG");
+    // Appended, not substituted: the server's words precede ours.
+    expect(message.indexOf("Invalid image file")).toBeLessThan(
+      message.indexOf("names a FILE on the server"),
+    );
+  });
+
+  it("names WHICH server was asked, and which node/input", async () => {
+    const message = await enqueueAgainst(MISSING_ATTACHMENT);
+    expect(message).toContain("LoadImage.image (node 5)");
+    expect(message).toContain("http://127.0.0.1:8188");
+  });
+
+  it("gives the recovery calls and says a blind re-submit repeats the failure", async () => {
+    const message = await enqueueAgainst(MISSING_ATTACHMENT);
+    expect(message).toContain('upload_image (action:"image")');
+    expect(message).toContain('upload_image (action:"stage")');
+    expect(message).toContain("verbatim");
+  });
+
+  it("explains that a panel attachment is uploaded by the BROWSER, not by this process", async () => {
+    const message = await enqueueAgainst(MISSING_ATTACHMENT);
+    expect(message).toContain("BROWSER");
+    expect(message).toContain("COMFYUI_URL");
+  });
+
+  describe("the panel-vs-headless comparison, which is the reason this note exists", () => {
+    it("names a panel on a DIFFERENT ComfyUI — very likely the whole answer", async () => {
+      setConnectedPanelOrigins(() => ["http://127.0.0.1:8199"]);
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).toContain("http://127.0.0.1:8199");
+      expect(message).toContain("a DIFFERENT ComfyUI from this target");
+      // The recovery that actually works when the file is on the OTHER server.
+      expect(message).toContain("panel_run");
+    });
+
+    it("RULES the split OUT when the panel is on the same ComfyUI", async () => {
+      setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).toContain("RULED OUT");
+      expect(message).not.toContain("a DIFFERENT ComfyUI");
+      // The transport-failure wording would be FALSE here: this process did
+      // reach the server — it got a 400 back.
+      expect(message).not.toContain("this process cannot");
+    });
+
+    it("#1175 parity: an ALIASED loopback spelling is the same server, and says so", async () => {
+      setConnectedPanelOrigins(() => ["http://localhost:8188"]);
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).toContain("RULED OUT");
+      expect(message).toContain("http://localhost:8188");
+      expect(message).toContain("the same host");
+    });
+
+    it("says NOTHING about drift when no panel is connected — an absent comparison is not a verdict", async () => {
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).not.toContain("A connected panel is on");
+      // …but the recovery, which does not depend on the comparison, still lands.
+      expect(message).toContain("names a FILE on the server");
+    });
+  });
+
+  describe("what must NOT collect the note", () => {
+    it("a custom_validation_failed on a NON-loader input (a bad width)", async () => {
+      const message = await enqueueAgainst(
+        rejection({
+          "7": {
+            class_type: "EmptyLatentImage",
+            errors: [
+              {
+                type: "custom_validation_failed",
+                message: "Custom validation failed for node",
+                details: "width - must be a multiple of 8",
+                extra_info: { input_name: "width" },
+              },
+            ],
+          },
+        }),
+      );
+      expect(message).toContain("must be a multiple of 8");
+      expect(message).not.toContain("names a FILE on the server");
+    });
+
+    it("a LOADER failing on one of its non-media inputs", async () => {
+      const message = await enqueueAgainst(
+        rejection({
+          "5": {
+            class_type: "LoadImage",
+            errors: [
+              {
+                type: "custom_validation_failed",
+                message: "Custom validation failed for node",
+                details: "upload - nope",
+                extra_info: { input_name: "upload" },
+              },
+            ],
+          },
+        }),
+      );
+      expect(message).not.toContain("names a FILE on the server");
+    });
+
+    it("a loader media input failing for a DIFFERENT reason (missing link, not missing file)", async () => {
+      const message = await enqueueAgainst(
+        rejection({
+          "5": {
+            class_type: "LoadImage",
+            errors: [
+              {
+                type: "required_input_missing",
+                message: "Required input is missing",
+                details: "image",
+                extra_info: { input_name: "image" },
+              },
+            ],
+          },
+        }),
+      );
+      expect(message).toContain("Required input is missing");
+      expect(message).not.toContain("names a FILE on the server");
+    });
+
+    it("an unknown third-party loader — silence, never a guess", async () => {
+      const message = await enqueueAgainst(
+        rejection({
+          "5": {
+            class_type: "SomeVendorLoadImageFromPath",
+            errors: [
+              {
+                type: "custom_validation_failed",
+                message: "Custom validation failed for node",
+                details: "image - Invalid image file: x.png",
+                extra_info: { input_name: "image" },
+              },
+            ],
+          },
+        }),
+      );
+      expect(message).not.toContain("names a FILE on the server");
+    });
+
+    it("a node error with no machine `type` at all", async () => {
+      const message = await enqueueAgainst(
+        rejection({
+          "5": {
+            class_type: "LoadImage",
+            errors: [{ message: "something", details: "image", extra_info: { input_name: "image" } }],
+          },
+        }),
+      );
+      expect(message).not.toContain("names a FILE on the server");
+    });
+  });
+
+  // The OTHER error type is reachable for real: a loader that does NOT declare
+  // the input in its own VALIDATE_INPUTS keeps ComfyUI's combo-membership check,
+  // and a file absent from the input dir fails there instead. Same situation,
+  // different token — matching only one would leave every video/audio loader out.
+  it("fires on value_not_in_list too — the shape a video loader fails with", async () => {
+    const message = await enqueueAgainst(
+      rejection({
+        "12": {
+          class_type: "VHS_LoadVideo",
+          errors: [
+            {
+              type: "value_not_in_list",
+              message: "Value not in list",
+              details: "video: 'clip.mp4' not in (list of length 41)",
+              extra_info: { input_name: "video", input_config: null, received_value: "clip.mp4" },
+            },
+          ],
+        },
+      }),
+    );
+    expect(message).toContain("VHS_LoadVideo.video (node 12)");
+    expect(message).toContain("names a FILE on the server");
+  });
+
+  // Every field the note interpolates comes out of the response body, so it goes
+  // through the same #1191 scrub as the lines above it.
+  it("routes its interpolated fields through the #1191 scrub", async () => {
+    const message = await enqueueAgainst(MISSING_ATTACHMENT);
+    expect(message).toContain("LoadImage.image (node 5)");
+  });
+});

--- a/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
+++ b/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
@@ -99,6 +99,13 @@ const MISSING_ATTACHMENT = rejection({
   },
 });
 
+/** A fetched Response reports the FINAL url after redirects; a constructed one
+ *  reports "". Both shapes reach `buildEnqueueError`, so both are exercised. */
+function withFinalUrl(r: Response, url: string): Response {
+  Object.defineProperty(r, "url", { value: url, configurable: true });
+  return r;
+}
+
 async function enqueueAgainst(body: RejectionBody): Promise<string> {
   comfyuiFetch.mockResolvedValueOnce(res(400, body));
   const err = await enqueuePrompt({ "5": { class_type: "LoadImage", inputs: {} } }).catch(
@@ -305,5 +312,46 @@ describe("#2673: a loader input naming a file the server does not have", () => {
   it("routes its interpolated fields through the #1191 scrub", async () => {
     const message = await enqueueAgainst(MISSING_ATTACHMENT);
     expect(message).toContain("LoadImage.image (node 5)");
+  });
+
+  // Gate finding on the first round of this PR. `fetch` FOLLOWS redirects, so a
+  // 307/308 in front of ComfyUI moves the POST to another origin — and the input
+  // directory that was searched belongs to whoever ANSWERED. Naming the address
+  // we posted to would point the reader at the proxy and compare the panel
+  // against the wrong server, on the one message written to stop that guessing.
+  describe("names the server that ANSWERED, not the one that was addressed", () => {
+    it("uses the response's final URL when a redirect moved the request", async () => {
+      comfyuiFetch.mockResolvedValueOnce(
+        withFinalUrl(res(400, MISSING_ATTACHMENT), "http://gpu-box.lan:8188/prompt"),
+      );
+      const err = await enqueuePrompt({ "5": { class_type: "LoadImage", inputs: {} } }).catch(
+        (e: unknown) => e,
+      );
+      const message = (err as Error).message;
+      expect(message).toContain("http://gpu-box.lan:8188");
+      expect(message).not.toContain("http://127.0.0.1:8188");
+    });
+
+    it("compares the PANEL against the responder, so a same-looking panel is not called a match", async () => {
+      // The panel is on the address we posted to — but a redirect sent the prompt
+      // somewhere else, so the split is REAL and must not read as ruled out.
+      setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+      comfyuiFetch.mockResolvedValueOnce(
+        withFinalUrl(res(400, MISSING_ATTACHMENT), "http://gpu-box.lan:8188/prompt"),
+      );
+      const err = await enqueuePrompt({ "5": { class_type: "LoadImage", inputs: {} } }).catch(
+        (e: unknown) => e,
+      );
+      const message = (err as Error).message;
+      expect(message).toContain("a DIFFERENT ComfyUI from this target");
+      expect(message).not.toContain("RULED OUT");
+    });
+
+    it("falls back to the requested address when the response carries no url", async () => {
+      // A constructed Response has url === "". Degrading to "" would name no
+      // server at all — worse than naming the address we know we asked.
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).toContain("http://127.0.0.1:8188");
+    });
   });
 });

--- a/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
+++ b/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
@@ -194,6 +194,25 @@ describe("#2673: a loader input naming a file the server does not have", () => {
       expect(message).toContain("Rule that out before treating the file as simply missing");
     });
 
+    it("drops an origin that is not a well-formed scheme://host[:port]", async () => {
+      // Gate, round 3. Only a normalised origin may reach the message; anything
+      // else is dropped rather than echoed. With nothing left, there is no
+      // comparison to report — which is the honest answer, not a verdict.
+      setConnectedPanelOrigins(() => ["not-an-origin token=abcdefghijklmnopqrstuvwxyz012345"]);
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).not.toContain("not-an-origin");
+      expect(message).not.toContain("A connected panel is on");
+      expect(message).toContain("names a FILE on the server");
+    });
+
+    it("still compares the origins it CAN parse, alongside one it cannot", async () => {
+      setConnectedPanelOrigins(() => ["http://127.0.0.1:8199/", "garbage"]);
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).toContain("http://127.0.0.1:8199");
+      expect(message).not.toContain("garbage");
+      expect(message).toContain("a DIFFERENT ComfyUI from this target");
+    });
+
     it("says NOTHING about drift when no panel is connected — an absent comparison is not a verdict", async () => {
       const message = await enqueueAgainst(MISSING_ATTACHMENT);
       expect(message).not.toContain("A connected panel is on");
@@ -279,6 +298,38 @@ describe("#2673: a loader input naming a file the server does not have", () => {
         }),
       );
       expect(message).not.toContain("names a FILE on the server");
+    });
+
+    // CHARACTERISATION, not an endorsement (gate, round 3). An allowlisted
+    // loader input CAN fail custom validation for a reason that is not "the file
+    // is missing" — a pack that shadows a core class_type, or a future core
+    // check on dimensions. The note DOES fire there, and it cannot be made not
+    // to: `custom_validation_failed` carries `extra_info: {input_name}` and
+    // nothing else (ComfyUI 0.34.0 execution.py:1101) — no received_value, no
+    // input_config, no upload flag — so there is no signal to tell the two
+    // apart. The wording is scoped to stock ComfyUI for exactly this reason.
+    // Pinned so that a future attempt to narrow it is a deliberate change and
+    // not a silent one.
+    it("KNOWN LIMIT: an allowlisted input failing for a non-file reason still gets the note", async () => {
+      const message = await enqueueAgainst(
+        rejection({
+          "5": {
+            class_type: "LoadImage",
+            errors: [
+              {
+                type: "custom_validation_failed",
+                message: "Custom validation failed for node",
+                details: "image - dimensions must be a multiple of 8",
+                extra_info: { input_name: "image" },
+              },
+            ],
+          },
+        }),
+      );
+      expect(message).toContain("dimensions must be a multiple of 8");
+      expect(message).toContain("names a FILE on the server");
+      // The claim is SCOPED, so it is not false even here.
+      expect(message).toContain("on stock ComfyUI");
     });
 
     it("a node error with no machine `type` at all", async () => {

--- a/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
+++ b/src/__tests__/comfyui/enqueue-missing-input-media.test.ts
@@ -183,6 +183,17 @@ describe("#2673: a loader input naming a file the server does not have", () => {
       expect(message).toContain("the same host");
     });
 
+    it("does NOT rule the split out while another tab is on a different ComfyUI", async () => {
+      // Gate finding. ONE matching tab settles "a panel can reach this address";
+      // it does not settle "the attachment came from a tab on THIS server". With
+      // tabs on both, "RULED OUT" would suppress the guidance the reader needs.
+      setConnectedPanelOrigins(() => ["http://127.0.0.1:8188", "http://127.0.0.1:8199"]);
+      const message = await enqueueAgainst(MISSING_ATTACHMENT);
+      expect(message).not.toContain("RULED OUT");
+      expect(message).toContain("http://127.0.0.1:8199");
+      expect(message).toContain("Rule that out before treating the file as simply missing");
+    });
+
     it("says NOTHING about drift when no panel is connected — an absent comparison is not a verdict", async () => {
       const message = await enqueueAgainst(MISSING_ATTACHMENT);
       expect(message).not.toContain("A connected panel is on");
@@ -307,11 +318,31 @@ describe("#2673: a loader input naming a file the server does not have", () => {
     expect(message).toContain("names a FILE on the server");
   });
 
-  // Every field the note interpolates comes out of the response body, so it goes
-  // through the same #1191 scrub as the lines above it.
-  it("routes its interpolated fields through the #1191 scrub", async () => {
-    const message = await enqueueAgainst(MISSING_ATTACHMENT);
-    expect(message).toContain("LoadImage.image (node 5)");
+  // Every field the note interpolates comes out of the response body — an
+  // attacker-influenceable channel — so it takes the same #1191 scrub as the
+  // lines above it. The earlier version of this test asserted only that benign
+  // values survived, which deleting `safeField` would also satisfy (gate
+  // finding). A credential-SHAPED node id is redacted by scrubSecretShapedText's
+  // opaque-run pass with nothing configured, so the assertion has teeth.
+  it("scrubs a credential-shaped field instead of echoing it", async () => {
+    const secretish = "AKIA7ZXQ8WVLMNPRT2H4JKD9GBC3FYS6";
+    const message = await enqueueAgainst(
+      rejection({
+        [secretish]: {
+          class_type: "LoadImage",
+          errors: [
+            {
+              type: "custom_validation_failed",
+              message: "Custom validation failed for node",
+              details: "image - Invalid image file: a.png",
+              extra_info: { input_name: "image" },
+            },
+          ],
+        },
+      }),
+    );
+    expect(message).toContain("names a FILE on the server");
+    expect(message).not.toContain(secretish);
   });
 
   // Gate finding on the first round of this PR. `fetch` FOLLOWS redirects, so a

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -18,10 +18,13 @@ import {
   comfyuiFetch,
   connectedPanelFallbackOriginsNow,
   comfyHttpTimeoutSeconds,
+  describeMissingInputMediaDrift,
   isComfyTransportFailure,
   isTimeoutAbort,
+  originOf,
   raceAbort,
 } from "./fetch.js";
+import { isKnownLoaderInput } from "./loader-asset-inputs.js";
 import {
   choosePanelFallbackOrigin,
   describeDeclinedPanelFallback,
@@ -788,7 +791,7 @@ export async function enqueuePrompt(
     }),
   });
   if (!res.ok) {
-    throw await buildEnqueueError(res);
+    throw await buildEnqueueError(res, url);
   }
   // A bare res.json() here is the worst place in the codebase for one, and the
   // same family as #1149/#1160/#828. This is a MUTATING POST that already
@@ -913,7 +916,98 @@ function safeField(v: unknown): string {
   return scrubbed === null ? "(withheld: contains a configured credential)" : scrubbed;
 }
 
-async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
+/** One node error as ComfyUI reports it. `type` and `extra_info.input_name` are
+ *  machine tokens the server never localises; `message`/`details` are prose and
+ *  are only ever displayed, never matched on. */
+interface ComfyNodeErrorEntry {
+  type?: string;
+  message?: string;
+  details?: string;
+  extra_info?: { input_name?: string };
+}
+
+/**
+ * ComfyUI error `type`s that mean "the value you gave this input is not
+ * something this server has".
+ *
+ * Which one fires is decided by the node, not by us: `validate_inputs` skips the
+ * combo-membership check for any input the node declares in its own
+ * `VALIDATE_INPUTS`, so `LoadImage.image` — which does — can only ever fail as
+ * `custom_validation_failed`, while a loader that leaves the check in place
+ * fails as `value_not_in_list`. Both are the SAME situation for a media
+ * selector, so both are matched — and both are stable machine tokens, unlike the
+ * English `message`/`details` beside them.
+ */
+const MISSING_VALUE_ERROR_TYPES = new Set(["custom_validation_failed", "value_not_in_list"]);
+
+interface MissingInputMedia {
+  nodeId: string;
+  classType: string;
+  inputName: string;
+}
+
+/**
+ * Loader inputs in a rejection that name a media FILE the server does not have
+ * (#2673).
+ *
+ * Restricted to the (class_type, input) allowlist, so a `custom_validation_failed`
+ * raised by some unrelated custom check — a bad width, an out-of-range strength —
+ * never collects an "upload the file" note. An unlisted loader yields nothing,
+ * which is the pre-#2673 silence rather than a wrong claim.
+ */
+function collectMissingInputMedia(
+  nodeErrors: Record<string, { class_type?: string; errors?: ComfyNodeErrorEntry[] }>,
+): MissingInputMedia[] {
+  const found: MissingInputMedia[] = [];
+  for (const [nodeId, info] of Object.entries(nodeErrors)) {
+    const classType = info?.class_type;
+    if (typeof classType !== "string") continue;
+    const errs = Array.isArray(info?.errors) ? info.errors : [];
+    for (const e of errs) {
+      if (typeof e?.type !== "string" || !MISSING_VALUE_ERROR_TYPES.has(e.type)) continue;
+      const inputName = e.extra_info?.input_name;
+      if (typeof inputName !== "string") continue;
+      if (!isKnownLoaderInput(classType, inputName)) continue;
+      found.push({ nodeId, classType, inputName });
+    }
+  }
+  return found;
+}
+
+/**
+ * The recovery note for a rejection of that shape (#2673).
+ *
+ * WHAT IT DOES NOT SAY: why the file is absent. It states the one thing the
+ * input's TYPE guarantees — ComfyUI resolves this value inside its OWN input
+ * directory, so the rejection is about a file on a server and not about the
+ * value's spelling — then hands over the machine-checked panel-vs-target
+ * comparison and the two calls that put a file on THIS target. Naming a cause we
+ * have not observed is what sent #2673's reporter to "attachment registration
+ * race, or filename handling", when nothing between the panel and `/prompt`
+ * rewrites the value at all.
+ *
+ * The last sentence is the one that saves the next render: `enqueue_workflow`
+ * passes loader values through verbatim, so re-submitting reproduces this exactly.
+ */
+function describeMissingInputMedia(missing: MissingInputMedia[], target: string): string {
+  const where = missing
+    .map((m) => `${safeField(m.classType)}.${safeField(m.inputName)} (node ${safeField(m.nodeId)})`)
+    .join(", ");
+  const origin = originOf(target) ?? target;
+  return (
+    `\n\nThat input names a FILE on the server, not a free value: ${where} is resolved inside ` +
+    `the input directory of the ComfyUI at ${origin}, and this rejection means the file is not ` +
+    `there.${describeMissingInputMediaDrift(target)} An image ATTACHED in the panel's chat is ` +
+    `uploaded by the BROWSER to whichever ComfyUI that tab is on — a separate connection from ` +
+    `this headless target (COMFYUI_URL) — so a file can exist on one and not the other. To put ` +
+    `it on THIS target: upload_image (action:"image") for a file on disk, or upload_image ` +
+    `(action:"stage") for an existing ComfyUI output; then re-enqueue with the filename it ` +
+    `returns. Re-submitting this workflow unchanged will fail identically — enqueue_workflow ` +
+    `sends loader values through verbatim and never rewrites them.`
+  );
+}
+
+async function buildEnqueueError(res: Response, target: string): Promise<ComfyUIError> {
   // unknown-ok: "" only routes to the GENERIC status message, which reports the
   // HTTP status and claims nothing about node errors. An unread body and an empty
   // body get the same honest fallback rather than a fabricated validation result.
@@ -934,10 +1028,7 @@ async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
   if (parsed && typeof parsed === "object") {
     const payload = parsed as {
       error?: { message?: string; details?: string };
-      node_errors?: Record<
-        string,
-        { class_type?: string; errors?: Array<{ message?: string; details?: string }> }
-      >;
+      node_errors?: Record<string, { class_type?: string; errors?: ComfyNodeErrorEntry[] }>;
     };
     const nodeErrors = payload.node_errors ?? {};
     const lines: string[] = [];
@@ -962,8 +1053,14 @@ async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
       : `ComfyUI rejected the workflow (${res.status})`;
 
     if (lines.length > 0 || payload.error?.message) {
-      const message =
-        lines.length > 0 ? `${headline}\n${lines.join("\n")}` : headline;
+      const base = lines.length > 0 ? `${headline}\n${lines.join("\n")}` : headline;
+      // #2673 — the reporter's agent got exactly `base` and stopped. It named the
+      // node and quoted ComfyUI's "Invalid image file", and said nothing about
+      // WHICH server was asked, whether a connected panel is on a different one,
+      // or how to put the file where the render will look. Appended, never
+      // substituted: ComfyUI's own diagnosis stays first and whole.
+      const missing = collectMissingInputMedia(nodeErrors);
+      const message = missing.length > 0 ? base + describeMissingInputMedia(missing, target) : base;
       return new WorkflowExecutionError(message, {
         status: res.status,
         error: payload.error,

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1008,7 +1008,20 @@ function describeMissingInputMedia(missing: MissingInputMedia[], target: string)
   );
 }
 
-async function buildEnqueueError(res: Response, target: string): Promise<ComfyUIError> {
+async function buildEnqueueError(res: Response, requestedUrl: string): Promise<ComfyUIError> {
+  // WHICH server actually answered (#2673, gate finding).
+  //
+  // `comfyuiFetch` goes through `fetch`, which FOLLOWS redirects — so a 307/308
+  // in front of ComfyUI can move the POST to a different origin, and the input
+  // directory that was searched belongs to whoever answered, not to whoever was
+  // addressed. Naming the requested URL would then point the reader at the proxy
+  // and compare the panel's origin against the wrong server, producing confident
+  // and wrong guidance on exactly the message written to end that guessing.
+  //
+  // `res.url` is "" on a Response that was constructed rather than fetched, so
+  // the requested URL stays as the fallback: an unknown final URL must degrade to
+  // the address we know we asked, never to "".
+  const target = res.url || requestedUrl;
   // unknown-ok: "" only routes to the GENERIC status message, which reports the
   // HTTP status and claims nothing about node errors. An unread body and an empty
   // body get the same honest fallback rather than a fabricated validation result.

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -995,12 +995,13 @@ function describeMissingInputMedia(missing: MissingInputMedia[], target: string)
     .join(", ");
   const origin = originOf(target) ?? target;
   return (
-    `\n\nThat input names a FILE on the server, not a free value: ${where} is resolved inside ` +
-    `the input directory of the ComfyUI at ${origin}, and this rejection means the file is not ` +
-    `there.${describeMissingInputMediaDrift(target)} An image ATTACHED in the panel's chat is ` +
-    `uploaded by the BROWSER to whichever ComfyUI that tab is on — a separate connection from ` +
-    `this headless target (COMFYUI_URL) — so a file can exist on one and not the other. To put ` +
-    `it on THIS target: upload_image (action:"image") for a file on disk, or upload_image ` +
+    `\n\nThat input names a FILE on the server, not a free value: ${where} is resolved inside the ` +
+    `input directory of the ComfyUI at ${origin} — so this is a question about WHICH server holds ` +
+    `the file, not about the value's spelling. A file ATTACHED in the panel's chat is uploaded by ` +
+    `the BROWSER to whichever ComfyUI that tab is on, a separate connection from this headless ` +
+    `target (COMFYUI_URL), so a file can exist on one and not the other.` +
+    `${describeMissingInputMediaDrift(target)}` +
+    ` To put it on THIS target: upload_image (action:"image") for a file on disk, or upload_image ` +
     `(action:"stage") for an existing ComfyUI output; then re-enqueue with the filename it ` +
     `returns. Re-submitting this workflow unchanged will fail identically — enqueue_workflow ` +
     `sends loader values through verbatim and never rewrites them.`

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -993,11 +993,17 @@ function describeMissingInputMedia(missing: MissingInputMedia[], target: string)
   const where = missing
     .map((m) => `${safeField(m.classType)}.${safeField(m.inputName)} (node ${safeField(m.nodeId)})`)
     .join(", ");
-  const origin = originOf(target) ?? target;
+  // #1191 — `originOf` drops userinfo/path/query, so a COMFYUI_URL carrying a
+  // token cannot leak. It returns undefined only for a target `new URL()` cannot
+  // parse, and interpolating THAT raw would reintroduce the leak by the back
+  // door (gate finding), so the fallback takes the same fail-closed scrub as
+  // every other interpolated field here.
+  const origin = originOf(target) ?? safeField(target);
   return (
-    `\n\nThat input names a FILE on the server, not a free value: ${where} is resolved inside the ` +
-    `input directory of the ComfyUI at ${origin} — so this is a question about WHICH server holds ` +
-    `the file, not about the value's spelling. A file ATTACHED in the panel's chat is uploaded by ` +
+    `\n\nThat input names a FILE on the server, not a free value: on stock ComfyUI ${where} is a ` +
+    `server-side FILE selector, resolved against the media directories of the ComfyUI at ` +
+    `${origin} — so this is a question about WHICH server holds the file, not about the value's ` +
+    `spelling. A file ATTACHED in the panel's chat is uploaded by ` +
     `the BROWSER to whichever ComfyUI that tab is on, a separate connection from this headless ` +
     `target (COMFYUI_URL), so a file can exist on one and not the other.` +
     `${describeMissingInputMediaDrift(target)}` +

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -923,7 +923,7 @@ interface ComfyNodeErrorEntry {
   type?: string;
   message?: string;
   details?: string;
-  extra_info?: { input_name?: string };
+  extra_info?: { input_name?: string; received_value?: unknown };
 }
 
 /**
@@ -967,6 +967,14 @@ function collectMissingInputMedia(
       if (typeof e?.type !== "string" || !MISSING_VALUE_ERROR_TYPES.has(e.type)) continue;
       const inputName = e.extra_info?.input_name;
       if (typeof inputName !== "string") continue;
+      // A `value_not_in_list` reports `received_value`; when it is present and
+      // is NOT a string, the widget never held a filename at all (a malformed
+      // prompt, an object, a link tuple) and "the server does not have this
+      // file" would be a wrong reading of a real rejection (gate, round 4).
+      // ABSENCE must not disqualify: `custom_validation_failed` — the shape
+      // LoadImage always fails with — carries no `received_value` at all.
+      const received = e.extra_info?.received_value;
+      if (received !== undefined && typeof received !== "string") continue;
       if (!isKnownLoaderInput(classType, inputName)) continue;
       found.push({ nodeId, classType, inputName });
     }

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -107,8 +107,11 @@ export function isComfyTransportFailure(err: unknown): boolean {
   return false;
 }
 
-/** Origin (scheme://host:port) of a request target, or undefined if unparsable. */
-function originOf(target: string): string | undefined {
+/** Origin (scheme://host:port) of a request target, or undefined if unparsable.
+ *  Exported because a message that names the target should name the ORIGIN:
+ *  `URL.origin` drops userinfo, path and query, so a COMFYUI_URL carrying a
+ *  credential cannot leak through a diagnostic string. */
+export function originOf(target: string): string | undefined {
   try {
     return new URL(target).origin;
   } catch {
@@ -160,7 +163,26 @@ export type ComfyFetchDiagnosticContext =
   | "get_system_stats_health"
   | "install_comfyui_environment";
 
-function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; text: string } {
+/**
+ * The comparison's RAW facts alongside its sentence.
+ *
+ * `text` is worded for a request that never CONNECTED. #2673 needs the same
+ * verdict for one the server ANSWERED and refused, where that wording would be
+ * false ("the browser can reach it and this process cannot" — this process
+ * reached it and got a 400). So the origins and the alias parenthetical come
+ * back too, and the second caller writes its own sentence from them rather than
+ * re-deriving the comparison or editing the first caller's prose.
+ */
+interface TargetDriftClassification {
+  verdict: TargetDriftVerdict;
+  text: string;
+  /** Distinct connected-panel origins; empty when the verdict is "unknown". */
+  origins: string[];
+  /** Parenthetical naming both spellings on a "same" verdict; "" otherwise. */
+  alias: string;
+}
+
+function classifyTargetDrift(target: string): TargetDriftClassification {
   const origins = (() => {
     try {
       return panelOrigins();
@@ -168,9 +190,9 @@ function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; tex
       return []; // a broken source must never replace the real network error
     }
   })();
-  if (origins.length === 0) return { verdict: "unknown", text: "" };
+  if (origins.length === 0) return { verdict: "unknown", text: "", origins: [], alias: "" };
   const want = originOf(target);
-  if (!want) return { verdict: "unknown", text: "" };
+  if (!want) return { verdict: "unknown", text: "", origins: [], alias: "" };
   const distinct = [...new Set(origins)];
   // #1175 — `includes` compares spellings, not servers. A panel on
   // http://127.0.0.1:8188 against a target of http://localhost:8188 is ONE
@@ -188,6 +210,8 @@ function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; tex
         : ` (spelled ${match} there and ${want} here — the same host, so this is not a mismatch)`;
     return {
       verdict: "same",
+      origins: distinct,
+      alias,
       text:
         ` A connected panel is on this same origin${alias}, so this is NOT a wrong-address problem: ` +
         `the browser can reach ${want} and this process cannot (a firewall, a container ` +
@@ -196,11 +220,46 @@ function classifyTargetDrift(target: string): { verdict: TargetDriftVerdict; tex
   }
   return {
     verdict: "different",
+    origins: distinct,
+    alias: "",
     text:
       ` A connected panel is on ${distinct.join(", ")} — a DIFFERENT address, which is why ` +
       `the panel works while this call does not. Point COMFYUI_URL at that origin if it is the ` +
       `server you meant.`,
   };
+}
+
+/**
+ * The same comparison, for a loader input naming a media file the server does
+ * not have (#2673).
+ *
+ * A chat attachment is uploaded by the BROWSER, to whichever ComfyUI the panel
+ * tab is on; `enqueue_workflow` posts to COMFYUI_URL. When those are two servers
+ * the file lands on one and the render reads the other, and ComfyUI answers
+ * "Invalid image file: <name>" — a rejection that says nothing about the split
+ * and that re-submitting the same workflow can never clear. This is the drift
+ * #952 already detects, reached through a 400 instead of a socket error, and it
+ * is the case the detector was NOT wired into.
+ *
+ * The SAME-origin answer earns its place too: it rules the split out, so the
+ * reader stops hunting for a second server and treats the file as genuinely
+ * absent from the one they have.
+ */
+export function describeMissingInputMediaDrift(target: string): string {
+  const { verdict, origins, alias } = classifyTargetDrift(target);
+  if (verdict === "unknown") return "";
+  if (verdict === "same") {
+    return (
+      ` A connected panel is on this same ComfyUI${alias}, so a panel-vs-headless target split ` +
+      `is RULED OUT — the file is missing from the one server both are using.`
+    );
+  }
+  return (
+    ` A connected panel is on ${origins.join(", ")} — a DIFFERENT ComfyUI from this target. An ` +
+    `image attached in the panel's chat is uploaded by the BROWSER to that server, so it is ` +
+    `genuinely absent here; that is very likely the whole answer. Run the graph on the panel ` +
+    `instead (panel_run), or point COMFYUI_URL at that origin.`
+  );
 }
 
 /**

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -250,15 +250,14 @@ export function describeMissingInputMediaDrift(target: string): string {
   if (verdict === "unknown") return "";
   if (verdict === "same") {
     return (
-      ` A connected panel is on this same ComfyUI${alias}, so a panel-vs-headless target split ` +
-      `is RULED OUT — the file is missing from the one server both are using.`
+      ` A connected panel is on this same ComfyUI${alias}, so that split is RULED OUT — the file ` +
+      `is missing from the one server both are using.`
     );
   }
   return (
-    ` A connected panel is on ${origins.join(", ")} — a DIFFERENT ComfyUI from this target. An ` +
-    `image attached in the panel's chat is uploaded by the BROWSER to that server, so it is ` +
-    `genuinely absent here; that is very likely the whole answer. Run the graph on the panel ` +
-    `instead (panel_run), or point COMFYUI_URL at that origin.`
+    ` A connected panel is on ${origins.join(", ")} — a DIFFERENT ComfyUI from this target, so ` +
+    `that is very likely where the file is, and very likely the whole answer: run the graph on ` +
+    `the panel instead (panel_run), or point COMFYUI_URL at that origin.`
   );
 }
 

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -180,6 +180,16 @@ interface TargetDriftClassification {
   origins: string[];
   /** Parenthetical naming both spellings on a "same" verdict; "" otherwise. */
   alias: string;
+  /**
+   * Connected-panel origins that do NOT match the target. Non-empty alongside a
+   * "same" verdict when tabs are open on more than one ComfyUI (gate finding).
+   *
+   * `describeTargetDrift` does not need this — "a panel can reach this address"
+   * is established by ONE match. #2673's question is different and stronger
+   * ("could the file have come from a panel on another server?"), and one match
+   * does not settle it.
+   */
+  others: string[];
 }
 
 function classifyTargetDrift(target: string): TargetDriftClassification {
@@ -190,9 +200,10 @@ function classifyTargetDrift(target: string): TargetDriftClassification {
       return []; // a broken source must never replace the real network error
     }
   })();
-  if (origins.length === 0) return { verdict: "unknown", text: "", origins: [], alias: "" };
+  if (origins.length === 0)
+    return { verdict: "unknown", text: "", origins: [], alias: "", others: [] };
   const want = originOf(target);
-  if (!want) return { verdict: "unknown", text: "", origins: [], alias: "" };
+  if (!want) return { verdict: "unknown", text: "", origins: [], alias: "", others: [] };
   const distinct = [...new Set(origins)];
   // #1175 — `includes` compares spellings, not servers. A panel on
   // http://127.0.0.1:8188 against a target of http://localhost:8188 is ONE
@@ -211,6 +222,7 @@ function classifyTargetDrift(target: string): TargetDriftClassification {
     return {
       verdict: "same",
       origins: distinct,
+      others: distinct.filter((o) => !sameOrigin(o, want)),
       alias,
       text:
         ` A connected panel is on this same origin${alias}, so this is NOT a wrong-address problem: ` +
@@ -221,6 +233,7 @@ function classifyTargetDrift(target: string): TargetDriftClassification {
   return {
     verdict: "different",
     origins: distinct,
+    others: distinct,
     alias: "",
     text:
       ` A connected panel is on ${distinct.join(", ")} — a DIFFERENT address, which is why ` +
@@ -246,12 +259,22 @@ function classifyTargetDrift(target: string): TargetDriftClassification {
  * absent from the one they have.
  */
 export function describeMissingInputMediaDrift(target: string): string {
-  const { verdict, origins, alias } = classifyTargetDrift(target);
+  const { verdict, origins, alias, others } = classifyTargetDrift(target);
   if (verdict === "unknown") return "";
   if (verdict === "same") {
+    // ONE matching tab does not rule the split out when OTHER tabs are open
+    // elsewhere: the attachment could have come from any of them, and "RULED
+    // OUT" would then suppress the very guidance the reader needs (gate finding).
+    if (others.length > 0) {
+      return (
+        ` A connected panel is on this same ComfyUI${alias} — but others are on ` +
+        `${others.join(", ")}, so a file attached in one of THOSE tabs is on that server and ` +
+        `not on this one. Rule that out before treating the file as simply missing.`
+      );
+    }
     return (
-      ` A connected panel is on this same ComfyUI${alias}, so that split is RULED OUT — the file ` +
-      `is missing from the one server both are using.`
+      ` A connected panel is on this same ComfyUI${alias}, and no other panel is on a different ` +
+      `one, so that split is RULED OUT — the file is missing from the one server both are using.`
     );
   }
   return (

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -113,7 +113,12 @@ export function isComfyTransportFailure(err: unknown): boolean {
  *  credential cannot leak through a diagnostic string. */
 export function originOf(target: string): string | undefined {
   try {
-    return new URL(target).origin;
+    const origin = new URL(target).origin;
+    // An OPAQUE origin (file:, data:, blob:) serialises to the literal string
+    // "null", which is truthy and would sail through every caller as if it were
+    // an address — printing "a connected panel is on null" (gate, round 4). It is
+    // not an address, so it is not an origin as far as this module is concerned.
+    return origin === "null" ? undefined : origin;
   } catch {
     return undefined;
   }
@@ -204,6 +209,18 @@ function classifyTargetDrift(target: string): TargetDriftClassification {
     return { verdict: "unknown", text: "", origins: [], alias: "", others: [] };
   const want = originOf(target);
   if (!want) return { verdict: "unknown", text: "", origins: [], alias: "", others: [] };
+  // WHY THESE ARE NOT PUT THROUGH #1191's SCRUB, asked three times by the gate.
+  //
+  // `scrubSecretShapedText`'s third pass redacts any unbroken run of >=24
+  // credential-alphabet characters. A cloudflared quick-tunnel hostname IS one —
+  // `http://abcdef0123456789abcdef0123456789.trycloudflare.com` has a 32-char
+  // label — and that is the most common remote-ComfyUI setup this project sees.
+  // Scrubbing would therefore redact exactly the origins a reader most needs
+  // named, on the one message whose entire job is to say WHICH server. A
+  // hostname is public routing information, not a credential; the credential
+  // risk in a URL lives in userinfo, path and query, and `originOf` drops all
+  // three. So the protection here is NORMALISATION, not redaction:
+  //
   // Only a well-formed `scheme://host[:port]` may ever reach a message (gate,
   // round 3). These values are server-observed handshake Origins, not client
   // prose — but "not attacker prose today" is a property of a call site three

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -204,7 +204,19 @@ function classifyTargetDrift(target: string): TargetDriftClassification {
     return { verdict: "unknown", text: "", origins: [], alias: "", others: [] };
   const want = originOf(target);
   if (!want) return { verdict: "unknown", text: "", origins: [], alias: "", others: [] };
-  const distinct = [...new Set(origins)];
+  // Only a well-formed `scheme://host[:port]` may ever reach a message (gate,
+  // round 3). These values are server-observed handshake Origins, not client
+  // prose — but "not attacker prose today" is a property of a call site three
+  // modules away, and this string lands in an agent's context. Normalising
+  // through `originOf` cannot mangle a legitimate origin (it is idempotent on
+  // one) and cannot echo anything that is not one. An unparsable entry is
+  // dropped rather than scrubbed: it could not have matched the target anyway,
+  // and a scrub-by-shape here would redact real long hostnames.
+  const distinct = [...new Set(origins)].flatMap((o) => {
+    const normalised = originOf(o);
+    return normalised ? [normalised] : [];
+  });
+  if (distinct.length === 0) return { verdict: "unknown", text: "", origins: [], alias: "", others: [] };
   // #1175 — `includes` compares spellings, not servers. A panel on
   // http://127.0.0.1:8188 against a target of http://localhost:8188 is ONE
   // ComfyUI, and reporting it as "a DIFFERENT address" sent a reporter to point
@@ -273,8 +285,9 @@ export function describeMissingInputMediaDrift(target: string): string {
       );
     }
     return (
-      ` A connected panel is on this same ComfyUI${alias}, and no other panel is on a different ` +
-      `one, so that split is RULED OUT — the file is missing from the one server both are using.`
+      ` A connected panel is on this same ComfyUI${alias}, and no OTHER tab is open on a ` +
+      `different one, so that split is RULED OUT for every panel visible right now — a tab that ` +
+      `has since closed or navigated away would not appear here.`
     );
   }
   return (

--- a/src/comfyui/loader-asset-inputs.ts
+++ b/src/comfyui/loader-asset-inputs.ts
@@ -1,0 +1,40 @@
+/**
+ * KNOWN server-side media/upload SELECTORS, keyed by (class_type → input name).
+ *
+ * These are the loader inputs whose value is a FILE that must exist on the
+ * *connected* ComfyUI — resolved inside that server's input directory — rather
+ * than a free string or a member of a true enum.
+ *
+ * Deliberately an ALLOWLIST, not a name or extension heuristic: a combo merely
+ * *named* `image`/`audio`/`video` on some other node, or a media-looking value
+ * (`.bmp`, `.mp4`, …) on a true enum, is NOT an asset selector. Two callers rely
+ * on that distinction in opposite directions, which is why the list lives here
+ * rather than in either of them:
+ *
+ *  - the UI→API converter (#504) PRESERVES an out-of-list value on these inputs
+ *    (so a staged file surfaces as an honest missing-asset error) while
+ *    substituting on a true enum;
+ *  - the enqueue error path (#2673) reads a ComfyUI rejection on one of these
+ *    inputs as "the server does not have this file" and says how to put it there.
+ *
+ * A false positive on a true enum would make the second caller advise an upload
+ * for a bad sampler name, so the list stays narrow: unknown loaders simply get
+ * no note, which is the pre-#2673 behaviour.
+ */
+export const LOADER_ASSET_INPUTS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["LoadImage", new Set(["image"])],
+  ["LoadImageMask", new Set(["image"])],
+  ["LoadImageOutput", new Set(["image"])],
+  ["VHS_LoadVideo", new Set(["video"])],
+  ["VHS_LoadVideoPath", new Set(["video"])],
+  ["VHS_LoadVideoFFmpeg", new Set(["video"])],
+  ["VHS_LoadVideoFFmpegPath", new Set(["video"])],
+  ["LoadAudio", new Set(["audio"])],
+  ["VHS_LoadAudio", new Set(["audio"])],
+  ["VHS_LoadAudioUpload", new Set(["audio"])],
+]);
+
+/** Whether (classType, name) is one of the media-file selectors above. */
+export function isKnownLoaderInput(classType: string, name: string): boolean {
+  return LOADER_ASSET_INPUTS.get(classType)?.has(name) ?? false;
+}

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -13,6 +13,7 @@ import type {
   SubgraphLink,
 } from "../comfyui/types.js";
 import { logger } from "../utils/logger.js";
+import { isKnownLoaderInput } from "../comfyui/loader-asset-inputs.js";
 import { isSelfProducingUeSender, isUeSender } from "./flatten-workflow.js";
 
 export interface ConversionResult {
@@ -247,34 +248,16 @@ const ASSET_WIDGET_NAMES = new Set([
 ]);
 
 /**
- * KNOWN server-side file/upload SELECTORS, keyed by (classType → input name):
- * real loader nodes whose combo lists media files present on the *connected*
- * server (uploads or on-disk inputs). For these — and ONLY these, plus the
- * model-loader widget names in ASSET_WIDGET_NAMES and object_info upload-flag
- * metadata (isUploadSelectorSpec) — a value absent from a STALE combo is
- * PRESERVED with a warning rather than silently rewritten to comboOpts[0]
- * (issue #504). This is deliberately an allowlist, NOT a global name/extension
- * heuristic: a combo merely *named* `image`/`audio`/`video`/`extension` on some
- * OTHER node, or a media-looking value (`.bmp`, `.mp4`, …) on a TRUE enum, is
- * NOT an asset selector and must take the enum fallback (substitute + warn) so
- * ComfyUI does not hard-reject a "Value not in list".
+ * KNOWN server-side file/upload SELECTORS, keyed by (classType → input name).
+ * For these — and ONLY these, plus the model-loader widget names in
+ * ASSET_WIDGET_NAMES and object_info upload-flag metadata (isUploadSelectorSpec)
+ * — a value absent from a STALE combo is PRESERVED with a warning rather than
+ * silently rewritten to comboOpts[0] (issue #504).
+ *
+ * The list itself moved to comfyui/loader-asset-inputs.ts when the enqueue error
+ * path became a second reader of it (#2673); see that module for why it is an
+ * allowlist rather than a name/extension heuristic.
  */
-const LOADER_ASSET_INPUTS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
-  ["LoadImage", new Set(["image"])],
-  ["LoadImageMask", new Set(["image"])],
-  ["LoadImageOutput", new Set(["image"])],
-  ["VHS_LoadVideo", new Set(["video"])],
-  ["VHS_LoadVideoPath", new Set(["video"])],
-  ["VHS_LoadVideoFFmpeg", new Set(["video"])],
-  ["VHS_LoadVideoFFmpegPath", new Set(["video"])],
-  ["LoadAudio", new Set(["audio"])],
-  ["VHS_LoadAudio", new Set(["audio"])],
-  ["VHS_LoadAudioUpload", new Set(["audio"])],
-]);
-
-function isKnownLoaderInput(classType: string, name: string): boolean {
-  return LOADER_ASSET_INPUTS.get(classType)?.has(name) ?? false;
-}
 
 /**
  * Whether object_info marks this input as an in-browser file/media UPLOAD


### PR DESCRIPTION
Closes #2673.

## What the reporter hit

A user attached an image in the panel; the sidebar showed `input/8058752600640.JPG`; a
headless workflow with `LoadImage image="8058752600640.JPG"` came back:

```
ComfyUI rejected the workflow (400): Prompt outputs failed validation
- LoadImage (node 5): Custom validation failed for node (image - Invalid image file: 8058752600640.JPG)
```

That is the **entire** message `buildEnqueueError` produced, and it is a dead end: it does
not say which server was asked, whether a connected panel is on a different one, or what
call would put the file where the render will look. The reporting agent guessed —
"attachment registration/race, or filename handling in comfyui-mcp" — and filed a P2.

## What is actually going on (checked, not assumed)

Read off the reporter's own ComfyUI **v0.34.0** checkout, not from memory:

- `LoadImage.VALIDATE_INPUTS(image)` (`nodes.py:1807`) returns `"Invalid image file: {}"` when
  `folder_paths.exists_annotated_filepath(image)` is false, which is a plain
  `os.path.exists(get_input_directory()/name)`.
- `/upload/image` (`server.py:397`) writes into `get_input_directory()` and returns the name it
  actually wrote — including its dedup rename.

Both use the same `get_input_directory()`, so **on one server they cannot disagree**: a 200
from `/upload/image` naming `N` means `input/N` exists, and validation checks that same path.
The reporter's failure therefore requires the upload and the enqueue to have reached
*different* input directories.

comfyui-mcp makes that structurally possible **by design**, and says so in
`src/comfyui/fetch.ts`: a chat attachment is uploaded by the **browser**, through whichever
ComfyUI the panel tab is on, while `enqueue_workflow` posts to `COMFYUI_URL`. #952 built
`describeTargetDrift` to detect exactly that split — but wired it only into **transport**
failures. The one error the split reliably produces is a 400, where the detector never ran.

Also checked, so the reporter's two hypotheses can be answered directly:
`enqueue_workflow action:"enqueue"` passes the workflow through verbatim
(`src/tools/workflow-execute.ts`) and nothing between the panel's `sendText` and `/prompt`
rewrites a loader value. It is not filename handling.

## The change

When a `/prompt` 400 names a **loader media input**, append a note to the message ComfyUI's
own diagnosis already produced (appended, never substituted):

> That input names a FILE on the server, not a free value: `LoadImage.image` (node 5) is
> resolved inside the input directory of the ComfyUI at http://127.0.0.1:8188 — so this is a
> question about WHICH server holds the file, not about the value's spelling. A file ATTACHED
> in the panel's chat is uploaded by the BROWSER to whichever ComfyUI that tab is on, a
> separate connection from this headless target (COMFYUI_URL), so a file can exist on one and
> not the other. **A connected panel is on http://127.0.0.1:8199 — a DIFFERENT ComfyUI from
> this target, so that is very likely where the file is, and very likely the whole answer: run
> the graph on the panel instead (`panel_run`), or point COMFYUI_URL at that origin.** To put
> it on THIS target: `upload_image (action:"image")` for a file on disk, or
> `upload_image (action:"stage")` for an existing ComfyUI output; then re-enqueue with the
> filename it returns. Re-submitting this workflow unchanged will fail identically —
> `enqueue_workflow` sends loader values through verbatim and never rewrites them.

The bold sentence is the machine-checked half. On a SAME-origin panel it instead says the
split is **RULED OUT**, which is worth as much: it stops the reader hunting for a second
server. With no panel connected it says nothing about origins at all — an absent comparison
is not a negative result.

## Where the load-bearing claims are — please push on these

1. **The detection predicate.** Keyed on `(class_type, extra_info.input_name)` from an
   allowlist, plus ComfyUI's machine `type` token (`custom_validation_failed` /
   `value_not_in_list`). Deliberately **not** on the prose `message`/`details`, and
   deliberately **not** on `extra_info.input_config`'s upload flag — I checked
   `execution.py:1101`, and `custom_validation_failed` carries `{"input_name": x}` and nothing
   else, so that flag is simply absent on the error that matters here.
2. **Why both error types.** `validate_inputs` skips the combo-membership check for any input
   the node declares in its own `VALIDATE_INPUTS` (`execution.py:1018`). `LoadImage.image`
   does, so it can only fail as `custom_validation_failed`; a loader that does not keeps the
   check and fails as `value_not_in_list`. Matching one would drop a whole class of loader.
3. **Over-firing.** The allowlist is the only thing stopping an unrelated
   `custom_validation_failed` (a bad width, an out-of-range strength) from collecting an
   "upload the file" note. Four negative tests pin it; an unlisted third-party loader gets
   silence rather than a guess.
4. **`LOADER_ASSET_INPUTS` moved** out of `services/workflow-converter.ts` into a new leaf
   `comfyui/loader-asset-inputs.ts` so both readers share one list. Pure move; the #504
   converter tests still pass.
5. **Redaction.** Every field the note interpolates comes from the response body and goes
   through the same `safeField` / #1191 scrub as the lines above it. The target is rendered via
   `originOf`, so a `COMFYUI_URL` carrying a token in its path or userinfo cannot leak.
6. **`classifyTargetDrift` now also returns `origins`/`alias`.** The existing
   `describeTargetDrift` text is byte-identical — its transport-failure wording ("the browser
   can reach it and this process cannot") would be *false* here, which is why the two share the
   comparison and not the sentences. `loopback-alias-origin.test.ts` (#1175) still passes, and
   the new suite re-pins alias handling through the new caller.

## Verification

- `npx vitest run` in this worktree: **745 files, 13694 passed** (6 skipped).
- `npm test` (the repo's own gate: vitest, i18n, docs, blog, vocabulary, unknown-collapse,
  vocab:export, changelog, asset-counts): all green after `npm run build`.
- **Mutation battery** — each gate deleted alone, each turns a named test red:

  | mutation | result |
  |---|---|
  | note never appended | 10 failed / 5 passed |
  | drift comparison removed from the note | 3 failed |
  | loader allowlist gate removed | 3 failed (all three negative tests) |
  | error-`type` gate removed | 1 failed (`required_input_missing` leaks a note) |
  | `value_not_in_list` dropped from the set | 1 failed (`VHS_LoadVideo`) |
  | `custom_validation_failed` dropped from the set | 9 failed |
  | same-origin verdict silenced | 2 failed |

- The fixture is the shape ComfyUI 0.34.0 actually emits, transcribed from `execution.py`,
  not invented — including `extra_info` carrying only `input_name`.
- Production reach: `buildEnqueueError` is the sole `/prompt` non-OK path in `enqueuePrompt`,
  which `services/workflow-executor.ts` and `services/queue-manager.ts` call for
  `enqueue_workflow`, `generate_image`, and every other headless render.

## What this deliberately does NOT do

- **It does not stop the file going missing.** I could not reproduce the reporter's session
  (no ComfyUI was allocated for this run, and the input dirs on this box have long since
  rotated), so the note names the one cause it can *check* and refuses to assert a cause it
  cannot. If a future reporter hits this with the drift verdict reading "RULED OUT", that is a
  new and much sharper bug report than #2673 was.
- **No panel-repo change.** The panel's chat line still says `input/<name>` with no hint of
  which server that is; making it say so is a separate change in a separate repo. Not done here.
- **No browser verification.** Nothing in this diff renders in the sidebar — it changes a
  string produced by the headless MCP child — so the Playwright suite was not run and I am not
  implying coverage I do not have.
- **Cloud mode untouched.** `enqueuePrompt` returns early into `cloud-client.ts` before this
  path; `panel_run` has its own rejection formatter (`formatRunRejection`) and runs against the
  panel's own server, where this split cannot arise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
