### PR TITLE
fix(2688): a promoted write refused by the ownership envelope names the invariant that failed

### DIFF
--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -3876,6 +3876,36 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
+  // Review finding (P2). The recovery path runs AFTER an outer graph_set_widget
+  // has already been dispatched and refused; only the INNER retry is skipped.
+  // Routing it through the standard refusal made it assert "No graph_set_widget
+  // was dispatched", which is false there and invites an agent to re-issue a
+  // write it has already made. The invariant is still named; the consequence
+  // clause is the one this path can actually stand behind.
+  it("names the invariant on the recovery path without claiming no write was dispatched", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "width", value: 1024 },
+      {
+        firstWrite: "contradict",
+        firstWriteError: CONTRADICTORY,
+        preflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
+        // Read 2 must also classify non-promoted, so the recovery preflight
+        // returns null and the LEGACY recovery re-read below is the one that
+        // meets the malformed envelope. That is the branch under test.
+        recoveryPreflightSubgraph: DEFINITIVE_NON_PROMOTED_SUBGRAPH,
+        subgraph: { ...SUBGRAPH, node_count: 5 },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/`node_count` claimed 5 inner node\(s\) but `nodes` carried 2/);
+    expect(text).toMatch(/The inner write was not retried\./);
+    expect(text).not.toMatch(/No graph_set_widget was dispatched/);
+    // The outer attempt is what produced the refusal being annotated, so it did
+    // happen — the message must not deny it.
+    expect(calls.filter((c) => c.cmd === "graph_set_widget").length).toBeGreaterThan(0);
+  });
+
   it("a truncated subgraph read is not treated as unique", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "width", value: 1024 },
@@ -3883,7 +3913,7 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     );
     expect(isError).toBe(true);
     expect(text).toMatch(
-      /the reply set `truncated`, so the inner node list it carried is not the whole subgraph/,
+      /the reply's `truncated` flag was not `false`, so the inner node list it carried cannot be taken as the whole subgraph/,
     );
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
@@ -4333,7 +4363,9 @@ describe("#2393 promoted-terminal witness is judged on the requested alias", () 
       /`promoted_terminals\[1\]` published neither a terminal endpoint \(`terminal_node_id`\/`terminal_node_type`\) nor an `error`/,
     );
     expect(text).toMatch(/accepted or rejected as a WHOLE/);
-    expect(text).toMatch(/panel_open_workflow and panel_set_workflow_target do not clear it/);
+    expect(text).toMatch(
+      /unless the panel's reply itself changes shape, panel_open_workflow and panel_set_workflow_target re-bind the tab and produce the identical refusal/,
+    );
     expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
@@ -4393,7 +4425,20 @@ describe("#2688 describePromotedSubgraphEnvelope names the failed invariant", ()
 
   it.each([
     ["a non-object reply", "nope", 78, /the reply was not a JSON object/],
-    ["asserted truncation", { ...VALID, truncated: true }, 78, /the reply set `truncated`/],
+    [
+      "a truncated flag",
+      { ...VALID, truncated: true },
+      78,
+      /the reply's `truncated` flag was not `false`/,
+    ],
+    // A malformed flag is not evidence of a SHORT read, so the reason must not
+    // claim one. Same rejection, different established fact.
+    [
+      "a malformed truncated flag",
+      { ...VALID, truncated: null },
+      78,
+      /the reply's `truncated` flag was not `false`/,
+    ],
     [
       "a missing subgraph_of",
       { ...VALID, subgraph_of: undefined },
@@ -4522,6 +4567,43 @@ describe("#2688 describePromotedSubgraphEnvelope names the failed invariant", ()
     // A corpus that rejected everything would pass the loop above while proving
     // nothing about the accepting half of the fence.
     expect(accepted).toBeGreaterThan(0);
+  });
+
+  // Review finding (P0). The first draft walked the untrusted arrays with
+  // `.entries()`, which is an own-property a reply can shadow. The loops it
+  // replaced walked `Symbol.iterator`, so a payload that shadowed `entries`
+  // would have been validated against a DIFFERENT list than the one
+  // `nodes.length !== node_count` was checked against — a way past the fence.
+  // The loops are indexed now, which depends on neither hook.
+  it("validates the array it counted, not a shadowed iterator", () => {
+    const nodes: unknown[] = [null];
+    Object.defineProperty(nodes, "entries", {
+      value: function* () {
+        yield [0, { id: 5, type: "X" }];
+      },
+    });
+    const shadowed = {
+      subgraph_of: { node_id: 78 },
+      node_count: 1,
+      nodes,
+    };
+    expect(describePromotedSubgraphEnvelope(shadowed, 78).ok).toBe(false);
+    expect(validatePromotedSubgraphEnvelope(shadowed, 78)).toBeNull();
+
+    const terminals: unknown[] = [null];
+    Object.defineProperty(terminals, "entries", {
+      value: function* () {
+        yield [0, { widget: "w", error: "e" }];
+      },
+    });
+    const shadowedTerminals = {
+      subgraph_of: { node_id: 78 },
+      node_count: 1,
+      nodes: [{ id: 5, type: "X" }],
+      promoted_terminals: terminals,
+    };
+    expect(describePromotedSubgraphEnvelope(shadowedTerminals, 78).ok).toBe(false);
+    expect(validatePromotedSubgraphEnvelope(shadowedTerminals, 78)).toBeNull();
   });
 });
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -31,6 +31,7 @@ import {
   parseSubgraphScopeRefusal,
   promotedInnerWidgetIsLinkDriven,
   resolveInnerPromotedTarget,
+  describePromotedSubgraphEnvelope,
   validatePromotedSubgraphEnvelope,
 } from "../../orchestrator/promoted-widget.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
@@ -2299,7 +2300,10 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    // #2688 — the refusal names the failed invariant, not just "malformed".
+    expect(text).toMatch(
+      /`promoted_terminals\[0\]` carried a `terminal_inputs` that is missing or not an array/,
+    );
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
@@ -2650,9 +2654,17 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(parentRailShortfall.text).toContain("0.15.101");
     expect(parentRailShortfall.text).not.toMatch(/binding and subgraph mapping are stable/);
 
-    // Branch 3: a genuinely TRANSIENT refusal — a malformed envelope from a
-    // current panel. Same guarantee, and this is the one a retry can clear.
-    const transient = await setWidget(
+    // Branch 3: an envelope-INVARIANT refusal from a current panel. Same
+    // guarantee, and it is neither a build skew nor a retry.
+    //
+    // #2688 corrected what this branch asserted. It used to call this shape "a
+    // genuinely TRANSIENT refusal … the one a retry can clear" and pin the
+    // retry wording, but `node_count: 2` against a one-node array is decided
+    // from that single reply: retrying reproduces it exactly. The reporter
+    // proved it the expensive way, looping through retries and re-binds on a
+    // sentence that named nothing. What panel#1859 is about is the message not
+    // being the BUILD-SKEW one, and that half is unchanged.
+    const invariantFailure = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
         firstWrite: "ok",
@@ -2660,10 +2672,13 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
         detailById: SAFE_ANIMA_IDENTITY_BY_ID,
       },
     );
