### PR TITLE
fix(2703): a PANEL_FETCH_FAILED panel read now names its cause

### DIFF
--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -224,4 +224,43 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
     await expect(getLogs()).rejects.toThrow(/read fallback failed safely \(TIMEOUT\)/);
     expect(panelRead).toHaveBeenCalledWith("logs");
   });
+
+  // #2703 — the reporter's own call. A dead COMFYUI_URL plus a live panel whose
+  // read declined, and the message named only the code. The relay now carries
+  // the cause; this pins that get_history's CALL SITE actually says it, because
+  // this message is built from the code here — not taken from the relay error —
+  // so a relay that carries a reason nobody reads would still ship the dead end.
+  it("names the panel-side cause behind a PANEL_FETCH_FAILED history read", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockRejectedValue(
+      new PanelComfyUIReadRelayError(
+        "The connected panel could not read ComfyUI.",
+        "PANEL_FETCH_FAILED",
+        false,
+        "fetch_comfyui_read response exceeds the 16777216-byte limit",
+      ),
+    );
+
+    const failure = await getHistory().then(
+      () => undefined,
+      (error: unknown) => error as Error,
+    );
+    expect(failure?.message).toContain("read fallback failed safely (PANEL_FETCH_FAILED)");
+    expect(failure?.message).toContain("The panel reported: fetch_comfyui_read response exceeds the 16777216-byte limit");
+    expect(panelRead).toHaveBeenCalledWith("history");
+  });
+
+  it("keeps the bare code when the relay carried no cause", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelRead.mockRejectedValue(
+      new PanelComfyUIReadRelayError("The connected panel could not read ComfyUI.", "PANEL_FETCH_FAILED"),
+    );
+
+    const failure = await getHistory().then(
+      () => undefined,
+      (error: unknown) => error as Error,
+    );
+    expect(failure?.message).toContain("read fallback failed safely (PANEL_FETCH_FAILED).");
+    expect(failure?.message).not.toContain("The panel reported:");
+  });
 });

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const panelRead = vi.hoisted(() => vi.fn());
+const panelImage = vi.hoisted(() => vi.fn());
 const fetchApi = vi.hoisted(() => vi.fn());
 
 const VALID_OBJECT_INFO = {
@@ -58,7 +59,7 @@ vi.mock("../../services/panel-image-relay.js", async () => {
   const actual = await vi.importActual<typeof import("../../services/panel-image-relay.js")>(
     "../../services/panel-image-relay.js",
   );
-  return { ...actual, requestPanelComfyUIRead: panelRead };
+  return { ...actual, requestPanelComfyUIRead: panelRead, requestPanelImage: panelImage };
 });
 
 import {
@@ -72,6 +73,7 @@ import {
 } from "../../comfyui/client.js";
 import {
   PanelComfyUIReadRelayError,
+  PanelImageRelayError,
   PANEL_COMFYUI_READ_MAX_BYTES,
   PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES,
 } from "../../services/panel-image-relay.js";
@@ -86,6 +88,7 @@ function transportFailure(): TypeError {
 beforeEach(() => {
   fetchApi.mockReset();
   panelRead.mockReset();
+  panelImage.mockReset();
   resetClient();
   resetObjectInfoCache();
   vi.stubGlobal("fetch", vi.fn(async () => { throw transportFailure(); }));
@@ -248,6 +251,28 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
     expect(failure?.message).toContain("read fallback failed safely (PANEL_FETCH_FAILED)");
     expect(failure?.message).toContain("The panel reported: fetch_comfyui_read response exceeds the 16777216-byte limit");
     expect(panelRead).toHaveBeenCalledWith("history");
+  });
+
+  // #2703 — the SIBLING call site. fetchImage builds its own message from the
+  // code the same way, and mutating this line alone left every other test green:
+  // a fix on one exit with an untested twin is a fix that half-ships.
+  it("names the panel-side cause behind a PANEL_FETCH_FAILED image read", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    panelImage.mockRejectedValue(
+      new PanelImageRelayError(
+        "The connected panel could not fetch that image.",
+        "PANEL_FETCH_FAILED",
+        false,
+        "fetch_image could not reach /view: Failed to fetch",
+      ),
+    );
+
+    const failure = await fetchImage("render.png").then(
+      () => undefined,
+      (error: unknown) => error as Error,
+    );
+    expect(failure?.message).toContain("image relay failed safely (PANEL_FETCH_FAILED)");
+    expect(failure?.message).toContain("The panel reported: fetch_image could not reach /view: Failed to fetch");
   });
 
   it("keeps the bare code when the relay carried no cause", async () => {

--- a/src/__tests__/services/panel-relay-failure-reason.test.ts
+++ b/src/__tests__/services/panel-relay-failure-reason.test.ts
@@ -380,12 +380,21 @@ describe("#2703 — a PANEL_FETCH_FAILED read names its cause", () => {
   });
 
   it("refuses a reason reached through a polluted prototype", async () => {
-    // `hasOwn` says "absent" for an inherited `reason` while every reader —
-    // including the MAC payload — sees it. The digest mismatch alone already
-    // refuses this reply, so the guard is the second line rather than the only
-    // one; it is here so the validator does not depend on another check's
-    // arithmetic to be correct (codex gate r2, finding 2).
+    // Codex gate r2, finding 2. `hasOwn` says "absent" for an inherited
+    // `reason` while every reader — including the MAC payload — sees it.
+    //
+    // The peer here signs the SIX-element digest INCLUDING the inherited value,
+    // which is what makes this a live hole rather than a redundancy: the
+    // response body carries no `reason` key at all, so an own-property check
+    // sees a plain reasonless failure, while `responseMacPayload` reads the
+    // prototype's value and computes exactly the digest the peer sent. The MAC
+    // therefore VERIFIES, and `validFailureReason` is the only thing left
+    // standing between a 5000-character string and the user's error message.
+    // (An earlier draft of this test had the peer sign the five-element digest;
+    // that reply is refused by the MAC and the guard never runs, so it proved
+    // nothing — mutation testing said so by leaving the guard alive.)
     const polluted: { reason?: string } = Object.prototype;
+    polluted.reason = "z".repeat(5_000);
     const server = await staticSignedReply((requestId) => {
       const unsigned = {
         version: PANEL_IMAGE_RELAY_VERSION,
@@ -398,12 +407,18 @@ describe("#2703 — a PANEL_FETCH_FAILED read names its cause", () => {
         ...unsigned,
         responseMac: createHmac("sha256", SECRET)
           .update(
-            JSON.stringify([unsigned.version, unsigned.requestId, false, unsigned.error, unsigned.updated]),
+            JSON.stringify([
+              unsigned.version,
+              unsigned.requestId,
+              false,
+              unsigned.error,
+              unsigned.updated,
+              polluted.reason,
+            ]),
           )
           .digest("hex"),
       };
     });
-    polluted.reason = "z".repeat(5_000);
     try {
       const failure = (await requestPanelComfyUIRead("history").then(
         () => undefined,

--- a/src/__tests__/services/panel-relay-failure-reason.test.ts
+++ b/src/__tests__/services/panel-relay-failure-reason.test.ts
@@ -385,7 +385,7 @@ describe("#2703 — a PANEL_FETCH_FAILED read names its cause", () => {
     // refuses this reply, so the guard is the second line rather than the only
     // one; it is here so the validator does not depend on another check's
     // arithmetic to be correct (codex gate r2, finding 2).
-    const polluted = Object.prototype as unknown as { reason?: string };
+    const polluted: { reason?: string } = Object.prototype;
     const server = await staticSignedReply((requestId) => {
       const unsigned = {
         version: PANEL_IMAGE_RELAY_VERSION,

--- a/src/__tests__/services/panel-relay-failure-reason.test.ts
+++ b/src/__tests__/services/panel-relay-failure-reason.test.ts
@@ -1,0 +1,274 @@
+// #2703 — a connected-panel read that fails must say WHY, not only that it failed.
+//
+// The reporter's session had a dead COMFYUI_URL and a live sidebar panel, so the
+// #2532 read fallback was the one path that could have answered. It declined
+// with `PANEL_FETCH_FAILED`, which the relay returns for EVERY non-timeout throw
+// out of `bridge.send` — the panel's own too_large / timeout / network_error /
+// http_error / invalid_origin / redirect_error / api_unavailable, the
+// workflow-reload guard, and "Unknown command" from a pre-relay panel all
+// collapse into that one token. The error naming which of them it was already
+// existed inside the relay; it was dropped before the response was built.
+//
+// These exercise the REAL loopback relay server end to end (a live HTTP round
+// trip, the real capability and the real response MAC), because the collapse
+// happened in the response the server writes, not in a helper.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHmac } from "node:crypto";
+import {
+  PANEL_IMAGE_RELAY_VERSION,
+  PanelComfyUIReadRelayError,
+  PanelImageRelayError,
+  requestPanelComfyUIRead,
+  requestPanelImage,
+  startPanelImageRelayServer,
+  verifyPanelComfyUIReadRelayCapability,
+  verifyPanelImageRelayCapability,
+} from "../../services/panel-image-relay.js";
+
+const SECRET = "b".repeat(64);
+const TARGET_URL = "http://127.0.0.1:8188";
+const TARGET_GENERATION = 3;
+
+const savedEnv = {
+  secret: process.env.COMFYUI_MCP_RELAY_SECRET,
+  url: process.env.COMFYUI_MCP_RELAY_URL,
+  comfyui: process.env.COMFYUI_URL,
+  generation: process.env.COMFYUI_MCP_TARGET_GENERATION,
+};
+
+beforeEach(() => {
+  process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+  process.env.COMFYUI_URL = TARGET_URL;
+  process.env.COMFYUI_MCP_TARGET_GENERATION = String(TARGET_GENERATION);
+});
+
+afterEach(() => {
+  for (const [key, value] of [
+    ["COMFYUI_MCP_RELAY_SECRET", savedEnv.secret],
+    ["COMFYUI_MCP_RELAY_URL", savedEnv.url],
+    ["COMFYUI_URL", savedEnv.comfyui],
+    ["COMFYUI_MCP_TARGET_GENERATION", savedEnv.generation],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+/** Start the real relay in front of a bridge whose send REJECTS, which is the
+ *  exact shape a panel executor throw takes when it reaches the relay. */
+async function relayRejectingWith(error: unknown) {
+  const server = await startPanelImageRelayServer({
+    resolvePanelAgent: (value) => {
+      // Each verifier answers for ONE request shape; asking the wrong one first
+      // is how this harness turned a PANEL_FETCH_FAILED into RELAY_UNAVAILABLE.
+      const ok = ((): boolean => {
+        try {
+          if ("operation" in (value as Record<string, unknown>)) {
+            return verifyPanelComfyUIReadRelayCapability(SECRET, value);
+          }
+          return verifyPanelImageRelayCapability(SECRET, value);
+        } catch {
+          return false;
+        }
+      })();
+      return ok ? { agentKey: "orchestrator::claude", secret: SECRET } : undefined;
+    },
+    resolvePanelTab: () => "panel-tab",
+    resolveCurrentTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+    resolvePanelTarget: () => ({ url: TARGET_URL, generation: TARGET_GENERATION }),
+    bridge: {
+      canReach: () => true,
+      send: vi.fn(async () => {
+        throw error;
+      }),
+    },
+  });
+  process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
+  return server;
+}
+
+describe("#2703 — a PANEL_FETCH_FAILED read names its cause", () => {
+  it("carries the panel's own message back through the signed response", async () => {
+    // The panel's real too_large text. This is the case that is INDISTINGUISH-
+    // ABLE from every other cause under the bare code, and the one where the
+    // remedy (ask for one prompt_id, not the whole history) depends entirely on
+    // knowing which it was.
+    const server = await relayRejectingWith(
+      new Error("fetch_comfyui_read response exceeds the 16777216-byte limit"),
+    );
+    try {
+      const failure = await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect(failure).toBeInstanceOf(PanelComfyUIReadRelayError);
+      const relayError = failure as PanelComfyUIReadRelayError;
+      expect(relayError.code).toBe("PANEL_FETCH_FAILED");
+      expect(relayError.reason).toBe("fetch_comfyui_read response exceeds the 16777216-byte limit");
+      expect(relayError.message).toContain("16777216-byte limit");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("distinguishes an old panel from a failed read, which the code alone cannot", async () => {
+    // Same code, entirely different remedy: update the panel.
+    const server = await relayRejectingWith(new Error('Unknown command "fetch_comfyui_read"'));
+    try {
+      const failure = await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect((failure as PanelComfyUIReadRelayError).code).toBe("PANEL_FETCH_FAILED");
+      expect((failure as PanelComfyUIReadRelayError).reason).toBe('Unknown command "fetch_comfyui_read"');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("bounds a hostile reason instead of forwarding it, and never drops the code", async () => {
+    // Control characters would let a panel forge extra lines in an agent-facing
+    // error; length would let it move a payload. Both are handled without
+    // losing the failure itself.
+    const server = await relayRejectingWith(
+      new Error(`line one\nline two${"x".repeat(500)}`),
+    );
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("PANEL_FETCH_FAILED");
+      expect(failure.reason).toBeDefined();
+      expect(failure.reason!.length).toBeLessThanOrEqual(200);
+      expect([...failure.reason!].every((char) => char.charCodeAt(0) >= 0x20 && char.charCodeAt(0) !== 0x7f)).toBe(true);
+      expect(failure.reason).toContain("line one line two");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("says nothing rather than something empty when the throw carries no message", async () => {
+    const server = await relayRejectingWith(new Error("   "));
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("PANEL_FETCH_FAILED");
+      expect(failure.reason).toBeUndefined();
+      // The pre-#2703 sentence, unchanged, with nothing bolted onto it.
+      expect(failure.message).toBe("The connected panel could not read ComfyUI.");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("carries the cause on the image relay too — one catch produces both codes", async () => {
+    const server = await relayRejectingWith(new Error("fetch_image could not reach /view: Failed to fetch"));
+    try {
+      const failure = (await requestPanelImage("render.png", "output", "").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelImageRelayError;
+      expect(failure).toBeInstanceOf(PanelImageRelayError);
+      expect(failure.code).toBe("PANEL_FETCH_FAILED");
+      expect(failure.reason).toBe("fetch_image could not reach /view: Failed to fetch");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("refuses a correctly SIGNED reason that breaks the bound", async () => {
+    // A peer holding the relay secret is not thereby allowed to hand the agent
+    // an unbounded sentence: the MAC proves WHO wrote it, never that what they
+    // wrote is within contract. Without the field validation this reply is
+    // authentic, oversized, and accepted.
+    const upstream = await relayRejectingWith(new Error("genuine cause"));
+    const honestEndpoint = process.env.COMFYUI_MCP_RELAY_URL as string;
+    const { createServer } = await import("node:http");
+    const resigner = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", async () => {
+        const forwarded = await fetch(honestEndpoint, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: Buffer.concat(chunks),
+        });
+        const body = (await forwarded.json()) as Record<string, unknown>;
+        body.reason = "z".repeat(5_000);
+        body.responseMac = createHmac("sha256", SECRET)
+          .update(
+            JSON.stringify([
+              PANEL_IMAGE_RELAY_VERSION,
+              body.requestId,
+              false,
+              body.error,
+              body.updated,
+              body.reason,
+            ]),
+          )
+          .digest("hex");
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(body));
+      });
+    });
+    await new Promise<void>((resolve) => resigner.listen(0, "127.0.0.1", () => resolve()));
+    const port = (resigner.address() as { port: number }).port;
+    process.env.COMFYUI_MCP_RELAY_URL = `http://127.0.0.1:${port}${new URL(honestEndpoint).pathname}`;
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("MALFORMED_REPLY");
+      expect(failure.reason).toBeUndefined();
+      expect(failure.message).not.toContain("zzz");
+    } finally {
+      await new Promise<void>((resolve) => resigner.close(() => resolve()));
+      await upstream.close();
+    }
+  });
+
+  it("refuses a reason the relay did not sign", async () => {
+    // The reason is read out loud and attributed to the panel, so it has to be
+    // covered by the response MAC. A man-in-the-middle on the loopback endpoint
+    // that appends one must be rejected outright, not believed.
+    const upstream = await relayRejectingWith(new Error("genuine cause"));
+    // Captured BEFORE the env is repointed at the proxy: reading it inside the
+    // handler makes the proxy forward to itself.
+    const honestEndpoint = process.env.COMFYUI_MCP_RELAY_URL as string;
+    const { createServer } = await import("node:http");
+    const tamper = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", async () => {
+        const forwarded = await fetch(honestEndpoint, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: Buffer.concat(chunks),
+        });
+        const body = (await forwarded.json()) as Record<string, unknown>;
+        // Same MAC, different sentence.
+        body.reason = "a cause the relay never signed";
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(body));
+      });
+    });
+    await new Promise<void>((resolve) => tamper.listen(0, "127.0.0.1", () => resolve()));
+    const port = (tamper.address() as { port: number }).port;
+    process.env.COMFYUI_MCP_RELAY_URL = `http://127.0.0.1:${port}${new URL(honestEndpoint).pathname}`;
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("MALFORMED_REPLY");
+      expect(failure.message).not.toContain("never signed");
+    } finally {
+      await new Promise<void>((resolve) => tamper.close(() => resolve()));
+      await upstream.close();
+    }
+  });
+});

--- a/src/__tests__/services/panel-relay-failure-reason.test.ts
+++ b/src/__tests__/services/panel-relay-failure-reason.test.ts
@@ -334,11 +334,13 @@ describe("#2703 — a PANEL_FETCH_FAILED read names its cause", () => {
     }
   });
 
-  it("does not attach a correctly signed reason to a code that never carries one", async () => {
-    // Codex gate, finding 1. Our writer only ever mints a reason alongside
-    // PANEL_FETCH_FAILED, but the response is input that merely has to verify —
-    // so the READER has to enforce that, not assume it. A signed TIMEOUT with a
-    // reason was previously appended to the caller's timeout message.
+  it("refuses a correctly signed reason on a code that never carries one", async () => {
+    // Codex gate r1 finding 1, then r2 finding 1. Our writer only ever mints a
+    // reason alongside PANEL_FETCH_FAILED, but the response is input that
+    // merely has to verify — so the READER enforces it. The first draft dropped
+    // the reason at render time and returned TIMEOUT; that fixed what the user
+    // reads while quietly widening the wire contract, since BEFORE this change
+    // the extra key made this reply MALFORMED_REPLY. It does again.
     const server = await staticSignedReply((requestId) => {
       const unsigned = {
         version: PANEL_IMAGE_RELAY_VERSION,
@@ -369,9 +371,93 @@ describe("#2703 — a PANEL_FETCH_FAILED read names its cause", () => {
         () => undefined,
         (error: unknown) => error,
       )) as PanelComfyUIReadRelayError;
-      expect(failure.code).toBe("TIMEOUT");
+      expect(failure.code).toBe("MALFORMED_REPLY");
       expect(failure.reason).toBeUndefined();
       expect(failure.message).not.toContain("must not carry");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("refuses a reason reached through a polluted prototype", async () => {
+    // `hasOwn` says "absent" for an inherited `reason` while every reader —
+    // including the MAC payload — sees it. The digest mismatch alone already
+    // refuses this reply, so the guard is the second line rather than the only
+    // one; it is here so the validator does not depend on another check's
+    // arithmetic to be correct (codex gate r2, finding 2).
+    const polluted = Object.prototype as unknown as { reason?: string };
+    const server = await staticSignedReply((requestId) => {
+      const unsigned = {
+        version: PANEL_IMAGE_RELAY_VERSION,
+        requestId,
+        ok: false,
+        error: "PANEL_FETCH_FAILED",
+        updated: Date.now(),
+      };
+      return {
+        ...unsigned,
+        responseMac: createHmac("sha256", SECRET)
+          .update(
+            JSON.stringify([unsigned.version, unsigned.requestId, false, unsigned.error, unsigned.updated]),
+          )
+          .digest("hex"),
+      };
+    });
+    polluted.reason = "z".repeat(5_000);
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("MALFORMED_REPLY");
+      expect(failure.message).not.toContain("zzz");
+    } finally {
+      delete polluted.reason;
+      await server.close();
+    }
+  });
+
+  it("ACCEPTS a well-formed signed reason on the same hand-built wire path", async () => {
+    // The positive control for every refusal above (codex gate r2, finding 3):
+    // those cases assert MALFORMED_REPLY, which the PRE-#2703 code also
+    // answered by rejecting the extra key — so on their own they cannot show
+    // the refusals are about the reason rather than about the path. This one
+    // travels the identical hand-built, hand-signed path and comes back
+    // ACCEPTED, so a change that broke reason support would fail HERE while the
+    // refusals stayed green, and the pair is what separates the two.
+    const server = await staticSignedReply((requestId) => {
+      const unsigned = {
+        version: PANEL_IMAGE_RELAY_VERSION,
+        requestId,
+        ok: false,
+        error: "PANEL_FETCH_FAILED",
+        updated: Date.now(),
+        reason: "fetch_comfyui_read history returned HTTP 403",
+      };
+      return {
+        ...unsigned,
+        responseMac: createHmac("sha256", SECRET)
+          .update(
+            JSON.stringify([
+              unsigned.version,
+              unsigned.requestId,
+              false,
+              unsigned.error,
+              unsigned.updated,
+              unsigned.reason,
+            ]),
+          )
+          .digest("hex"),
+      };
+    });
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("PANEL_FETCH_FAILED");
+      expect(failure.reason).toBe("fetch_comfyui_read history returned HTTP 403");
+      expect(failure.message).toContain("HTTP 403");
     } finally {
       await server.close();
     }

--- a/src/__tests__/services/panel-relay-failure-reason.test.ts
+++ b/src/__tests__/services/panel-relay-failure-reason.test.ts
@@ -15,6 +15,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHmac } from "node:crypto";
 import {
+  PANEL_IMAGE_RELAY_HTTP_PATH,
   PANEL_IMAGE_RELAY_VERSION,
   PanelComfyUIReadRelayError,
   PanelImageRelayError,
@@ -85,6 +86,31 @@ async function relayRejectingWith(error: unknown) {
   });
   process.env.COMFYUI_MCP_RELAY_URL = server.endpointUrl;
   return server;
+}
+
+/** A fake relay peer that answers every request with one hand-built, hand-signed
+ *  reply. Used to exercise digests this codebase's own writer never produces. */
+async function staticSignedReply(
+  build: (requestId: string) => Record<string, unknown>,
+): Promise<{ close: () => Promise<void> }> {
+  const { createServer } = await import("node:http");
+  const fake = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const input = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { requestId: string };
+      const body = JSON.stringify(build(input.requestId));
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "content-length": String(Buffer.byteLength(body)),
+      });
+      res.end(body);
+    });
+  });
+  await new Promise<void>((resolve) => fake.listen(0, "127.0.0.1", () => resolve()));
+  const port = (fake.address() as { port: number }).port;
+  process.env.COMFYUI_MCP_RELAY_URL = `http://127.0.0.1:${port}${PANEL_IMAGE_RELAY_HTTP_PATH}`;
+  return { close: () => new Promise<void>((resolve) => fake.close(() => resolve())) };
 }
 
 describe("#2703 — a PANEL_FETCH_FAILED read names its cause", () => {
@@ -228,6 +254,126 @@ describe("#2703 — a PANEL_FETCH_FAILED read names its cause", () => {
     } finally {
       await new Promise<void>((resolve) => resigner.close(() => resolve()));
       await upstream.close();
+    }
+  });
+
+  // Codex gate, finding 2: the tampering cases above are also satisfied by the
+  // PRE-#2703 reject-all-extra-keys rule, so on their own they do not separate
+  // the new contract from the old one. These three do — each one is about a
+  // response this diff must treat differently from how it treated it before.
+
+  it("verifies a hand-signed LEGACY five-element failure unchanged", async () => {
+    // The compatibility claim, stated directly instead of resting on an
+    // unrelated shipped test: a peer that signed the pre-#2703 payload (an old
+    // orchestrator serving a child spawned after an in-place package update)
+    // must still verify, and must produce the bare pre-#2703 sentence.
+    const server = await staticSignedReply((requestId) => {
+      const unsigned = {
+        version: PANEL_IMAGE_RELAY_VERSION,
+        requestId,
+        ok: false,
+        error: "PANEL_FETCH_FAILED",
+        updated: Date.now(),
+      };
+      return {
+        ...unsigned,
+        responseMac: createHmac("sha256", SECRET)
+          .update(
+            JSON.stringify([unsigned.version, unsigned.requestId, false, unsigned.error, unsigned.updated]),
+          )
+          .digest("hex"),
+      };
+    });
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("PANEL_FETCH_FAILED");
+      expect(failure.reason).toBeUndefined();
+      expect(failure.message).toBe("The connected panel could not read ComfyUI.");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("refuses a six-element digest whose reason was stripped in flight", async () => {
+    // The other direction from the append attack: a response SIGNED with a
+    // reason, delivered without it. Believing it would let a man-in-the-middle
+    // silently delete the diagnosis this whole change exists to deliver.
+    const server = await staticSignedReply((requestId) => {
+      const unsigned = {
+        version: PANEL_IMAGE_RELAY_VERSION,
+        requestId,
+        ok: false,
+        error: "PANEL_FETCH_FAILED",
+        updated: Date.now(),
+      };
+      const mac = createHmac("sha256", SECRET)
+        .update(
+          JSON.stringify([
+            unsigned.version,
+            unsigned.requestId,
+            false,
+            unsigned.error,
+            unsigned.updated,
+            "the reason that was signed",
+          ]),
+        )
+        .digest("hex");
+      return { ...unsigned, responseMac: mac };
+    });
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("MALFORMED_REPLY");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not attach a correctly signed reason to a code that never carries one", async () => {
+    // Codex gate, finding 1. Our writer only ever mints a reason alongside
+    // PANEL_FETCH_FAILED, but the response is input that merely has to verify —
+    // so the READER has to enforce that, not assume it. A signed TIMEOUT with a
+    // reason was previously appended to the caller's timeout message.
+    const server = await staticSignedReply((requestId) => {
+      const unsigned = {
+        version: PANEL_IMAGE_RELAY_VERSION,
+        requestId,
+        ok: false,
+        error: "TIMEOUT",
+        updated: Date.now(),
+        reason: "a sentence TIMEOUT must not carry",
+      };
+      return {
+        ...unsigned,
+        responseMac: createHmac("sha256", SECRET)
+          .update(
+            JSON.stringify([
+              unsigned.version,
+              unsigned.requestId,
+              false,
+              unsigned.error,
+              unsigned.updated,
+              unsigned.reason,
+            ]),
+          )
+          .digest("hex"),
+      };
+    });
+    try {
+      const failure = (await requestPanelComfyUIRead("history").then(
+        () => undefined,
+        (error: unknown) => error,
+      )) as PanelComfyUIReadRelayError;
+      expect(failure.code).toBe("TIMEOUT");
+      expect(failure.reason).toBeUndefined();
+      expect(failure.message).not.toContain("must not carry");
+    } finally {
+      await server.close();
     }
   });
 

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -274,8 +274,19 @@ async function panelReadFallback(
     if (error instanceof PanelComfyUIReadRelayError && error.unavailable) return undefined;
     const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
     const code = error instanceof PanelComfyUIReadRelayError ? error.code : "RELAY_ERROR";
+    // #2703 - the code alone was the whole answer, and PANEL_FETCH_FAILED does
+    // not distinguish "the read exceeded the relay's byte ceiling" from "the
+    // panel's fetch timed out" from "ComfyUI answered 403" from "that panel
+    // predates the read relay". The reporter got `fetch failed: connect
+    // ECONNREFUSED 127.0.0.1:8188 ... (PANEL_FETCH_FAILED)` and had nothing to
+    // act on: the headless target was dead AND the one path that could have
+    // answered declined without saying why. The relay now carries the cause
+    // (services/panel-image-relay.ts, panelFailureReason); say it here, because
+    // this message - not the relay error - is what reaches the caller.
+    const reason = error instanceof PanelComfyUIReadRelayError ? error.reason : undefined;
     throw new Error(
-      `${primary} The connected panel ComfyUI read fallback failed safely (${code}).`,
+      `${primary} The connected panel ComfyUI read fallback failed safely (${code}).` +
+        (reason ? ` The panel reported: ${reason}` : ""),
       { cause: error },
     );
   }
@@ -1628,8 +1639,13 @@ export async function fetchImage(
       } catch (relayError) {
         if (relayError instanceof PanelImageRelayError && !relayError.unavailable) {
           const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+          // #2703 - the same collapse on the image relay's own dead end. Both
+          // codes are produced by ONE catch in the relay, so leaving this one
+          // bare would have left half the reports unactionable for the same
+          // reason the history path was.
           throw new Error(
-            `${primary} The connected panel image relay failed safely (${relayError.code}).`,
+            `${primary} The connected panel image relay failed safely (${relayError.code}).` +
+              (relayError.reason ? ` The panel reported: ${relayError.reason}` : ""),
             { cause: relayError },
           );
         }

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -810,16 +810,25 @@ function responseMacPayload(response: PanelRelayResponse): string {
     // `reason` is part of the SIGNED payload. A field the MAC does not cover is
     // a field the reader may not rely on, and this one is read out loud to the
     // user - an unauthenticated sentence attributed to the panel is worse than
-    // no sentence at all. `?? null` keeps "no reason" a distinct signed value,
-    // so a reasonless failure and a reasoned one never digest the same.
-    return JSON.stringify([
-      response.version,
-      response.requestId,
-      false,
-      response.error,
-      response.updated,
-      response.reason ?? null,
-    ]);
+    // no sentence at all.
+    //
+    // APPENDED, not always-present-as-null. Writing it unconditionally changed
+    // the digest of a REASONLESS failure too, and that is a compatibility break
+    // this fix has no business making: the relay server and its client are two
+    // PROCESSES. An in-place package update swaps `dist` under a running
+    // orchestrator, and the children it spawns afterwards load the new code
+    // while it still runs the old - so an old signer would meet a new verifier
+    // and every relay failure would read MALFORMED_REPLY until the orchestrator
+    // restarted. (Caught by the shipped `classifies an authenticated server
+    // TIMEOUT before deadline freshness` test, which hand-signs the pre-#2703
+    // payload; that test was the old signer, and it was right to reject the
+    // change.) Appending keeps the old shape byte-identical.
+    //
+    // The two forms still cannot be confused: a 5-element array and a
+    // 6-element one never serialise to the same string, so stripping a reason
+    // or adding one both fail verification.
+    const base = [response.version, response.requestId, false, response.error, response.updated];
+    return JSON.stringify(response.reason === undefined ? base : [...base, response.reason]);
   }
   if ("operation" in response) {
     return JSON.stringify([

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -132,6 +132,11 @@ interface PanelImageRelayResponseFailure {
   ok: false;
   error: string;
   updated: number;
+  /** #2703 - WHY the panel could not answer, when the code alone cannot say.
+   *  Carried only for PANEL_FETCH_FAILED, the one code that stands for a whole
+   *  family of distinct panel-side causes. Signed with the rest of the response;
+   *  see panelFailureReason for what may appear here. */
+  reason?: string;
 }
 
 interface PanelImageRelayResponseSuccess extends PanelImageRelaySuccess {
@@ -173,24 +178,31 @@ export interface PanelImageRelayBridge {
 export class PanelImageRelayError extends Error {
   readonly code: string;
   readonly unavailable: boolean;
+  /** #2703 - the panel-side cause behind a PANEL_FETCH_FAILED, when one was
+   *  carried. DIAGNOSTIC PROSE ONLY: nothing branches on it. */
+  readonly reason?: string;
 
-  constructor(message: string, code: string, unavailable = false) {
+  constructor(message: string, code: string, unavailable = false, reason?: string) {
     super(message);
     this.name = "PanelImageRelayError";
     this.code = code;
     this.unavailable = unavailable;
+    if (reason !== undefined) this.reason = reason;
   }
 }
 
 export class PanelComfyUIReadRelayError extends Error {
   readonly code: string;
   readonly unavailable: boolean;
+  /** #2703 - see PanelImageRelayError.reason. */
+  readonly reason?: string;
 
-  constructor(message: string, code: string, unavailable = false) {
+  constructor(message: string, code: string, unavailable = false, reason?: string) {
     super(message);
     this.name = "PanelComfyUIReadRelayError";
     this.code = code;
     this.unavailable = unavailable;
+    if (reason !== undefined) this.reason = reason;
   }
 }
 
@@ -213,6 +225,75 @@ function isSafeText(value: unknown, max: number): value is string {
       return code < 0x20 || code === 0x7f;
     })
   );
+}
+
+/**
+ * How much of a panel-side failure cause may ride back with the code (#2703).
+ *
+ * 200 rather than the 160 used for `error`: `error` is a fixed token from a
+ * closed set, while this is a sentence. The panel's longest shipped message
+ * ("fetch_comfyui_read response exceeds the 16777216-byte limit") fits well
+ * inside it, and a bound this size cannot be used to move a payload.
+ */
+const PANEL_FAILURE_REASON_MAX = 200;
+
+/**
+ * Turn the rejected bridge send into ONE sentence naming what actually went
+ * wrong (#2703).
+ *
+ * WHY THIS EXISTS. `PANEL_FETCH_FAILED` is the answer for every non-timeout
+ * throw out of `bridge.send`, and that is a whole family of distinct,
+ * differently-actionable causes: the panel's own `too_large` (the read exceeded
+ * its byte ceiling), `timeout`, `network_error`, `http_error` with a status,
+ * `invalid_origin`, `redirect_error`, `api_unavailable`, the workflow-reload
+ * guard, and an "Unknown command" from a panel that predates the read relay.
+ * The code separates NONE of them, so the reporter on #2703 was told
+ * "the connected panel ComfyUI read fallback failed safely (PANEL_FETCH_FAILED)"
+ * - true, and unactionable. The error this catch is already holding says which
+ * one it was; it was simply being dropped on the floor.
+ *
+ * TRUST. This is panel-authored prose reaching an agent, so it is treated the
+ * way the image path already treats a panel-authored `error` string: bounded,
+ * control characters removed, and gated on `isSafeText`. Nothing parses it and
+ * nothing branches on it - it is one sentence appended to an error message.
+ * There is no credential-reflection surface behind it either: the panel's read
+ * helper builds its messages from a FIXED route, a status number, a byte count
+ * and the browser's own fetch error, never from a response body (the class of
+ * leak #385 hit). Anything that fails the guard is dropped whole rather than
+ * repaired, so the worst case is exactly the pre-#2703 bare code.
+ */
+/**
+ * ABSENT or a bounded safe string - never anything else (#2703).
+ *
+ * Written as absent-OR-valid rather than folded into the `hasOnlyKeys` list
+ * alone, because those two say different things: the key list decides which
+ * fields MAY appear, and this decides what the field is allowed to contain. A
+ * `reason` present but malformed is a malformed reply, not a reply with the
+ * field quietly ignored - the MAC covers it, so a value we would not accept is
+ * a value the writer and reader disagree about.
+ */
+function validFailureReason(record: Record<string, unknown>): boolean {
+  if (!hasOwn(record, "reason")) return true;
+  return isSafeText(record.reason, PANEL_FAILURE_REASON_MAX);
+}
+
+/** The one rendering of a carried reason, shared by both readers. */
+function reasonSuffix(reason: string | undefined): string {
+  return reason ? ` The panel reported: ${reason}` : "";
+}
+
+function panelFailureReason(error: unknown): string | undefined {
+  const raw = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  // Control characters are folded to spaces rather than rejecting the whole
+  // string: a message that merely wraps a line still carries its cause, and
+  // dropping it would put us back at the bare code this exists to replace.
+  const flattened = raw.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!flattened) return undefined;
+  const clipped =
+    flattened.length > PANEL_FAILURE_REASON_MAX
+      ? `${flattened.slice(0, PANEL_FAILURE_REASON_MAX - 1)}\u2026`
+      : flattened;
+  return isSafeText(clipped, PANEL_FAILURE_REASON_MAX) ? clipped : undefined;
 }
 
 /** Strict wire-level validation. Keep this stricter than the legacy tool path. */
@@ -671,20 +752,30 @@ function validateResponse(value: unknown, requestId: string): PanelImageRelayRes
     typeof record.error === "string" &&
     record.error.length <= 160 &&
     isSafeText(record.error, 160) &&
-    hasOnlyKeys(record, ["version", "requestId", "ok", "error", "updated"])
+    validFailureReason(record) &&
+    hasOnlyKeys(record, ["version", "requestId", "ok", "error", "updated", "reason"])
   ) {
     return record as unknown as PanelImageRelayResponseFailure;
   }
   throw new PanelImageRelayError("The panel returned a malformed image relay reply.", "MALFORMED_REPLY");
 }
 
-function failureResponse(requestId: string, error: string, updated = Date.now()): PanelImageRelayResponseFailure {
+function failureResponse(
+  requestId: string,
+  error: string,
+  updated = Date.now(),
+  reason?: string,
+): PanelImageRelayResponseFailure {
   return {
     version: PANEL_IMAGE_RELAY_VERSION,
     requestId,
     ok: false,
     error,
     updated,
+    // Omitted rather than set to undefined: the far side validates the KEY SET
+    // with hasOnlyKeys, and JSON.stringify drops an explicit undefined anyway -
+    // which would leave the two sides disagreeing about the shape they signed.
+    ...(reason === undefined ? {} : { reason }),
   };
 }
 
@@ -700,17 +791,35 @@ function responseFailureMessage(response: PanelImageRelayResponseFailure): never
     "TIMEOUT",
   ]);
   const code = known.has(response.error) ? response.error : "PANEL_FETCH_FAILED";
+  // #2703 - only trust the reason on the code it was minted for. An unknown
+  // `error` is remapped to PANEL_FETCH_FAILED above, and attaching a reason to
+  // THAT would attribute a sentence to a code the writer never sent.
+  const reason = response.error === code ? response.reason : undefined;
   throw new PanelImageRelayError(
     code === "PANEL_FETCH_FAILED"
-      ? "The connected panel could not fetch that image."
+      ? `The connected panel could not fetch that image.${reasonSuffix(reason)}`
       : `The connected panel image relay failed (${code}).`,
     code,
+    false,
+    reason,
   );
 }
 
 function responseMacPayload(response: PanelRelayResponse): string {
   if (!response.ok) {
-    return JSON.stringify([response.version, response.requestId, false, response.error, response.updated]);
+    // `reason` is part of the SIGNED payload. A field the MAC does not cover is
+    // a field the reader may not rely on, and this one is read out loud to the
+    // user - an unauthenticated sentence attributed to the panel is worse than
+    // no sentence at all. `?? null` keeps "no reason" a distinct signed value,
+    // so a reasonless failure and a reasoned one never digest the same.
+    return JSON.stringify([
+      response.version,
+      response.requestId,
+      false,
+      response.error,
+      response.updated,
+      response.reason ?? null,
+    ]);
   }
   if ("operation" in response) {
     return JSON.stringify([
@@ -762,7 +871,8 @@ function validateReadResponse(
       typeof record.error === "string" &&
       record.error.length <= 160 &&
       isSafeText(record.error, 160) &&
-      hasOnlyKeys(record, ["version", "requestId", "ok", "error", "updated"])
+      validFailureReason(record) &&
+      hasOnlyKeys(record, ["version", "requestId", "ok", "error", "updated", "reason"])
     ) return record as unknown as PanelImageRelayResponseFailure;
     throw new PanelComfyUIReadRelayError("The panel returned a malformed ComfyUI read reply.", "MALFORMED_REPLY");
   }
@@ -1128,6 +1238,10 @@ export async function startPanelImageRelayServer(
                   request.requestId,
                   timedOut ? "TIMEOUT" : "PANEL_FETCH_FAILED",
                   timedOut ? requestDeadline(request) : Date.now(),
+                  // #2703 - TIMEOUT already says what happened and by when; only
+                  // PANEL_FETCH_FAILED is the code that stands for many causes,
+                  // so only it needs the sentence.
+                  timedOut ? undefined : panelFailureReason(error),
                 );
               }
             }
@@ -1334,11 +1448,15 @@ export async function requestPanelComfyUIRead(
       "TIMEOUT",
     ]);
     const code = known.has(response.error) ? response.error : "PANEL_FETCH_FAILED";
+    // #2703 - see responseFailureMessage: a remapped code keeps no reason.
+    const reason = response.error === code ? response.reason : undefined;
     throw new PanelComfyUIReadRelayError(
       code === "PANEL_FETCH_FAILED"
-        ? "The connected panel could not read ComfyUI."
+        ? `The connected panel could not read ComfyUI.${reasonSuffix(reason)}`
         : `The connected panel ComfyUI read relay failed (${code}).`,
       code,
+      false,
+      reason,
     );
   }
   return {

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -277,27 +277,42 @@ function panelFailureReason(error: unknown): string | undefined {
 }
 
 /**
- * ABSENT or a bounded safe string - never anything else (#2703).
+ * ABSENT, or an OWN bounded safe string on the ONE code that carries one
+ * (#2703). Anything else is a malformed reply.
  *
- * Written as absent-OR-valid rather than folded into the `hasOnlyKeys` list
- * alone, because those two say different things: the key list decides which
- * fields MAY appear, and this decides what the field is allowed to contain. A
- * `reason` present but malformed is a malformed reply, not a reply with the
- * field quietly ignored - the MAC covers it, so a value we would not accept is
- * a value the writer and reader disagree about.
+ * Kept separate from the `hasOnlyKeys` list because the two say different
+ * things: the key list decides which fields MAY appear, and this decides what
+ * the field is allowed to be. A `reason` present but wrong is a malformed
+ * reply, not a reply with the field quietly ignored - the MAC covers it, so a
+ * value we would not accept is a value the writer and reader disagree about.
+ *
+ * Two refusals here that the first draft did not have (codex gate, round 2):
+ *
+ *  - THE CODE. Widening the key set let a signed `TIMEOUT` carrying a `reason`
+ *    validate, where before the extra key made it MALFORMED_REPLY. Dropping
+ *    that reason at RENDER time (the first draft did) fixed what the user sees
+ *    while still loosening the wire contract for every code except the one that
+ *    legitimately changed. Refusing it here restores the old answer for all of
+ *    them, and makes this the single place the rule is stated - the two readers
+ *    downstream may then simply repeat `response.reason`.
+ *
+ *  - INHERITANCE. `hasOwn` said "absent" for a `reason` reached through the
+ *    prototype while `record.reason` downstream reads it, so a polluted
+ *    `Object.prototype` slipped past this gate. It does NOT reach the user even
+ *    without this line - `responseMacPayload` reads the same inherited value and
+ *    the digest then disagrees with the sender's, so the reply is refused as
+ *    unauthenticated - but a guard whose correctness depends on a DIFFERENT
+ *    guard's arithmetic is not one worth keeping. An inherited value is refused
+ *    outright rather than accepted-if-safe: nothing on the wire put it there.
  */
 function validFailureReason(record: Record<string, unknown>): boolean {
-  if (!hasOwn(record, "reason")) return true;
-  return isSafeText(record.reason, PANEL_FAILURE_REASON_MAX);
-}
-
-/**
- * The reason a reader may believe: present, and on the ONE code it is minted
- * for (#2703). Shared by both readers so the rule cannot drift between them.
- */
-function keptFailureReason(response: PanelImageRelayResponseFailure, code: string): string | undefined {
-  if (code !== "PANEL_FETCH_FAILED") return undefined;
-  return response.error === code ? response.reason : undefined;
+  // The EFFECTIVE value (own or inherited), because that is what every reader
+  // of this record - including the MAC payload - will see.
+  const effective = (record as { reason?: unknown }).reason;
+  if (effective === undefined) return true;
+  if (!hasOwn(record, "reason")) return false;
+  if (record.error !== "PANEL_FETCH_FAILED") return false;
+  return isSafeText(effective, PANEL_FAILURE_REASON_MAX);
 }
 
 /** The one rendering of a carried reason, shared by both readers. */
@@ -800,17 +815,14 @@ function responseFailureMessage(response: PanelImageRelayResponseFailure): never
     "TIMEOUT",
   ]);
   const code = known.has(response.error) ? response.error : "PANEL_FETCH_FAILED";
-  // #2703 - only trust the reason on the code it was minted for, which is
-  // PANEL_FETCH_FAILED and nothing else. Two ways to get this wrong, and the
-  // first draft had the second (codex gate, finding 1):
-  //   - an UNKNOWN `error` is remapped to PANEL_FETCH_FAILED above, so keeping
-  //     its reason would attribute a sentence to a code the writer never sent;
-  //   - a known-but-different code (TIMEOUT) never carries a reason from OUR
-  //     writer, but `response` is attacker-supplied input that merely has to
-  //     verify. A correctly signed TIMEOUT+reason was accepted and appended to
-  //     the caller's timeout message. Enforce the invariant the writer honours
-  //     rather than assuming the peer honours it too.
-  const reason = keptFailureReason(response, code);
+  // #2703 - `response` reached here through validFailureReason, which admits a
+  // reason ONLY alongside a literal `PANEL_FETCH_FAILED` error. So a reason
+  // present here cannot belong to a remapped unknown code or to a TIMEOUT, and
+  // `code` necessarily equals `response.error`. A second filter at this point
+  // was written first and then removed: mutation testing showed it unreachable,
+  // and an unreachable guard that looks load-bearing misdirects the next reader
+  // about where the rule actually lives. It lives in validFailureReason.
+  const reason = response.reason;
   throw new PanelImageRelayError(
     code === "PANEL_FETCH_FAILED"
       ? `The connected panel could not fetch that image.${reasonSuffix(reason)}`
@@ -1473,9 +1485,9 @@ export async function requestPanelComfyUIRead(
       "TIMEOUT",
     ]);
     const code = known.has(response.error) ? response.error : "PANEL_FETCH_FAILED";
-    // #2703 - see responseFailureMessage for why this is PANEL_FETCH_FAILED
-    // only, and not "any code the writer did not remap".
-    const reason = keptFailureReason(response, code);
+    // #2703 - see responseFailureMessage: validFailureReason is where "only
+    // PANEL_FETCH_FAILED carries a reason" is enforced, on the way in.
+    const reason = response.reason;
     throw new PanelComfyUIReadRelayError(
       code === "PANEL_FETCH_FAILED"
         ? `The connected panel could not read ComfyUI.${reasonSuffix(reason)}`

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -262,6 +262,20 @@ const PANEL_FAILURE_REASON_MAX = 200;
  * leak #385 hit). Anything that fails the guard is dropped whole rather than
  * repaired, so the worst case is exactly the pre-#2703 bare code.
  */
+function panelFailureReason(error: unknown): string | undefined {
+  const raw = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  // Control characters are folded to spaces rather than rejecting the whole
+  // string: a message that merely wraps a line still carries its cause, and
+  // dropping it would put us back at the bare code this exists to replace.
+  const flattened = raw.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!flattened) return undefined;
+  const clipped =
+    flattened.length > PANEL_FAILURE_REASON_MAX
+      ? `${flattened.slice(0, PANEL_FAILURE_REASON_MAX - 1)}\u2026`
+      : flattened;
+  return isSafeText(clipped, PANEL_FAILURE_REASON_MAX) ? clipped : undefined;
+}
+
 /**
  * ABSENT or a bounded safe string - never anything else (#2703).
  *
@@ -280,20 +294,6 @@ function validFailureReason(record: Record<string, unknown>): boolean {
 /** The one rendering of a carried reason, shared by both readers. */
 function reasonSuffix(reason: string | undefined): string {
   return reason ? ` The panel reported: ${reason}` : "";
-}
-
-function panelFailureReason(error: unknown): string | undefined {
-  const raw = error instanceof Error ? error.message : typeof error === "string" ? error : "";
-  // Control characters are folded to spaces rather than rejecting the whole
-  // string: a message that merely wraps a line still carries its cause, and
-  // dropping it would put us back at the bare code this exists to replace.
-  const flattened = raw.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
-  if (!flattened) return undefined;
-  const clipped =
-    flattened.length > PANEL_FAILURE_REASON_MAX
-      ? `${flattened.slice(0, PANEL_FAILURE_REASON_MAX - 1)}\u2026`
-      : flattened;
-  return isSafeText(clipped, PANEL_FAILURE_REASON_MAX) ? clipped : undefined;
 }
 
 /** Strict wire-level validation. Keep this stricter than the legacy tool path. */

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -291,6 +291,15 @@ function validFailureReason(record: Record<string, unknown>): boolean {
   return isSafeText(record.reason, PANEL_FAILURE_REASON_MAX);
 }
 
+/**
+ * The reason a reader may believe: present, and on the ONE code it is minted
+ * for (#2703). Shared by both readers so the rule cannot drift between them.
+ */
+function keptFailureReason(response: PanelImageRelayResponseFailure, code: string): string | undefined {
+  if (code !== "PANEL_FETCH_FAILED") return undefined;
+  return response.error === code ? response.reason : undefined;
+}
+
 /** The one rendering of a carried reason, shared by both readers. */
 function reasonSuffix(reason: string | undefined): string {
   return reason ? ` The panel reported: ${reason}` : "";
@@ -791,10 +800,17 @@ function responseFailureMessage(response: PanelImageRelayResponseFailure): never
     "TIMEOUT",
   ]);
   const code = known.has(response.error) ? response.error : "PANEL_FETCH_FAILED";
-  // #2703 - only trust the reason on the code it was minted for. An unknown
-  // `error` is remapped to PANEL_FETCH_FAILED above, and attaching a reason to
-  // THAT would attribute a sentence to a code the writer never sent.
-  const reason = response.error === code ? response.reason : undefined;
+  // #2703 - only trust the reason on the code it was minted for, which is
+  // PANEL_FETCH_FAILED and nothing else. Two ways to get this wrong, and the
+  // first draft had the second (codex gate, finding 1):
+  //   - an UNKNOWN `error` is remapped to PANEL_FETCH_FAILED above, so keeping
+  //     its reason would attribute a sentence to a code the writer never sent;
+  //   - a known-but-different code (TIMEOUT) never carries a reason from OUR
+  //     writer, but `response` is attacker-supplied input that merely has to
+  //     verify. A correctly signed TIMEOUT+reason was accepted and appended to
+  //     the caller's timeout message. Enforce the invariant the writer honours
+  //     rather than assuming the peer honours it too.
+  const reason = keptFailureReason(response, code);
   throw new PanelImageRelayError(
     code === "PANEL_FETCH_FAILED"
       ? `The connected panel could not fetch that image.${reasonSuffix(reason)}`
@@ -1457,8 +1473,9 @@ export async function requestPanelComfyUIRead(
       "TIMEOUT",
     ]);
     const code = known.has(response.error) ? response.error : "PANEL_FETCH_FAILED";
-    // #2703 - see responseFailureMessage: a remapped code keeps no reason.
-    const reason = response.error === code ? response.reason : undefined;
+    // #2703 - see responseFailureMessage for why this is PANEL_FETCH_FAILED
+    // only, and not "any code the writer did not remap".
+    const reason = keptFailureReason(response, code);
     throw new PanelComfyUIReadRelayError(
       code === "PANEL_FETCH_FAILED"
         ? `The connected panel could not read ComfyUI.${reasonSuffix(reason)}`

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -298,12 +298,17 @@ function panelFailureReason(error: unknown): string | undefined {
  *
  *  - INHERITANCE. `hasOwn` said "absent" for a `reason` reached through the
  *    prototype while `record.reason` downstream reads it, so a polluted
- *    `Object.prototype` slipped past this gate. It does NOT reach the user even
- *    without this line - `responseMacPayload` reads the same inherited value and
- *    the digest then disagrees with the sender's, so the reply is refused as
- *    unauthenticated - but a guard whose correctness depends on a DIFFERENT
- *    guard's arithmetic is not one worth keeping. An inherited value is refused
- *    outright rather than accepted-if-safe: nothing on the wire put it there.
+ *    `Object.prototype` slipped past this gate. This one is LOAD-BEARING, and
+ *    a first draft of the comment here wrongly said it was not: the reasoning
+ *    was that `responseMacPayload` reads the same inherited value, so the
+ *    digest would disagree and the reply be refused anyway. It disagrees only
+ *    when the SENDER did not account for it. A peer that signs the six-element
+ *    digest over the inherited value sends a body with no `reason` key at all,
+ *    and the MAC then verifies perfectly - leaving this the only check between
+ *    an unbounded string and the user's error message. Mutation testing is what
+ *    said so: deleting this line killed nothing until the test signed the
+ *    polluted value. An inherited value is refused outright rather than
+ *    accepted-if-safe; nothing on the wire put it there.
  */
 function validFailureReason(record: Record<string, unknown>): boolean {
   // The EFFECTIVE value (own or inherited), because that is what every reader


### PR DESCRIPTION
Closes #2703.

## The report, and what it actually was

#2703 arrived as "get_history cannot reach connected local ComfyUI target": a dead `COMFYUI_URL` (`ECONNREFUSED 127.0.0.1:8188`) while the sidebar panel was connected and working, and — the part that matters — the panel read fallback declining with

```
connected panel fallback failed safely (PANEL_FETCH_FAILED)
```

The headless half is already handled. Reproduced on `origin/main` against a dead port with a live panel origin published on the orchestrator→child channel:

```
fetch failed: connect ECONNREFUSED 127.0.0.1:56214 (ECONNREFUSED) — while requesting
http://127.0.0.1:56214/history?clientId=comfyui-mcp (GET). … A connected panel is on
http://127.0.0.1:56213 — a DIFFERENT address …
```

That leg names the drift correctly. The **fallback** leg is the dead end.

`PANEL_FETCH_FAILED` is the answer the relay returns for **every non-timeout throw out of `bridge.send`**. Behind that one token sit at least nine distinct, differently-actionable causes:

| panel-side cause | what the user should do |
|---|---|
| `too_large` — the read exceeded the 16 MiB relay ceiling | ask for one `prompt_id`, not the whole `/history` |
| `timeout` — 8 s for `/history` | retry, or narrow the read |
| `http_error` with a status | fix ComfyUI's auth / route |
| `network_error`, `invalid_origin`, `redirect_error`, `api_unavailable` | fix what is in front of ComfyUI |
| the workflow-reload guard | retry in a moment |
| `Unknown command "fetch_comfyui_read"` | update the panel |

The `catch` that builds the failure response is holding the error that says which one it was, and drops it. So neither the reporter nor I can tell these apart — which is precisely why #2703 could not be resolved as filed.

## What this changes

The relay now carries a bounded, **signed** sentence naming the cause alongside the code, and both consumer call sites say it:

```
fetch failed: connect ECONNREFUSED 127.0.0.1:8188 … The connected panel ComfyUI read
fallback failed safely (PANEL_FETCH_FAILED). The panel reported: fetch_comfyui_read
response exceeds the 16777216-byte limit
```

- **`services/panel-image-relay.ts`** — `panelFailureReason()` flattens the rejected `bridge.send` error to one line, folds control characters to spaces, bounds it at 200 chars and re-gates it on the existing `isSafeText`. Minted **only** for `PANEL_FETCH_FAILED` (`TIMEOUT` already says what happened and by when).
  - `responseMacPayload` **appends** it, so a reasonless failure keeps its pre-#2703 five-element digest byte-for-byte.
  - `validFailureReason` is the single place the wire rule lives: absent, or an **own** bounded safe string on a literal `PANEL_FETCH_FAILED`. Anything else is `MALFORMED_REPLY`, exactly as before this change.
- **`comfyui/client.ts`** — `panelReadFallback` (the `get_history` / `system_stats` / `logs` / `object_info` funnel) and `fetchImage`'s image-relay branch each append it. Both build their message from the *code*, so a relay carrying a reason nobody reads would still have shipped the dead end.

**This does not make the reporter's failing read succeed, and it does not claim to.** It cannot: the one fact that would say how to make it succeed was the thing being discarded. It turns an unresolvable report into a one-line diagnosis.

## What I deliberately did NOT do

The report's own suggested fix — *"read history through the proven live panel origin when the headless route is unavailable"* — is already built (`choosePanelFallbackOrigin`, #2149) and **deliberately disarmed in production**:

```ts
// Direct /view fallback authorization. … Production installs no source: a
// tokenless loopback WebSocket has no browser-only provenance that could
// authorize MCP to make a new HTTP request.
let connectedPanelFallbackOrigins: (() => string[]) | null = null;
```

with `orchestrator/index.ts` calling `setConnectedPanelFallbackOrigins(null)`. The published origin set is diagnostic data and explicitly *not* permission to contact an origin. Adopting that resolver for `/history` would re-arm a hazard closed on purpose, so I left it closed and said so on the issue.

## Where the load-bearing claims are

1. **Panel-authored prose now reaches an agent.** Bounded, control-characters-folded, `isSafeText`-gated, and **nothing parses or branches on it** — one sentence appended to an error message. The #385 credential-reflection hazard does not apply: the panel's read helper builds its messages from a fixed route, a status number, a byte count and the browser's own fetch error, never from a response body (`web/js/lib/fetch-comfyui-read.js`). Anything failing the guard is dropped whole, so the worst case is the pre-#2703 bare code.
2. **The MAC payload gained a sixth element, but only when a reason is present.** A reasonless failure signs exactly the old array. Five- and six-element JSON arrays cannot serialise identically, so adding, altering or *stripping* a reason all fail verification.
3. **`validFailureReason` refuses an INHERITED `reason`, and that guard is load-bearing** — I first wrote a comment claiming the MAC made it redundant, and mutation testing proved me wrong. A peer that signs the six-element digest *over the prototype's value* sends a body with no `reason` key at all; an own-property check sees a plain reasonless failure, `responseMacPayload` reads the prototype, and the MAC verifies perfectly. The guard is the only thing left. The test now signs the polluted value, which is what makes it kill the mutation.

## Verification

**Codex gate — 3 rounds, on the SHA that will merge.**

| round | SHA | verdict |
|---|---|---|
| r1 | `b0c7b6f` | NEEDS-REVISION — 2×P2 |
| r2 | `4efa216` | NEEDS-REVISION — 1×P1, 2×P2 |
| r3 | **`19579c3`** | **PASS, no findings** |

(The `codex-gate.mjs` wrapper returned `CreateProcessAsUserW failed: 5 (Access is denied)` — a sandbox failure, not a verdict — so all three rounds were run as direct `codex exec -s read-only` with the diff supplied inline.)

Every gate finding was real and is fixed, not argued away:

- **r1/1** — the reason was kept for any *unchanged known* code, so a signed `TIMEOUT` carrying one was appended to the caller's timeout message.
- **r1/2** — no test pinned the legacy five-element digest or a stripped reason. Added both.
- **r2/1 (P1)** — widening the key set let a signed `TIMEOUT+reason` validate where the extra key previously made it `MALFORMED_REPLY`. Dropping the reason at *render* time fixed what the user sees while still loosening the wire contract; refusing it in `validFailureReason` restores the old answer for every code but the one that legitimately changed. That also made the render-time filter unreachable, so it was **deleted** rather than shipped as a guard mutation testing proves dead.
- **r2/2 (P2)** — the prototype hole above.
- **r2/3 (P2)** — the refusal tests are also satisfied by the pre-change extra-key rule, so they cannot show the refusals are about the *reason*. Added a positive control that travels the identical hand-built, hand-signed path and comes back **accepted**.

**Mutation testing — 10 mutations, each applied alone, all killed by a named test:**

| # | mutation | killed by |
|---|---|---|
| 1 | relay stops carrying the reason (pre-#2703 catch) | 4 tests |
| 2 | history call site stops saying it | `names the panel-side cause behind a PANEL_FETCH_FAILED history read` |
| 3 | reason dropped from the MAC payload | `refuses a reason the relay did not sign` + the positive control |
| 4 | `isSafeText` bound removed from the validator | `refuses a correctly SIGNED reason that breaks the bound` |
| 5 | `reasonSuffix` renders nothing | 2 tests |
| 6 | length clip removed from the sanitiser | `bounds a hostile reason instead of forwarding it` |
| 7 | image call site stops saying it | `names the panel-side cause behind a PANEL_FETCH_FAILED image read` |
| 8 | reason always folded into the digest | the **shipped** `classifies an authenticated server TIMEOUT before deadline freshness` + the legacy-digest test |
| 9 | validator stops checking which code carries it | `refuses a correctly signed reason on a code that never carries one` |
| 10 | validator stops refusing an inherited reason | `refuses a reason reached through a polluted prototype` |

Mutations 7 and 10 **survived their first round** and are why the image-relay sibling test and the signing variant of the pollution test exist. A fix on one exit with an untested twin half-ships.

**Suite: `750/750 files, 13846 passed | 6 skipped` on `19579c3`, run with nothing else on the machine.** Worth recording how it got there, because two of the three earlier runs were red and only one of those reds was mine: the first was a genuine regression (`panel-image-relay` — my original always-present MAC element broke a shipped test that hand-signs the old payload, which is what produced the append-only digest above), and the next two were a different file each time (`console-secrets`, then `mutating-reply-timeout-disclosure`), both timing out just past the 30s budget while the 10-mutation matrix and the gate ran alongside, and both green in isolation with no relation to this diff. `tsc --noEmit` clean; `check-anti-slop` clean (1161 linted, none added — it caught a chained cast in my test, fixed).

**No panel-repo change and no browser-visible change**: this is entirely the MCP side of the relay and the error text it produces, so the Playwright suite is not implicated and I did not run it.
