### PR TITLE
chore: release 0.52.166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,24 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.166] - 2026-09-01
+
 ### MCP
 
 #### Fixed
-- panel_run(to_node_id) treats the paired random-mode seed-control graph-stamp diff as queue-time volatility rather than a real graph mismatch, while outer WorkerTransport failures remain outcome-unknown and are fenced for control-plane recovery (#2120)
-- panel-connected apply_manifest adopts the current panel-reported local ComfyUI path when COMFYUI_PATH is unset (#463)
+- panel_run(to_node_id) treats the paired random-mode seed-control graph-stamp diff as queue-time volatility rather than a real graph mismatch, while outer WorkerTransport failures remain outcome-unknown and are fenced for control-plane recovery (#2120, #2670)
+- panel-connected apply_manifest adopts the current panel-reported local ComfyUI path when COMFYUI_PATH is unset (#463, #2695)
+
+- handle DaSiWa seed stamp recurrence safely
+- ignore seed-only run-to-node stamp races
+- a promoted write refused by the ownership envelope names the invariant that failed (#2690)
+- terminate a generated API-node prompt with a sink matching its output type (#2687)
+- stop asserting a run the ComfyUI server has not confirmed (#2685)
+- flag an image-edit graph whose sampled canvas is not derived from the reference (#2683)
+- flag a sampler set below full denoise over an empty latent before it renders a flat field (#2682)
+- a loader input naming a file the server does not have says where it looked, and how to fix it (#2679)
+- a Windows updater that cannot reach npm or git says so, and says what to do (#2672)
+
 
 ## [0.52.165] - 2026-08-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.165",
+  "version": "0.52.166",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.165",
+      "version": "0.52.166",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.165",
+  "version": "0.52.166",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Release 0.52.166

Includes merged fixes #2670 and #2695.

## Validation
- check-changelog
- git diff --check
- Release CI must pass before merge/tag
- No init.py or apps_routes.py changes.