### PR TITLE
fix(2684): stop asserting a run the ComfyUI server has not confirmed

### DIFF
--- a/src/__tests__/orchestrator/queue-busy-unconfirmed.test.ts
+++ b/src/__tests__/orchestrator/queue-busy-unconfirmed.test.ts
@@ -307,6 +307,36 @@ describe("#2684: the STALLED notice and the busy note can no longer contradict",
     }
   });
 
+  it("a RETARGET to another ComfyUI does not inherit the old target's confirmation", async () => {
+    // Raised as a P1 by the review gate: after retargeting from a running ComfyUI A
+    // to a different ComfyUI B, does the old heartbeat stay "fresh" and let these
+    // notes go on asserting A's prompt as running on B?
+    //
+    // It does not, and this pins why by EXECUTION rather than by reading start():
+    // start() nulls both liveness heartbeats on retarget, while deliberately NOT
+    // clearing runningPromptId (the first /queue poll of the new target reconciles
+    // that). So the surviving prompt id meets a null heartbeat — which this change
+    // classifies as unconfirmed, not fresh. Before it, that same state asserted a
+    // foreign server's prompt as present-tense fact, with no expiry at all.
+    startRender(0); // A is live and confirmed: heartbeats are NOW
+    expect(QueueMonitor.snapshot().lastServerContactTs).not.toBeNull();
+
+    try {
+      QueueMonitor.start("http://127.0.0.1:9998"); // genuine retarget to B
+      expect(QueueMonitor.snapshot().lastServerContactTs).toBeNull();
+      expect(QueueMonitor.snapshot().runningPromptId).not.toBeNull();
+
+      const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+      const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+      const text = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+      expect(text).not.toMatch(/is still running/);
+      expect(text).toMatch(/UNCONFIRMED/);
+    } finally {
+      QueueMonitor.stop();
+    }
+  });
+
   it("a server that has NEVER answered is unconfirmed, not fresh", async () => {
     // The one case that cannot be dated. It is MORE unverified than a lapsed
     // heartbeat, so it must not fall through to the present-tense branch — the

--- a/src/__tests__/orchestrator/queue-busy-unconfirmed.test.ts
+++ b/src/__tests__/orchestrator/queue-busy-unconfirmed.test.ts
@@ -1,0 +1,292 @@
+// #2684 — a believed running prompt that the monitored ComfyUI has stopped
+// confirming must not keep being reported as present-tense fact.
+//
+// The reported session is the shape under test. A render wedged inside
+// SamplerCustomAdvanced for ~1461 s; the orchestrator's own turn note said the
+// server had gone dark ("appears STALLED", which fires off the LAPSE of the
+// liveness heartbeat), while the queue-busy notes simultaneously asserted a
+// specific prompt "is still running" — and a headless `queue` read showed
+// `running: 0, pending: 0` at the same moment. Two statements reached the agent,
+// one derived from the other's negation.
+//
+// The mechanism is not a race. `QueueMonitor` clears a run on exactly two paths
+// (a ws `status` frame with queue_remaining === 0, or a `/queue` poll seeing an
+// empty queue_running) and BOTH require the monitored server to answer. When it
+// stops answering, `fetchJson` returns null, `applyQueue` returns before the
+// clear can run, and `runningPromptId` persists with no upper bound and no
+// expiry. Keeping last-known state across a blip is deliberate and right; having
+// no point at which it becomes "unverified" rather than "true" is the defect.
+//
+// These tests drive the SHIPPED tool path — handler → fence/timeout → note — not
+// the note helpers directly, because the load-bearing claim is what an agent
+// actually receives from a tool call.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { QueueMonitor, RUNNING_UNCONFIRMED_MS } from "../../services/queue-monitor.js";
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { formatQueueNote } from "../../orchestrator/queue-note.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "11111111-2222-4333-8444-555555555555";
+const STALL_MS = 180_000;
+
+type QMPriv = {
+  url: string | null;
+  stopped: boolean;
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    currentNode: string | null;
+    queueRemaining: number;
+    lastActivityTs: number | null;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+const qm = QueueMonitor as unknown as QMPriv;
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+function makeBridge(opts?: { timeoutCmds?: Set<string> }) {
+  const sent: string[] = [];
+  const timeoutCmds = opts?.timeoutCmds ?? new Set<string>();
+  const bridge = {
+    send: async (cmd: Record<string, unknown>, o?: { onDispatchedRid?: (rid: string) => void }) => {
+      sent.push(String(cmd.cmd));
+      o?.onDispatchedRid?.("rid-timeout-1");
+      if (timeoutCmds.has(String(cmd.cmd))) {
+        throw markReplyTimeout(
+          new Error(
+            `Panel tab ${TAB} did not reply to "${cmd.cmd}" within 20000 ms — the ComfyUI tab ` +
+              `may be backgrounded or frozen`,
+          ),
+        );
+      }
+      return { ok: true, ids: [1], node_count: 1 };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: true, uuid: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge, sent };
+}
+
+/** A run believed in flight. `silentForMs` back-dates BOTH liveness heartbeats
+ *  — the only thing the monitor has that can date its own belief. */
+function startRender(silentForMs: number, promptId = "383f84bb-dead-4beef-8000-000000000001"): void {
+  const now = Date.now();
+  qm.state.runningPromptId = promptId;
+  qm.state.currentNode = "12";
+  qm.state.queueRemaining = 1;
+  // Forward progress stopped when the server did — the reporter's ~1461 s wedge.
+  qm.state.lastActivityTs = now - silentForMs;
+  qm.state.lastServerAliveTs = now - silentForMs;
+  qm.state.lastFrameTs = now - silentForMs;
+}
+
+beforeEach(() => {
+  qm.url = "http://127.0.0.1:9999";
+  qm.stopped = false;
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.connected = true;
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.currentNode = null;
+  qm.state.queueRemaining = 0;
+  qm.state.lastActivityTs = null;
+  qm.state.lastServerAliveTs = Date.now();
+  qm.state.lastFrameTs = Date.now();
+});
+
+afterEach(() => {
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.runningPromptId = null;
+  qm.state.currentNode = null;
+  qm.state.queueRemaining = 0;
+  qm.state.lastActivityTs = null;
+  qm.stopped = true;
+  qm.url = null;
+});
+
+describe("#2684: an ack timeout stops blaming a run the server never confirmed", () => {
+  it("does not assert the prompt is still running once the server has gone dark", async () => {
+    startRender(1461_000);
+
+    const { bridge, sent } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const text = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+    expect(sent).toContain("graph_outline");
+    // The exact sentence the reporter was handed. It is a present-tense claim
+    // about a server that had not answered for ~1461 s.
+    expect(text).not.toMatch(/a ComfyUI prompt is still running/);
+    expect(text).toMatch(/UNCONFIRMED/);
+    // It must still say WHICH run it last knew about — downgrading the tense
+    // must not cost the agent the prompt id it needs to go check.
+    expect(text).toMatch(/383f84bb-dead-4beef-8000-000000000001/);
+    // And it must date the belief rather than leaving it undated.
+    expect(text).toMatch(/has not answered this orchestrator for ~14\d\ds/);
+  });
+
+  it("stops offering the stale run as the CAUSE of the tab's silence", async () => {
+    startRender(1461_000);
+
+    const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const text = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+    // "which is the most likely reason the tab did not answer in time" is the
+    // misexplanation: the same lapsed heartbeat that makes the run unconfirmed
+    // is itself the likelier story.
+    expect(text).not.toMatch(/most likely reason/);
+    // "Retry after queue (action:"list") shows running: 0" was advice against a
+    // queue that was ALREADY idle — the reporter had just read running: 0.
+    expect(text).not.toMatch(/if it still does not answer once the queue is idle/i);
+    expect(text).toMatch(/Settle it with queue \(action:"list"\)/);
+  });
+
+  it("a live server keeps the original present-tense diagnosis", async () => {
+    startRender(0);
+
+    const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const text = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+    // #1639's diagnosis is correct when the monitor can still see the server —
+    // a render really can occupy the panel's main thread. Nothing about that case
+    // changes here.
+    expect(text).toMatch(/QUEUE BUSY: a ComfyUI prompt is still running/);
+    expect(text).toMatch(/most likely reason/);
+    expect(text).not.toMatch(/UNCONFIRMED/);
+  });
+
+  it("tolerates a transient blip: one lapsed poll does not downgrade the run", async () => {
+    // Deliberately right, and stated as a property so it cannot be tuned away:
+    // a single timed-out poll is not evidence a render finished. The downgrade
+    // only fires past the threshold.
+    startRender(RUNNING_UNCONFIRMED_MS - 5_000);
+
+    const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const text = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+    expect(text).toMatch(/a ComfyUI prompt is still running/);
+    expect(text).not.toMatch(/UNCONFIRMED/);
+  });
+});
+
+describe("#2684: the mutation fence still fences — only its wording changes", () => {
+  it("a graph edit is STILL refused unsent on an unconfirmed run", async () => {
+    startRender(1461_000);
+
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "text", value: "a cat" } as never,
+      ctx,
+    );
+    const text = textOf(res);
+
+    // Fail-closed is CORRECT here and must not be loosened: an unverified run is
+    // not a verified idle, and a delivered mutation cannot be retracted. The bug
+    // was never that the fence fenced — it was what the refusal claimed.
+    expect(sent).toEqual([]);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/QUEUE BUSY/);
+    expect(text).toMatch(/panel_set_widget was NOT sent — nothing was applied/);
+    // ...but it no longer states the run as fact.
+    expect(text).not.toMatch(/QUEUE BUSY: a ComfyUI prompt is running/);
+    expect(text).toMatch(/was last seen running/);
+    expect(text).toMatch(/UNCONFIRMED/);
+  });
+
+  it("an idle queue still dispatches the mutation", async () => {
+    const { bridge, sent } = makeBridge();
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "text", value: "a cat" } as never,
+      ctx,
+    );
+
+    expect(sent).toContain("graph_set_widget");
+    expect(res.isError).not.toBe(true);
+  });
+});
+
+describe("#2684: the STALLED notice and the busy note can no longer contradict", () => {
+  it("when the turn note says the server went dark, the busy note agrees", async () => {
+    startRender(1461_000);
+
+    // Both statements the reporter received in one session, produced from the
+    // same monitor state. formatQueueNote fires off `serverAlive` — i.e. the
+    // server has NOT answered recently.
+    const stallNote = formatQueueNote(QueueMonitor.report(STALL_MS));
+    expect(stallNote).toMatch(/appears STALLED/);
+
+    const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const busy = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+    // The contradiction: one message derived from "the server has not answered",
+    // the other asserting a specific prompt is present-tense running.
+    expect(busy).not.toMatch(/is still running/);
+    expect(busy).toMatch(/UNCONFIRMED/);
+  });
+
+  it("the two notes read one heartbeat, so they cannot drift apart", () => {
+    startRender(1461_000);
+    const contact = QueueMonitor.snapshot().lastServerContactTs;
+    expect(contact).not.toBeNull();
+
+    // `report()`'s serverAlive and the snapshot's lastServerContactTs are the
+    // same reduction of the same two fields. Moving the heartbeat forward must
+    // move BOTH: a fresh contact un-stalls the report and re-confirms the run.
+    expect(QueueMonitor.report(STALL_MS).stalled).toBe(true);
+    qm.state.lastServerAliveTs = Date.now();
+    expect(QueueMonitor.snapshot().lastServerContactTs).toBeGreaterThan(contact as number);
+    expect(QueueMonitor.report(STALL_MS).stalled).toBe(false);
+  });
+
+  it("a server that has NEVER answered is unconfirmed, not fresh", async () => {
+    // The one case that cannot be dated. It is MORE unverified than a lapsed
+    // heartbeat, so it must not fall through to the present-tense branch — the
+    // null-is-falsy reading is exactly how this class of bug returns.
+    startRender(1461_000);
+    qm.state.lastServerAliveTs = null;
+    qm.state.lastFrameTs = null;
+    expect(QueueMonitor.snapshot().lastServerContactTs).toBeNull();
+
+    const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+    const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+    const text = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+    expect(text).not.toMatch(/is still running/);
+    expect(text).toMatch(/UNCONFIRMED/);
+    expect(text).toMatch(/has never answered this orchestrator/);
+  });
+});