-    expect(transient.isError).toBe(true);
-    expect(transient.text).toMatch(/No graph_set_widget was dispatched/);
-    expect(transient.text).toMatch(/binding and subgraph mapping are stable/);
-    expect(transient.text).not.toContain("0.15.101");
+    expect(invariantFailure.isError).toBe(true);
+    expect(invariantFailure.text).toMatch(/No graph_set_widget was dispatched/);
+    expect(invariantFailure.text).toMatch(
+      /`node_count` claimed 2 inner node\(s\) but `nodes` carried 1/,
+    );
+    expect(invariantFailure.text).not.toMatch(/binding and subgraph mapping are stable/);
+    expect(invariantFailure.text).not.toContain("0.15.101");
   });
 
   it("refuses a promoted mapping for a receiver without the final parent-rail fence", async () => {
@@ -2705,30 +2720,49 @@ describe("panel_set_widget promoted container success guards (#2314)", () => {
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
+  // #2688 — each row also pins WHICH invariant the refusal names. Six shapes
+  // that used to produce one indistinguishable sentence are six distinct
+  // reports now, and a row that starts naming a different field is a behaviour
+  // change this table will catch.
   it.each([
-    ["stale owner", { ...SAFE_ANIMA_SUBGRAPH, subgraph_of: { node_id: 79 } }],
-    ["wrong node count", { ...SAFE_ANIMA_SUBGRAPH, node_count: 2 }],
-    ["malformed viewing identity", { ...SAFE_ANIMA_SUBGRAPH, viewing: null }],
+    [
+      "stale owner",
+      { ...SAFE_ANIMA_SUBGRAPH, subgraph_of: { node_id: 79 } },
+      /`subgraph_of\.node_id` named node 79, not the addressed node 78/,
+    ],
+    [
+      "wrong node count",
+      { ...SAFE_ANIMA_SUBGRAPH, node_count: 2 },
+      /`node_count` claimed 2 inner node\(s\) but `nodes` carried 1/,
+    ],
+    [
+      "malformed viewing identity",
+      { ...SAFE_ANIMA_SUBGRAPH, viewing: null },
+      /`viewing` was present but did not parse as a graph-scope identity/,
+    ],
     [
       "malformed viewing workflow identity",
       { ...SAFE_ANIMA_SUBGRAPH, viewing: { scope: "subgraph", owner_node_id: 78, workflow_uuid: 42 } },
+      /`viewing` was present but did not parse as a graph-scope identity/,
     ],
     [
       "malformed viewing graph identity",
       { ...SAFE_ANIMA_SUBGRAPH, viewing: { scope: "subgraph", owner_node_id: 78, graph_identity: "" } },
+      /`viewing` was present but did not parse as a graph-scope identity/,
     ],
     [
       "malformed target graph identity",
       { ...SAFE_ANIMA_SUBGRAPH, subgraph_of: { node_id: 78, graph_identity: "" } },
+      /`subgraph_of\.graph_identity` was present but not a string of 1-256 characters/,
     ],
-  ])("refuses a %s envelope before writing the container", async (_name, subgraph) => {
+  ])("refuses a %s envelope before writing the container", async (_name, subgraph, invariant) => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       { firstWrite: "ok", subgraph },
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(text).toMatch(invariant);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
@@ -3848,7 +3882,9 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
       { subgraph: { ...SUBGRAPH, truncated: true } },
     );
     expect(isError).toBe(true);
-    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(text).toMatch(
+      /the reply set `truncated`, so the inner node list it carried is not the whole subgraph/,
+    );
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
@@ -4053,9 +4089,12 @@ describe("panel_set_widget promoted write against a pre-#2314 panel build (panel
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
-  it("leaves the transient refusals on a CURRENT panel saying retry", async () => {
-    // Same handler, same fixture, current build: a malformed envelope is a
-    // genuine transient and must keep the retry advice it has always had.
+  it("keeps an envelope-invariant refusal on a CURRENT panel off the build-skew message", async () => {
+    // Same handler, same fixture, current build. #2688: this used to assert the
+    // retry wording on the premise that "a malformed envelope is a genuine
+    // transient". It is not — the invariant is decided from one reply, so the
+    // retry never arrives anywhere new. The claim this test exists to make is
+    // the build-skew one, and that is what it makes now.
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
       {
@@ -4066,7 +4105,8 @@ describe("panel_set_widget promoted write against a pre-#2314 panel build (panel
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/retry only after the panel binding and subgraph mapping are stable/);
+    expect(text).toMatch(/`node_count` claimed 2 inner node\(s\) but `nodes` carried 1/);
+    expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
     expect(text).not.toContain("0.15.101");
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
@@ -4245,7 +4285,9 @@ describe("#2393 promoted-terminal witness is judged on the requested alias", () 
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    // #2688 — names the OFFENDING index, which is not the requested alias's.
+    expect(text).toMatch(/`promoted_terminals\[1\]` was not an object/);
+    expect(text).toMatch(/accepted or rejected as a WHOLE/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
   });
 
@@ -4261,8 +4303,225 @@ describe("#2393 promoted-terminal witness is judged on the requested alias", () 
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(text).toMatch(/`promoted_terminals\[1\]` had a missing or empty `widget`/);
     expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  // #2688 — the WIRING. The reporter's exit from this refusal was the sentence
+  // itself: it named no invariant, and it prescribed "retry only after the
+  // panel binding and subgraph mapping are stable". They retried, re-opened the
+  // workflow, and re-bound the tab, and got the identical text every time.
+  //
+  // Deleting either half of the fix breaks a line here: drop the named
+  // invariant and the first assertion fails; route this branch back through
+  // `promotedWriteRefusal` and the last one does.
+  it("names the failed invariant and drops the retry remedy that cannot clear it", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        // An entry that resolved to neither a terminal nor an error. It is not
+        // the requested alias, and under the old wording that was invisible.
+        subgraph: withTerminals([ownEntry, { widget: "unrelated_alias" }]),
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(
+      /`promoted_terminals\[1\]` published neither a terminal endpoint \(`terminal_node_id`\/`terminal_node_type`\) nor an `error`/,
+    );
+    expect(text).toMatch(/accepted or rejected as a WHOLE/);
+    expect(text).toMatch(/panel_open_workflow and panel_set_workflow_target do not clear it/);
+    expect(text).not.toMatch(/retry only after the panel binding and subgraph mapping are stable/);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  // The refusal must not become a read of the graph it is refusing to write to.
+  it("names the shape without quoting the offending entry's own names", async () => {
+    const { text } = await setWidget(
+      { node_id: 78, widget: "quality_prompt", value: "masterpiece" },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        subgraph: withTerminals([
+          ownEntry,
+          { widget: "SECRET_ALIAS", immediate_widget: "SECRET_INNER" },
+        ]),
+        detailById: SAFE_ANIMA_IDENTITY_BY_ID,
+      },
+    );
+
+    expect(text).toMatch(/`promoted_terminals\[1\]`/);
+    expect(text).not.toMatch(/SECRET_ALIAS|SECRET_INNER/);
+  });
+});
+
+describe("#2688 describePromotedSubgraphEnvelope names the failed invariant", () => {
+  const VALID = {
+    viewing: { scope: "subgraph", owner_node_id: 78, workflow_uuid: "wf", graph_identity: "g" },
+    subgraph_of: { node_id: 78, graph_identity: "gi" },
+    node_count: 1,
+    truncated: false,
+    nodes: [{ id: 5, type: "CheckpointLoaderSimple", widgets: { ckpt_name: "secret.safetensors" } }],
+    promoted_terminals: [{ widget: "ckpt_name", error: "unresolved" }],
+  };
+
+  const withNodes = (nodes: unknown[]) => ({ ...VALID, node_count: nodes.length, nodes });
+  const terminals = (promoted_terminals: unknown) => ({ ...VALID, promoted_terminals });
+  const goodTerminal = {
+    widget: "ckpt_name",
+    parent_rail: { authoritative: true, widget: "ckpt_name" },
+    immediate_node_id: 5,
+    immediate_widget: "ckpt_name",
+    terminal_node_id: 5,
+    terminal_node_type: "CheckpointLoaderSimple",
+    terminal_widget: "ckpt_name",
+    terminal_inputs: [{ name: "ckpt_name", type: "COMBO" }],
+    chain_depth: 0,
+  };
+  const terminalMinus = (drop: string) => {
+    const entry: Record<string, unknown> = { ...goodTerminal };
+    delete entry[drop];
+    return terminals([entry]);
+  };
+
+  it("accepts a complete envelope", () => {
+    expect(describePromotedSubgraphEnvelope(VALID, 78).ok).toBe(true);
+  });
+
+  it.each([
+    ["a non-object reply", "nope", 78, /the reply was not a JSON object/],
+    ["asserted truncation", { ...VALID, truncated: true }, 78, /the reply set `truncated`/],
+    [
+      "a missing subgraph_of",
+      { ...VALID, subgraph_of: undefined },
+      78,
+      /`subgraph_of` was missing or not an object/,
+    ],
+    [
+      "an unusable owner id",
+      { ...VALID, subgraph_of: { node_id: {} } },
+      78,
+      /`subgraph_of\.node_id` was missing or not a node id/,
+    ],
+    ["an unusable addressed id", VALID, "not-an-id", /the addressed node id was not a usable node id/],
+    [
+      "a non-integer node_count",
+      { ...VALID, node_count: 1.5 },
+      78,
+      /`node_count` was missing or not a non-negative integer/,
+    ],
+    ["a non-array nodes", { ...VALID, nodes: {} }, 78, /`nodes` was missing or not an array/],
+    [
+      "an inner node without an id",
+      withNodes([{ type: "X" }]),
+      78,
+      /`nodes\[0\]` was not an object carrying a usable `id`/,
+    ],
+    [
+      "a non-array promoted_terminals",
+      terminals({}),
+      78,
+      /`promoted_terminals` was present but not an array/,
+    ],
+    [
+      "an entry carrying both a terminal and an error",
+      terminals([{ ...goodTerminal, error: "boom" }]),
+      78,
+      /published a terminal endpoint AND an `error`/,
+    ],
+    [
+      "a terminal without immediate_node_id",
+      terminalMinus("immediate_node_id"),
+      78,
+      /published a terminal endpoint without `immediate_node_id`/,
+    ],
+    [
+      "a terminal without immediate_widget",
+      terminalMinus("immediate_widget"),
+      78,
+      /published a terminal endpoint without `immediate_widget`/,
+    ],
+    [
+      "a terminal without an authoritative parent rail",
+      terminalMinus("parent_rail"),
+      78,
+      /without a `parent_rail` asserting `authoritative:true`/,
+    ],
+    [
+      "an out-of-range chain_depth",
+      terminals([{ ...goodTerminal, chain_depth: 17 }]),
+      78,
+      /carried a `chain_depth` that is missing or outside 0-16/,
+    ],
+    [
+      "a terminal input without a name",
+      terminals([{ ...goodTerminal, terminal_inputs: [{ type: "COMBO" }] }]),
+      78,
+      /carried a `terminal_inputs\[0\]` without a non-empty `name`/,
+    ],
+    [
+      "an entry that is neither resolved nor errored",
+      terminals([{ widget: "ckpt_name" }]),
+      78,
+      /published neither a terminal endpoint .* nor an `error`/,
+    ],
+  ])("names %s", (_label, payload, owner, invariant) => {
+    const described = describePromotedSubgraphEnvelope(
+      payload as Record<string, unknown>,
+      owner as number | string,
+    );
+    expect(described.ok).toBe(false);
+    if (described.ok) return;
+    expect(described.invariant).toMatch(invariant as RegExp);
+    // Shape only: no widget value and no node type out of the graph itself.
+    expect(described.invariant).not.toMatch(/secret\.safetensors|CheckpointLoaderSimple/);
+  });
+
+  // The fence must not have moved. `validatePromotedSubgraphEnvelope` is the
+  // authorization surface every promoted write still runs through, and it is
+  // this function with the reason dropped — so the two have to agree on every
+  // shape, including the ones that are ACCEPTED.
+  it("agrees with the fence on accept, reject, and the envelope value", () => {
+    const corpus: unknown[] = [
+      VALID,
+      { ...VALID, viewing: undefined },
+      { ...VALID, promoted_terminals: undefined },
+      { ...VALID, truncated: undefined },
+      { ...VALID, subgraph_of: { node_id: "78" } },
+      withNodes([]),
+      terminals([goodTerminal]),
+      terminals([{ ...goodTerminal, chain_depth: 3 }]),
+      "nope",
+      null,
+      undefined,
+      { ...VALID, truncated: true },
+      { ...VALID, node_count: 9 },
+      { ...VALID, viewing: null },
+      terminals([{ widget: "x" }]),
+      terminalMinus("parent_rail"),
+    ];
+    let accepted = 0;
+    for (const owner of [78, "78", 79, "bad"]) {
+      for (const payload of corpus) {
+        const described = describePromotedSubgraphEnvelope(
+          payload as Record<string, unknown>,
+          owner as number | string,
+        );
+        const fenced = validatePromotedSubgraphEnvelope(
+          payload as Record<string, unknown>,
+          owner as number | string,
+        );
+        expect(described.ok).toBe(fenced !== null);
+        expect(described.ok ? described.envelope : null).toEqual(fenced);
+        if (described.ok) accepted += 1;
+      }
+    }
+    // A corpus that rejected everything would pass the loop above while proving
+    // nothing about the accepting half of the fence.
+    expect(accepted).toBeGreaterThan(0);
   });
 });
 
@@ -4722,7 +4981,9 @@ describe("panel_set_widget promoted inner identity forwarding (#2478)", () => {
     );
 
     expect(isError).toBe(true);
-    expect(text).toMatch(/malformed, stale, or incomplete ownership envelope/);
+    expect(text).toMatch(
+      /`nodes\[0\]\.node_identity` was present but not a string of 1-256 characters/,
+    );
     expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
     expect(mutations).toBe(0);
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -171,7 +171,7 @@ import {
   resolveLegacyInnerPromotedTarget,
   promotedInnerWidgetIsLinkDriven,
   resolveInnerPromotedTarget,
-  validatePromotedSubgraphEnvelope,
+  describePromotedSubgraphEnvelope,
   isInnerLinkDrivenWriteWarning,
   shapeParentAuthoritativePromotedWrite,
   type PromotedParentRailWitness,
@@ -8024,6 +8024,47 @@ function promotedWriteRefusal(widget: string, reason: string): ToolResult {
   );
 }
 
+/**
+ * #2688 — the ownership-envelope refusal, which a retry can NOT clear.
+ *
+ * `validatePromotedSubgraphEnvelope` rejects for about twenty distinct reasons
+ * and every one of them used to arrive as "graph_get_subgraph returned a
+ * malformed, stale, or incomplete ownership envelope" plus
+ * {@link promotedWriteRefusal}'s "retry only after the panel binding and
+ * subgraph mapping are stable". The reporter did exactly that — retried,
+ * re-opened the workflow, re-bound the tab — and got the identical sentence
+ * every time, because every invariant is a pure function of ONE reply and not a
+ * binding state that settles. There was no exit from that loop and nothing to
+ * report but "something was wrong".
+ *
+ * Same fail-closed decision as before; the only thing that changes is what the
+ * caller is told. The invariant text is shape-only (field paths, indices,
+ * counts, the two compared node ids) — naming it must not become a way to read
+ * a graph this fence is refusing to write to.
+ *
+ * The all-or-nothing sentence is load-bearing, not filler: the envelope is
+ * rejected as a whole, so a caller whose OWN widget maps perfectly can be
+ * refused by an unrelated `promoted_terminals` entry, and without that line the
+ * named index reads as irrelevant to their write.
+ */
+function promotedEnvelopeInvariantRefusal(
+  widget: string,
+  invariant: string,
+  subject = "graph_get_subgraph",
+): ToolResult {
+  return fail(
+    `panel_set_widget refused the promoted "${widget}" write because ${subject}'s ownership ` +
+      `envelope failed a completeness invariant: ${invariant}. No graph_set_widget was dispatched.\n` +
+      `This is a SHAPE defect in the reply, not a binding state. Every invariant is decided from ` +
+      `that one reply alone, so against an unchanged graph the same read reproduces it — retrying, ` +
+      `panel_open_workflow and panel_set_workflow_target do not clear it.\n` +
+      `The envelope is accepted or rejected as a WHOLE: one unusable field, or one malformed ` +
+      `promoted_terminals entry, refuses every promoted write on this wrapper, including widgets ` +
+      `whose own mapping is fine. Report the invariant above together with the panel version — it ` +
+      `names the field to fix.`,
+  );
+}
+
 /** True when a successful inner write is the panel's link-driven no-op. The
  * stored value was verified, but the enclosing subgraph input still holds the
  * render value — reporting that as a durable write is the #2488 lie. */
@@ -8577,13 +8618,11 @@ async function preparePromotedWidgetWrite(
     return promotedWriteRefusal(widget, "the panel session or connection changed while the mapping was read");
   }
 
-  const envelope = validatePromotedSubgraphEnvelope(payload, nodeId as number | string);
-  if (!envelope) {
-    return promotedWriteRefusal(
-      widget,
-      "graph_get_subgraph returned a malformed, stale, or incomplete ownership envelope",
-    );
+  const described = describePromotedSubgraphEnvelope(payload, nodeId as number | string);
+  if (!described.ok) {
+    return promotedEnvelopeInvariantRefusal(widget, described.invariant);
   }
+  const envelope = described.envelope;
   // panel#1859 — ask the HELLO before reading the witness out of the envelope.
   // A build that never advertised this fence also never writes
   // `subgraph_of.graph_identity` (both landed in panel 0.15.101; v0.15.85
@@ -8820,18 +8859,27 @@ async function recheckPromotedOuterMapping(
       "the current receiver advertised complete promoted-terminal witnesses but omitted the witness array",
     );
   }
-  const envelope = validatePromotedSubgraphEnvelope(payload, outerNodeId);
-  const observedScope = envelope ? promotedScopeWitnessFromEnvelope(envelope) : null;
-  const inner = envelope
-    ? resolvePromotedWriteTarget(
-        payload,
-        widget,
-        outerNodeId,
-        ctx.tabPromotedTerminalWitnessCapability?.() === true,
-      )
-    : null;
+  // #2688 — an envelope that fails a completeness invariant is named here too.
+  // Folding it into the combined refusal below reported a shape defect in the
+  // re-read as "the promoted inner mapping changed", which sends the caller
+  // looking for a canvas edit that never happened.
+  const describedRecheck = describePromotedSubgraphEnvelope(payload, outerNodeId);
+  if (!describedRecheck.ok) {
+    return promotedEnvelopeInvariantRefusal(
+      widget,
+      describedRecheck.invariant,
+      "the pre-write graph_get_subgraph re-read",
+    );
+  }
+  const envelope = describedRecheck.envelope;
+  const observedScope = promotedScopeWitnessFromEnvelope(envelope);
+  const inner = resolvePromotedWriteTarget(
+    payload,
+    widget,
+    outerNodeId,
+    ctx.tabPromotedTerminalWitnessCapability?.() === true,
+  );
   if (
-    !envelope ||
     !observedScope ||
     observedScope.workflowUuid !== expectedScope.workflowUuid ||
     observedScope.ownerNodeId !== expectedScope.ownerNodeId ||
@@ -8933,18 +8981,23 @@ async function recheckPromotedInnerTarget(
       );
     }
     const nestedPayload = parseToolResultJson(nested);
-    const nestedEnvelope = validatePromotedSubgraphEnvelope(
+    const describedNested = describePromotedSubgraphEnvelope(
       nestedPayload,
       expectedInner.innerNodeId,
     );
-    const nestedInner = nestedEnvelope
-      ? resolvePromotedWriteTarget(
-          nestedPayload,
-          expectedInner.widget,
-          expectedInner.innerNodeId,
-          ctx.tabPromotedTerminalWitnessCapability?.() === true,
-        )
-      : null;
+    if (!describedNested.ok) {
+      return promotedEnvelopeInvariantRefusal(
+        widget,
+        describedNested.invariant,
+        "the nested graph_get_subgraph read",
+      );
+    }
+    const nestedInner = resolvePromotedWriteTarget(
+      nestedPayload,
+      expectedInner.widget,
+      expectedInner.innerNodeId,
+      ctx.tabPromotedTerminalWitnessCapability?.() === true,
+    );
     if (
       !nestedInner?.terminal ||
       (ctx.tabPromotedTerminalWitnessCapability?.() === true && !nestedInner.parentRail) ||
@@ -21401,16 +21454,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
         const recoveryPayload = parseToolResultJson(sub);
-        const recoveryEnvelope = validatePromotedSubgraphEnvelope(
+        const describedRecovery = describePromotedSubgraphEnvelope(
           recoveryPayload,
           args.node_id as number | string,
         );
-        if (promotedEnvelopeCarriesEvidence(recoveryPayload) && !recoveryEnvelope) {
+        const recoveryEnvelope = describedRecovery.ok ? describedRecovery.envelope : null;
+        if (promotedEnvelopeCarriesEvidence(recoveryPayload) && !describedRecovery.ok) {
+          // #2688 — the recovery path had the same unnamed refusal. A legacy
+          // envelope that carries no evidence still falls through untouched
+          // below; only a receiver that DID publish evidence and then failed an
+          // invariant reaches here, and that one is worth naming.
           return appendToolResultText(
             first,
-            `\n\n(The panel listed "${refusal.widget}" as promoted while refusing it. ` +
-              `graph_get_subgraph returned a malformed, stale, or incomplete ownership ` +
-              `envelope, so the inner write was not retried.)`,
+            `\n\n${textOfToolResult(
+              promotedEnvelopeInvariantRefusal(refusal.widget, describedRecovery.invariant),
+            )}`,
           );
         }
         const recoveryScope = recoveryEnvelope

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8047,21 +8047,38 @@ function promotedWriteRefusal(widget: string, reason: string): ToolResult {
  * refused by an unrelated `promoted_terminals` entry, and without that line the
  * named index reads as irrelevant to their write.
  */
+function promotedEnvelopeInvariantText(
+  subject: string,
+  invariant: string,
+  consequence: string,
+): string {
+  return (
+    `${subject}'s ownership envelope failed a completeness invariant: ${invariant}. ` +
+    `${consequence}\n` +
+    // The remedy claim is scoped to what the verdict is actually a function of.
+    // An earlier draft said these three "do not clear it" outright; the verdict
+    // is decided from the REPLY, so what is provable is that re-reading the same
+    // receiver re-runs the same check on the same shape. Stating more than that
+    // would send the next reader hunting for a shape change that never happened.
+    `This is a SHAPE defect in the reply, not a binding state. The verdict is decided from that ` +
+    `one reply alone, so retrying re-reads the same receiver: unless the panel's reply itself ` +
+    `changes shape, panel_open_workflow and panel_set_workflow_target re-bind the tab and ` +
+    `produce the identical refusal.\n` +
+    `The envelope is accepted or rejected as a WHOLE: one unusable field, or one malformed ` +
+    `promoted_terminals entry, refuses every promoted write on this wrapper, including widgets ` +
+    `whose own mapping is fine. Report the invariant above together with the panel version — it ` +
+    `names the field to fix.`
+  );
+}
+
 function promotedEnvelopeInvariantRefusal(
   widget: string,
   invariant: string,
   subject = "graph_get_subgraph",
 ): ToolResult {
   return fail(
-    `panel_set_widget refused the promoted "${widget}" write because ${subject}'s ownership ` +
-      `envelope failed a completeness invariant: ${invariant}. No graph_set_widget was dispatched.\n` +
-      `This is a SHAPE defect in the reply, not a binding state. Every invariant is decided from ` +
-      `that one reply alone, so against an unchanged graph the same read reproduces it — retrying, ` +
-      `panel_open_workflow and panel_set_workflow_target do not clear it.\n` +
-      `The envelope is accepted or rejected as a WHOLE: one unusable field, or one malformed ` +
-      `promoted_terminals entry, refuses every promoted write on this wrapper, including widgets ` +
-      `whose own mapping is fine. Report the invariant above together with the panel version — it ` +
-      `names the field to fix.`,
+    `panel_set_widget refused the promoted "${widget}" write because ` +
+      promotedEnvelopeInvariantText(subject, invariant, "No graph_set_widget was dispatched."),
   );
 }
 
@@ -21466,9 +21483,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // invariant reaches here, and that one is worth naming.
           return appendToolResultText(
             first,
-            `\n\n${textOfToolResult(
-              promotedEnvelopeInvariantRefusal(refusal.widget, describedRecovery.invariant),
-            )}`,
+            `\n\n(The panel listed "${refusal.widget}" as promoted while refusing it. ` +
+              `${promotedEnvelopeInvariantText(
+                "graph_get_subgraph",
+                describedRecovery.invariant,
+                "The inner write was not retried.",
+              )})`,
           );
         }
         const recoveryScope = recoveryEnvelope

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -448,32 +448,85 @@ export function parsePromotedViewingIdentity(value: unknown): PromotedViewingIde
 }
 
 /**
- * Validate the ownership and completeness claims made by graph_get_subgraph.
+ * #2688 — WHY THIS RETURNS A REASON AND NOT JUST `null`.
+ *
+ * This validator has ~20 distinct rejection exits and every one of them used to
+ * surface as a single sentence: "graph_get_subgraph returned a malformed,
+ * stale, or incomplete ownership envelope", followed by "retry only after the
+ * panel binding and subgraph mapping are stable".
+ *
+ * That sentence is undiagnosable AND its remedy is wrong. Every check below is
+ * a pure function of ONE reply captured in ONE snapshot, so none of them is a
+ * binding state that settles: the reporter re-opened the workflow, re-bound the
+ * tab, and retried, and got the identical refusal every time, with no exit from
+ * the loop and nothing to report except "something in the envelope was wrong".
+ *
+ * The reason strings are deliberately SHAPE-ONLY — field paths, array indices,
+ * counts, and the two node ids that were compared (one of which is the caller's
+ * own argument). No widget name, no widget value, no node type, no title.
+ * Naming the failed invariant must not become a way to read a graph the fence
+ * is refusing to write to.
+ *
+ * The fence itself does not move. {@link validatePromotedSubgraphEnvelope} is
+ * this function with the reason discarded, so accept/reject is one decision in
+ * one place and cannot drift between the diagnostic and the authorization.
+ */
+export type PromotedSubgraphEnvelopeResult =
+  | { ok: true; envelope: PromotedSubgraphEnvelope }
+  | { ok: false; invariant: string };
+
+function envelopeInvariant(invariant: string): { ok: false; invariant: string } {
+  return { ok: false, invariant };
+}
+
+/**
+ * Validate the ownership and completeness claims made by graph_get_subgraph,
+ * and name the first claim that failed.
+ *
  * A node list is useful for a promoted write only when it names the wrapper the
  * caller asked about and contains exactly the advertised number of inner nodes.
  * The panel currently emits `truncated:false` for complete reads, but omission
  * remains accepted for older compatible replies; any asserted truncation is not.
  */
-export function validatePromotedSubgraphEnvelope(
+export function describePromotedSubgraphEnvelope(
   subgraph: Record<string, unknown> | null | undefined,
   ownerNodeId: number | string,
-): PromotedSubgraphEnvelope | null {
-  if (!isRecord(subgraph)) return null;
-  if (subgraph.truncated !== undefined && subgraph.truncated !== false) return null;
+): PromotedSubgraphEnvelopeResult {
+  if (!isRecord(subgraph)) {
+    return envelopeInvariant("the reply was not a JSON object");
+  }
+  if (subgraph.truncated !== undefined && subgraph.truncated !== false) {
+    return envelopeInvariant(
+      "the reply set `truncated`, so the inner node list it carried is not the whole subgraph",
+    );
+  }
 
   const viewing = Object.prototype.hasOwnProperty.call(subgraph, "viewing")
     ? parsePromotedViewingIdentity(subgraph.viewing)
     : undefined;
-  if (Object.prototype.hasOwnProperty.call(subgraph, "viewing") && !viewing) return null;
+  if (Object.prototype.hasOwnProperty.call(subgraph, "viewing") && !viewing) {
+    return envelopeInvariant(
+      "`viewing` was present but did not parse as a graph-scope identity " +
+        '(`scope` must be "root" or "subgraph"; `owner_node_id` must be a node id or null; ' +
+        "`workflow_uuid` and `graph_identity`, when present, must be non-empty strings)",
+    );
+  }
 
   const owner = subgraph.subgraph_of;
-  if (
-    !isRecord(owner) ||
-    !isNodeId(owner.node_id) ||
-    !isNodeId(ownerNodeId) ||
-    !sameNodeId(owner.node_id, ownerNodeId)
-  ) {
-    return null;
+  if (!isRecord(owner)) {
+    return envelopeInvariant("`subgraph_of` was missing or not an object");
+  }
+  if (!isNodeId(owner.node_id)) {
+    return envelopeInvariant("`subgraph_of.node_id` was missing or not a node id");
+  }
+  if (!isNodeId(ownerNodeId)) {
+    return envelopeInvariant("the addressed node id was not a usable node id");
+  }
+  if (!sameNodeId(owner.node_id, ownerNodeId)) {
+    return envelopeInvariant(
+      `\`subgraph_of.node_id\` named node ${stripNodeId(String(owner.node_id))}, ` +
+        `not the addressed node ${stripNodeId(String(ownerNodeId))}`,
+    );
   }
   const targetGraphIdentity = owner.graph_identity;
   if (
@@ -482,105 +535,191 @@ export function validatePromotedSubgraphEnvelope(
       targetGraphIdentity.length === 0 ||
       targetGraphIdentity.length > 256)
   ) {
-    return null;
+    return envelopeInvariant(
+      "`subgraph_of.graph_identity` was present but not a string of 1-256 characters",
+    );
   }
 
   const nodeCount = subgraph.node_count;
   const nodes = subgraph.nodes;
-  if (
-    !Number.isSafeInteger(nodeCount) ||
-    (nodeCount as number) < 0 ||
-    !Array.isArray(nodes) ||
-    nodes.length !== nodeCount
-  ) {
-    return null;
+  if (!Number.isSafeInteger(nodeCount) || (nodeCount as number) < 0) {
+    return envelopeInvariant("`node_count` was missing or not a non-negative integer");
+  }
+  if (!Array.isArray(nodes)) {
+    return envelopeInvariant("`nodes` was missing or not an array");
+  }
+  if (nodes.length !== nodeCount) {
+    return envelopeInvariant(
+      `\`node_count\` claimed ${nodeCount as number} inner node(s) but \`nodes\` carried ${nodes.length}`,
+    );
   }
 
   const normalized: Array<Record<string, unknown>> = [];
-  for (const raw of nodes) {
-    if (!isRecord(raw) || innerNodeId(raw) == null) return null;
+  for (const [index, raw] of nodes.entries()) {
+    if (!isRecord(raw) || innerNodeId(raw) == null) {
+      return envelopeInvariant(`\`nodes[${index}]\` was not an object carrying a usable \`id\``);
+    }
     const nodeIdentity = raw.node_identity;
     if (
       nodeIdentity !== undefined &&
       (typeof nodeIdentity !== "string" || nodeIdentity.length === 0 || nodeIdentity.length > 256)
     ) {
-      return null;
+      return envelopeInvariant(
+        `\`nodes[${index}].node_identity\` was present but not a string of 1-256 characters`,
+      );
     }
     normalized.push(raw);
   }
-  const promotedTerminals = Object.prototype.hasOwnProperty.call(subgraph, "promoted_terminals")
-    ? parsePromotedTerminalEntries(subgraph.promoted_terminals)
-    : undefined;
-  if (Object.prototype.hasOwnProperty.call(subgraph, "promoted_terminals") && !promotedTerminals) {
-    return null;
+  let promotedTerminals: PromotedTerminalEntry[] | undefined;
+  if (Object.prototype.hasOwnProperty.call(subgraph, "promoted_terminals")) {
+    const parsed = describePromotedTerminalEntries(subgraph.promoted_terminals);
+    if (!parsed.ok) return envelopeInvariant(parsed.invariant);
+    promotedTerminals = parsed.entries;
   }
   return {
-    nodes: normalized,
-    nodeId: stripNodeId(String(owner.node_id)),
-    nodeCount: nodeCount as number,
-    ...(targetGraphIdentity !== undefined ? { targetGraphIdentity } : {}),
-    ...(viewing ? { viewing } : {}),
-    ...(promotedTerminals ? { promotedTerminals } : {}),
+    ok: true,
+    envelope: {
+      nodes: normalized,
+      nodeId: stripNodeId(String(owner.node_id)),
+      nodeCount: nodeCount as number,
+      ...(targetGraphIdentity !== undefined ? { targetGraphIdentity } : {}),
+      ...(viewing ? { viewing } : {}),
+      ...(promotedTerminals ? { promotedTerminals } : {}),
+    },
   };
 }
 
-function parsePromotedTerminalEntries(value: unknown): PromotedTerminalEntry[] | null {
-  if (!Array.isArray(value)) return null;
+/**
+ * The fence. Identical accept/reject to
+ * {@link describePromotedSubgraphEnvelope} by construction — it IS that
+ * function with the reason dropped, so a diagnostic change can never widen
+ * what authorizes a promoted write.
+ */
+export function validatePromotedSubgraphEnvelope(
+  subgraph: Record<string, unknown> | null | undefined,
+  ownerNodeId: number | string,
+): PromotedSubgraphEnvelope | null {
+  const result = describePromotedSubgraphEnvelope(subgraph, ownerNodeId);
+  return result.ok ? result.envelope : null;
+}
+
+type PromotedTerminalEntriesResult =
+  | { ok: true; entries: PromotedTerminalEntry[] }
+  | { ok: false; invariant: string };
+
+/**
+ * The witness array is ALL-OR-NOTHING: one unusable entry refuses every
+ * promoted write on the wrapper, including widgets whose own entry is fine.
+ * That is deliberate — an array that cannot be fully parsed is not evidence of
+ * a complete alias mapping, and a partial mapping is exactly what would let a
+ * renamed promotion resolve to the wrong terminal. So each reason below names
+ * the OFFENDING INDEX, because the caller's own widget is usually not it.
+ */
+function describePromotedTerminalEntries(value: unknown): PromotedTerminalEntriesResult {
+  if (!Array.isArray(value)) {
+    return envelopeInvariant("`promoted_terminals` was present but not an array");
+  }
+  const at = (index: number, detail: string) =>
+    envelopeInvariant(`\`promoted_terminals[${index}]\` ${detail}`);
   const entries: PromotedTerminalEntry[] = [];
-  for (const raw of value) {
-    if (!isRecord(raw) || typeof raw.widget !== "string" || raw.widget.length === 0) return null;
+  for (const [index, raw] of value.entries()) {
+    if (!isRecord(raw)) return at(index, "was not an object");
+    if (typeof raw.widget !== "string" || raw.widget.length === 0) {
+      return at(index, "had a missing or empty `widget`");
+    }
     const immediateNodeId = raw.immediate_node_id;
-    if (immediateNodeId !== undefined && !isNodeId(immediateNodeId)) return null;
+    if (immediateNodeId !== undefined && !isNodeId(immediateNodeId)) {
+      return at(index, "carried an `immediate_node_id` that is not a node id");
+    }
     const immediateWidget = raw.immediate_widget;
-    if (immediateWidget !== undefined && (typeof immediateWidget !== "string" || immediateWidget.length === 0)) {
-      return null;
+    if (
+      immediateWidget !== undefined &&
+      (typeof immediateWidget !== "string" || immediateWidget.length === 0)
+    ) {
+      return at(index, "carried an `immediate_widget` that is not a non-empty string");
     }
     const error = raw.error;
-    if (error !== undefined && (typeof error !== "string" || error.length === 0)) return null;
-    const terminalRaw = raw.terminal_node_id === undefined && raw.terminal_node_type === undefined
-      ? undefined
-      : raw;
+    if (error !== undefined && (typeof error !== "string" || error.length === 0)) {
+      return at(index, "carried an `error` that is not a non-empty string");
+    }
+    const terminalRaw =
+      raw.terminal_node_id === undefined && raw.terminal_node_type === undefined ? undefined : raw;
     const parentRailRaw = raw.parent_rail;
     let parentRail: PromotedParentRailWitness | undefined;
     let terminal: PromotedTerminalWitness | undefined;
     if (terminalRaw) {
-      if (error !== undefined || immediateNodeId === undefined || immediateWidget === undefined) return null;
+      if (error !== undefined) {
+        return at(
+          index,
+          "published a terminal endpoint AND an `error`; a witness is one or the other",
+        );
+      }
+      if (immediateNodeId === undefined) {
+        return at(index, "published a terminal endpoint without `immediate_node_id`");
+      }
+      if (immediateWidget === undefined) {
+        return at(index, "published a terminal endpoint without `immediate_widget`");
+      }
       if (
         !isRecord(parentRailRaw) ||
         parentRailRaw.authoritative !== true ||
         typeof parentRailRaw.widget !== "string" ||
         parentRailRaw.widget.length === 0
       ) {
-        return null;
+        return at(
+          index,
+          "published a terminal endpoint without a `parent_rail` asserting `authoritative:true` and a non-empty `widget`",
+        );
       }
       const parentRailWidgetId = parentRailRaw.widget_id;
       if (
         parentRailWidgetId !== undefined &&
         (typeof parentRailWidgetId !== "string" || parentRailWidgetId.length === 0)
       ) {
-        return null;
+        return at(index, "carried a `parent_rail.widget_id` that is not a non-empty string");
       }
       parentRail = {
         authoritative: true,
         widget: parentRailRaw.widget,
         ...(parentRailWidgetId !== undefined ? { widgetId: parentRailWidgetId } : {}),
       };
-      if (!isNodeId(terminalRaw.terminal_node_id)) return null;
-      if (typeof terminalRaw.terminal_node_type !== "string" || terminalRaw.terminal_node_type.length === 0) {
-        return null;
+      if (!isNodeId(terminalRaw.terminal_node_id)) {
+        return at(index, "carried a `terminal_node_id` that is missing or not a node id");
       }
-      if (typeof terminalRaw.terminal_widget !== "string" || terminalRaw.terminal_widget.length === 0) {
-        return null;
+      if (
+        typeof terminalRaw.terminal_node_type !== "string" ||
+        terminalRaw.terminal_node_type.length === 0
+      ) {
+        return at(index, "carried a `terminal_node_type` that is missing or not a non-empty string");
+      }
+      if (
+        typeof terminalRaw.terminal_widget !== "string" ||
+        terminalRaw.terminal_widget.length === 0
+      ) {
+        return at(index, "carried a `terminal_widget` that is missing or not a non-empty string");
       }
       const chainDepth = terminalRaw.chain_depth;
-      if (!Number.isSafeInteger(chainDepth) || (chainDepth as number) < 0 || (chainDepth as number) > 16) {
-        return null;
+      if (
+        !Number.isSafeInteger(chainDepth) ||
+        (chainDepth as number) < 0 ||
+        (chainDepth as number) > 16
+      ) {
+        return at(index, "carried a `chain_depth` that is missing or outside 0-16");
       }
-      if (!Array.isArray(terminalRaw.terminal_inputs)) return null;
+      if (!Array.isArray(terminalRaw.terminal_inputs)) {
+        return at(index, "carried a `terminal_inputs` that is missing or not an array");
+      }
       const inputs: PromotedTerminalInput[] = [];
-      for (const input of terminalRaw.terminal_inputs) {
-        if (!isRecord(input) || typeof input.name !== "string" || input.name.length === 0) return null;
-        if (input.type !== undefined && typeof input.type !== "string") return null;
+      for (const [inputIndex, input] of terminalRaw.terminal_inputs.entries()) {
+        if (!isRecord(input) || typeof input.name !== "string" || input.name.length === 0) {
+          return at(
+            index,
+            `carried a \`terminal_inputs[${inputIndex}]\` without a non-empty \`name\``,
+          );
+        }
+        if (input.type !== undefined && typeof input.type !== "string") {
+          return at(index, `carried a \`terminal_inputs[${inputIndex}].type\` that is not a string`);
+        }
         inputs.push({ name: input.name, ...(input.type !== undefined ? { type: input.type } : {}) });
       }
       terminal = {
@@ -591,7 +730,11 @@ function parsePromotedTerminalEntries(value: unknown): PromotedTerminalEntry[] |
         chainDepth: chainDepth as number,
       };
     } else if (error === undefined) {
-      return null;
+      return at(
+        index,
+        "published neither a terminal endpoint (`terminal_node_id`/`terminal_node_type`) nor an `error`, " +
+          "so the witness array cannot be read as a complete alias mapping",
+      );
     }
     entries.push({
       widget: raw.widget,
@@ -602,7 +745,7 @@ function parsePromotedTerminalEntries(value: unknown): PromotedTerminalEntry[] |
       ...(error !== undefined ? { error } : {}),
     });
   }
-  return entries;
+  return { ok: true, entries };
 }
 
 /** Extract the target owner and workflow identity from a validated promotion

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -497,7 +497,8 @@ export function describePromotedSubgraphEnvelope(
   }
   if (subgraph.truncated !== undefined && subgraph.truncated !== false) {
     return envelopeInvariant(
-      "the reply set `truncated`, so the inner node list it carried is not the whole subgraph",
+      "the reply's `truncated` flag was not `false`, so the inner node list it carried " +
+        "cannot be taken as the whole subgraph",
     );
   }
 
@@ -555,7 +556,12 @@ export function describePromotedSubgraphEnvelope(
   }
 
   const normalized: Array<Record<string, unknown>> = [];
-  for (const [index, raw] of nodes.entries()) {
+  // Indexed, not `nodes.entries()`: the array is parsed from an untrusted reply
+  // and `entries` is an own-property a caller can shadow, which would iterate
+  // something other than what `nodes.length !== nodeCount` was checked against.
+  // The loops this replaced walked `Symbol.iterator`; an index walks neither.
+  for (let index = 0; index < nodes.length; index += 1) {
+    const raw: unknown = nodes[index];
     if (!isRecord(raw) || innerNodeId(raw) == null) {
       return envelopeInvariant(`\`nodes[${index}]\` was not an object carrying a usable \`id\``);
     }
@@ -622,7 +628,9 @@ function describePromotedTerminalEntries(value: unknown): PromotedTerminalEntrie
   const at = (index: number, detail: string) =>
     envelopeInvariant(`\`promoted_terminals[${index}]\` ${detail}`);
   const entries: PromotedTerminalEntry[] = [];
-  for (const [index, raw] of value.entries()) {
+  // Indexed for the same reason as the node loop above.
+  for (let index = 0; index < value.length; index += 1) {
+    const raw: unknown = value[index];
     if (!isRecord(raw)) return at(index, "was not an object");
     if (typeof raw.widget !== "string" || raw.widget.length === 0) {
       return at(index, "had a missing or empty `widget`");
@@ -710,7 +718,9 @@ function describePromotedTerminalEntries(value: unknown): PromotedTerminalEntrie
         return at(index, "carried a `terminal_inputs` that is missing or not an array");
       }
       const inputs: PromotedTerminalInput[] = [];
-      for (const [inputIndex, input] of terminalRaw.terminal_inputs.entries()) {
+      const rawInputs: unknown[] = terminalRaw.terminal_inputs;
+      for (let inputIndex = 0; inputIndex < rawInputs.length; inputIndex += 1) {
+        const input: unknown = rawInputs[inputIndex];
         if (!isRecord(input) || typeof input.name !== "string" || input.name.length === 0) {
           return at(
             index,


### PR DESCRIPTION
Closes #2688.

## The defect

`panel_set_widget` refused a promoted COMBO write with:

> graph_get_subgraph returned a malformed, stale, or incomplete ownership envelope. No graph_set_widget was dispatched; retry only after the panel binding and subgraph mapping are stable.

`validatePromotedSubgraphEnvelope` has **~20 distinct `return null` exits** — asserted truncation, an unparseable `viewing`, an owner id that does not name the addressed node, a `node_count`/`nodes` disagreement, an inner node without a usable id, and a dozen promoted-terminal witness shapes. All of them collapsed into that one sentence.

Both halves of it failed the reporter:

1. **It named nothing**, so there was no way to tell whether the cause was panel-side drift or an over-strict invariant on our side. They filed the issue asking us to "make `graph_get_subgraph` publish a complete envelope" without being able to say *which field was missing* — because nothing told them.
2. **Its remedy is wrong.** Every invariant is decided from ONE reply in ONE snapshot; none of them is a binding state that settles. They retried, re-opened the workflow, and re-bound the tab, and got the identical text every time, on the same node. There was no exit from that loop.

Same defect class as #2374 / panel#1869, which relayed the panel's own divergence diagnosis instead of overwriting it with this file's retry advice.

## The change

`describePromotedSubgraphEnvelope` is the same decision, returning the reason it rejected on. `validatePromotedSubgraphEnvelope` is now **that function with the reason dropped** — one decision in one place, so the diagnostic cannot drift from the authorization. All four refusal sites route through it (initial classification, the pre-write re-read, the nested-terminal read, and the post-refusal recovery path); the last three had the identical unnamed wording.

**The fence does not move.** No invariant was added, removed, loosened or reordered.

**The reason text is shape-only** — field paths, array indices, counts, and the two node ids that were compared (one of which is the caller's own argument). No widget name, no widget value, no node type, no title. Naming the invariant must not become a way to read a graph the fence is refusing to write to. That is asserted, not just intended.

## Where the load-bearing claims are

- **`promoted-widget.ts` — the fence-equivalence claim.** Everything rests on `validatePromotedSubgraphEnvelope` still accepting and rejecting exactly what it did. It is now a two-line wrapper, so the risk is not in the wrapper but in whether the *reordered* checks inside `describePromotedSubgraphEnvelope` are the same predicate. The `node_count`/`nodes` block in particular was one combined `if` and is now three, and `parsePromotedTerminalEntries` was split into per-condition returns. Evidence below.
- **`panel-tools.ts:8823` — a behaviour change beyond wording.** The pre-write re-read used to fold an envelope failure into `"the promoted inner mapping changed or became unverifiable before the write"`, together with five other conditions. It now returns early and names the invariant. Still fail-closed, but a shape defect there no longer reports as a canvas edit the user did not make.
- **The two corrected tests.** They asserted the retry wording on the stated premise that *"a malformed envelope is a genuine transient … the one a retry can clear."* That premise is what this issue disproves. Both keep the panel#1859 claim they exist to make (a current build must not receive the build-skew message) and drop the false one.

## Evidence

**Differential equivalence vs. the pre-change fence.** A throwaway harness vendored `origin/main`'s validator and compared it against the new one over a generated corpus — every field of a valid envelope deleted and poisoned with 28 values, plus legacy/edge shapes, across 9 owner ids:

```
cases=12753 accepted=1108 rejected=11645
mismatches=0 leaks=0
```

Zero disagreement on accept/reject, zero disagreement on the returned envelope value, no input mutation, and no graph content in any reason string.

**Controls — the harness detects a fence movement in both directions:**

| mutation | result |
|---|---|
| relax the `truncated` check (accept more) | 50 mismatches |
| require `viewing` (accept less) | 6 mismatches |
| leak the offending array into a reason | 184 leaks |

**Mutation-testing the committed tests** (fix committed first, then reverted piecewise):

| mutation | tests red |
|---|---|
| primary call site back to `promotedWriteRefusal` + the generic sentence | **15** |
| every invariant collapsed to one generic reason | **31** |
| the fence made to disagree with the description (accepts a truncated read) | **2** (incl. the parity test) |
| graph content leaked into two invariants | **3** (incl. both privacy assertions) |

The parity test also asserts `accepted > 0`, so a corpus that rejected everything cannot pass it vacuously.

## Verification

- `npx vitest run` — **746 files, 13787 passed**, 6 skipped, 0 failed.
- `tsc --noEmit` clean. Note `tsconfig` excludes the test tree, so the test changes were validated by vitest, not by tsc.
- `check-anti-slop.mjs` — `785 known finding(s) … none added` (oxlint 1.79.0 installed into the worktree first; it is absent by default and the gate exits non-zero without it, which reads as a pass if you only check that the command ran).
- `check-tool-vocabulary.mts` OK, `check-unknown-collapse.mjs` OK.
- **No Playwright run, and none is claimed.** This change is orchestrator-side only: it alters a refusal string returned by the `panel_set_widget` MCP tool. Nothing the sidebar renders is touched — no file under the panel repo is in this diff.

## What I deliberately did NOT do

The reporter asked for two things. This is the second one.

The first — *"make `graph_get_subgraph` publish a complete envelope for this live subgraph"* — is a **panel** change, and I could not identify which field their receiver failed on. Their panel (0.15.149) is current with panel `origin/main`, `panel_enter_subgraph` succeeds on the same node, and `panel_graph_outline` reads the wrapper correctly, so the envelope is being built by code that mostly works. Guessing at a producer fix without knowing the failing invariant risks a change premised on a defect that does not exist.

That is precisely what this PR unblocks: their next reproduction reports the field. I have not relaxed anything to compensate for not knowing, and I did not attempt the "safe local relaxation of the ownership fence" they correctly declined to make themselves.

One candidate worth naming for whoever picks up the panel half: `promotedTerminalWitnesses` builds error entries as `{ widget, immediate_node_id: resolution.target.node?.id, immediate_widget: …, error }`, and the consumer rejects the **entire** array if any single entry publishes neither a terminal endpoint nor an `error`, or publishes a terminal without an authoritative `parent_rail`. So one unrelated promoted alias can refuse every promoted write on the wrapper — which matches the reported symptom (deterministic, unaffected by rebinding, while the widget itself looks fine). Unconfirmed against their graph; the named invariant will confirm or kill it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
