### PR TITLE
fix(manifest): accept current panel path metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - panel_run(to_node_id) treats the paired random-mode seed-control graph-stamp diff as queue-time volatility rather than a real graph mismatch, while outer WorkerTransport failures remain outcome-unknown and are fenced for control-plane recovery (#2120)
+- panel-connected apply_manifest adopts the current panel-reported local ComfyUI path when COMFYUI_PATH is unset (#463)
 
 ## [0.52.165] - 2026-08-30
 

--- a/src/__tests__/services/panel-status-base-path.test.ts
+++ b/src/__tests__/services/panel-status-base-path.test.ts
@@ -81,6 +81,19 @@ describe("fetchPanelBasePath (#296)", () => {
     expect(await fetchPanelBasePath("http://127.0.0.1:8188")).toBe("/opt/ComfyUI");
   });
 
+  it("reads the current panel status comfyui_path field", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      // Current panel builds expose folder_paths.base_path under this key.
+      json: async () => ({ comfyui_path: "/panel/current/ComfyUI" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    expect(await fetchPanelBasePath("http://127.0.0.1:8188")).toBe("/panel/current/ComfyUI");
+  });
+
   it("carries the ComfyUI auth headers so a token-gated panel answers", async () => {
     process.env.COMFYUI_AUTH_TOKEN = "abc123";
     const fetchMock = vi.fn().mockResolvedValue({
@@ -191,6 +204,27 @@ describe("resolveComfyuiPathForTarget (#296 adoption decision)", () => {
     });
     expect(out).toBe("/panel/ComfyUI");
     expect(fetchBasePath).toHaveBeenCalledWith(LOOPBACK);
+  });
+
+  it("adopts a current panel comfyui_path through the production fetcher", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ comfyui_path: "/panel/current/ComfyUI" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { resolveComfyuiPathForTarget } = await import("../../services/secure-bridge.js");
+    const out = await resolveComfyuiPathForTarget({
+      target: LOOPBACK,
+      localPath: undefined,
+      forceRemote: false,
+      isLoopback: true,
+      exists: (p) => p === "/panel/current/ComfyUI",
+    });
+
+    expect(out).toBe("/panel/current/ComfyUI");
+    expect(fetchMock).toHaveBeenCalled();
   });
 
   it("REFUSES a panel base_path that does not exist on this machine", async () => {

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -141,8 +141,11 @@ export async function fetchPanelBasePath(
     if (!res.ok) return undefined;
     const data = (await res.json()) as unknown;
     if (!data || typeof data !== "object") return undefined;
-    // The route's field is snake_case `base_path`; tolerate a camelCase alias.
+    // Current panel builds publish this as `comfyui_path` (the live
+    // folder_paths.base_path). Keep the original `base_path` spelling and the
+    // camelCase alias for older/interoperating panel builds.
     const raw =
+      (data as { comfyui_path?: unknown }).comfyui_path ??
       (data as { base_path?: unknown }).base_path ??
       (data as { basePath?: unknown }).basePath;
     if (typeof raw === "string" && raw.trim()) return raw.trim();


### PR DESCRIPTION
Summary: Accept the current panel status comfyui_path field when resolving the local ComfyUI root; preserve legacy base_path/basePath compatibility and existing loopback, existence, and fail-closed checks; add production-path coverage for adoption with COMFYUI_PATH unset. The panel status route publishes the verified local folder_paths.base_path as comfyui_path; missing that field caused the #463 recurrence. This fix does not infer a path from argv[0], dispatch remote targets, or alter authorization. Validation: focused 41 tests, full Vitest 746 files / 13,792 passed / 6 skipped, build, lint, changelog, and diff checks passed. Aggregate npm test could not start because the environment rejected process creation with Access denied. Fixes #463