--- a/src/__tests__/orchestrator/queue-busy-unconfirmed.test.ts
+++ b/src/__tests__/orchestrator/queue-busy-unconfirmed.test.ts
@@ -189,7 +189,14 @@ describe("#2684: an ack timeout stops blaming a run the server never confirmed",
     // Deliberately right, and stated as a property so it cannot be tuned away:
     // a single timed-out poll is not evidence a render finished. The downgrade
     // only fires past the threshold.
-    startRender(RUNNING_UNCONFIRMED_MS - 5_000);
+    //
+    // The blip is a FIXED 5 s, not `RUNNING_UNCONFIRMED_MS - 5_000`. Deriving the
+    // setup from the constant under test makes it move with any mutation of that
+    // constant, so the assertion below stays green no matter what the threshold
+    // becomes — a control that shares the mutation's dependency is not a control.
+    // Setting the threshold to 0 must fail this test, so pin the premise first.
+    expect(RUNNING_UNCONFIRMED_MS).toBeGreaterThan(5_000);
+    startRender(5_000);
 
     const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
     const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());

--- a/src/__tests__/orchestrator/queue-busy-unconfirmed.test.ts
+++ b/src/__tests__/orchestrator/queue-busy-unconfirmed.test.ts
@@ -32,6 +32,7 @@ import {
 import { QueueMonitor, RUNNING_UNCONFIRMED_MS } from "../../services/queue-monitor.js";
 import { markReplyTimeout } from "../../services/ui-bridge.js";
 import { formatQueueNote } from "../../orchestrator/queue-note.js";
+import { stallThresholdMs } from "../../services/stall-threshold.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 const TAB = "11111111-2222-4333-8444-555555555555";
@@ -53,6 +54,7 @@ type QMPriv = {
     lastFrameTs: number | null;
   };
 };
