### PR TITLE
fix(2681): flag an image-edit graph whose sampled canvas is not derived from the reference

### DIFF
--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -38,7 +38,7 @@ Author and check ComfyUI workflow JSON. Driven by the `action` parameter:
   action:"modify" (REQUIRED) — Array of operations to apply in order. Each has an 'op' field: set_input, add_node, remove_node, connect, or insert_between
 </ParamField>
 <ParamField path="health" type="boolean" default="true">
-  action:"validate" — Include graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed nodes, a sampler running denoise below 1.0 on an empty latent) as info/warning issues plus a structured health section. Never affects `valid`.
+  action:"validate" — Include graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed nodes, a sampler running denoise below 1.0 on an empty latent, an image-edit graph whose sampled canvas is not derived from the reference) as info/warning issues plus a structured health section. Never affects `valid`.
 </ParamField>
 <ParamField path="node_type" type="string">
   action:"node_info" — Filter by node class_type name (case-insensitive substring match). Omit to list all available nodes.

--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -48,7 +48,7 @@ Return, list, summarize or query a SAVED workflow FILE — files on disk, named 
   action:"from_image" (REQUIRED) — Absolute path to a ComfyUI-generated PNG file
 </ParamField>
 <ParamField path="view" type="enum" default="summary">
-  action:"analyze" — summary (default): structured text with sections, node IDs, key settings, virtual wires, and full connection graph — best for AI understanding. overview: mermaid diagram showing sections as summary nodes with cross-section data flow. detail: mermaid diagram for one section (requires section parameter). list: text listing of all sections with data flow summary. flat: single mermaid flowchart of the entire workflow (best for small workflows). health: graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed, a sampler running denoise below 1.0 on an empty latent).
+  action:"analyze" — summary (default): structured text with sections, node IDs, key settings, virtual wires, and full connection graph — best for AI understanding. overview: mermaid diagram showing sections as summary nodes with cross-section data flow. detail: mermaid diagram for one section (requires section parameter). list: text listing of all sections with data flow summary. flat: single mermaid flowchart of the entire workflow (best for small workflows). health: graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed, a sampler running denoise below 1.0 on an empty latent, an image-edit graph whose sampled canvas is not derived from the reference).
   Options: `summary`, `overview`, `detail`, `list`, `flat`, `health`.
 </ParamField>
 <ParamField path="section" type="string">

--- a/plugin/skills/qwen-image-edit/SKILL.md
+++ b/plugin/skills/qwen-image-edit/SKILL.md
@@ -153,11 +153,20 @@ latent (`comfy_extras/nodes_qwen.py`).
 The model then lays the reference tokens and the tokens it is generating on **one
 shared, centred coordinate grid** (`comfy/ldm/qwen_image/model.py`, `process_img`), so
 reference position (i, j) and output position (i, j) mean the same place only when the
-two grids are the same size. That is the whole reason the official templates run the
-one image through `FluxKontextImageScale` and then feed the sampler a `VAEEncode` of
-*that* scaled image: canvas geometry and reference geometry come out identical by
-construction. Every `PREFERRED_KONTEXT_RESOLUTIONS` entry is ~1.05 MP for the same
-reason.
+two grids are the same size. That is the whole reason the official templates run the one
+image through `FluxKontextImageScale` and then feed the sampler a `VAEEncode` of *that*
+scaled image — both branches then see the same pixels at the same ~1 MP scale and the
+same aspect. Every `PREFERRED_KONTEXT_RESOLUTIONS` entry is ~1.05 MP for the same reason.
+
+It is agreement to within the encoder's round-to-8, not exact equality, and the
+difference is worth knowing precisely. `FluxKontextImageScale` snaps to a preferred pair;
+the encoder then renormalises *that* to its own 1,048,576 px budget. For 12 of the 18
+preferred pairs the two land on the same latent grid. For the other 6 — 688x1504,
+800x1328, 832x1248 and their landscape mirrors — the reference lands one latent row or
+column off: at 800x1328 the sampler's grid is 100x166 and the reference's is 99x165.
+ComfyUI's own bundled 2511 template does exactly this, so a sub-patch offset is evidently
+fine in practice. **The failure this page is about is one of SCALE, not of rounding** — an
+empty latent at 1104x1472 sits 1.24x away linearly, not one row.
 
 So on an edit graph you do not choose a resolution — you inherit one:
 
@@ -280,7 +289,7 @@ and it fails silently. A `VAEEncode` removes the coincidence — it cannot be th
 size, because it is derived from the same pixels the encoder saw.
 
 Feed `latent_image` from a `VAEEncode` of the same image you gave the encoder, scaled
-once up front so both see identical geometry:
+once up front so both branches see the same pixels at the same scale:
 
 ```json
 {

--- a/plugin/skills/qwen-image-edit/SKILL.md
+++ b/plugin/skills/qwen-image-edit/SKILL.md
@@ -262,16 +262,22 @@ If `qweneditutils` custom node is unavailable, use the built-in `TextEncodeQwenI
 Replace node 6 and add node 8. KSampler latent_image connects to `["8", 0]` instead of `["6", 1]`.
 
 **Do not leave that `EmptyLatentImage` wired to the sampler.** It is shown above only
-because it is what the Plus encoder's own signature leaves you needing, and it is wrong
-at *every* denoise:
+because it is what the Plus encoder's own signature leaves you needing, and it fails in a
+different way on each side of denoise 1.0:
 
