### PR TITLE
fix(2686): terminate a generated API-node prompt with a sink matching its output type

### DIFF
--- a/src/__tests__/services/api-nodes.test.ts
+++ b/src/__tests__/services/api-nodes.test.ts
@@ -140,6 +140,22 @@ function sampleObjectInfo(): ObjectInfo {
         },
       },
     }),
+    // Core output node, as every real ComfyUI registers it. generate picks its
+    // auto-added sink out of /object_info, so the fixture has to carry the sinks
+    // a real server would offer. Deliberately NO SaveVideo/SaveAudio* here: that
+    // is the older-server shape, and it keeps the "no registered sink" fallback
+    // exercised by the KlingVideoNode (VIDEO) case below.
+    SaveImage: nodeDef({
+      category: "image",
+      display_name: "Save Image",
+      output_node: true,
+      input: {
+        required: {
+          images: ["IMAGE", {}],
+          filename_prefix: ["STRING", { default: "ComfyUI" }],
+        },
+      },
+    }),
   };
 }
 
@@ -428,7 +444,9 @@ describe("generateWithApiNode", () => {
     expect(result.notes.some((n) => /SaveImage/.test(n))).toBe(false);
   });
 
-  it("warns when a non-output node has no IMAGE output to wire", async () => {
+  it("warns when the server registers no output node for the declared type", async () => {
+    // KlingVideoNode returns VIDEO; sampleObjectInfo deliberately has no
+    // SaveVideo (the older-server shape), so there is nothing to wire.
     const { deps, enqueued } = makeDeps();
     const result = await generateWithApiNode(
       { class_type: "KlingVideoNode", inputs: { prompt: "x" } },
@@ -436,6 +454,249 @@ describe("generateWithApiNode", () => {
     );
     expect(Object.keys(enqueued[0].wf)).toEqual(["1"]);
     expect(result.notes.some((n) => /prompt_no_outputs/.test(n))).toBe(true);
+    // The note names the type we could not terminate, so the caller knows what
+    // to wire via extra_nodes.
+    expect(result.notes.some((n) => /returns VIDEO/.test(n))).toBe(true);
+  });
+
+  // ── #2686 — terminal output sinks beyond IMAGE ─────────────────────────────
+  //
+  // generate only ever wired a SaveImage, so every API node returning something
+  // else shipped a prompt with no output node and ComfyUI 400d it with
+  // "prompt_no_outputs". On ComfyUI 0.33 that is 173 of the 241 non-output API
+  // nodes (VIDEO 112, STRING ~25, AUDIO 10, SVG 5).
+
+  /** Core sinks, shaped as ComfyUI 0.33 /object_info reports them. */
+  const SAVE_AUDIO_ADVANCED = nodeDef({
+    category: "audio",
+    display_name: "Save Audio (Advanced)",
+    output_node: true,
+    input: {
+      required: {
+        audio: ["AUDIO", {}],
+        filename_prefix: ["STRING", { default: "audio/ComfyUI" }],
+        format: [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            options: [
+              { key: "flac", inputs: { required: {} } },
+              {
+                key: "mp3",
+                inputs: {
+                  required: {
+                    quality: ["COMBO", { options: ["V0", "128k", "320k"], default: "V0" }],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  /** The deprecated-but-still-registered FLAC saver older builds ship. */
+  const SAVE_AUDIO_LEGACY = nodeDef({
+    category: "audio",
+    display_name: "Save Audio (FLAC)",
+    output_node: true,
+    input: {
+      required: {
+        audio: ["AUDIO", {}],
+        filename_prefix: ["STRING", { default: "audio/ComfyUI" }],
+      },
+    },
+  });
+
+  const SAVE_VIDEO = nodeDef({
+    category: "video",
+    display_name: "Save Video",
+    output_node: true,
+    input: {
+      required: {
+        video: ["VIDEO", {}],
+        filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+        format: [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            options: [
+              {
+                key: "auto",
+                inputs: {
+                  required: { codec: ["COMBO", { options: ["auto", "h264", "av1"] }] },
+                },
+              },
+              {
+                key: "webm",
+                inputs: { required: { codec: ["COMBO", { options: ["auto", "av1"] }] } },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  const SAVE_TEXT = nodeDef({
+    category: "text",
+    display_name: "Save Text",
+    output_node: true,
+    input: {
+      required: {
+        text: ["STRING", { forceInput: true }],
+        filename_prefix: ["STRING", { default: "ComfyUI" }],
+        format: ["COMBO", { options: ["txt", "csv", "md", "json"], default: "txt" }],
+      },
+    },
+  });
+
+  /** The node from the report: AUDIO out, not itself an OUTPUT_NODE. */
+  const BYTEDANCE_SEED_AUDIO = nodeDef({
+    api_node: true,
+    category: "partner/audio/ByteDance",
+    display_name: "ByteDance Seed Audio 1.0",
+    output: ["AUDIO"],
+    output_name: ["audio"],
+    input: { required: { text_prompt: ["STRING", { default: "", multiline: true }] } },
+  });
+
+  /** A node returning ("STRING", "VIDEO") — the 13-node Kling-style shape. */
+  const VIDEO_AND_TEXT = nodeDef({
+    api_node: true,
+    category: "api node/video/Kling",
+    display_name: "Kling With Text",
+    output: ["STRING", "VIDEO"],
+    output_name: ["response", "video"],
+    input: { required: { prompt: ["STRING", {}] } },
+  });
+
+  it("wires an audio sink for an AUDIO-returning API node (the #2686 repro)", async () => {
+    const { deps, enqueued } = makeDeps({
+      getObjectInfo: async () => ({
+        ByteDanceSeedAudio: BYTEDANCE_SEED_AUDIO,
+        SaveAudioAdvanced: SAVE_AUDIO_ADVANCED,
+      }),
+    });
+    const result = await generateWithApiNode(
+      { class_type: "ByteDanceSeedAudio", inputs: { text_prompt: "hello" } },
+      deps,
+    );
+
+    const wf = enqueued[0].wf;
+    expect(wf["2"].class_type).toBe("SaveAudioAdvanced");
+    expect(wf["2"].inputs.audio).toEqual(["1", 0]);
+    expect(wf["2"].inputs.filename_prefix).toBe("audio/ComfyUI");
+    // The graph now HAS a terminal output node, which is the whole point: a
+    // prompt without one is what ComfyUI rejected with prompt_no_outputs.
+    expect(result.notes.some((n) => /prompt_no_outputs/.test(n))).toBe(false);
+    expect(result.notes.some((n) => /SaveAudioAdvanced output node/.test(n))).toBe(true);
+  });
+
+  it("fills the sink's own required dynamic combo in the dotted server form", async () => {
+    // SaveVideo's `format` is a REQUIRED v3 dynamic combo. Sending only the link
+    // + filename_prefix would 400 with required_input_missing, so the sink's own
+    // widgets are resolved from its /object_info entry.
+    const { deps, enqueued } = makeDeps({
+      getObjectInfo: async () => ({
+        KlingVideoNode: sampleObjectInfo().KlingVideoNode,
+        SaveVideo: SAVE_VIDEO,
+      }),
+    });
+    await generateWithApiNode({ class_type: "KlingVideoNode", inputs: { prompt: "x" } }, deps);
+
+    const sink = enqueued[0].wf["2"];
+    expect(sink.class_type).toBe("SaveVideo");
+    expect(sink.inputs).toEqual({
+      video: ["1", 0],
+      filename_prefix: "video/ComfyUI",
+      format: "auto",
+      "format.codec": "auto",
+    });
+  });
+
+  it("falls back to a sink the server actually registers", async () => {
+    // An older ComfyUI has no SaveAudioAdvanced. Naming it anyway would swap a
+    // "no outputs" 400 for a "node type not found" 400 — no better.
+    const { deps, enqueued } = makeDeps({
+      getObjectInfo: async () => ({
+        ByteDanceSeedAudio: BYTEDANCE_SEED_AUDIO,
+        SaveAudio: SAVE_AUDIO_LEGACY,
+      }),
+    });
+    await generateWithApiNode(
+      { class_type: "ByteDanceSeedAudio", inputs: { text_prompt: "hello" } },
+      deps,
+    );
+
+    const sink = enqueued[0].wf["2"];
+    expect(sink.class_type).toBe("SaveAudio");
+    expect(sink.inputs).toEqual({ audio: ["1", 0], filename_prefix: "audio/ComfyUI" });
+  });
+
+  it("prefers the media output over a sibling STRING output", async () => {
+    const { deps, enqueued } = makeDeps({
+      getObjectInfo: async () => ({
+        KlingWithText: VIDEO_AND_TEXT,
+        SaveVideo: SAVE_VIDEO,
+        SaveText: SAVE_TEXT,
+      }),
+    });
+    await generateWithApiNode({ class_type: "KlingWithText", inputs: { prompt: "x" } }, deps);
+
+    const sink = enqueued[0].wf["2"];
+    expect(sink.class_type).toBe("SaveVideo");
+    // Wired to slot 1 — the VIDEO output's real index, not a hardcoded 0.
+    expect(sink.inputs.video).toEqual(["1", 1]);
+  });
+
+  it("falls through to another declared type when the preferred sink is absent", async () => {
+    // Same node, but this server has no SaveVideo. The STRING output can still
+    // terminate the graph, so the run happens instead of being rejected.
+    const { deps, enqueued } = makeDeps({
+      getObjectInfo: async () => ({ KlingWithText: VIDEO_AND_TEXT, SaveText: SAVE_TEXT }),
+    });
+    await generateWithApiNode({ class_type: "KlingWithText", inputs: { prompt: "x" } }, deps);
+
+    const sink = enqueued[0].wf["2"];
+    expect(sink.class_type).toBe("SaveText");
+    expect(sink.inputs).toEqual({
+      text: ["1", 0],
+      filename_prefix: "ComfyUI",
+      format: "txt", // required COMBO filled from its schema default
+    });
+  });
+
+  it("wires SaveGLB for a 3D API node, preferring the model over its STRING", async () => {
+    // The ('FILE_3D_GLB', 'STRING') shape services/generate-3d.ts drives behind
+    // generate_image (action:"3d"). SaveGLB's `mesh` is a MultiType covering the
+    // whole File3D family, so one sink serves them all.
+    const model3d = nodeDef({
+      api_node: true,
+      category: "api node/3d/Tripo",
+      display_name: "Tripo Model",
+      output: ["FILE_3D_GLB", "STRING"],
+      output_name: ["model_file", "task_id"],
+      input: { required: { prompt: ["STRING", {}] } },
+    });
+    const saveGlb = nodeDef({
+      category: "3d",
+      display_name: "Save 3D Model",
+      output_node: true,
+      input: {
+        required: {
+          mesh: ["MESH", {}],
+          filename_prefix: ["STRING", { default: "3d/ComfyUI" }],
+        },
+      },
+    });
+    const { deps, enqueued } = makeDeps({
+      getObjectInfo: async () => ({ TripoModel: model3d, SaveGLB: saveGlb, SaveText: SAVE_TEXT }),
+    });
+    await generateWithApiNode({ class_type: "TripoModel", inputs: { prompt: "a chair" } }, deps);
+
+    const sink = enqueued[0].wf["2"];
+    expect(sink.class_type).toBe("SaveGLB");
+    expect(sink.inputs).toEqual({ mesh: ["1", 0], filename_prefix: "3d/ComfyUI" });
   });
 
   it("forwards disable_random_seed to enqueue", async () => {

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -678,12 +678,31 @@ function describeInputs(
   });
 }
 
-/** Return the input schema for a given API node (from its /object_info entry). */
-export async function getApiNodeSchema(
-  classType: string,
-  deps: ApiNodesDeps = defaultDeps,
-): Promise<ApiNodeSchema> {
-  const objectInfo = await deps.getObjectInfo();
+/**
+ * Project an /object_info entry into the schema shape. No API-node guard — the
+ * auto-added output sink (see OUTPUT_SINKS) is a plain CORE node and needs the
+ * same input description to resolve its own widget defaults.
+ */
+function nodeSchemaFrom(classType: string, def: ComfyUINodeDef): ApiNodeSchema {
+  return {
+    class_type: classType,
+    display_name: def.display_name || classType,
+    category: def.category ?? "",
+    description: def.description ?? "",
+    is_api_node: isApiNode(def),
+    is_output_node: def.output_node === true,
+    inputs: [
+      ...describeInputs(def.input?.required, true),
+      ...describeInputs(def.input?.optional, false),
+    ],
+    hidden_inputs: def.input?.hidden ? Object.keys(def.input.hidden) : [],
+    output: Array.isArray(def.output) ? def.output : [],
+    output_name: Array.isArray(def.output_name) ? def.output_name : [],
+  };
+}
+
+/** Resolve an API node's schema against an already-fetched /object_info. */
+function apiNodeSchemaFrom(objectInfo: ObjectInfo, classType: string): ApiNodeSchema {
   const def = objectInfo[classType];
 
   if (!def) {
@@ -699,21 +718,15 @@ export async function getApiNodeSchema(
     );
   }
 
-  return {
-    class_type: classType,
-    display_name: def.display_name || classType,
-    category: def.category ?? "",
-    description: def.description ?? "",
-    is_api_node: true,
-    is_output_node: def.output_node === true,
-    inputs: [
-      ...describeInputs(def.input?.required, true),
-      ...describeInputs(def.input?.optional, false),
-    ],
-    hidden_inputs: def.input?.hidden ? Object.keys(def.input.hidden) : [],
-    output: Array.isArray(def.output) ? def.output : [],
-    output_name: Array.isArray(def.output_name) ? def.output_name : [],
-  };
+  return nodeSchemaFrom(classType, def);
+}
+
+/** Return the input schema for a given API node (from its /object_info entry). */
+export async function getApiNodeSchema(
+  classType: string,
+  deps: ApiNodesDeps = defaultDeps,
+): Promise<ApiNodeSchema> {
+  return apiNodeSchemaFrom(await deps.getObjectInfo(), classType);
 }
 
 // ── V3 dynamic-combo (dotted widget) serialization ──────────────────────────
@@ -883,6 +896,113 @@ export function buildApiNodeInputs(
   return { inputs, consumed };
 }
 
+// ── Terminal output sinks ───────────────────────────────────────────────────
+//
+// ComfyUI only executes graphs that reach an OUTPUT_NODE; a bare non-output API
+// node fails /prompt validation with "prompt_no_outputs". Most API nodes are NOT
+// output nodes, so `generate` has to terminate the graph itself.
+//
+// #2686: that termination used to be "wire a SaveImage, or give up", which left
+// every non-IMAGE API node un-runnable. Measured by AST-scanning comfy_api_nodes/
+// on ComfyUI 0.33: of 241 non-output API nodes, 173 have no IMAGE output — VIDEO
+// is 112 of them, STRING ~25, AUDIO 10 (the reported ByteDanceSeedAudio), SVG 5,
+// File3D ~16. So dispatch on the node's DECLARED output type instead; that takes
+// the table to 219 of the 241. The remaining 22 return custom handle types
+// (voice selectors, Gemini input files) that no core output node consumes, and
+// keep the explanatory note.
+//
+// The chosen sink must be one the CONNECTED server registers: ComfyUI versions
+// differ on which savers exist (SaveAudioAdvanced is current, SaveAudio/-MP3/
+// -Opus are deprecated-but-still-registered, older builds have neither), and
+// naming a class the server has never heard of turns a "no outputs" 400 into a
+// "node type not found" 400 — no better. Checking /object_info, which we have
+// already fetched to resolve the API node itself, lets an older ComfyUI degrade
+// to the explanatory note instead.
+
+interface OutputSink {
+  /** Core output node that terminates the graph. */
+  class_type: string;
+  /** The sink input the API node's output link is wired into. */
+  link_input: string;
+  /** Seeds for the sink's own widgets, matching its core schema defaults. */
+  defaults?: Record<string, unknown>;
+}
+
+/**
+ * Output type → candidate sinks. BOTH lists are in preference order.
+ *
+ * Types are searched first, media before text, so a node declaring
+ * ("VIDEO", "STRING") saves the video rather than the response text. Within a
+ * type, candidates run current → deprecated → preview-only, so we write to
+ * output/ when we can and only fall back to a temp-dir preview when we can't.
+ */
+const OUTPUT_SINKS: ReadonlyArray<{ type: string; sinks: readonly OutputSink[] }> = [
+  {
+    type: "IMAGE",
+    sinks: [
+      { class_type: "SaveImage", link_input: "images", defaults: { filename_prefix: "ComfyUI" } },
+    ],
+  },
+  {
+    type: "VIDEO",
+    sinks: [
+      { class_type: "SaveVideo", link_input: "video", defaults: { filename_prefix: "video/ComfyUI" } },
+    ],
+  },
+  {
+    type: "AUDIO",
+    sinks: [
+      { class_type: "SaveAudioAdvanced", link_input: "audio", defaults: { filename_prefix: "audio/ComfyUI" } },
+      { class_type: "SaveAudio", link_input: "audio", defaults: { filename_prefix: "audio/ComfyUI" } },
+      { class_type: "PreviewAudio", link_input: "audio" },
+    ],
+  },
+  {
+    type: "SVG",
+    sinks: [
+      { class_type: "SaveSVGNode", link_input: "svg", defaults: { filename_prefix: "svg/ComfyUI" } },
+    ],
+  },
+  // SaveGLB's `mesh` is a MultiType accepting the whole File3D family, so one
+  // sink serves every 3D API node (Hunyuan3D/Tripo/Rodin/Meshy…). These are the
+  // io_type WIRE strings ("FILE_3D_GLB"), not the python class names.
+  ...(["FILE_3D_GLB", "FILE_3D_OBJ", "FILE_3D_FBX", "FILE_3D"] as const).map((type) => ({
+    type,
+    sinks: [
+      { class_type: "SaveGLB", link_input: "mesh", defaults: { filename_prefix: "3d/ComfyUI" } },
+    ],
+  })),
+  // Text last: it is the fallback for nodes that return only a response string,
+  // and for media nodes whose media sink this server does not register.
+  {
+    type: "STRING",
+    sinks: [
+      { class_type: "SaveText", link_input: "text", defaults: { filename_prefix: "ComfyUI" } },
+    ],
+  },
+];
+
+/**
+ * Pick the output node to terminate `schema`'s graph with: the first preferred
+ * output type the node declares that has a candidate sink this server registers.
+ * Returns the sink, its /object_info entry, and the API-node output slot to wire.
+ */
+function pickOutputSink(
+  schema: ApiNodeSchema,
+  objectInfo: ObjectInfo,
+): { sink: OutputSink; def: ComfyUINodeDef; slot: number } | null {
+  const outputs = schema.output.map((o) => String(o).toUpperCase());
+  for (const { type, sinks } of OUTPUT_SINKS) {
+    const slot = outputs.indexOf(type);
+    if (slot < 0) continue;
+    for (const sink of sinks) {
+      const def = objectInfo[sink.class_type];
+      if (def) return { sink, def, slot };
+    }
+  }
+  return null;
+}
+
 export interface GenerateWithApiNodeArgs {
   class_type: string;
   inputs: Record<string, unknown>;
@@ -890,7 +1010,7 @@ export interface GenerateWithApiNodeArgs {
   /**
    * Extra supporting nodes to merge into the enqueued workflow (e.g. a
    * LoadImage feeding the API node's IMAGE link input). The API node itself is
-   * always node "1", and "2" may be used for an auto-added SaveImage — extra
+   * always node "1", and "2" may be used for an auto-added output node — extra
    * node ids must avoid both.
    */
   extra_nodes?: WorkflowJSON;
@@ -919,7 +1039,10 @@ export async function generateWithApiNode(
   args: GenerateWithApiNodeArgs,
   deps: ApiNodesDeps = defaultDeps,
 ): Promise<GenerateWithApiNodeResult> {
-  const schema = await getApiNodeSchema(args.class_type, deps);
+  // One fetch, two readers: the API node's own schema and the output-sink pick
+  // both come out of this /object_info snapshot.
+  const objectInfo = await deps.getObjectInfo();
+  const schema = apiNodeSchemaFrom(objectInfo, args.class_type);
   const notes: string[] = [];
 
   const provided = args.inputs ?? {};
@@ -993,26 +1116,38 @@ export async function generateWithApiNode(
 
   // ComfyUI only executes graphs that reach a terminal OUTPUT_NODE; a bare
   // non-output API node fails validation with "prompt_no_outputs". If the API
-  // node isn't itself an output node, wire its IMAGE output into a SaveImage.
+  // node isn't itself an output node, terminate it with a sink that matches the
+  // type it actually returns (#2686 — this was IMAGE-only).
   if (!schema.is_output_node) {
-    const imageIdx = schema.output.findIndex(
-      (o) => String(o).toUpperCase() === "IMAGE",
-    );
-    if (imageIdx >= 0) {
+    const picked = pickOutputSink(schema, objectInfo);
+    if (picked) {
+      const { sink, def, slot } = picked;
+      // Resolve the sink's OWN widget values from its /object_info entry rather
+      // than hardcoding them: SaveVideo and SaveAudioAdvanced both take a
+      // REQUIRED v3 dynamic combo (`format`), which the server rebuilds from the
+      // dotted `format` + `format.<nested>` keys buildApiNodeInputs emits.
+      // Sending only the link would 400 with required_input_missing instead.
+      const { inputs: sinkInputs } = buildApiNodeInputs(nodeSchemaFrom(sink.class_type, def), {
+        [sink.link_input]: ["1", slot],
+        ...(sink.defaults ?? {}),
+      });
       workflow["2"] = {
-        class_type: "SaveImage",
-        inputs: { images: ["1", imageIdx], filename_prefix: "ComfyUI" },
-        _meta: { title: "Save Image" },
+        class_type: sink.class_type,
+        inputs: sinkInputs,
+        _meta: { title: def.display_name || sink.class_type },
       };
       notes.push(
-        "Added a SaveImage output node — ComfyUI requires a terminal output node " +
-          "for the prompt to execute.",
+        `Added a ${sink.class_type} output node wired to the ${
+          schema.output[slot]
+        } output — ComfyUI requires a terminal output node for the prompt to execute.`,
       );
     } else {
+      const declared = schema.output.length > 0 ? schema.output.join(", ") : "nothing";
       notes.push(
-        `"${args.class_type}" is not an output node and has no IMAGE output, so no ` +
-          "output node was auto-added; the prompt may fail with 'prompt_no_outputs'. " +
-          "Wire a terminal output node yourself if needed.",
+        `"${args.class_type}" is not an output node and returns ${declared}, which this ` +
+          "ComfyUI has no registered output node for, so none was auto-added; the prompt " +
+          "may fail with 'prompt_no_outputs'. Pass a terminal output node via extra_nodes " +
+          "if you need one.",
       );
     }
   }


### PR DESCRIPTION
Closes #2686

## The defect

`list_api_nodes` (action:`"generate"`) builds a single-node prompt. Since `777c30f` it appends a terminal output node, because ComfyUI refuses any graph that does not reach an `OUTPUT_NODE`. That appending was **IMAGE-only**:

```ts
const imageIdx = schema.output.findIndex((o) => String(o).toUpperCase() === "IMAGE");
if (imageIdx >= 0) { /* wire a SaveImage */ }
else { /* note, and enqueue a graph with NO output node */ }
```

`ByteDanceSeedAudio` returns `(AUDIO,)` and is not itself an output node, so it took the `else` branch and the server 400d with `prompt_no_outputs`, exactly as filed.

## Size of the gap (measured, not assumed)

AST-scanned `comfy_api_nodes/` on the local ComfyUI 0.33 install. Of **241 non-output API nodes, 173 have no IMAGE output** and were un-generatable:

| type | nodes |
|---|---|
| VIDEO | 112 |
| STRING | ~25 |
| File3D | ~16 |
| AUDIO | 10 (the reported node) |
| SVG | 5 |

## The fix

A table of output type → candidate sinks, replacing the IMAGE special case. Coverage goes to **219 of 241**.

## Where the load-bearing claims are — please look here

**1. The sink must exist on the *connected* server.** ComfyUI versions disagree about which savers exist: `SaveAudioAdvanced` is current, `SaveAudio`/`-MP3`/`-Opus` are `is_deprecated=True` but *still registered* (`server.py:784` just tags `deprecated: true` in `/object_info`), and older builds have neither. Naming a class the server never registered converts a `prompt_no_outputs` 400 into a `node type not found` 400 — no improvement. So the pick is filtered through the `/object_info` snapshot already fetched to resolve the API node itself. **If that presence check is wrong, an old server gets a worse error than today.** Pinned by `falls back to a sink the server actually registers`.

**2. The sink's own widgets come from its schema, not from a literal.** `SaveVideo` and `SaveAudioAdvanced` both take a **required** v3 dynamic combo (`format`). Wiring only the link would 400 with `required_input_missing`. The sink's inputs are built through the existing `buildApiNodeInputs`, which emits the dotted `format` + `format.<nested>` form. I verified against ComfyUI source that the server really rebuilds that shape — `DynamicCombo._expand_schema_for_dynamic` (`comfy_api/latest/_io.py:1258`) reads `live_inputs[finalized_id]` for the option key, then resolves the option's nested inputs under the prefixed id. Pinned by `fills the sink's own required dynamic combo in the dotted server form`.

**3. The 3D type keys are wire strings, not class names.** My first scan read `File3DGLB` off the Python class and I nearly used it as the type key. The `@comfytype` io_type is **`FILE_3D_GLB`** — underscored. `IMAGE`/`AUDIO`/`VIDEO`/`SVG`/`STRING` I re-checked individually and they do match their class names. A wrong key here would silently never match and reintroduce the bug for that type.

**4. Two behaviour changes beyond the reported node, called out deliberately:**
- IMAGE now also requires `SaveImage` in `/object_info`. Every real ComfyUI registers it; the unit fixture did not, so I added a faithful `SaveImage` def rather than relax the check. That is a fixture correction, not a loosened assertion.
- `services/generate-3d.ts` shares this path. Its `('FILE_3D_GLB','STRING')` nodes previously got no output node; they now get `SaveGLB`. Type order is media-before-text specifically so those save the model rather than the task-id string.

## Evidence

- `npx vitest run` — **13,769 passed**, 1 failure that is the known unbuilt-worktree artifact (`package-hooks` `files` entry `dist` missing); `npm run build` then re-running that file: 3/3 pass.
- `npm run check:vocabulary` OK (it caught a `generate_3d` mention in one of my comments — fixed the comment, did not widen `allowedIn`), `check:unknown-collapse` OK, `tsc --noEmit` clean.
- `npm run lint` cannot complete in this worktree — `oxlint` is not installed here. CI runs it.
- **Mutation-tested.** Seven independent mutations, each caught, none survived:

| mutation | tests turned RED |
|---|---|
| revert to IMAGE-only | 6 |
| drop AUDIO from the table | 2 |
| drop VIDEO from the table | 2 |
| drop File3D from the table | 1 |
| remove the `/object_info` presence check | 1 |
| hardcode the sink inputs | 2 |
| hardcode the wired slot to 0 | 1 |

No panel surface is touched (this is the headless `list_api_nodes` path), so no Playwright run — flagging that rather than implying coverage I do not have. I also could not execute a real `ByteDanceSeedAudio` job: no ComfyUI was running on this host and the node bills a paid partner API, so the wire-format claims rest on ComfyUI source plus the dotted-form behaviour already verified live in `777c30f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