+// oxlint-disable-next-line anti-slop/no-chained-type-assertions -- the defect is a TIMESTAMP the monitor exposes no setter for; back-dating the real singleton's heartbeat is the only way to reach it, and mocking snapshot() would test the mock (same reach as graph-read-during-render.test.ts).
 const qm = QueueMonitor as unknown as QMPriv;
 
 function defByName(name: string) {
@@ -67,6 +69,7 @@ const textOf = (res: ToolResult): string =>
 function makeBridge(opts?: { timeoutCmds?: Set<string> }) {
   const sent: string[] = [];
   const timeoutCmds = opts?.timeoutCmds ?? new Set<string>();
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- a test double for the bridge surface these tools touch; widening to the full interface would add dozens of unused members without making the double more faithful.
   const bridge = {
     send: async (cmd: Record<string, unknown>, o?: { onDispatchedRid?: (rid: string) => void }) => {
       sent.push(String(cmd.cmd));
@@ -277,6 +280,31 @@ describe("#2684: the STALLED notice and the busy note can no longer contradict",
     qm.state.lastServerAliveTs = Date.now();
     expect(QueueMonitor.snapshot().lastServerContactTs).toBeGreaterThan(contact as number);
     expect(QueueMonitor.report(STALL_MS).stalled).toBe(false);
+  });
+
+  it("a LOWER stall threshold moves the downgrade with it, not past it", async () => {
+    // The contradiction is only gone if the busy note downgrades no later than
+    // the stall note calls the server dead. A fixed 30 s constant does NOT get
+    // that: `COMFYUI_MCP_STALL_S` accepts any value above zero and the live panel
+    // setting floors at 15 s, so at a 10 s threshold and 20 s of silence the old
+    // shape would print "appears STALLED" and "is still running" together again —
+    // the reported session, reproduced under a supported configuration.
+    const prev = process.env.COMFYUI_MCP_STALL_S;
+    process.env.COMFYUI_MCP_STALL_S = "10";
+    try {
+      startRender(20_000);
+      expect(formatQueueNote(QueueMonitor.report(stallThresholdMs()))).toMatch(/appears STALLED/);
+
+      const { bridge } = makeBridge({ timeoutCmds: new Set(["graph_outline"]) });
+      const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+      const text = textOf(await defByName("panel_graph_outline").handler({} as never, ctx));
+
+      expect(text).not.toMatch(/is still running/);
+      expect(text).toMatch(/UNCONFIRMED/);
+    } finally {
+      if (prev === undefined) delete process.env.COMFYUI_MCP_STALL_S;
+      else process.env.COMFYUI_MCP_STALL_S = prev;
+    }
   });
 
   it("a server that has NEVER answered is unconfirmed, not fresh", async () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -272,6 +272,11 @@ import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import { formatQueueNote } from "./queue-note.js";
 import {
+  liveStallSecondsValue,
+  setLiveStallSeconds,
+  stallThresholdMs,
+} from "../services/stall-threshold.js";
+import {
   RunCompletions,
   describe as describeCorrelation,
   type CompletionPayload,
@@ -584,24 +589,10 @@ const HEADLESS_DIRECTIVE =
   "missing models (exact file + the widget holding it) and missing node types that the list action omits, in one call. It is " +
   "the canvas-less equivalent of the panel's \"why is this red?\", so also do NOT try panel_get_errors here.";
 
-/** Live stall threshold (seconds) pushed from the panel setting via a `set_config`
- *  frame — applies WITHOUT a reconnect. null = not set, fall back to env then the
- *  built-in default. Process-global: one ComfyUI per orchestrator. */
-let liveStallSeconds: number | null = null;
-function setLiveStallSeconds(v: unknown): void {
-  const n = Number(v);
-  liveStallSeconds = Number.isFinite(n) && n > 0 ? Math.min(3600, Math.max(15, Math.round(n))) : null;
-}
-
-/** Stall threshold (ms): a running job with no node/progress advance for this long
- *  is treated as stalled. Video steps are legitimately slow, so the DEFAULT is high
- *  (180s). Precedence: live panel setting (set_config) → COMFYUI_MCP_STALL_S env
- *  (spawn value) → 180s default. */
-function stallThresholdMs(): number {
-  if (liveStallSeconds != null) return liveStallSeconds * 1000;
-  const s = Number(process.env.COMFYUI_MCP_STALL_S);
-  return Number.isFinite(s) && s > 0 ? Math.round(s * 1000) : 180000;
-}
+// #2684 — the stall threshold moved to services/stall-threshold.ts so the
+// queue-busy notes in panel-tools.ts read the SAME number this file does. While
+// it was private here, those notes could assert a run was live at a moment this
+// file was already calling the server dark.
 
 /**
  * Lockfile path for a given bridge port. The orchestrator self-registers its
@@ -4933,12 +4924,12 @@ export async function runPanelOrchestrator(): Promise<void> {
     // live ollama sessions keep their connection until restarted.
     if (event.type === "set_config" && event.tab_id) {
       if ("stall_seconds" in event) {
-        const _prevStall = liveStallSeconds;
+        const _prevStall = liveStallSecondsValue();
         setLiveStallSeconds((event as { stall_seconds?: unknown }).stall_seconds);
         // The panel re-sends set_config on every heartbeat; only log an ACTUAL change.
-        if (liveStallSeconds !== _prevStall) {
+        if (liveStallSecondsValue() !== _prevStall) {
           logger.info(
-            `[panel-orchestrator] live stall threshold → ${liveStallSeconds ?? "default"}s`,
+            `[panel-orchestrator] live stall threshold → ${liveStallSecondsValue() ?? "default"}s`,
           );
         }
       }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -442,7 +442,8 @@ import {
   resolveEffectiveComfyUIBase,
 } from "../services/workspace-env.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
-import { QueueMonitor } from "../services/queue-monitor.js";
+import { QueueMonitor, RUNNING_UNCONFIRMED_MS } from "../services/queue-monitor.js";
+import type { QueueSnapshot } from "../services/queue-monitor.js";
 import { RunCompletions } from "./run-completion-journal.js";
 import {
   AskAnswers,
@@ -1571,6 +1572,56 @@ function queueBusySnapshotNote(): string {
 }
 
 /**
+ * #2684 — how long the believed running prompt has gone with NO evidence from
+ * the monitored ComfyUI, or null while that belief is still fresh.
+ *
+ * `QueueSnapshot.running` is last-known state, not a live reading. When the
+ * monitored target stops answering, `fetchJson` returns null, `applyQueue`
+ * returns before the empty-queue clear can run, and `runningPromptId` persists
+ * unbounded — so every message built from it goes on asserting a run the server
+ * never confirmed. That is what the reporter hit: a `queue` read showed
+ * `running: 0, pending: 0` while these notes still named a specific prompt as
+ * present-tense fact.
+ *
+ * `sinceMs` is null in the one case where we cannot even date the belief: the
+ * server has never answered here at all. That is MORE unverified, not less, so
+ * it must not read as fresh — hence a null age inside an unconfirmed result,
+ * never a null result.
+ */
+function unconfirmedRun(snap: QueueSnapshot): { sinceMs: number | null } | null {
+  if (!snap.running) return null;
+  if (snap.lastServerContactTs === null) return { sinceMs: null };
+  const sinceMs = Date.now() - snap.lastServerContactTs;
+  return sinceMs >= RUNNING_UNCONFIRMED_MS ? { sinceMs } : null;
+}
+
+/**
+ * #2684 — the queue-busy subject clause, in the tense the evidence supports.
+ *
+ * Returns "" when nothing is believed in flight, so a caller can only ever
+ * embed a claim the monitor actually holds. The fence decisions upstream are
+ * untouched: a stale belief still fences exactly as before (fail-closed is
+ * correct — an unverified run is not a verified idle). Only what we SAY about
+ * it changes, because the previous wording folded "could not determine" into
+ * "determined not" (#796's shape).
+ */
+function queueBusyRunClause(still: boolean): string {
+  const snap = QueueMonitor.snapshot();
+  if (!snap.running) return "";
+  const detail = queueBusySnapshotNote();
+  const un = unconfirmedRun(snap);
+  if (!un) return `a ComfyUI prompt is ${still ? "still " : ""}running${detail}`;
+  const age =
+    un.sinceMs === null
+      ? "the ComfyUI server has never answered this orchestrator"
+      : `the ComfyUI server has not answered this orchestrator for ~${Math.round(un.sinceMs / 1000)}s`;
+  return (
+    `a ComfyUI prompt was last seen running${detail}, but ${age}, so that run is ` +
+    `UNCONFIRMED — it may already have finished, failed, or been cancelled`
+  );
+}
+
+/**
  * panel#1489 — is this `graph_*` command one the queue-busy fence must let past?
  *
  * Answered from GRAPH_CMD_EFFECT, which is the ledger that classifies a graph
@@ -1675,8 +1726,8 @@ function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | 
       return (
         `${deferSubject} was NOT sent — nothing was applied. You asked to park this ` +
         `edit until the queue is idle (defer_until_idle:true), but the request does ` +
-        `not qualify: ${gap}. QUEUE BUSY: a ComfyUI prompt is running` +
-        `${queueBusySnapshotNote()}, so the edit was fenced as an ordinary mutation. ` +
+        `not qualify: ${gap}. QUEUE BUSY: ${queueBusyRunClause(false)}, ` +
+        `so the edit was fenced as an ordinary mutation. ` +
         `Fix the request above and retry — or drop defer_until_idle and retry after ` +
         `queue (action:"list") shows running: 0.`
       );
@@ -1693,8 +1744,8 @@ function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | 
   // fixed here, not a smaller version of it.
   const subject = panelToolForGraphCmd(name) ?? "This edit";
   return (
-    `${subject} was NOT sent — nothing was applied. QUEUE BUSY: a ComfyUI prompt is running` +
-    `${queueBusySnapshotNote()}. ${subject} MUTATES the workflow, and the panel tab often ` +
+    `${subject} was NOT sent — nothing was applied. QUEUE BUSY: ${queueBusyRunClause(false)}. ` +
+    `${subject} MUTATES the workflow, and the panel tab often ` +
     `cannot service a graph edit while a prompt is executing — delivering it would only ` +
     `surface a generic "tab may be backgrounded or frozen" timeout with an unknown ` +
     `outcome, leaving you unable to say whether the edit applied. Read-only graph calls ` +
@@ -1704,12 +1755,36 @@ function graphCmdBlockedByRunningPrompt(cmd: Record<string, unknown>): string | 
 }
 
 function queueBusyTimeoutNote(): string {
-  if (!QueueMonitor.snapshot().running) return "";
+  const snap = QueueMonitor.snapshot();
+  if (!snap.running) return "";
+  const un = unconfirmedRun(snap);
+  if (!un) {
+    return (
+      `\n\nQUEUE BUSY: a ComfyUI prompt is still running${queueBusySnapshotNote()}, which is the ` +
+      `most likely reason the tab did not answer in time — a render can occupy the panel's main ` +
+      `thread. Retry after queue (action:"list") shows running: 0; if it still does not answer ` +
+      `once the queue is idle, THEN treat the tab as backgrounded or frozen.`
+    );
+  }
+  // #2684 — the branch above offers the running prompt as the CAUSE of the ack
+  // timeout. Reusing it on an unverified belief is how this note misexplained a
+  // dead render: the reporter's `queue (action:"list")` read `running: 0` at the
+  // very moment this text named a specific prompt as "still running", so "retry
+  // once the queue is idle" was advice against a queue that was ALREADY idle.
+  //
+  // The same lapsed heartbeat that makes the run unconfirmed is itself the more
+  // likely story — an unreachable ComfyUI, or one this orchestrator is polling
+  // at a different target than the tab is bound to (#1593). So state the age of
+  // the belief and hand over the check that can actually settle it, instead of
+  // folding "could not determine" into "determined not".
   return (
-    `\n\nQUEUE BUSY: a ComfyUI prompt is still running${queueBusySnapshotNote()}, which is the ` +
-    `most likely reason the tab did not answer in time — a render can occupy the panel's main ` +
-    `thread. Retry after queue (action:"list") shows running: 0; if it still does not answer ` +
-    `once the queue is idle, THEN treat the tab as backgrounded or frozen.`
+    `\n\nQUEUE STATE UNCONFIRMED: ${queueBusyRunClause(false)}. Do NOT treat that run as the ` +
+    `reason the tab did not answer — it is last-known state this orchestrator has been unable ` +
+    `to re-verify, not a live reading. Settle it with queue (action:"list"), which reads the ` +
+    `server directly: if that reports running: 0 the run is already over and the tab's silence ` +
+    `has another cause; if it cannot reach the server either, ComfyUI is down or this ` +
+    `orchestrator is polling a different target than the tab is bound to — compare ` +
+    `get_system_stats (action:"health").`
   );
 }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -444,6 +444,7 @@ import {
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor, RUNNING_UNCONFIRMED_MS } from "../services/queue-monitor.js";
 import type { QueueSnapshot } from "../services/queue-monitor.js";
+import { stallThresholdMs } from "../services/stall-threshold.js";
 import { RunCompletions } from "./run-completion-journal.js";
 import {
   AskAnswers,
@@ -1592,7 +1593,26 @@ function unconfirmedRun(snap: QueueSnapshot): { sinceMs: number | null } | null 
   if (!snap.running) return null;
   if (snap.lastServerContactTs === null) return { sinceMs: null };
   const sinceMs = Date.now() - snap.lastServerContactTs;
-  return sinceMs >= RUNNING_UNCONFIRMED_MS ? { sinceMs } : null;
+  return sinceMs >= unconfirmedAfterMs() ? { sinceMs } : null;
+}
+
+/**
+ * #2684 — the silence past which a believed run stops being stated as fact.
+ *
+ * `min` of the two, and the direction matters. `report()` calls the server dead
+ * at `stallThresholdMs()` — that is when the STALLED notice fires. If this note
+ * downgraded LATER than that, the reported contradiction survives verbatim for
+ * any threshold under 30 s, and both are reachable: `COMFYUI_MCP_STALL_S` takes
+ * any value above zero, and the live panel setting floors at 15 s. Taking the
+ * min means the busy note is never more confident than the stall note about the
+ * same server, whatever the threshold is configured to.
+ *
+ * It can only ever downgrade EARLIER, never later, which is the safe direction:
+ * the cost is a note that says "unconfirmed" a little sooner, and the fence it
+ * annotates does not move either way.
+ */
+function unconfirmedAfterMs(): number {
+  return Math.min(RUNNING_UNCONFIRMED_MS, stallThresholdMs());
 }
 
 /**

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -130,6 +130,16 @@ export interface QueueSnapshot {
    *  reported depth is fully accounted for — the coarse recent-self-queue
    *  fallback never counts here. */
   selfAttributedProven: boolean;
+  /** #2684 — ms epoch of the last evidence the monitored ComfyUI answered HERE:
+   *  a successful `/queue` poll (`lastServerAliveTs`) or any decodable ws frame
+   *  (`lastFrameTs`), whichever is newer. null when neither has ever happened.
+   *
+   *  This is the SAME heartbeat `report()` reduces to `serverAlive`, exposed so
+   *  a consumer of `running`/`runningPromptId` can tell a live claim from a
+   *  last-known one. Every other field here is last-known state with no expiry;
+   *  without this there is no way to ask how old that state is, which is how a
+   *  never-confirmed run kept being named as present-tense fact (#2684). */
+  lastServerContactTs: number | null;
 }
 
 /**
@@ -182,6 +192,26 @@ const HISTORY_TAIL_ITEMS = 32;
 // Training nodes legitimately exceed it (hours of silent tqdm), which is why
 // report() exempts runs whose graph contains a known trainer class (#1652).
 const HARD_STALL_FLOOR_MS = 30 * 60 * 1000; // 30 minutes
+/**
+ * #2684 — how long the monitored ComfyUI may stay SILENT before a believed
+ * running prompt stops being reported as present-tense fact.
+ *
+ * Keeping the last-known run across a blip is deliberate and right: one timed-out
+ * poll is not proof a render finished, and clearing on it would falsely report an
+ * active job as done. What was wrong is that the belief had no upper bound — when
+ * the monitored target stops answering entirely (`fetchJson` returns null on abort,
+ * timeout or non-2xx, and `applyQueue` then returns before it can clear), nothing
+ * ever downgrades "is running" to "was running, unverified since".
+ *
+ * 30 s is chosen against the two clocks that bound it. Below: the poll runs at
+ * ~1 Hz with a 2.5 s timeout, so 30 s of total silence is ten-plus consecutive
+ * failed polls AND zero ws frames — well past any transient blip. Above: the
+ * default stall threshold is 180 s and the live setting floors at 15 s, so the
+ * busy note downgrades BEFORE `report()` can raise a STALLED notice off the same
+ * lapsed heartbeat. That ordering is the point: the reported session got both
+ * statements at once, one derived from the other's negation.
+ */
+export const RUNNING_UNCONFIRMED_MS = 30_000;
 // Node classes whose HEALTHY runtime legitimately exceeds the hard floor with
 // ZERO forward-progress frames: ComfyUI's built-in LoRA training only rewrites
 // a tqdm bar on stdout — no per-step `progress` WS frames — so lastActivityTs
@@ -926,7 +956,16 @@ class QueueMonitorImpl {
       lastCompleted: this.state.lastCompleted,
       selfAttributed: this.isSelfAttributed(),
       selfAttributedProven: this.isSelfAttributedProven(),
+      lastServerContactTs: this.lastServerContactTs(),
     };
+  }
+
+  /** #2684 — newest of the two liveness heartbeats, null when the monitored
+   *  server has never answered here. Shared with `report()` so the busy notes
+   *  and the STALLED notice cannot disagree about whether the server is alive. */
+  private lastServerContactTs(): number | null {
+    const ts = Math.max(this.state.lastServerAliveTs ?? 0, this.state.lastFrameTs ?? 0);
+    return ts > 0 ? ts : null;
   }
 
   /** Stall/backlog report for the turn-start injector. */
@@ -943,8 +982,8 @@ class QueueMonitorImpl {
     // 1 Hz poll fresh, so a busy decode stays live and is NOT flagged; a server
     // that stops answering (crashed / event-loop wedged) lets the heartbeat
     // lapse → a real stall still surfaces.
-    const heartbeatTs = Math.max(this.state.lastServerAliveTs ?? 0, this.state.lastFrameTs ?? 0);
-    const serverAlive = heartbeatTs > 0 && now - heartbeatTs < stallMs;
+    const heartbeatTs = this.lastServerContactTs();
+    const serverAlive = heartbeatTs !== null && now - heartbeatTs < stallMs;
     // Backstop so a genuine in-node DEADLOCK on a still-reachable server isn't
     // suppressed FOREVER: after a long hard floor of zero forward progress, flag
     // regardless of liveness. A real deadlock usually holds Python's GIL, which

--- a/src/services/stall-threshold.ts
+++ b/src/services/stall-threshold.ts
@@ -1,0 +1,39 @@
+// The stall threshold, as ONE source of truth.
+//
+// #2684 — this lived as a private pair of functions inside orchestrator/index.ts,
+// which meant the only consumer that could read it was the turn-start stall note.
+// The queue-busy notes in panel-tools.ts describe the SAME belief about the SAME
+// server and could not see it, so they were free to disagree with the stall note
+// about whether ComfyUI was answering — and did, in the reported session: an
+// "appears STALLED" notice (which fires off the LAPSE of the liveness heartbeat)
+// arrived alongside a flat assertion that a specific prompt "is still running".
+//
+// Sharing the number is what makes that contradiction unrepresentable, so it is
+// deliberately a module, not a duplicated constant: a second copy would drift the
+// moment either default moved.
+
+/** Live stall threshold (seconds) pushed from the panel setting via a `set_config`
+ *  frame — applies WITHOUT a reconnect. null = not set, fall back to env then the
+ *  built-in default. Process-global: one ComfyUI per orchestrator. */
+let liveStallSeconds: number | null = null;
+
+export function setLiveStallSeconds(v: unknown): void {
+  const n = Number(v);
+  liveStallSeconds = Number.isFinite(n) && n > 0 ? Math.min(3600, Math.max(15, Math.round(n))) : null;
+}
+
+/** The live setting's current value in seconds, or null when unset. Exposed only
+ *  so the orchestrator can log a CHANGE without keeping its own shadow copy. */
+export function liveStallSecondsValue(): number | null {
+  return liveStallSeconds;
+}
+
+/** Stall threshold (ms): a running job with no node/progress advance for this long
+ *  is treated as stalled. Video steps are legitimately slow, so the DEFAULT is high
+ *  (180s). Precedence: live panel setting (set_config) → COMFYUI_MCP_STALL_S env
+ *  (spawn value) → 180s default. */
+export function stallThresholdMs(): number {
+  if (liveStallSeconds != null) return liveStallSeconds * 1000;
+  const s = Number(process.env.COMFYUI_MCP_STALL_S);
+  return Number.isFinite(s) && s > 0 ? Math.round(s * 1000) : 180000;
+}


### PR DESCRIPTION
Fixes the first of the two pieces #2684 asks for — the message-only half. The identity-gate
half is deliberately NOT in this PR; see "What this does not do".

## The defect

`QueueMonitor` clears a running prompt on exactly two paths — a ws `status` frame with
`queue_remaining === 0` (`queue-monitor.ts:598`) and a `/queue` poll seeing an empty
`queue_running` (`:801`). **Both require the monitored ComfyUI to answer.** `fetchJson`
returns `null` on any failure (abort, 2.5 s timeout, non-2xx) and `applyQueue` returns
immediately on `null`, so when the target stops answering, `runningPromptId` persists with
no upper bound and no expiry — and every message built from it went on naming that prompt
as present-tense fact.

That produced two statements in one session, one derived from the other's negation:

- `⚠️ The current ComfyUI render appears STALLED …` — which fires off `serverAlive`, i.e.
  *the server has not answered recently*;
- `QUEUE BUSY: a ComfyUI prompt is still running (running prompt 383f84bb-…)` — asserting a
  specific prompt is running right now.

…while a headless `queue` read returned `running: 0, pending: 0` at the same moment. The
`#796` shape: "could not determine" folded into "determined not".

## The fix

- `QueueSnapshot` gains `lastServerContactTs` — the newest of the two liveness heartbeats,
  the same reduction `report()` already collapses into `serverAlive`. `report()` now reads
  it through the same private helper, so the two cannot drift.
- The queue-busy notes downgrade the tense once that heartbeat has lapsed: **"was last seen
  running (prompt X), but the ComfyUI server has not answered this orchestrator for ~1461s,
  so that run is UNCONFIRMED"**, instead of "is still running".
- `queueBusyTimeoutNote()` stops offering the stale run as the *cause* of an ack timeout.
  "Retry after `queue (action:"list")` shows `running: 0`" was advice against a queue that
  was already idle. It now points at the check that can actually settle it, and names the
  target split (#1593) as a candidate cause.
- `stallThresholdMs()` moves out of `orchestrator/index.ts` into `services/stall-threshold.ts`
  so the busy notes can read the same number the stall note does.

**No fence changes, nothing loosened.** A stale belief still fences graph mutations exactly
as before — an unverified run is not a verified idle, and a delivered mutation cannot be
retracted. Only the wording moved.

## Where the load-bearing claims are

Please push hardest on these:

1. **`Math.min(RUNNING_UNCONFIRMED_MS, stallThresholdMs())`** (`panel-tools.ts`). A fixed 30 s
   constant does *not* remove the contradiction: `COMFYUI_MCP_STALL_S` takes any value above
   zero and the live panel setting floors at 15 s, so at a 10 s threshold with 20 s of silence
   the old shape reproduces the reported session verbatim under a supported config. The `min`
   makes the busy note never more confident than the stall note. Is the direction right?
2. **The 30 s constant itself is a judgment call.** Anchored below by the ~1 Hz poll with a
   2.5 s timeout (30 s ≈ ten-plus consecutive failures *and* zero ws frames — past any blip),
   above by the 180 s default stall. Keeping last-known state across a blip is deliberate.
3. **Extracting `stallThresholdMs`/`setLiveStallSeconds` from `index.ts`** must be behaviour-
   identical. The one caller read the module-private `liveStallSeconds` directly for its
   change-only logging; it now calls `liveStallSecondsValue()`.
4. **`lastServerContactTs` is deliberately NOT in the broadcast frame.** `buildQueueStatusFrame`
   field-maps rather than spreads, so the wire payload is unchanged — adding a
   once-per-second-changing timestamp there would defeat the change-only broadcaster.
5. **The timeout note's prefix changes to `QUEUE STATE UNCONFIRMED`** on the stale branch only.
   The mutation-fence messages keep `QUEUE BUSY`. No production code matches these strings.

## Verification

Every piece was proved by deleting it and watching a named test fail (10 new tests, all
driving the shipped tool path — handler → fence/timeout → note — not the helpers):

| mutation | result |
|---|---|
| downgrade disabled entirely | **5 fail**, 4 controls survive |
| revert timeout note only | **4 fail**, fence test survives |
| revert fence message only | **1 fail**, timeout tests survive |
| never-answered reads as confirmed (null-is-falsy) | **1 fail** |
| threshold → 0 (no blip tolerance) | **2 fail** (live-server + blip controls) |
| `min(…)` → fixed constant | **1 fail** (the low-threshold parity test) |

The blip control was rewritten mid-review: it originally derived its input from
`RUNNING_UNCONFIRMED_MS - 5_000`, which moved with the constant under test and stayed green
under the threshold mutation. A control must not share the mutation's dependency.

- Full suite: **746 files, 13760 passed, 6 skipped, 0 failed**
- `npm run lint` (`tsc --noEmit` + anti-slop): clean, none added
- `check:unknown-collapse` (the #796 gate): no new collapses
- `check:vocabulary`: OK

**Not browser-verified, and it does not need to be:** no file in comfyui-mcp-panel changed,
and the wire frame is byte-identical. These strings are MCP tool-result text read by the
agent, not sidebar-rendered UI.

## What this does not do

Piece 2 of #2684 — a proven-origin handoff that would let a tab which demonstrably fronts a
reachable ComfyUI authorise `/free` — is **not** here. `settleFreeVramAfterAckTimeout` and
`panel_restart_comfyui` both fail closed on `captureRebootHealthBase`, which is why both
recovery routes closed at once. That gate is correct as written; changing who may authorise
a write is a design decision the issue itself defers to the owner, and it is already open as
#1593 / comfyui-mcp-panel#2068. Recording the `/free` half there rather than deciding it here.

Closes #2684