-- Below 1.0 it renders a flat, near-uniform field. The encoder emits CONDITIONING only,
-  so the latent is genuinely empty, and a truncated sigma schedule exists to preserve an
-  incoming latent that here has nothing in it (#2678).
-- At 1.0 it renders a plausible image that is not your source. The reference the encoder
-  attached is ~1.05 MP at the source's aspect ratio, the empty latent's size is a
-  literal, and the model aligns the two on one shared grid — so it re-synthesises rather
-  than copies (#2681). See "Resolution on an edit graph".
+- Below 1.0 it renders a flat, near-uniform field, always. The encoder emits CONDITIONING
+  only, so the latent is genuinely empty, and a truncated sigma schedule exists to
+  preserve an incoming latent that here has nothing in it (#2678).
+- At 1.0 it renders a plausible image that is not your source — *unless* its width and
+  height happen to equal the geometry the encoder derived, which is ~1.05 MP at the
+  source's aspect ratio. A 1024x1024 empty latent over an exactly-square source does line
+  up, and is fine. 1104x1472 over that same source does not: the model aligns reference
+  and output on one shared grid, cannot copy across grids that far apart, and
+  re-synthesises instead (#2681). See "Resolution on an edit graph".
+
+The second case is the trap, because it depends on a source you may not have looked at
+and it fails silently. A `VAEEncode` removes the coincidence — it cannot be the wrong
+size, because it is derived from the same pixels the encoder saw.
 
 Feed `latent_image` from a `VAEEncode` of the same image you gave the encoder, scaled
 once up front so both see identical geometry:
@@ -350,7 +356,7 @@ This produces a grid image showing all combinations, useful for finding the best
 1. **Upload source images first** with `upload_image (action:"image")` before building the workflow
 2. **Match output resolution** to the next pipeline step (e.g., 832x480 for WAN FLF) — but only on a *generation* graph. On an edit graph the size is the source's; resize the RESULT afterwards instead of sampling at the size you want
 3. **Lightning LoRA + denoise 1.0** works well. The model handles structure preservation through conditioning
-4. **An edit graph's `latent_image` always comes from a `VAEEncode` of the source, never from an `EmptyLatentImage`** — at sub-1.0 denoise the empty latent decodes to a flat, near-uniform field (#2678), and at denoise 1.0 it decouples the sampled canvas from the reference and the subject gets re-synthesised (#2681). Neither errors. `create_workflow (action:"validate")` flags both pairings (`partial_denoise_empty_latent`, `edit_reference_empty_latent`)
+4. **Take an edit graph's `latent_image` from a `VAEEncode` of the source, not from an `EmptyLatentImage`** — at sub-1.0 denoise the empty latent decodes to a flat, near-uniform field (#2678), and at denoise 1.0 it is right only if its literal size happens to equal the geometry the encoder derived from the source, which is exactly the coincidence a `VAEEncode` removes (#2681). Neither failure errors. `create_workflow (action:"validate")` flags both pairings (`partial_denoise_empty_latent`, `edit_reference_empty_latent`)
 5. The **lrzjason Pro variant** is best for multi-image compositions where you need fine control over which images get VL-resized
 6. **Use `get_workflow (action:"analyze")`** to understand any saved Qwen edit workflow before modifying or executing it. It returns a structured summary, not raw JSON. Only use `get_workflow` when you need the actual JSON for `enqueue_workflow` or `create_workflow (action:"modify")`.
 

--- a/plugin/skills/qwen-image-edit/SKILL.md
+++ b/plugin/skills/qwen-image-edit/SKILL.md
@@ -125,7 +125,12 @@ For non-edit models (txt2img, 2512):
 
 ## Resolutions
 
-Qwen operates at ~1.6 megapixels natively:
+> **This table is for Qwen-Image TEXT-TO-IMAGE. Do not pick an edit graph's output
+> size from it.** An edit graph's geometry is decided by the SOURCE image, not by you
+> — see "Resolution on an edit graph" below. Choosing 1104x1472 here for an edit was
+> #2681.
+
+Qwen-Image operates at ~1.6 megapixels natively:
 
 | Aspect | Resolution | Use Case |
 |--------|-----------|----------|
@@ -137,6 +142,36 @@ Qwen operates at ~1.6 megapixels natively:
 | Video-ready | 832x480 | For WAN 2.2 FLF pipeline |
 
 **For video pipelines**: Use 832x480 to match WAN 2.2's default resolution.
+
+### Resolution on an edit graph
+
+`TextEncodeQwenImageEdit` and `TextEncodeQwenImageEditPlus` do not take a size. They
+scale every reference image to a hard-coded `int(1024 * 1024)` px — **~1.05 MP, at the
+source's own aspect ratio** — VAE-encode it, and hand it to the model as a reference
+latent (`comfy_extras/nodes_qwen.py`).
+
+The model then lays the reference tokens and the tokens it is generating on **one
+shared, centred coordinate grid** (`comfy/ldm/qwen_image/model.py`, `process_img`), so
+reference position (i, j) and output position (i, j) mean the same place only when the
+two grids are the same size. That is the whole reason the official templates run the
+one image through `FluxKontextImageScale` and then feed the sampler a `VAEEncode` of
+*that* scaled image: canvas geometry and reference geometry come out identical by
+construction. Every `PREFERRED_KONTEXT_RESOLUTIONS` entry is ~1.05 MP for the same
+reason.
+
+So on an edit graph you do not choose a resolution — you inherit one:
+
+- **Right:** `LoadImage` -> `FluxKontextImageScale` -> (`TextEncodeQwenImageEditPlus`
+  *and* `VAEEncode`) -> KSampler `latent_image`.
+- **Wrong:** an `EmptyLatentImage` at a size from the table above. Its dimensions are
+  literals; the reference's are computed from the source when the graph runs. At
+  1104x1472 (1.63 MP) against a 1.05 MP reference the grids are 1.24x apart linearly,
+  the model cannot copy detail across them, and it re-synthesises the subject instead —
+  materials come back looking plastic/CGI and printed detail comes back as a generic
+  shape (#2681). Nothing errors; the image just is not the edit you asked for.
+
+`create_workflow (action:"validate")` now flags this pairing as
+`edit_reference_empty_latent`.
 
 ## Prompt Patterns
 
@@ -226,13 +261,33 @@ If `qweneditutils` custom node is unavailable, use the built-in `TextEncodeQwenI
 
 Replace node 6 and add node 8. KSampler latent_image connects to `["8", 0]` instead of `["6", 1]`.
 
-**Set `denoise` to 1.0 on this path.** `TextEncodeQwenImageEditPlus` emits CONDITIONING only, so the `EmptyLatentImage` here is genuinely empty and carries no source pixels. A sub-1.0 denoise over it produces a flat texture instead of the edited image (#2678). If you want a sub-1.0 denoise, drop the `EmptyLatentImage` and feed `latent_image` from a `VAEEncode` of the source image instead:
+**Do not leave that `EmptyLatentImage` wired to the sampler.** It is shown above only
+because it is what the Plus encoder's own signature leaves you needing, and it is wrong
+at *every* denoise:
+
+- Below 1.0 it renders a flat, near-uniform field. The encoder emits CONDITIONING only,
+  so the latent is genuinely empty, and a truncated sigma schedule exists to preserve an
+  incoming latent that here has nothing in it (#2678).
+- At 1.0 it renders a plausible image that is not your source. The reference the encoder
+  attached is ~1.05 MP at the source's aspect ratio, the empty latent's size is a
+  literal, and the model aligns the two on one shared grid — so it re-synthesises rather
+  than copies (#2681). See "Resolution on an edit graph".
+
+Feed `latent_image` from a `VAEEncode` of the same image you gave the encoder, scaled
+once up front so both see identical geometry:
 
 ```json
 {
-  "8": { "class_type": "VAEEncode", "inputs": { "pixels": ["5", 0], "vae": ["4", 0] }}
+  "5b": { "class_type": "FluxKontextImageScale", "inputs": { "image": ["5", 0] }},
+  "6":  { "class_type": "TextEncodeQwenImageEditPlus", "inputs": {
+    "clip": ["3", 0], "prompt": "<edit instruction>", "vae": ["4", 0], "image1": ["5b", 0]
+  }},
+  "8":  { "class_type": "VAEEncode", "inputs": { "pixels": ["5b", 0], "vae": ["4", 0] }}
 }
 ```
+
+KSampler `latent_image` connects to `["8", 0]`. Any denoise is then meaningful: 1.0 for
+a full edit, sub-1.0 to stay closer to the source.
 
 ### Basic Variant (Official ComfyUI Example)
 
@@ -293,9 +348,9 @@ This produces a grid image showing all combinations, useful for finding the best
 ## Tips
 
 1. **Upload source images first** with `upload_image (action:"image")` before building the workflow
-2. **Match output resolution** to the next pipeline step (e.g., 832x480 for WAN FLF)
+2. **Match output resolution** to the next pipeline step (e.g., 832x480 for WAN FLF) — but only on a *generation* graph. On an edit graph the size is the source's; resize the RESULT afterwards instead of sampling at the size you want
 3. **Lightning LoRA + denoise 1.0** works well. The model handles structure preservation through conditioning
-4. For **img2img editing** (denoise < 1.0), use `VAEEncode` on the source image instead of `EmptyLatentImage` — a sub-1.0 denoise over an empty latent decodes to a flat, near-uniform field with no error (#2678). `create_workflow (action:"validate")` now flags this pairing
+4. **An edit graph's `latent_image` always comes from a `VAEEncode` of the source, never from an `EmptyLatentImage`** — at sub-1.0 denoise the empty latent decodes to a flat, near-uniform field (#2678), and at denoise 1.0 it decouples the sampled canvas from the reference and the subject gets re-synthesised (#2681). Neither errors. `create_workflow (action:"validate")` flags both pairings (`partial_denoise_empty_latent`, `edit_reference_empty_latent`)
 5. The **lrzjason Pro variant** is best for multi-image compositions where you need fine control over which images get VL-resized
 6. **Use `get_workflow (action:"analyze")`** to understand any saved Qwen edit workflow before modifying or executing it. It returns a structured summary, not raw JSON. Only use `get_workflow` when you need the actual JSON for `enqueue_workflow` or `create_workflow (action:"modify")`.
 

--- a/src/__tests__/services/workflow-health.test.ts
+++ b/src/__tests__/services/workflow-health.test.ts
@@ -80,6 +80,19 @@ const OBJECT_INFO = {
     output: ["*"],
     output_node: false,
   },
+  // One typed conditioning input and one untyped one — a fork that a CONDITIONING-only
+  // count would read as a chain.
+  AnyConditioningMux: {
+    input: { required: { conditioning: ["CONDITIONING"], alt: ["*"] } },
+    output: ["CONDITIONING"],
+    output_node: false,
+  },
+  // One conditioning input plus scalar widgets that can be converted to inputs.
+  ConditioningSetTimestepRange: {
+    input: { required: { conditioning: ["CONDITIONING"], start: ["INT"], end: ["INT"] } },
+    output: ["CONDITIONING"],
+    output_node: false,
+  },
   ConditioningZeroOut: {
     input: { required: { conditioning: ["CONDITIONING"] } },
     output: ["CONDITIONING"],
@@ -884,6 +897,40 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     expect(hits).toHaveLength(1);
     expect(hits[0].detail).toContain("where the grids differ");
     expect(hits[0].detail).toContain("Where they happen to coincide it is fine");
+  });
+
+  it("does not count a converted scalar widget as a second branch", () => {
+    // `start` converted from a widget to an input is a NUMBER feed, not a fork arm.
+    // Counting every connected input instead of the CONDITIONING-typed ones would make
+    // this node look like a two-branch fork and silently drop the finding.
+    const g = editGraph();
+    (g as unknown as Record<string, unknown>)["73"] = {
+      class_type: "ConditioningSetTimestepRange",
+      inputs: { conditioning: ["6", 0], start: ["74", 0], end: 1 },
+    };
+    (g as unknown as Record<string, unknown>)["74"] = {
+      class_type: "PrimitiveInt",
+      inputs: { value: 0 },
+    };
+    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["73", 0];
+    const h = analyzeGraphHealth(g, OBJECT_INFO);
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(1);
+  });
+
+  it("counts a connected wildcard slot as a fork arm, not as nothing", () => {
+    // One typed CONDITIONING input from the encoder plus one connected `*`. The wildcard
+    // may be what actually reaches the output, so the typed branch is not proof. Counting
+    // only CONDITIONING-typed inputs would read this as a chain of one and fire -- and
+    // then suppress rule 6, turning a false positive into a lost warning.
+    const g = editGraph({ denoise: 0.65, steps: 50 });
+    (g as unknown as Record<string, unknown>)["72"] = {
+      class_type: "AnyConditioningMux",
+      inputs: { conditioning: ["6", 0], alt: ["7", 0] },
+    };
+    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["72", 0];
+    const h = analyzeGraphHealth(g, OBJECT_INFO);
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(1);
   });
 
   it("replaces the partial-denoise finding rather than double-reporting the same sampler", () => {

--- a/src/__tests__/services/workflow-health.test.ts
+++ b/src/__tests__/services/workflow-health.test.ts
@@ -85,6 +85,12 @@ const OBJECT_INFO = {
     output: ["CONDITIONING"],
     output_node: false,
   },
+  // Two inbound CONDITIONING slots: a fork, not a link in a chain.
+  ConditioningCombine: {
+    input: { required: { conditioning_1: ["CONDITIONING"], conditioning_2: ["CONDITIONING"] } },
+    output: ["CONDITIONING"],
+    output_node: false,
+  },
   // The generic edit-reference node. Deliberately NOT in QWEN_EDIT_ENCODERS -- its
   // reference geometry is whatever latent it is handed, and ComfyUI's own
   // Qwen-Image-Layered templates pair it with an empty layered latent on purpose.
@@ -851,6 +857,33 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     expect(hits).toHaveLength(1);
     expect(hits[0].detail).toContain("builds an EMPTY sigma schedule");
     expect(hits[0].detail).not.toContain("truncates the sigma schedule");
+  });
+
+  it("stops at a node with two inbound conditionings, and leaves rule 6 its warning", () => {
+    // A fork: which branch survives to the output is a run-time decision, so an encoder
+    // on one of them is not proof the sampler receives its reference. Declining is the
+    // safe half; the load-bearing half is that rule 6 must NOT be suppressed here, or a
+    // false positive would have cost a real warning.
+    const g = editGraph({ denoise: 0.65, steps: 50 });
+    (g as unknown as Record<string, unknown>)["71"] = {
+      class_type: "ConditioningCombine",
+      inputs: { conditioning_1: ["6", 0], conditioning_2: ["7", 0] },
+    };
+    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["71", 0];
+    const h = analyzeGraphHealth(g, OBJECT_INFO);
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(1);
+  });
+
+  it("makes the re-synthesis consequence conditional on the grids actually differing", () => {
+    // The checker cannot see the source image, so it cannot know whether the literal
+    // canvas happened to match. Asserting the plastic/CGI outcome unconditionally would
+    // claim more than it establishes.
+    const h = analyzeGraphHealth(editGraph({ width: 1024, height: 1024 }), OBJECT_INFO);
+    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].detail).toContain("where the grids differ");
+    expect(hits[0].detail).toContain("Where they happen to coincide it is fine");
   });
 
   it("replaces the partial-denoise finding rather than double-reporting the same sampler", () => {

--- a/src/__tests__/services/workflow-health.test.ts
+++ b/src/__tests__/services/workflow-health.test.ts
@@ -66,6 +66,27 @@ const OBJECT_INFO = {
     output: ["LATENT"],
     output_node: false,
   },
+  TextEncodeQwenImageEdit: {
+    input: {
+      required: { clip: ["CLIP"], prompt: ["STRING"] },
+      optional: { vae: ["VAE"], image: ["IMAGE"] },
+    },
+    output: ["CONDITIONING"],
+    output_node: false,
+  },
+  ConditioningZeroOut: {
+    input: { required: { conditioning: ["CONDITIONING"] } },
+    output: ["CONDITIONING"],
+    output_node: false,
+  },
+  // The generic edit-reference node. Deliberately NOT in QWEN_EDIT_ENCODERS -- its
+  // reference geometry is whatever latent it is handed, and ComfyUI's own
+  // Qwen-Image-Layered templates pair it with an empty layered latent on purpose.
+  ReferenceLatent: {
+    input: { required: { conditioning: ["CONDITIONING"] }, optional: { latent: ["LATENT"] } },
+    output: ["CONDITIONING"],
+    output_node: false,
+  },
   TextEncodeQwenImageEditPlus: {
     input: {
       required: { clip: ["CLIP"], prompt: ["STRING"] },
@@ -574,5 +595,199 @@ describe("analyzeGraphHealth", () => {
     const f = h.findings.filter((x) => x.kind === "partial_denoise_empty_latent");
     expect(f).toHaveLength(1);
     expect(f[0].node_type).toBe("SomeCustomKSampler");
+  });
+});
+
+describe("analyzeGraphHealth — empty latent under an image-edit reference (#2681)", () => {
+  // The encoder's `vae` and `image1` are both wired: ComfyUI only appends
+  // reference_latents when BOTH are present, so this conditioning really does carry
+  // a reference and the sampled canvas really is expected to match its geometry.
+  const editGraph = (
+    over: {
+      width?: number;
+      height?: number;
+      denoise?: number;
+      steps?: number;
+      latentFrom?: string;
+      encoderInputs?: Record<string, unknown>;
+    } = {},
+  ) =>
+    wf({
+      "4": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd_xl_base.safetensors" } },
+      "5": { class_type: "LoadImage", inputs: { image: "8058752590630.JPG" } },
+      "6": {
+        class_type: "TextEncodeQwenImageEditPlus",
+        inputs: over.encoderInputs ?? {
+          clip: ["4", 1],
+          prompt: "remove the hanger, steamed symmetric e-commerce still life",
+          vae: ["4", 2],
+          image1: ["5", 0],
+        },
+      },
+      "7": { class_type: "ConditioningZeroOut", inputs: { conditioning: ["6", 0] } },
+      "8": {
+        class_type: "EmptyLatentImage",
+        inputs: { width: over.width ?? 1104, height: over.height ?? 1472, batch_size: 1 },
+      },
+      "80": { class_type: "VAEEncode", inputs: { pixels: ["5", 0], vae: ["4", 2] } },
+      "9": {
+        class_type: "KSampler",
+        inputs: {
+          model: ["4", 0],
+          positive: ["6", 0],
+          negative: ["7", 0],
+          latent_image: [over.latentFrom ?? "8", 0],
+          seed: 42,
+          steps: over.steps ?? 50,
+          cfg: 4,
+          sampler_name: "euler",
+          scheduler: "simple",
+          denoise: over.denoise ?? 1.0,
+        },
+      },
+      "10": { class_type: "VAEDecode", inputs: { samples: ["9", 0], vae: ["4", 2] } },
+      "11": { class_type: "SaveImage", inputs: { images: ["10", 0] } },
+    });
+
+  it("reproduces the #2681 graph: Plus encoder + EmptyLatentImage 1104x1472 at denoise 1.0", () => {
+    const h = analyzeGraphHealth(editGraph(), OBJECT_INFO);
+    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].node_ids).toEqual(["9", "8", "6"]);
+    // The arithmetic, not a vague adjective: 1104*1472 = 1625088 px against the
+    // encoder's hard-coded int(1024*1024) = 1048576 px reference budget.
+    expect(hits[0].detail).toContain("1104x1472 = 1625088 px is 1.55x the 1048576 px budget");
+    expect(hits[0].detail).toContain("1.24x linear");
+    // Rule 6 is silent here -- denoise is 1.0, so the schedule is never truncated.
+    expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(0);
+  });
+
+  it("stays silent when the encoder has no VAE — it emits no reference latents at all", () => {
+    // ComfyUI: `if vae is not None: ref_latents.append(vae.encode(...))`. Without a
+    // VAE the node is a plain VL-conditioned text encoder and an empty latent is
+    // ordinary txt2img. This is also the shape of the #2678 regression test above.
+    const h = analyzeGraphHealth(
+      editGraph({
+        encoderInputs: { clip: ["4", 1], prompt: "change the garment", image1: ["5", 0] },
+      }),
+      OBJECT_INFO,
+    );
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+  });
+
+  it("stays silent when no image is connected to the encoder", () => {
+    const h = analyzeGraphHealth(
+      editGraph({ encoderInputs: { clip: ["4", 1], prompt: "a cat", vae: ["4", 2] } }),
+      OBJECT_INFO,
+    );
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+  });
+
+  it("stays silent when latent_image comes from a VAEEncode — the official edit shape", () => {
+    const h = analyzeGraphHealth(editGraph({ latentFrom: "80" }), OBJECT_INFO);
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+  });
+
+  it("follows the CONDITIONING chain through a pass-through node", () => {
+    // positive <- ConditioningZeroOut <- the encoder. The walk must reach it.
+    const g = editGraph();
+    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["7", 0];
+    const h = analyzeGraphHealth(g, OBJECT_INFO);
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(1);
+  });
+
+  it("does NOT fire on a generic ReferenceLatent — the Qwen-Image-Layered shape", () => {
+    // Both bundled layered templates reach reference_latents through a
+    // `ReferenceLatent` fed by a `CLIPTextEncode`, over an empty layered latent, on
+    // purpose. Keying the rule on ReferenceLatent scores 2 false positives on the
+    // 533-template corpus; keying it on the Qwen edit encoders scores 0.
+    const h = analyzeGraphHealth(
+      wf({
+        "4": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd_xl_base.safetensors" } },
+        "5": { class_type: "LoadImage", inputs: { image: "ref.png" } },
+        "6": { class_type: "CLIPTextEncode", inputs: { clip: ["4", 1], text: "layers" } },
+        "60": { class_type: "VAEEncode", inputs: { pixels: ["5", 0], vae: ["4", 2] } },
+        "61": { class_type: "ReferenceLatent", inputs: { conditioning: ["6", 0], latent: ["60", 0] } },
+        "8": { class_type: "EmptyLatentImage", inputs: { width: 640, height: 640, batch_size: 1 } },
+        "9": {
+          class_type: "KSampler",
+          inputs: {
+            model: ["4", 0],
+            positive: ["61", 0],
+            negative: ["6", 0],
+            latent_image: ["8", 0],
+            steps: 20,
+            denoise: 1.0,
+          },
+        },
+        "10": { class_type: "VAEDecode", inputs: { samples: ["9", 0], vae: ["4", 2] } },
+        "11": { class_type: "SaveImage", inputs: { images: ["10", 0] } },
+      }),
+      OBJECT_INFO,
+    );
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+  });
+
+  it("says equal-area-is-not-equal-shape rather than claiming a mismatch it cannot prove", () => {
+    const h = analyzeGraphHealth(editGraph({ width: 1024, height: 1024 }), OBJECT_INFO);
+    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].detail).toContain("equal area is not equal shape");
+    expect(hits[0].detail).not.toContain("provably differ");
+  });
+
+  it("omits the geometry clause when the empty latent's dimensions are not literals", () => {
+    const g = editGraph();
+    (g["8"] as unknown as { inputs: Record<string, unknown> }).inputs.width = ["12", 0];
+    (g as unknown as Record<string, unknown>)["12"] = {
+      class_type: "PrimitiveInt",
+      inputs: { value: 1104 },
+    };
+    const h = analyzeGraphHealth(g, OBJECT_INFO);
+    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].detail).not.toContain("px budget");
+    expect(hits[0].detail).not.toContain("equal area");
+  });
+
+  it("scopes the encoder to the sampler's OWN conditioning chain", () => {
+    // Two samplers in one graph: node 9 is a correct edit (VAEEncode latent), node 19
+    // is a plain txt2img whose positive is a CLIPTextEncode. The edit encoder is
+    // present in the graph but is NOT upstream of 19, so 19 must stay silent -- a
+    // per-graph "is there an edit encoder anywhere?" test would flag it.
+    const g = editGraph({ latentFrom: "80" });
+    (g as unknown as Record<string, unknown>)["18"] = {
+      class_type: "CLIPTextEncode",
+      inputs: { clip: ["4", 1], text: "a landscape" },
+    };
+    (g as unknown as Record<string, unknown>)["180"] = {
+      class_type: "EmptyLatentImage",
+      inputs: { width: 1104, height: 1472, batch_size: 1 },
+    };
+    (g as unknown as Record<string, unknown>)["19"] = {
+      class_type: "KSampler",
+      inputs: {
+        model: ["4", 0],
+        positive: ["18", 0],
+        negative: ["18", 0],
+        latent_image: ["180", 0],
+        steps: 20,
+        denoise: 1.0,
+      },
+    };
+    const h = analyzeGraphHealth(g, OBJECT_INFO);
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+  });
+
+  it("replaces the partial-denoise finding rather than double-reporting the same sampler", () => {
+    // At denoise 0.65 BOTH conditions hold. Rule 6 would add "to generate from
+    // scratch, set denoise to 1.0" -- which for an edit graph is how you land on
+    // #2681. One finding, and it carries rule 6's arithmetic so nothing is lost.
+    const h = analyzeGraphHealth(editGraph({ denoise: 0.65, steps: 50 }), OBJECT_INFO);
+    expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(0);
+    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].detail).toContain("ALSO runs denoise=0.65");
+    expect(hits[0].detail).toContain("#2678");
   });
 });

--- a/src/__tests__/services/workflow-health.test.ts
+++ b/src/__tests__/services/workflow-health.test.ts
@@ -624,6 +624,12 @@ describe("analyzeGraphHealth", () => {
 });
 
 describe("analyzeGraphHealth — empty latent under an image-edit reference (#2681)", () => {
+  // Built as a plain typed record, not as a WorkflowJSON, so the cases below can edit
+  // and extend a graph without an assertion at every site. The single widening cast
+  // stays where every other case in this file puts it: at the `wf(...)` call.
+  type TestNode = { class_type: string; inputs: Record<string, unknown> };
+  type TestGraph = Record<string, TestNode>;
+
   // The encoder's `vae` and `image1` are both wired: ComfyUI only appends
   // reference_latents when BOTH are present, so this conditioning really does carry
   // a reference and the sampled canvas really is expected to match its geometry.
@@ -636,47 +642,51 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
       latentFrom?: string;
       encoderInputs?: Record<string, unknown>;
     } = {},
-  ) =>
-    wf({
-      "4": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd_xl_base.safetensors" } },
-      "5": { class_type: "LoadImage", inputs: { image: "8058752590630.JPG" } },
-      "6": {
-        class_type: "TextEncodeQwenImageEditPlus",
-        inputs: over.encoderInputs ?? {
-          clip: ["4", 1],
-          prompt: "remove the hanger, steamed symmetric e-commerce still life",
-          vae: ["4", 2],
-          image1: ["5", 0],
-        },
+  ): TestGraph => ({
+    "4": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd_xl_base.safetensors" } },
+    "5": { class_type: "LoadImage", inputs: { image: "8058752590630.JPG" } },
+    "6": {
+      class_type: "TextEncodeQwenImageEditPlus",
+      inputs: over.encoderInputs ?? {
+        clip: ["4", 1],
+        prompt: "remove the hanger, steamed symmetric e-commerce still life",
+        vae: ["4", 2],
+        image1: ["5", 0],
       },
-      "7": { class_type: "ConditioningZeroOut", inputs: { conditioning: ["6", 0] } },
-      "8": {
-        class_type: "EmptyLatentImage",
-        inputs: { width: over.width ?? 1104, height: over.height ?? 1472, batch_size: 1 },
+    },
+    "7": { class_type: "ConditioningZeroOut", inputs: { conditioning: ["6", 0] } },
+    "8": {
+      class_type: "EmptyLatentImage",
+      inputs: { width: over.width ?? 1104, height: over.height ?? 1472, batch_size: 1 },
+    },
+    "80": { class_type: "VAEEncode", inputs: { pixels: ["5", 0], vae: ["4", 2] } },
+    "9": {
+      class_type: "KSampler",
+      inputs: {
+        model: ["4", 0],
+        positive: ["6", 0],
+        negative: ["7", 0],
+        latent_image: [over.latentFrom ?? "8", 0],
+        seed: 42,
+        steps: over.steps ?? 50,
+        cfg: 4,
+        sampler_name: "euler",
+        scheduler: "simple",
+        denoise: over.denoise ?? 1.0,
       },
-      "80": { class_type: "VAEEncode", inputs: { pixels: ["5", 0], vae: ["4", 2] } },
-      "9": {
-        class_type: "KSampler",
-        inputs: {
-          model: ["4", 0],
-          positive: ["6", 0],
-          negative: ["7", 0],
-          latent_image: [over.latentFrom ?? "8", 0],
-          seed: 42,
-          steps: over.steps ?? 50,
-          cfg: 4,
-          sampler_name: "euler",
-          scheduler: "simple",
-          denoise: over.denoise ?? 1.0,
-        },
-      },
-      "10": { class_type: "VAEDecode", inputs: { samples: ["9", 0], vae: ["4", 2] } },
-      "11": { class_type: "SaveImage", inputs: { images: ["10", 0] } },
-    });
+    },
+    "10": { class_type: "VAEDecode", inputs: { samples: ["9", 0], vae: ["4", 2] } },
+    "11": { class_type: "SaveImage", inputs: { images: ["10", 0] } },
+  });
+
+  const editHealth = (g: TestGraph, objectInfo: ObjectInfo = OBJECT_INFO) =>
+    analyzeGraphHealth(wf(g), objectInfo).findings;
+  const editHits = (g: TestGraph, objectInfo: ObjectInfo = OBJECT_INFO) =>
+    editHealth(g, objectInfo).filter((x) => x.kind === "edit_reference_empty_latent");
 
   it("reproduces the #2681 graph: Plus encoder + EmptyLatentImage 1104x1472 at denoise 1.0", () => {
-    const h = analyzeGraphHealth(editGraph(), OBJECT_INFO);
-    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    const findings = editHealth(editGraph());
+    const hits = findings.filter((x) => x.kind === "edit_reference_empty_latent");
     expect(hits).toHaveLength(1);
     expect(hits[0].node_ids).toEqual(["9", "8", "6"]);
     // The arithmetic, not a vague adjective: 1104*1472 = 1625088 px against the
@@ -689,41 +699,37 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     expect(hits[0].detail).not.toContain("provably");
     expect(hits[0].detail).toContain("line up only by coincidence");
     // Rule 6 is silent here -- denoise is 1.0, so the schedule is never truncated.
-    expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(0);
+    expect(findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(0);
   });
 
   it("stays silent when the encoder has no VAE — it emits no reference latents at all", () => {
     // ComfyUI: `if vae is not None: ref_latents.append(vae.encode(...))`. Without a
     // VAE the node is a plain VL-conditioned text encoder and an empty latent is
     // ordinary txt2img. This is also the shape of the #2678 regression test above.
-    const h = analyzeGraphHealth(
-      editGraph({
-        encoderInputs: { clip: ["4", 1], prompt: "change the garment", image1: ["5", 0] },
-      }),
-      OBJECT_INFO,
-    );
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    expect(
+      editHits(
+        editGraph({
+          encoderInputs: { clip: ["4", 1], prompt: "change the garment", image1: ["5", 0] },
+        }),
+      ),
+    ).toHaveLength(0);
   });
 
   it("stays silent when no image is connected to the encoder", () => {
-    const h = analyzeGraphHealth(
-      editGraph({ encoderInputs: { clip: ["4", 1], prompt: "a cat", vae: ["4", 2] } }),
-      OBJECT_INFO,
-    );
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    expect(
+      editHits(editGraph({ encoderInputs: { clip: ["4", 1], prompt: "a cat", vae: ["4", 2] } })),
+    ).toHaveLength(0);
   });
 
   it("stays silent when latent_image comes from a VAEEncode — the official edit shape", () => {
-    const h = analyzeGraphHealth(editGraph({ latentFrom: "80" }), OBJECT_INFO);
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    expect(editHits(editGraph({ latentFrom: "80" }))).toHaveLength(0);
   });
 
   it("follows the CONDITIONING chain through a pass-through node", () => {
     // positive <- ConditioningZeroOut <- the encoder. The walk must reach it.
     const g = editGraph();
-    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["7", 0];
-    const h = analyzeGraphHealth(g, OBJECT_INFO);
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(1);
+    g["9"].inputs.positive = ["7", 0];
+    expect(editHits(g)).toHaveLength(1);
   });
 
   it("does NOT fire on a generic ReferenceLatent — the Qwen-Image-Layered shape", () => {
@@ -731,36 +737,32 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     // `ReferenceLatent` fed by a `CLIPTextEncode`, over an empty layered latent, on
     // purpose. Keying the rule on ReferenceLatent scores 2 false positives on the
     // 533-template corpus; keying it on the Qwen edit encoders scores 0.
-    const h = analyzeGraphHealth(
-      wf({
-        "4": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd_xl_base.safetensors" } },
-        "5": { class_type: "LoadImage", inputs: { image: "ref.png" } },
-        "6": { class_type: "CLIPTextEncode", inputs: { clip: ["4", 1], text: "layers" } },
-        "60": { class_type: "VAEEncode", inputs: { pixels: ["5", 0], vae: ["4", 2] } },
-        "61": { class_type: "ReferenceLatent", inputs: { conditioning: ["6", 0], latent: ["60", 0] } },
-        "8": { class_type: "EmptyLatentImage", inputs: { width: 640, height: 640, batch_size: 1 } },
-        "9": {
-          class_type: "KSampler",
-          inputs: {
-            model: ["4", 0],
-            positive: ["61", 0],
-            negative: ["6", 0],
-            latent_image: ["8", 0],
-            steps: 20,
-            denoise: 1.0,
-          },
+    const g: TestGraph = {
+      "4": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd_xl_base.safetensors" } },
+      "5": { class_type: "LoadImage", inputs: { image: "ref.png" } },
+      "6": { class_type: "CLIPTextEncode", inputs: { clip: ["4", 1], text: "layers" } },
+      "60": { class_type: "VAEEncode", inputs: { pixels: ["5", 0], vae: ["4", 2] } },
+      "61": { class_type: "ReferenceLatent", inputs: { conditioning: ["6", 0], latent: ["60", 0] } },
+      "8": { class_type: "EmptyLatentImage", inputs: { width: 640, height: 640, batch_size: 1 } },
+      "9": {
+        class_type: "KSampler",
+        inputs: {
+          model: ["4", 0],
+          positive: ["61", 0],
+          negative: ["6", 0],
+          latent_image: ["8", 0],
+          steps: 20,
+          denoise: 1.0,
         },
-        "10": { class_type: "VAEDecode", inputs: { samples: ["9", 0], vae: ["4", 2] } },
-        "11": { class_type: "SaveImage", inputs: { images: ["10", 0] } },
-      }),
-      OBJECT_INFO,
-    );
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+      },
+      "10": { class_type: "VAEDecode", inputs: { samples: ["9", 0], vae: ["4", 2] } },
+      "11": { class_type: "SaveImage", inputs: { images: ["10", 0] } },
+    };
+    expect(editHits(g)).toHaveLength(0);
   });
 
   it("says equal-area-is-not-equal-shape rather than claiming a mismatch it cannot prove", () => {
-    const h = analyzeGraphHealth(editGraph({ width: 1024, height: 1024 }), OBJECT_INFO);
-    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    const hits = editHits(editGraph({ width: 1024, height: 1024 }));
     expect(hits).toHaveLength(1);
     expect(hits[0].detail).toContain("equal area is not equal shape");
     expect(hits[0].detail).not.toContain("provably differ");
@@ -768,13 +770,9 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
 
   it("omits the geometry clause when the empty latent's dimensions are not literals", () => {
     const g = editGraph();
-    (g["8"] as unknown as { inputs: Record<string, unknown> }).inputs.width = ["12", 0];
-    (g as unknown as Record<string, unknown>)["12"] = {
-      class_type: "PrimitiveInt",
-      inputs: { value: 1104 },
-    };
-    const h = analyzeGraphHealth(g, OBJECT_INFO);
-    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    g["8"].inputs.width = ["12", 0];
+    g["12"] = { class_type: "PrimitiveInt", inputs: { value: 1104 } };
+    const hits = editHits(g);
     expect(hits).toHaveLength(1);
     expect(hits[0].detail).not.toContain("px budget");
     expect(hits[0].detail).not.toContain("equal area");
@@ -786,15 +784,12 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     // present in the graph but is NOT upstream of 19, so 19 must stay silent -- a
     // per-graph "is there an edit encoder anywhere?" test would flag it.
     const g = editGraph({ latentFrom: "80" });
-    (g as unknown as Record<string, unknown>)["18"] = {
-      class_type: "CLIPTextEncode",
-      inputs: { clip: ["4", 1], text: "a landscape" },
-    };
-    (g as unknown as Record<string, unknown>)["180"] = {
+    g["18"] = { class_type: "CLIPTextEncode", inputs: { clip: ["4", 1], text: "a landscape" } };
+    g["180"] = {
       class_type: "EmptyLatentImage",
       inputs: { width: 1104, height: 1472, batch_size: 1 },
     };
-    (g as unknown as Record<string, unknown>)["19"] = {
+    g["19"] = {
       class_type: "KSampler",
       inputs: {
         model: ["4", 0],
@@ -805,8 +800,7 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
         denoise: 1.0,
       },
     };
-    const h = analyzeGraphHealth(g, OBJECT_INFO);
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    expect(editHits(g)).toHaveLength(0);
   });
 
   it("ends the walk at a wildcard-typed reroute rather than guessing what it carries", () => {
@@ -816,13 +810,9 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     // have raised on a rerouted graph and can never cost a false one; the test exists
     // so that trade is asserted rather than accidental.
     const g = editGraph();
-    (g as unknown as Record<string, unknown>)["70"] = {
-      class_type: "Reroute",
-      inputs: { "": ["6", 0] },
-    };
-    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["70", 0];
-    const h = analyzeGraphHealth(g, OBJECT_INFO);
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    g["70"] = { class_type: "Reroute", inputs: { "": ["6", 0] } };
+    g["9"].inputs.positive = ["70", 0];
+    expect(editHits(g)).toHaveLength(0);
   });
 
   it("requires an image slot the encoder's own CLASS declares", () => {
@@ -830,43 +820,37 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     // malformed, and matching on the NAME alone would classify it as emitting a
     // reference over a slot its class does not have.
     const bad = editGraph();
-    (bad["6"] as unknown as { class_type: string; inputs: Record<string, unknown> }).class_type =
-      "TextEncodeQwenImageEdit";
-    expect(
-      analyzeGraphHealth(bad, OBJECT_INFO).findings.filter(
-        (x) => x.kind === "edit_reference_empty_latent",
-      ),
-    ).toHaveLength(0);
+    bad["6"].class_type = "TextEncodeQwenImageEdit";
+    expect(editHits(bad)).toHaveLength(0);
 
     // Control: the same class with the slot it DOES declare still fires, so the test
     // above is measuring the slot and not the rename.
     const good = editGraph();
-    const enc = good["6"] as unknown as { class_type: string; inputs: Record<string, unknown> };
-    enc.class_type = "TextEncodeQwenImageEdit";
-    enc.inputs = { clip: ["4", 1], prompt: "remove the hanger", vae: ["4", 2], image: ["5", 0] };
-    expect(
-      analyzeGraphHealth(good, OBJECT_INFO).findings.filter(
-        (x) => x.kind === "edit_reference_empty_latent",
-      ),
-    ).toHaveLength(1);
+    good["6"].class_type = "TextEncodeQwenImageEdit";
+    good["6"].inputs = {
+      clip: ["4", 1],
+      prompt: "remove the hanger",
+      vae: ["4", 2],
+      image: ["5", 0],
+    };
+    expect(editHits(good)).toHaveLength(1);
   });
 
   it("declines when the encoder's class is absent from object_info", () => {
     // Same direction producesEmptyLatent takes: an uninstalled class has no known slot
     // types, so whether it emits a reference is unknowable. Costs a warning, never
     // raises a false one -- and the validator already errors on the unknown class.
-    const withoutEncoder = { ...(OBJECT_INFO as unknown as Record<string, unknown>) };
-    delete withoutEncoder.TextEncodeQwenImageEditPlus;
-    const h = analyzeGraphHealth(editGraph(), withoutEncoder as unknown as ObjectInfo);
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    const withoutEncoder: ObjectInfo = Object.fromEntries(
+      Object.entries(OBJECT_INFO).filter(([name]) => name !== "TextEncodeQwenImageEditPlus"),
+    );
+    expect(editHits(editGraph(), withoutEncoder)).toHaveLength(0);
   });
 
   it("calls denoise 0 an EMPTY schedule, not a truncated one", () => {
     // startsBelowSigmaMax is true for two different reasons. At denoise <= 0 ComfyUI
     // builds an empty sigma tensor and runs no sampling steps at all -- the latent comes
     // back untouched. Saying "truncates the schedule" there would be false.
-    const h = analyzeGraphHealth(editGraph({ denoise: 0, steps: 50 }), OBJECT_INFO);
-    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    const hits = editHits(editGraph({ denoise: 0, steps: 50 }));
     expect(hits).toHaveLength(1);
     expect(hits[0].detail).toContain("builds an EMPTY sigma schedule");
     expect(hits[0].detail).not.toContain("truncates the sigma schedule");
@@ -878,43 +862,14 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     // safe half; the load-bearing half is that rule 6 must NOT be suppressed here, or a
     // false positive would have cost a real warning.
     const g = editGraph({ denoise: 0.65, steps: 50 });
-    (g as unknown as Record<string, unknown>)["71"] = {
+    g["71"] = {
       class_type: "ConditioningCombine",
       inputs: { conditioning_1: ["6", 0], conditioning_2: ["7", 0] },
     };
-    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["71", 0];
-    const h = analyzeGraphHealth(g, OBJECT_INFO);
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
-    expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(1);
-  });
-
-  it("makes the re-synthesis consequence conditional on the grids actually differing", () => {
-    // The checker cannot see the source image, so it cannot know whether the literal
-    // canvas happened to match. Asserting the plastic/CGI outcome unconditionally would
-    // claim more than it establishes.
-    const h = analyzeGraphHealth(editGraph({ width: 1024, height: 1024 }), OBJECT_INFO);
-    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
-    expect(hits).toHaveLength(1);
-    expect(hits[0].detail).toContain("where the grids differ");
-    expect(hits[0].detail).toContain("Where they happen to coincide it is fine");
-  });
-
-  it("does not count a converted scalar widget as a second branch", () => {
-    // `start` converted from a widget to an input is a NUMBER feed, not a fork arm.
-    // Counting every connected input instead of the CONDITIONING-typed ones would make
-    // this node look like a two-branch fork and silently drop the finding.
-    const g = editGraph();
-    (g as unknown as Record<string, unknown>)["73"] = {
-      class_type: "ConditioningSetTimestepRange",
-      inputs: { conditioning: ["6", 0], start: ["74", 0], end: 1 },
-    };
-    (g as unknown as Record<string, unknown>)["74"] = {
-      class_type: "PrimitiveInt",
-      inputs: { value: 0 },
-    };
-    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["73", 0];
-    const h = analyzeGraphHealth(g, OBJECT_INFO);
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(1);
+    g["9"].inputs.positive = ["71", 0];
+    const findings = editHealth(g);
+    expect(findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    expect(findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(1);
   });
 
   it("counts a connected wildcard slot as a fork arm, not as nothing", () => {
@@ -923,23 +878,47 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     // only CONDITIONING-typed inputs would read this as a chain of one and fire -- and
     // then suppress rule 6, turning a false positive into a lost warning.
     const g = editGraph({ denoise: 0.65, steps: 50 });
-    (g as unknown as Record<string, unknown>)["72"] = {
+    g["72"] = {
       class_type: "AnyConditioningMux",
       inputs: { conditioning: ["6", 0], alt: ["7", 0] },
     };
-    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["72", 0];
-    const h = analyzeGraphHealth(g, OBJECT_INFO);
-    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
-    expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(1);
+    g["9"].inputs.positive = ["72", 0];
+    const findings = editHealth(g);
+    expect(findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+    expect(findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(1);
+  });
+
+  it("does not count a converted scalar widget as a second branch", () => {
+    // `start` converted from a widget to an input is a NUMBER feed, not a fork arm.
+    // Counting every connected input instead of the CONDITIONING-typed ones would make
+    // this node look like a two-branch fork and silently drop the finding.
+    const g = editGraph();
+    g["73"] = {
+      class_type: "ConditioningSetTimestepRange",
+      inputs: { conditioning: ["6", 0], start: ["74", 0], end: 1 },
+    };
+    g["74"] = { class_type: "PrimitiveInt", inputs: { value: 0 } };
+    g["9"].inputs.positive = ["73", 0];
+    expect(editHits(g)).toHaveLength(1);
+  });
+
+  it("makes the re-synthesis consequence conditional on the grids actually differing", () => {
+    // The checker cannot see the source image, so it cannot know whether the literal
+    // canvas happened to match. Asserting the plastic/CGI outcome unconditionally would
+    // claim more than it establishes.
+    const hits = editHits(editGraph({ width: 1024, height: 1024 }));
+    expect(hits).toHaveLength(1);
+    expect(hits[0].detail).toContain("where the grids differ");
+    expect(hits[0].detail).toContain("Where they happen to coincide it is fine");
   });
 
   it("replaces the partial-denoise finding rather than double-reporting the same sampler", () => {
     // At denoise 0.65 BOTH conditions hold. Rule 6 would add "to generate from
     // scratch, set denoise to 1.0" -- which for an edit graph is how you land on
     // #2681. One finding, and it carries rule 6's arithmetic so nothing is lost.
-    const h = analyzeGraphHealth(editGraph({ denoise: 0.65, steps: 50 }), OBJECT_INFO);
-    expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(0);
-    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    const findings = editHealth(editGraph({ denoise: 0.65, steps: 50 }));
+    expect(findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(0);
+    const hits = findings.filter((x) => x.kind === "edit_reference_empty_latent");
     expect(hits).toHaveLength(1);
     expect(hits[0].detail).toContain("ALSO runs denoise=0.65");
     expect(hits[0].detail).toContain("#2678");

--- a/src/__tests__/services/workflow-health.test.ts
+++ b/src/__tests__/services/workflow-health.test.ts
@@ -74,6 +74,12 @@ const OBJECT_INFO = {
     output: ["CONDITIONING"],
     output_node: false,
   },
+  // A reroute: its input slot is the wildcard type, not CONDITIONING.
+  Reroute: {
+    input: { required: { "": ["*"] } },
+    output: ["*"],
+    output_node: false,
+  },
   ConditioningZeroOut: {
     input: { required: { conditioning: ["CONDITIONING"] } },
     output: ["CONDITIONING"],
@@ -775,6 +781,22 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
         denoise: 1.0,
       },
     };
+    const h = analyzeGraphHealth(g, OBJECT_INFO);
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+  });
+
+  it("ends the walk at a wildcard-typed reroute rather than guessing what it carries", () => {
+    // Only CONDITIONING-typed slots are followed. A `*` reroute could be carrying
+    // anything, so the walk stops and the finding is not raised -- the same direction
+    // producesEmptyLatent takes for an unknown class. This costs a warning we could
+    // have raised on a rerouted graph and can never cost a false one; the test exists
+    // so that trade is asserted rather than accidental.
+    const g = editGraph();
+    (g as unknown as Record<string, unknown>)["70"] = {
+      class_type: "Reroute",
+      inputs: { "": ["6", 0] },
+    };
+    (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["70", 0];
     const h = analyzeGraphHealth(g, OBJECT_INFO);
     expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
   });

--- a/src/__tests__/services/workflow-health.test.ts
+++ b/src/__tests__/services/workflow-health.test.ts
@@ -662,8 +662,13 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     expect(hits[0].node_ids).toEqual(["9", "8", "6"]);
     // The arithmetic, not a vague adjective: 1104*1472 = 1625088 px against the
     // encoder's hard-coded int(1024*1024) = 1048576 px reference budget.
-    expect(hits[0].detail).toContain("1104x1472 = 1625088 px is 1.55x the 1048576 px budget");
+    expect(hits[0].detail).toContain("1104x1472 = 1625088 px is 1.55x that 1048576 px budget");
     expect(hits[0].detail).toContain("1.24x linear");
+    // Area is strong evidence, not a theorem -- the encoder rounds each reference
+    // dimension to a multiple of 8, so an extreme aspect ratio can move its area a few
+    // percent. The message states the arithmetic and does not claim proof from it.
+    expect(hits[0].detail).not.toContain("provably");
+    expect(hits[0].detail).toContain("line up only by coincidence");
     // Rule 6 is silent here -- denoise is 1.0, so the schedule is never truncated.
     expect(h.findings.filter((x) => x.kind === "partial_denoise_empty_latent")).toHaveLength(0);
   });
@@ -799,6 +804,53 @@ describe("analyzeGraphHealth — empty latent under an image-edit reference (#26
     (g["9"] as unknown as { inputs: Record<string, unknown> }).inputs.positive = ["70", 0];
     const h = analyzeGraphHealth(g, OBJECT_INFO);
     expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+  });
+
+  it("requires an image slot the encoder's own CLASS declares", () => {
+    // TextEncodeQwenImageEdit takes `image`, not `image1`. A node carrying `image1` is
+    // malformed, and matching on the NAME alone would classify it as emitting a
+    // reference over a slot its class does not have.
+    const bad = editGraph();
+    (bad["6"] as unknown as { class_type: string; inputs: Record<string, unknown> }).class_type =
+      "TextEncodeQwenImageEdit";
+    expect(
+      analyzeGraphHealth(bad, OBJECT_INFO).findings.filter(
+        (x) => x.kind === "edit_reference_empty_latent",
+      ),
+    ).toHaveLength(0);
+
+    // Control: the same class with the slot it DOES declare still fires, so the test
+    // above is measuring the slot and not the rename.
+    const good = editGraph();
+    const enc = good["6"] as unknown as { class_type: string; inputs: Record<string, unknown> };
+    enc.class_type = "TextEncodeQwenImageEdit";
+    enc.inputs = { clip: ["4", 1], prompt: "remove the hanger", vae: ["4", 2], image: ["5", 0] };
+    expect(
+      analyzeGraphHealth(good, OBJECT_INFO).findings.filter(
+        (x) => x.kind === "edit_reference_empty_latent",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("declines when the encoder's class is absent from object_info", () => {
+    // Same direction producesEmptyLatent takes: an uninstalled class has no known slot
+    // types, so whether it emits a reference is unknowable. Costs a warning, never
+    // raises a false one -- and the validator already errors on the unknown class.
+    const withoutEncoder = { ...(OBJECT_INFO as unknown as Record<string, unknown>) };
+    delete withoutEncoder.TextEncodeQwenImageEditPlus;
+    const h = analyzeGraphHealth(editGraph(), withoutEncoder as unknown as ObjectInfo);
+    expect(h.findings.filter((x) => x.kind === "edit_reference_empty_latent")).toHaveLength(0);
+  });
+
+  it("calls denoise 0 an EMPTY schedule, not a truncated one", () => {
+    // startsBelowSigmaMax is true for two different reasons. At denoise <= 0 ComfyUI
+    // builds an empty sigma tensor and runs no sampling steps at all -- the latent comes
+    // back untouched. Saying "truncates the schedule" there would be false.
+    const h = analyzeGraphHealth(editGraph({ denoise: 0, steps: 50 }), OBJECT_INFO);
+    const hits = h.findings.filter((x) => x.kind === "edit_reference_empty_latent");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].detail).toContain("builds an EMPTY sigma schedule");
+    expect(hits[0].detail).not.toContain("truncates the sigma schedule");
   });
 
   it("replaces the partial-denoise finding rather than double-reporting the same sampler", () => {

--- a/src/services/workflow-health.ts
+++ b/src/services/workflow-health.ts
@@ -212,9 +212,12 @@ function emitsEditReferenceLatents(node: WorkflowNode | undefined): boolean {
  *
  * Only CONDITIONING-typed slots are followed, decided from real `/object_info` types
  * rather than slot names — so a `ControlNetApply`'s `image` input is not mistaken for
- * part of the conditioning chain. A node absent from object_info ends the walk on that
- * branch: an uninstalled class has no known slot types, and guessing them would be the
- * only way to produce a false positive here.
+ * part of the conditioning chain. Two shapes therefore end the walk: a node absent from
+ * object_info (an uninstalled class has no known slot types), and a wildcard `*` slot
+ * such as a Reroute's, which could be carrying anything. Both cost a warning that could
+ * have been raised and neither can raise a false one, which is the same direction
+ * `producesEmptyLatent` takes. It is a real trade, not an oversight, and
+ * workflow-health.test.ts asserts both halves of it.
  */
 function findEditReferenceEncoder(
   workflow: WorkflowJSON,

--- a/src/services/workflow-health.ts
+++ b/src/services/workflow-health.ts
@@ -246,7 +246,9 @@ function emitsEditReferenceLatents(
  * part of the conditioning chain. Three shapes end the walk, all in the same direction:
  *
  *   - a node absent from object_info (an uninstalled class has no known slot types)
- *   - a wildcard `*` slot such as a Reroute's, which could be carrying anything
+ *   - any connected wildcard `*` slot, such as a Reroute's — it could be carrying
+ *     anything, including the conditioning that actually reaches the output, so it
+ *     counts as a fork arm even when a typed conditioning input sits beside it
  *   - a node with MORE THAN ONE connected CONDITIONING input. That is a fork, not a
  *     link in a chain, and which branch reaches the output is not knowable statically:
  *     a switch/mux passes one through and discards the rest, `ConditioningAverage`
@@ -284,14 +286,20 @@ function findEditReferenceEncoder(
     if (!def) continue;
     const slots = { ...(def.input?.required ?? {}), ...(def.input?.optional ?? {}) };
     const upstream: string[] = [];
+    let wildcardInput = false;
     for (const [slot, value] of Object.entries(node.inputs ?? {})) {
       if (!isConnection(value)) continue;
-      if (slots[slot]?.[0] !== "CONDITIONING") continue;
-      upstream.push(value[0]);
+      const declared = slots[slot]?.[0];
+      // A connected `*` is a fork arm of unknown type — it may well be carrying the
+      // conditioning that actually reaches the output. Counting only the TYPED inputs
+      // would let a node with one typed conditioning and one wildcard look like a chain.
+      if (declared === "*") wildcardInput = true;
+      else if (declared === "CONDITIONING") upstream.push(value[0]);
     }
-    // Exactly one inbound conditioning is a chain and can be followed. Two or more is a
-    // fork whose surviving branch is a run-time decision — stop rather than guess.
-    if (upstream.length === 1) queue.push(upstream[0]);
+    // Exactly one inbound conditioning and nothing untyped beside it is a chain and can
+    // be followed. Anything else is a fork whose surviving branch is a run-time
+    // decision — stop rather than guess.
+    if (!wildcardInput && upstream.length === 1) queue.push(upstream[0]);
   }
   return null;
 }

--- a/src/services/workflow-health.ts
+++ b/src/services/workflow-health.ts
@@ -1,4 +1,4 @@
-import type { WorkflowJSON, ObjectInfo } from "../comfyui/types.js";
+import type { WorkflowJSON, WorkflowNode, ObjectInfo } from "../comfyui/types.js";
 
 /**
  * Graph-health heuristics for ComfyUI workflows.
@@ -8,7 +8,8 @@ import type { WorkflowJSON, ObjectInfo } from "../comfyui/types.js";
  * duplicate model loads wasting VRAM, sampler branches whose outputs never reach
  * a save node, muted/bypassed nodes silently dropping connections, and samplers set
  * to a partial denoise over an empty latent (a graph that runs clean and returns a
- * flat field).
+ * flat field), and image-edit graphs whose sampled canvas is not derived from the
+ * reference image at all.
  *
  * Prior art: filliptm/ComfyUI_FL-MCP `workflow_overview` reports node-type
  * histograms, disconnected nodes, and missing required inputs — but client-side
@@ -28,7 +29,8 @@ export interface HealthFinding {
     | "orphaned_branch"
     | "muted_or_bypassed"
     | "no_output_reachable"
-    | "partial_denoise_empty_latent";
+    | "partial_denoise_empty_latent"
+    | "edit_reference_empty_latent";
   severity: "warning" | "info";
   node_ids: string[];
   node_type?: string;
@@ -134,6 +136,115 @@ function producesEmptyLatent(
     return false; // IMAGE / LATENT / … — this latent may be derived
   }
   return true;
+}
+
+// --- Image-edit reference geometry ---------------------------------------
+//
+// ComfyUI's Qwen edit text encoders carry the source image on CONDITIONING as
+// `reference_latents`, at a HARD-CODED budget (comfy_extras/nodes_qwen.py, both
+// TextEncodeQwenImageEdit and …Plus):
+//
+//   total = int(1024 * 1024)
+//   scale_by = math.sqrt(total / (w * h))
+//   width = round(w * scale_by / 8.0) * 8   # height likewise
+//   ref_latents.append(vae.encode(...))
+//
+// so the reference is always ~1.05 MP at the SOURCE image's aspect ratio — a
+// geometry computed at run time from pixels a static check cannot see.
+//
+// The transformer then places the reference tokens and the sampled tokens on the
+// SAME centred RoPE grid (comfy/ldm/qwen_image/model.py `process_img`, called once
+// for `x` and once per ref): both get
+// `linspace(offset, len - 1 + offset) - (len // 2)` on the h and w axes, differing
+// only in the `index` (t) channel. Reference token (i, j) and output token (i, j)
+// therefore name the same coordinate ONLY when the two grids have the same shape.
+//
+// An `Empty*Latent*` node's dimensions are literals, so they can agree with a
+// run-time-derived reference only by coincidence. #2681 sampled a 1104x1472 canvas
+// (1.63 MP) against that 1.05 MP reference — 1.24x linear. Unlike #2678 this does
+// not depend on denoise: at denoise 1.0 the graph renders a plausible image, it just
+// re-synthesises the subject instead of copying it.
+//
+// Measured on the 533 workflow templates ComfyUI bundles
+// (comfyui_workflow_templates_json): 33 samplers take `positive` from a node that
+// sets reference_latents, 31 of them take `latent_image` from a `VAEEncode`, and NONE
+// takes it from an empty latent. The remaining 2 are the Qwen-Image-Layered templates,
+// whose `EmptyQwenImageLayeredLatentImage` genuinely is a different tensor rank from
+// its reference — they reach reference_latents through a generic `ReferenceLatent`
+// fed by a `CLIPTextEncode`, never through a Qwen edit encoder. That measurement is
+// why this rule keys on the two Qwen edit ENCODERS and not on `ReferenceLatent`:
+// including `ReferenceLatent` scores 2 false positives on the same corpus, and its
+// reference geometry is whatever latent it is handed, so the equal-shape invariant
+// is not universal for it.
+const QWEN_EDIT_ENCODERS = new Set(["TextEncodeQwenImageEdit", "TextEncodeQwenImageEditPlus"]);
+
+// `total = int(1024 * 1024)` in both encoders' execute().
+const QWEN_EDIT_REFERENCE_PIXELS = 1024 * 1024;
+
+// `image` on TextEncodeQwenImageEdit, `image1`..`image3` on …Plus.
+const EDIT_IMAGE_SLOT_RE = /^image[0-9]*$/;
+
+// Bound on the conditioning walk. Chains are a handful of nodes long in practice;
+// this only stops a pathological graph from costing real time.
+const CONDITIONING_WALK_LIMIT = 64;
+
+/**
+ * Does this node actually append `reference_latents`?
+ *
+ * Both guards transcribe the encoder's own control flow, and both are
+ * false-positive guards rather than defensive noise:
+ *   - `if vae is not None` — with no VAE the node never calls `vae.encode` and
+ *     appends nothing, so it is a plain (if VL-conditioned) text encoder and an
+ *     empty latent under it is ordinary txt2img.
+ *   - `if image is not None` — same, with no image there is no reference at all.
+ */
+function emitsEditReferenceLatents(node: WorkflowNode | undefined): boolean {
+  if (!node || !QWEN_EDIT_ENCODERS.has(node.class_type)) return false;
+  if (!isConnection(node.inputs?.vae)) return false;
+  return Object.entries(node.inputs ?? {}).some(
+    ([slot, value]) => EDIT_IMAGE_SLOT_RE.test(slot) && isConnection(value),
+  );
+}
+
+/**
+ * Walk a sampler's `positive` input upstream along CONDITIONING links, looking for
+ * an edit encoder that really emits reference latents. Returns its node id, or null.
+ *
+ * Only CONDITIONING-typed slots are followed, decided from real `/object_info` types
+ * rather than slot names — so a `ControlNetApply`'s `image` input is not mistaken for
+ * part of the conditioning chain. A node absent from object_info ends the walk on that
+ * branch: an uninstalled class has no known slot types, and guessing them would be the
+ * only way to produce a false positive here.
+ */
+function findEditReferenceEncoder(
+  workflow: WorkflowJSON,
+  sampler: WorkflowNode,
+  objectInfo: ObjectInfo,
+): string | null {
+  const start = sampler.inputs?.positive;
+  if (!isConnection(start)) return null;
+
+  const seen = new Set<string>();
+  const queue: string[] = [start[0]];
+  while (queue.length > 0 && seen.size < CONDITIONING_WALK_LIMIT) {
+    const id = queue.shift() as string;
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const node = workflow[id];
+    if (!node) continue;
+    if (emitsEditReferenceLatents(node)) return id;
+
+    const def = objectInfo[node.class_type];
+    if (!def) continue;
+    const slots = { ...(def.input?.required ?? {}), ...(def.input?.optional ?? {}) };
+    for (const [slot, value] of Object.entries(node.inputs ?? {})) {
+      if (!isConnection(value)) continue;
+      if (slots[slot]?.[0] !== "CONDITIONING") continue;
+      queue.push(value[0]);
+    }
+  }
+  return null;
 }
 
 // Hardcoded output classes, mirroring workflow-validator.ts step 4.
@@ -391,6 +502,22 @@ export function analyzeGraphHealth(
     }
   }
 
+  // --- Empty latent under an image-edit reference (shared by rules 6 and 7) --
+  // Computed before rule 6 so that rule 6 can stand down where rule 7 speaks: both
+  // findings would name the same sampler and prescribe the same fix, but rule 6 also
+  // offers "to generate from scratch, set denoise to 1.0", which for an edit graph is
+  // the wrong half of the advice — #2681 is exactly that graph at denoise 1.0.
+  const editReferenceSamplers = new Map<string, { encoderId: string; emptyId: string }>();
+  for (const id of nodeIds) {
+    const node = workflow[id];
+    const latentInput = node.inputs?.latent_image;
+    if (!isConnection(latentInput)) continue;
+    if (!producesEmptyLatent(workflow[latentInput[0]], objectInfo)) continue;
+    const encoderId = findEditReferenceEncoder(workflow, node, objectInfo);
+    if (encoderId === null) continue;
+    editReferenceSamplers.set(id, { encoderId, emptyId: latentInput[0] });
+  }
+
   // --- 6. Partial denoise fed by an empty latent (warning) -----------------
   // A denoise low enough to truncate the schedule exists to PRESERVE part of the
   // incoming latent. If that latent is generated empty there is nothing to preserve:
@@ -423,6 +550,7 @@ export function analyzeGraphHealth(
   //     connection whose runtime value cannot be known statically.
   //   - The schedule test is ComfyUI's own arithmetic, not a rounded threshold.
   for (const id of nodeIds) {
+    if (editReferenceSamplers.has(id)) continue; // rule 7 says it, and says more
     const node = workflow[id];
     const denoise = node.inputs?.denoise;
     if (typeof denoise !== "number" || !Number.isFinite(denoise)) continue;
@@ -457,6 +585,70 @@ export function analyzeGraphHealth(
         `error; on flow-matching models (Qwen, Flux, SD3, WAN) the output collapses to a flat, ` +
         `near-uniform field. To edit an existing image, feed latent_image from an encode of it ` +
         `(VAEEncode; VAEEncodeAudio for audio). To generate from scratch, set denoise to 1.0.`,
+    });
+  }
+
+  // --- 7. Empty latent under an image-edit reference (warning) -------------
+  // See QWEN_EDIT_ENCODERS above for the mechanism and the corpus measurement. In
+  // short: the encoder's reference latent is built from the SOURCE at run time and
+  // the transformer aligns it with the sampled latent on a shared centred RoPE grid,
+  // so a canvas whose size is a literal cannot be relied on to line up with it.
+  //
+  // Scope matches rule 6's: DIRECT latent connection only, and the encoder must be
+  // reached through CONDITIONING slots typed by real object_info. Unlike rule 6 there
+  // is no denoise condition — this one fires at denoise 1.0, which is the whole point.
+  for (const [id, { encoderId, emptyId }] of editReferenceSamplers) {
+    const node = workflow[id];
+    const emptyNode = workflow[emptyId];
+    const encoderType = workflow[encoderId].class_type;
+
+    const width = emptyNode.inputs?.width;
+    const height = emptyNode.inputs?.height;
+    const area =
+      typeof width === "number" && typeof height === "number" && width > 0 && height > 0
+        ? width * height
+        : null;
+
+    let geometry = "";
+    if (area !== null) {
+      const ratio = area / QWEN_EDIT_REFERENCE_PIXELS;
+      geometry =
+        ratio >= 0.95 && ratio <= 1.05
+          ? ` Its ${width}x${height} canvas does match that budget in AREA, but the reference also keeps the SOURCE image's aspect ratio, which is not knowable until the graph runs — equal area is not equal shape.`
+          : ` Here ${width}x${height} = ${area} px is ${ratio.toFixed(2)}x the ${QWEN_EDIT_REFERENCE_PIXELS} px budget (${Math.sqrt(ratio).toFixed(2)}x linear), so the two grids provably differ.`;
+    }
+
+    // Rule 6 stood down for this node, so say its part here rather than lose it.
+    const denoise = node.inputs?.denoise;
+    const steps = node.inputs?.steps;
+    const alsoTruncated =
+      typeof denoise === "number" &&
+      Number.isFinite(denoise) &&
+      startsBelowSigmaMax(denoise, steps);
+    const truncation = alsoTruncated
+      ? ` This sampler ALSO runs denoise=${denoise} over that empty latent, which truncates the sigma schedule and collapses the output to a flat field (#2678); feeding latent_image from the source fixes both.`
+      : "";
+
+    findings.push({
+      kind: "edit_reference_empty_latent",
+      severity: "warning",
+      node_ids: [id, emptyId, encoderId],
+      node_type: node.class_type,
+      detail:
+        `Node ${id} (${node.class_type}) takes latent_image straight from node ${emptyId} ` +
+        `(${emptyNode.class_type}), which generates an EMPTY latent, while its positive ` +
+        `conditioning comes from node ${encoderId} (${encoderType}) with a VAE and a reference ` +
+        `image connected — so that conditioning carries reference_latents. ComfyUI scales every ` +
+        `such reference to int(1024*1024) px at the SOURCE's aspect ratio and then aligns the ` +
+        `reference tokens with the sampled tokens on one shared, centred RoPE grid, so the model ` +
+        `can only copy detail when the sampled latent has the reference's geometry.${geometry} ` +
+        `Unlike a partial denoise this does not depend on denoise: the graph runs clean at ` +
+        `denoise 1.0 and returns a plausible image, but re-synthesises the subject instead of ` +
+        `preserving it — materials read as plastic/CGI and printed detail comes back as generic ` +
+        `shapes (#2681).${truncation} Feed latent_image from a VAEEncode of the same image you ` +
+        `gave the encoder (ComfyUI's own Qwen edit templates use FluxKontextImageScale -> ` +
+        `VAEEncode). If you deliberately want a canvas unrelated to the reference, this warning ` +
+        `is expected.`,
     });
   }
 

--- a/src/services/workflow-health.ts
+++ b/src/services/workflow-health.ts
@@ -181,7 +181,10 @@ const QWEN_EDIT_ENCODERS = new Set(["TextEncodeQwenImageEdit", "TextEncodeQwenIm
 // `total = int(1024 * 1024)` in both encoders' execute().
 const QWEN_EDIT_REFERENCE_PIXELS = 1024 * 1024;
 
-// `image` on TextEncodeQwenImageEdit, `image1`..`image3` on …Plus.
+// `image` on TextEncodeQwenImageEdit, `image1`..`image3` on …Plus. The name alone is
+// not enough — a `TextEncodeQwenImageEdit` carrying an `image1` key is malformed, and
+// accepting it would classify a node as emitting references over a slot its own class
+// does not have. So the slot must ALSO be declared IMAGE in object_info.
 const EDIT_IMAGE_SLOT_RE = /^image[0-9]*$/;
 
 // Bound on the conditioning walk. Chains are a handful of nodes long in practice;
@@ -198,17 +201,45 @@ const CONDITIONING_WALK_LIMIT = 64;
  *     empty latent under it is ordinary txt2img.
  *   - `if image is not None` — same, with no image there is no reference at all.
  */
-function emitsEditReferenceLatents(node: WorkflowNode | undefined): boolean {
+function emitsEditReferenceLatents(
+  node: WorkflowNode | undefined,
+  objectInfo: ObjectInfo,
+): boolean {
   if (!node || !QWEN_EDIT_ENCODERS.has(node.class_type)) return false;
+
+  // `vae` is the first half of ComfyUI's own condition, transcribed: with nothing wired
+  // there the encoder never calls `vae.encode` and appends nothing.
   if (!isConnection(node.inputs?.vae)) return false;
+
+  // The image slot is the second half, and its TYPE is checked as well as its name: a
+  // key the class does not declare cannot stand in for one it does (a
+  // `TextEncodeQwenImageEdit` carrying `image1` is malformed, not an edit graph). That
+  // one test also settles the unknown-class case without a separate branch — a class
+  // absent from object_info has no declared slots, so nothing is typed IMAGE and the
+  // answer is "decline", the same direction `producesEmptyLatent` takes. Guards that
+  // only restate this were removed after a mutation run showed no test could tell them
+  // apart from their absence.
+  const def = objectInfo[node.class_type];
+  const slots = { ...(def?.input?.required ?? {}), ...(def?.input?.optional ?? {}) };
   return Object.entries(node.inputs ?? {}).some(
-    ([slot, value]) => EDIT_IMAGE_SLOT_RE.test(slot) && isConnection(value),
+    ([slot, value]) =>
+      EDIT_IMAGE_SLOT_RE.test(slot) && isConnection(value) && slots[slot]?.[0] === "IMAGE",
   );
 }
 
 /**
  * Walk a sampler's `positive` input upstream along CONDITIONING links, looking for
  * an edit encoder that really emits reference latents. Returns its node id, or null.
+ *
+ * KNOWN LIMIT (raised in review): the walk assumes a node that passes CONDITIONING
+ * through also passes `reference_latents` through, and a transform that rebuilt the
+ * entry from a fresh dict would break that — rule 7 would report a reference the sampler
+ * never receives, and would suppress rule 6 while doing it. Measured against the
+ * installed ComfyUI: the only conditioning entries built from a fresh `{}` are in
+ * nodes_hunyuan3d.py and nodes_lotus.py, and neither node takes a CONDITIONING input, so
+ * neither can sit mid-chain. Every stock transform (`ConditioningZeroOut`,
+ * `conditioning_set_values`, …) does `t[1].copy()` and preserves the key. A custom node
+ * could still do it; if one ever shows up, this is where to key off it.
  *
  * Only CONDITIONING-typed slots are followed, decided from real `/object_info` types
  * rather than slot names — so a `ControlNetApply`'s `image` input is not mistaken for
@@ -236,7 +267,7 @@ function findEditReferenceEncoder(
 
     const node = workflow[id];
     if (!node) continue;
-    if (emitsEditReferenceLatents(node)) return id;
+    if (emitsEditReferenceLatents(node, objectInfo)) return id;
 
     const def = objectInfo[node.class_type];
     if (!def) continue;
@@ -615,10 +646,15 @@ export function analyzeGraphHealth(
     let geometry = "";
     if (area !== null) {
       const ratio = area / QWEN_EDIT_REFERENCE_PIXELS;
+      // Deliberately NOT phrased as proof. The encoder rounds each reference dimension
+      // to a multiple of 8, so an extreme aspect ratio can move the reference's area a
+      // few percent off the budget; an area gap is strong evidence, not a theorem. The
+      // claim that always holds — a literal cannot track a run-time geometry — is in the
+      // main sentence, and these clauses only add the arithmetic.
       geometry =
         ratio >= 0.95 && ratio <= 1.05
           ? ` Its ${width}x${height} canvas does match that budget in AREA, but the reference also keeps the SOURCE image's aspect ratio, which is not knowable until the graph runs — equal area is not equal shape.`
-          : ` Here ${width}x${height} = ${area} px is ${ratio.toFixed(2)}x the ${QWEN_EDIT_REFERENCE_PIXELS} px budget (${Math.sqrt(ratio).toFixed(2)}x linear), so the two grids provably differ.`;
+          : ` Here ${width}x${height} = ${area} px is ${ratio.toFixed(2)}x that ${QWEN_EDIT_REFERENCE_PIXELS} px budget in area, ${Math.sqrt(ratio).toFixed(2)}x linear.`;
     }
 
     // Rule 6 stood down for this node, so say its part here rather than lose it.
@@ -628,9 +664,15 @@ export function analyzeGraphHealth(
       typeof denoise === "number" &&
       Number.isFinite(denoise) &&
       startsBelowSigmaMax(denoise, steps);
-    const truncation = alsoTruncated
-      ? ` This sampler ALSO runs denoise=${denoise} over that empty latent, which truncates the sigma schedule and collapses the output to a flat field (#2678); feeding latent_image from the source fixes both.`
-      : "";
+    // `startsBelowSigmaMax` is true for two different reasons and they are not the same
+    // sentence: denoise <= 0 gives an EMPTY sigma tensor (zero sampling steps, the latent
+    // is handed straight back), while a positive denoise gives a schedule missing its
+    // leading sigmas. Both end in a flat field over zeros; only the second is truncation.
+    const truncation = !alsoTruncated
+      ? ""
+      : (denoise as number) <= 0
+        ? ` This sampler ALSO runs denoise=${denoise} over that empty latent, which builds an EMPTY sigma schedule — no sampling steps at all, so the empty latent is returned untouched and decodes to a flat field (#2678); feeding latent_image from the source fixes both.`
+        : ` This sampler ALSO runs denoise=${denoise} over that empty latent, which truncates the sigma schedule and collapses the output to a flat field (#2678); feeding latent_image from the source fixes both.`;
 
     findings.push({
       kind: "edit_reference_empty_latent",
@@ -644,7 +686,9 @@ export function analyzeGraphHealth(
         `image connected — so that conditioning carries reference_latents. ComfyUI scales every ` +
         `such reference to int(1024*1024) px at the SOURCE's aspect ratio and then aligns the ` +
         `reference tokens with the sampled tokens on one shared, centred RoPE grid, so the model ` +
-        `can only copy detail when the sampled latent has the reference's geometry.${geometry} ` +
+        `can only copy detail when the sampled latent has the reference's geometry. An ` +
+        `Empty*Latent* node's size is a literal and the reference's is computed from the ` +
+        `source when the graph runs, so the two line up only by coincidence.${geometry} ` +
         `Unlike a partial denoise this does not depend on denoise: the graph runs clean at ` +
         `denoise 1.0 and returns a plausible image, but re-synthesises the subject instead of ` +
         `preserving it — materials read as plastic/CGI and printed detail comes back as generic ` +

--- a/src/services/workflow-health.ts
+++ b/src/services/workflow-health.ts
@@ -243,12 +243,23 @@ function emitsEditReferenceLatents(
  *
  * Only CONDITIONING-typed slots are followed, decided from real `/object_info` types
  * rather than slot names — so a `ControlNetApply`'s `image` input is not mistaken for
- * part of the conditioning chain. Two shapes therefore end the walk: a node absent from
- * object_info (an uninstalled class has no known slot types), and a wildcard `*` slot
- * such as a Reroute's, which could be carrying anything. Both cost a warning that could
- * have been raised and neither can raise a false one, which is the same direction
- * `producesEmptyLatent` takes. It is a real trade, not an oversight, and
- * workflow-health.test.ts asserts both halves of it.
+ * part of the conditioning chain. Three shapes end the walk, all in the same direction:
+ *
+ *   - a node absent from object_info (an uninstalled class has no known slot types)
+ *   - a wildcard `*` slot such as a Reroute's, which could be carrying anything
+ *   - a node with MORE THAN ONE connected CONDITIONING input. That is a fork, not a
+ *     link in a chain, and which branch reaches the output is not knowable statically:
+ *     a switch/mux passes one through and discards the rest, `ConditioningAverage`
+ *     carries `reference_latents` from `conditioning_to` only, and
+ *     `ControlNetApplyAdvanced` takes a positive and a negative and emits both on
+ *     separate slots. Walking every branch would report a reference the sampler never
+ *     receives — and, worse, would suppress rule 6 while doing it, turning a false
+ *     positive into a LOST warning. (Raised in review; `ConditioningCombine` really
+ *     does merge both branches, so declining costs a warning there.)
+ *
+ * Each costs a warning that could have been raised and none can raise a false one,
+ * which is the same direction `producesEmptyLatent` takes. These are real trades, not
+ * oversights, and workflow-health.test.ts asserts each of them.
  */
 function findEditReferenceEncoder(
   workflow: WorkflowJSON,
@@ -272,11 +283,15 @@ function findEditReferenceEncoder(
     const def = objectInfo[node.class_type];
     if (!def) continue;
     const slots = { ...(def.input?.required ?? {}), ...(def.input?.optional ?? {}) };
+    const upstream: string[] = [];
     for (const [slot, value] of Object.entries(node.inputs ?? {})) {
       if (!isConnection(value)) continue;
       if (slots[slot]?.[0] !== "CONDITIONING") continue;
-      queue.push(value[0]);
+      upstream.push(value[0]);
     }
+    // Exactly one inbound conditioning is a chain and can be followed. Two or more is a
+    // fork whose surviving branch is a run-time decision — stop rather than guess.
+    if (upstream.length === 1) queue.push(upstream[0]);
   }
   return null;
 }
@@ -689,10 +704,12 @@ export function analyzeGraphHealth(
         `can only copy detail when the sampled latent has the reference's geometry. An ` +
         `Empty*Latent* node's size is a literal and the reference's is computed from the ` +
         `source when the graph runs, so the two line up only by coincidence.${geometry} ` +
-        `Unlike a partial denoise this does not depend on denoise: the graph runs clean at ` +
-        `denoise 1.0 and returns a plausible image, but re-synthesises the subject instead of ` +
-        `preserving it — materials read as plastic/CGI and printed detail comes back as generic ` +
-        `shapes (#2681).${truncation} Feed latent_image from a VAEEncode of the same image you ` +
+        `Unlike a partial denoise this does not depend on denoise: where the grids differ the ` +
+        `graph still runs clean at denoise 1.0 and returns a plausible image, but re-synthesises ` +
+        `the subject instead of preserving it — materials read as plastic/CGI and printed detail ` +
+        `comes back as generic shapes (#2681). Where they happen to coincide it is fine, which is ` +
+        `the trap: nothing here tells you which one you got.${truncation} Feed latent_image from ` +
+        `a VAEEncode of the same image you ` +
         `gave the encoder (ComfyUI's own Qwen edit templates use FluxKontextImageScale -> ` +
         `VAEEncode). If you deliberately want a canvas unrelated to the reference, this warning ` +
         `is expected.`,

--- a/src/tools/workflow-compose.ts
+++ b/src/tools/workflow-compose.ts
@@ -146,7 +146,7 @@ export function registerWorkflowComposeTools(server: McpServer): void {
         .optional()
         .default(true)
         .describe(
-          'action:"validate" — Include graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed nodes, a sampler running denoise below 1.0 on an empty latent) as info/warning issues plus a structured health section. Never affects `valid`.',
+          'action:"validate" — Include graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed nodes, a sampler running denoise below 1.0 on an empty latent, an image-edit graph whose sampled canvas is not derived from the reference) as info/warning issues plus a structured health section. Never affects `valid`.',
         ),
       node_type: z
         .string()

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -284,7 +284,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
             "detail: mermaid diagram for one section (requires section parameter). " +
             "list: text listing of all sections with data flow summary. " +
             "flat: single mermaid flowchart of the entire workflow (best for small workflows). " +
-            "health: graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed, a sampler running denoise below 1.0 on an empty latent).",
+            "health: graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed, a sampler running denoise below 1.0 on an empty latent, an image-edit graph whose sampled canvas is not derived from the reference).",
         ),
       section: z
         .string()


### PR DESCRIPTION
Fixes #2681.

## What the reporter hit

Qwen Image Edit 2511, `TextEncodeQwenImageEditPlus` with `image1`, `EmptyLatentImage`
1104x1472, 50 steps, cfg 4, **denoise 1.0**. Validated green, executed without error. The
garment came back looking plastic/CGI, a printed tag came back as a rectangular patch, and
the removal instruction did not take.

This is **not** #2678. That was the denoise dimension — a truncated sigma schedule over an
empty latent, fixed in #2682. At denoise 1.0 that rule is silent by design, and the graph
is still wrong for a second reason our guidance never stated.

## The mechanism, off ComfyUI's source

- `comfy_extras/nodes_qwen.py` — both edit encoders scale every reference image to a
  hard-coded `total = int(1024 * 1024)` px, aspect preserved, dims rounded to /8, then
  `vae.encode(...)` it onto the conditioning as `reference_latents`. ~1.05 MP, always, at
  the **source's** aspect ratio — a geometry decided at run time.
- `comfy/ldm/qwen_image/model.py` `process_img` runs once for the noise latent and once
  per reference, building both grids the same way:
  `linspace(offset, len - 1 + offset) - (len // 2)` on h and w, differing only in the
  `index` channel. Reference token (i, j) and output token (i, j) name the same coordinate
  **only when the two grids have the same shape**.

1104x1472 = 1,625,088 px against 1,048,576 px is 1.55x in area, **1.24x linear**.

## Our part in it

`plugin/skills/qwen-image-edit/SKILL.md` composes to the reporter's graph from two
individually-true sentences: "Simpler Alternative" offers the Plus encoder + a separate
`EmptyLatentImage` and (after #2682) says **"Set `denoise` to 1.0 on this path"**; the
Resolutions table says "Qwen operates at ~1.6 megapixels natively" and lists **1104x1472**.
The second is a Qwen-Image **txt2img** fact. On an edit graph you inherit a resolution, you
do not choose one.

## The change

**`src/services/workflow-health.ts`** — new `edit_reference_empty_latent` warning: a
sampler whose `latent_image` comes directly from an `Empty*Latent*` node while its
`positive` traces along single-inbound, no-wildcard CONDITIONING links to a Qwen edit
encoder that really emits reference latents. No denoise condition — firing at denoise 1.0
is the entire point. Rule 6 stands down where rule 7 speaks, because rule 6 also offers
*"to generate from scratch, set denoise to 1.0"*, which for an edit graph is how you land
here; rule 7 carries rule 6's sigma arithmetic when it applies.

**`plugin/skills/qwen-image-edit/SKILL.md`** — a "Resolution on an edit graph" section
with the mechanism and the official `FluxKontextImageScale` -> `VAEEncode` shape; the
resolution table marked txt2img-only; the empty-latent path rewritten.

## Where to push on this

**The node-type scope is the load-bearing choice, and it came from a measurement.** Across
the 533 templates ComfyUI bundles, 33 samplers take `positive` from a node that sets
`reference_latents`; **31 take `latent_image` from a `VAEEncode` and none from an empty
latent.** The other 2 are `image_qwen_image_layered{,_control}.json`, where an
`EmptyQwenImageLayeredLatentImage` under a `ReferenceLatent` is deliberate — a different
tensor rank from its reference. So keying on the two Qwen edit encoders → **0 false
positives**; adding the generic `ReferenceLatent` → **2**. I took the first and pinned the
layered shape with a test. If you think `ReferenceLatent` should be covered anyway, that is
the argument to have.

**The walk declines more than it could.** It stops at a class absent from `object_info`, at
any connected wildcard `*` slot, and at any node with two or more inbound conditionings.
Each costs a warning; none can raise a false one. All three are asserted by tests so the
trade is visible rather than accidental.

**One known limit, kept on purpose.** A conditioning transform that rebuilt its entry from
a fresh dict would drop `reference_latents`, and rule 7 would report a reference the sampler
never receives. No stock node does: the only fresh-`{}` conditioning sites are
`nodes_hunyuan3d.py` and `nodes_lotus.py`, and neither accepts a CONDITIONING input, so
neither can sit mid-chain. Recorded in the code where a future one would be keyed off.

## Evidence

- **The rule run over the corpus**: 533 templates / 797 graphs / 309 latent-consuming nodes
  through the shipped `analyzeGraphHealth` → **0 fires**. Positive control: the reporter's
  graph injected into the same harness fires once, on nodes 9/8/6. Re-measured after every
  change to the guards. A zero without that control would only prove the harness never
  reached the rule.
- **Mutation battery: 13 mutations, 0 survivors**, each killed by the test written for it —
  including one that follows every fork branch again, one that ignores the wildcard fork
  arm, one that collapses the denoise-0 branch into truncation, and one that makes the
  consequence categorical. Two guards were *deleted* rather than kept when the battery
  showed no test could tell them from their absence.
- **Full suite** 745 files / 13,742 tests, `npm run lint` clean, `npm run check:vocabulary`
  OK, all four CI jobs green.

**Not verified by me:** no browser run. Nothing here touches panel-rendered behaviour — a
health heuristic, two tool-description strings, and a skill document.

**Not claimed:** that the geometry mismatch is why the hanger survived. Prompt adherence on
a removal instruction is a model-quality question and Qwen can miss it on a correctly built
graph. The material and printed-detail artifacts are what this explains.

## Review record

Seven codex rounds. Five produced a real finding; one was wrong and was rejected with
evidence; the last two passed clean.

| round | finding | outcome |
|---|---|---|
| 1 | "provably differ" claimed from area alone; `^image[0-9]*$` not class-specific; denoise<=0 called "truncated"; SKILL.md "wrong at every denoise" | 4 accepted, fixed |
| 1 | a conditioning transform could drop `reference_latents` | real as a class, no stock instance — documented |
| 2 | the walk followed **every** inbound conditioning, so an encoder on a dead branch fired **and suppressed rule 6** — a false positive that costs a real warning | accepted, fixed |
| 2 | the message asserted the plastic/CGI outcome even where the diff says the geometry lines up | accepted, fixed |
| 3 | `FluxKontextImageScale` needs `upscale_method`/`megapixels`/`crop` | **rejected** — its schema declares exactly one input, `image`; method and target are hardcoded; ComfyUI's own 2511 template ships the node with `widgets_values: []`. That signature belongs to `ImageScaleToTotalPixels` |
| 4 | SKILL.md's "identical by construction" is false — at 800x1328 the sampler grid is 100x166 and the reference is 99x165 | **accepted, and it was right.** Computed all nine portrait pairs: 688x1504, 800x1328 and 832x1248 differ by one latent row/column, the other six match |
| 5 | a connected wildcard beside a typed conditioning input still read as a chain | accepted, fixed |
| 6, 7 | — | PASS, no findings |

CI also caught something no round did: the anti-slop ratchet counts chained type assertions
per file against a shrink-only baseline, and the new cases had pushed this file from 2 to
21. The fixtures are now typed records that need no assertion to edit. It was invisible
locally because `oxlint` was not installed in the worktree — it is now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
