### PR TITLE
fix(2704): prove a VRAM release landed before reporting the reading as settled

### DIFF
--- a/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
+++ b/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
@@ -1,0 +1,204 @@
+// #2704 on the PANEL path. The same lagging driver that made clear_vram print
+// a stale VRAM figure makes panel_free_vram publish a stale VERDICT: a card
+// read before the driver released looks globally occupied, so the reply names
+// occupied_devices and reports the pre-release byte count as the outcome of
+// the free.
+//
+// The frozen-tab path is the one that can be fixed, because freeVramDirect
+// already samples the counters BEFORE it posts /free — that pre-mutation
+// sample is what turns "the number stopped moving" into "the release landed".
+// The ack path has no such sample (the tab posted /free before it replied) and
+// deliberately keeps the older best-effort rule.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  comfyuiFetch: vi.fn(),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (...args: unknown[]) => mocks.comfyuiFetch(...args),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import type { ToolResult } from "../../orchestrator/panel-tools.js";
+import { VRAM_SETTLE_INTERVAL_MS, VRAM_SETTLE_TIMEOUT_MS } from "../../services/vram-settle.js";
+
+const TAB = "11111111-2222-3333-4444-555555555555";
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+const ackTimeout = (cmd: string, ms: number): Error =>
+  new Error(
+    `Panel tab ${TAB} did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be ` +
+      `backgrounded or frozen. This command MUTATES and was already delivered to the tab, so it ` +
+      `may have been applied despite the missing reply — check the current state before ` +
+      `re-issuing it; a blind retry can apply it twice`,
+  );
+
+function bridge() {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd !== "free_vram") return { ok: true };
+      throw markReplyTimeout(ackTimeout("free_vram", 15000));
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    tabIsLocal: () => true,
+    tabServerOrigin: () => BOOT_BASE,
+  };
+}
+
+const GIB = 1024 * 1024 * 1024;
+const TOTAL = 12 * GIB;
+/** 1.2 GB of 12 GB = 10% free: "occupied" by the same rule the panel applies. */
+const STALE_FREE = Math.round(1.2 * GIB);
+/** What the card really had once the driver caught up. */
+const SETTLED_FREE = Math.round(10.7 * GIB);
+const TORCH_TOTAL = 32 * 1024 * 1024;
+
+function gpu(vramFree: number, torchFree: number) {
+  return {
+    name: "cuda:0",
+    index: 0,
+    vram_total: TOTAL,
+    vram_free: vramFree,
+    torch_vram_total: TORCH_TOTAL,
+    torch_vram_free: torchFree,
+  };
+}
+
+/**
+ * The reported timing: torch hands its pool back almost at once, the driver
+ * stays frozen at the pre-/free number until `driverReleasesAtMs`.
+ *
+ * The torch movement is the whole trap — it is enough to make the combined
+ * counters "change then plateau", which is what certified the frozen driver
+ * number as settled.
+ */
+function setDriverLag(driverReleasesAtMs: number): { sampledAt: number[]; freeAt: () => number } {
+  let freeAt: number | null = null;
+  const sampledAt: number[] = [];
+  mocks.comfyuiFetch.mockImplementation(async () => {
+    freeAt = Date.now();
+    return { status: 200 };
+  });
+  __panelToolsTestHooks.setReadVramDevices(async () => {
+    sampledAt.push(Date.now());
+    if (freeAt == null) return [gpu(STALE_FREE, 0)];
+    const since = Date.now() - freeAt;
+    return [
+      gpu(since >= driverReleasesAtMs ? SETTLED_FREE : STALE_FREE, since >= 400 ? TORCH_TOTAL : 0),
+    ];
+  });
+  return { sampledAt, freeAt: () => freeAt as number };
+}
+
+/** An idle card: /free releases nothing and no counter moves, before or after. */
+function setIdleCard(): { sampledAt: number[]; freeAt: () => number } {
+  let freeAt: number | null = null;
+  const sampledAt: number[] = [];
+  mocks.comfyuiFetch.mockImplementation(async () => {
+    freeAt = Date.now();
+    return { status: 200 };
+  });
+  __panelToolsTestHooks.setReadVramDevices(async () => {
+    sampledAt.push(Date.now());
+    return [gpu(SETTLED_FREE, TORCH_TOTAL)];
+  });
+  return { sampledAt, freeAt: () => freeAt as number };
+}
+
+async function runFrozenTab(): Promise<ToolResult> {
+  const ctx = makePanelToolCtx(bridge() as never, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_free_vram");
+  if (!def) throw new Error("panel_free_vram is not registered");
+  const pending = def.handler({} as never, ctx);
+  await vi.advanceTimersByTimeAsync(VRAM_SETTLE_TIMEOUT_MS + VRAM_SETTLE_INTERVAL_MS * 2);
+  return await pending;
+}
+
+beforeEach(() => {
+  mocks.comfyuiFetch.mockReset();
+  mocks.comfyuiFetch.mockResolvedValue({ status: 200 });
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  __panelToolsTestHooks.setFreeVramDirect(null);
+  __panelToolsTestHooks.setReadVramDevices(null);
+});
+
+describe("panel_free_vram against a driver that releases late (#2704)", () => {
+  it("does not call the card occupied on counters the driver had not released", async () => {
+    setDriverLag(8_000);
+
+    const res = await runFrozenTab();
+    const text = textOf(res);
+
+    expect(res.isError).not.toBe(true);
+    expect(text).toMatch(/"verified": "server-side"/);
+    // The verdict, not just the number: a stale read names cuda:0 occupied.
+    expect(text).not.toMatch(/occupied_devices/);
+    const payload = JSON.parse(text) as {
+      vram_after?: Array<{ vram_free?: number }>;
+      vram_after_settled?: boolean;
+    };
+    expect(payload.vram_after?.[0]?.vram_free).toBe(SETTLED_FREE);
+    // It waited and SAW the release, so it must not hedge.
+    expect(payload.vram_after_settled).toBeUndefined();
+  });
+
+  it("marks the counters unconfirmed when the release never lands", async () => {
+    setDriverLag(Number.MAX_SAFE_INTEGER);
+
+    const res = await runFrozenTab();
+    const text = textOf(res);
+    const payload = JSON.parse(text) as {
+      vram_after?: Array<{ vram_free?: number }>;
+      vram_after_settled?: boolean;
+    };
+
+    // Still reported — it is the best reading available — but a card that never
+    // released is not a measured post-release figure, and saying so is the
+    // difference between an honest unknown and a false occupancy claim.
+    expect(payload.vram_after?.[0]?.vram_free).toBe(STALE_FREE);
+    expect(payload.vram_after_settled).toBe(false);
+  });
+
+  it("does not wait for a release on a card that was already free", async () => {
+    // Waiting for movement is only justified where movement is expected. An
+    // idle card has nothing to release, so this must not sit out the whole cap
+    // on a path that has already spent 15s waiting for the tab's ack.
+    const { sampledAt, freeAt } = setIdleCard();
+
+    const res = await runFrozenTab();
+
+    expect(sampledAt.at(-1)! - freeAt()).toBeLessThan(VRAM_SETTLE_TIMEOUT_MS);
+    const payload = JSON.parse(textOf(res)) as { vram_after_settled?: boolean };
+    expect(payload.vram_after_settled).toBeUndefined();
+  });
+});

--- a/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
+++ b/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
@@ -232,6 +232,52 @@ describe("panel_free_vram against a driver that releases late (#2704)", () => {
     expect(payload.vram_after_settled).toBe(false);
   });
 
+  it("does not read a REORDERED device list as both cards having released", async () => {
+    // /system_stats does not promise a stable device order. Matching the
+    // baseline positionally would compare cuda:0's value against cuda:1's,
+    // find both "changed", and certify a box where nothing released at all.
+    let freeAt: number | null = null;
+    mocks.comfyuiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return { status: 200 };
+    });
+    const zero = () => gpu(STALE_FREE, 0);
+    // Same occupancy, DIFFERENT byte counts, so a positional compare sees a
+    // change on both entries the moment the order flips.
+    const one = () => ({ ...gpu(STALE_FREE - 4096, 0), name: "cuda:1", index: 1 });
+    __panelToolsTestHooks.setReadVramDevices(async () => {
+      if (freeAt == null) return [zero(), one()];
+      return [one(), zero()]; // reordered, but neither card moved
+    });
+
+    const res = await runFrozenTab();
+    const payload = JSON.parse(textOf(res)) as { vram_after_settled?: boolean };
+
+    expect(payload.vram_after_settled).toBe(false);
+  });
+
+  it("does not read a VANISHED device as one that released", async () => {
+    // A card that drops out of the sample proves nothing about its memory.
+    // Reading its absence as a release would certify a value nobody observed.
+    let freeAt: number | null = null;
+    mocks.comfyuiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return { status: 200 };
+    });
+    __panelToolsTestHooks.setReadVramDevices(async () => {
+      const busy = { ...gpu(STALE_FREE, 0), name: "cuda:1", index: 1 };
+      if (freeAt == null) return [gpu(STALE_FREE, 0), busy];
+      // cuda:1 disappears; cuda:0 genuinely releases.
+      const since = Date.now() - freeAt;
+      return [gpu(since >= 2_000 ? SETTLED_FREE : STALE_FREE, since >= 400 ? TORCH_TOTAL : 0)];
+    });
+
+    const res = await runFrozenTab();
+    const payload = JSON.parse(textOf(res)) as { vram_after_settled?: boolean };
+
+    expect(payload.vram_after_settled).toBe(false);
+  });
+
   it("does not wait for a release on a card that was already free", async () => {
     // Waiting for movement is only justified where movement is expected. An
     // idle card has nothing to release, so this must not sit out the whole cap

--- a/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
+++ b/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
@@ -278,6 +278,30 @@ describe("panel_free_vram against a driver that releases late (#2704)", () => {
     expect(payload.vram_after_settled).toBe(false);
   });
 
+  it("does not certify a release when two occupied cards share an identity", async () => {
+    // Identities that collide cannot be attributed per card. Keying a Map on
+    // them makes the later device overwrite the earlier, so ONE card moving
+    // clears the other's entry and certifies memory nobody saw released.
+    let freeAt: number | null = null;
+    mocks.comfyuiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return { status: 200 };
+    });
+    // Both devices report index 0 — indistinguishable to a per-card baseline.
+    const twin = (vramFree: number) => ({ ...gpu(vramFree, 0), name: "cuda:0", index: 0 });
+    __panelToolsTestHooks.setReadVramDevices(async () => {
+      if (freeAt == null) return [twin(STALE_FREE), twin(STALE_FREE)];
+      const since = Date.now() - freeAt;
+      // The SECOND twin releases; the first never does.
+      return [twin(STALE_FREE), twin(since >= 2_000 ? SETTLED_FREE : STALE_FREE)];
+    });
+
+    const res = await runFrozenTab();
+    const payload = JSON.parse(textOf(res)) as { vram_after_settled?: boolean };
+
+    expect(payload.vram_after_settled).toBe(false);
+  });
+
   it("does not wait for a release on a card that was already free", async () => {
     // Waiting for movement is only justified where movement is expected. An
     // idle card has nothing to release, so this must not sit out the whole cap

--- a/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
+++ b/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
@@ -189,6 +189,26 @@ describe("panel_free_vram against a driver that releases late (#2704)", () => {
     expect(payload.vram_after_settled).toBe(false);
   });
 
+  it("does not claim the counters are settled when the pre-/free read failed", async () => {
+    // No baseline because the read FAILED is not the same as no baseline
+    // because there was nothing to release. Only the second may be published
+    // as a measured figure.
+    let freeAt: number | null = null;
+    mocks.comfyuiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return { status: 200 };
+    });
+    __panelToolsTestHooks.setReadVramDevices(async () => {
+      if (freeAt == null) return null;
+      return [gpu(STALE_FREE, TORCH_TOTAL)];
+    });
+
+    const res = await runFrozenTab();
+    const payload = JSON.parse(textOf(res)) as { vram_after_settled?: boolean };
+
+    expect(payload.vram_after_settled).toBe(false);
+  });
+
   it("does not let one GPU releasing certify a second that never moved", async () => {
     // Two occupied cards. cuda:0 releases at 2s; cuda:1 stays frozen for good.
     // A release signature joined across devices changes the moment cuda:0

--- a/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
+++ b/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
@@ -189,6 +189,29 @@ describe("panel_free_vram against a driver that releases late (#2704)", () => {
     expect(payload.vram_after_settled).toBe(false);
   });
 
+  it("does not let one GPU releasing certify a second that never moved", async () => {
+    // Two occupied cards. cuda:0 releases at 2s; cuda:1 stays frozen for good.
+    // A release signature joined across devices changes the moment cuda:0
+    // moves, so the next stable sample would report BOTH as settled — the torch
+    // substitution one level up.
+    let freeAt: number | null = null;
+    mocks.comfyuiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return { status: 200 };
+    });
+    __panelToolsTestHooks.setReadVramDevices(async () => {
+      const busy = { ...gpu(STALE_FREE, 0), name: "cuda:1", index: 1 };
+      if (freeAt == null) return [gpu(STALE_FREE, 0), busy];
+      const since = Date.now() - freeAt;
+      return [gpu(since >= 2_000 ? SETTLED_FREE : STALE_FREE, since >= 400 ? TORCH_TOTAL : 0), busy];
+    });
+
+    const res = await runFrozenTab();
+    const payload = JSON.parse(textOf(res)) as { vram_after_settled?: boolean };
+
+    expect(payload.vram_after_settled).toBe(false);
+  });
+
   it("does not wait for a release on a card that was already free", async () => {
     // Waiting for movement is only justified where movement is expected. An
     // idle card has nothing to release, so this must not sit out the whole cap

--- a/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
+++ b/src/__tests__/orchestrator/free-vram-driver-lag.test.ts
@@ -302,6 +302,30 @@ describe("panel_free_vram against a driver that releases late (#2704)", () => {
     expect(payload.vram_after_settled).toBe(false);
   });
 
+  it("does not certify when the POST-free sample duplicates a watched identity", async () => {
+    // The baseline is clean — one occupied, uniquely identified card — but the
+    // sample after /free reports that identity twice. Keeping the last entry
+    // would let the released twin answer for the stale one.
+    let freeAt: number | null = null;
+    mocks.comfyuiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return { status: 200 };
+    });
+    __panelToolsTestHooks.setReadVramDevices(async () => {
+      if (freeAt == null) return [gpu(STALE_FREE, 0)];
+      const since = Date.now() - freeAt;
+      return [
+        gpu(STALE_FREE, since >= 400 ? TORCH_TOTAL : 0),
+        gpu(since >= 2_000 ? SETTLED_FREE : STALE_FREE, TORCH_TOTAL),
+      ];
+    });
+
+    const res = await runFrozenTab();
+    const payload = JSON.parse(textOf(res)) as { vram_after_settled?: boolean };
+
+    expect(payload.vram_after_settled).toBe(false);
+  });
+
   it("does not wait for a release on a card that was already free", async () => {
     // Waiting for movement is only justified where movement is expected. An
     // idle card has nothing to release, so this must not sit out the whole cap

--- a/src/__tests__/tools/clear-vram-driver-lag.test.ts
+++ b/src/__tests__/tools/clear-vram-driver-lag.test.ts
@@ -257,6 +257,33 @@ describe("clear_vram against a driver that releases late (#2704)", () => {
     expect(textOf(res)).toContain(UNSETTLED_CAVEAT);
   });
 
+  it("does not wait for a release nobody asked for", async () => {
+    // /free with both flags off releases nothing. Arming the wait purely on
+    // baseline occupancy would sit out the full cap on a busy card and then
+    // warn that it "had not finished releasing" — for an operation that was
+    // never going to move the number.
+    const sampledAt: number[] = [];
+    let freeAt: number | null = null;
+    mocks.comfyApiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return freeOk();
+    });
+    mocks.getSystemStats.mockImplementation(async () => {
+      sampledAt.push(Date.now());
+      return gpuStats(STALE_FREE, TORCH_BUSY); // occupied and perfectly static
+    });
+
+    const pending = call({ unload_models: false, free_memory: false });
+    await vi.advanceTimersByTimeAsync(
+      CLEAR_VRAM_SETTLE_TIMEOUT_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS * 2,
+    );
+    const res = await pending;
+
+    expect(sampledAt.at(-1)! - freeAt!).toBeLessThan(CLEAR_VRAM_SETTLE_TIMEOUT_MS);
+    expect(textOf(res)).toContain(STALE_LINE);
+    expect(textOf(res)).not.toContain(UNSETTLED_CAVEAT);
+  });
+
   it("does not arm the wait on a device that reports no usable VRAM total", async () => {
     // `free / total` says nothing when total is 0 or tiny, and an occupancy
     // rule that reads such a device as "occupied" would block every clear_vram

--- a/src/__tests__/tools/clear-vram-driver-lag.test.ts
+++ b/src/__tests__/tools/clear-vram-driver-lag.test.ts
@@ -284,6 +284,30 @@ describe("clear_vram against a driver that releases late (#2704)", () => {
     expect(textOf(res)).not.toContain(UNSETTLED_CAVEAT);
   });
 
+  it("does not hedge a no-op clear just because the baseline read failed", async () => {
+    // Nothing was asked to be released, so there is nothing to prove and the
+    // missing baseline costs nothing. Hedging here would attach a warning about
+    // an unfinished release to a call that never requested one.
+    let freeAt: number | null = null;
+    mocks.comfyApiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return freeOk();
+    });
+    mocks.getSystemStats.mockImplementation(async () => {
+      if (freeAt == null) throw new Error("ECONNRESET");
+      return gpuStats(STALE_FREE, TORCH_BUSY);
+    });
+
+    const pending = call({ unload_models: false, free_memory: false });
+    await vi.advanceTimersByTimeAsync(
+      CLEAR_VRAM_SETTLE_TIMEOUT_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS * 2,
+    );
+    const res = await pending;
+
+    expect(textOf(res)).toContain(STALE_LINE);
+    expect(textOf(res)).not.toContain(UNSETTLED_CAVEAT);
+  });
+
   it("does not arm the wait on a device that reports no usable VRAM total", async () => {
     // `free / total` says nothing when total is 0 or tiny, and an occupancy
     // rule that reads such a device as "occupied" would block every clear_vram

--- a/src/__tests__/tools/clear-vram-driver-lag.test.ts
+++ b/src/__tests__/tools/clear-vram-driver-lag.test.ts
@@ -117,6 +117,14 @@ function freeOk(): Response {
 async function runClear(opts: {
   driverReleasesAtMs: number;
   baselineFree?: number;
+  /**
+   * An idle card: nothing was loaded, so /free releases nothing and NO counter
+   * moves — before or after. Keeping the counters genuinely static is what
+   * makes this a control: a fixture whose driver value differs across /free
+   * would satisfy the movement test by accident and could not detect the
+   * occupancy gate being removed.
+   */
+  idle?: boolean;
 }) {
   const sampledAt: number[] = [];
   let freeAt: number | null = null;
@@ -127,8 +135,10 @@ async function runClear(opts: {
   mocks.getSystemStats.mockImplementation(async () => {
     const now = Date.now();
     sampledAt.push(now);
+    const baselineFree = opts.baselineFree ?? STALE_FREE;
+    if (opts.idle) return gpuStats(baselineFree, TORCH_FREE_AFTER);
     // Before POST /free: the loaded card, torch pool occupied.
-    if (freeAt == null) return gpuStats(opts.baselineFree ?? STALE_FREE, TORCH_BUSY);
+    if (freeAt == null) return gpuStats(baselineFree, TORCH_BUSY);
     const since = now - freeAt;
     return gpuStats(
       since >= opts.driverReleasesAtMs ? TRUE_FREE : STALE_FREE,
@@ -210,11 +220,51 @@ describe("clear_vram against a driver that releases late (#2704)", () => {
     const { res, sampledAt, freeAt } = await runClear({
       driverReleasesAtMs: Number.MAX_SAFE_INTEGER,
       baselineFree: TRUE_FREE, // ~94% free: not occupied
+      idle: true,
     });
 
     const waited = sampledAt.at(-1)! - freeAt()!;
     expect(waited).toBeLessThan(CLEAR_VRAM_SETTLE_MIN_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS * 3);
     expect(waited).toBeLessThan(CLEAR_VRAM_SETTLE_TIMEOUT_MS);
-    expect(textOf(res)).toContain(STALE_LINE);
+    expect(textOf(res)).toContain(TRUE_LINE);
+    // Nothing was in doubt here, so nothing should be hedged.
+    expect(textOf(res)).not.toContain(UNSETTLED_CAVEAT);
+  });
+
+  it("does not arm the wait on a device that reports no usable VRAM total", async () => {
+    // `free / total` says nothing when total is 0 or tiny, and an occupancy
+    // rule that reads such a device as "occupied" would block every clear_vram
+    // for the full cap on hardware it cannot measure at all.
+    const sampledAt: number[] = [];
+    let freeAt: number | null = null;
+    mocks.comfyApiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return freeOk();
+    });
+    mocks.getSystemStats.mockImplementation(async () => {
+      sampledAt.push(Date.now());
+      return {
+        system: { os: "win32", python_version: "3.12", embedded_python: false },
+        devices: [
+          {
+            name: "cpu",
+            type: "cpu",
+            index: 0,
+            vram_total: 0,
+            vram_free: 0,
+            torch_vram_total: 0,
+            torch_vram_free: 0,
+          },
+        ],
+      } satisfies SystemStats;
+    });
+
+    const pending = call({ unload_models: true, free_memory: true });
+    await vi.advanceTimersByTimeAsync(
+      CLEAR_VRAM_SETTLE_TIMEOUT_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS * 2,
+    );
+    await pending;
+
+    expect(sampledAt.at(-1)! - freeAt!).toBeLessThan(CLEAR_VRAM_SETTLE_TIMEOUT_MS);
   });
 });

--- a/src/__tests__/tools/clear-vram-driver-lag.test.ts
+++ b/src/__tests__/tools/clear-vram-driver-lag.test.ts
@@ -1,0 +1,220 @@
+// #2704 — clear_vram printed `Current VRAM: 2805/32607 MB free` on an RTX 5090
+// (cudaMallocAsync) right after unloading ~29 GB, while a get_system_stats
+// moments later read 32268615680 (~30 GB) from the SAME endpoint. A Qwen Image
+// Edit generation needing ~19 GB then ran fine, so ~30 GB really was free.
+//
+// The report blamed the 5s settle cap and prescribed raising it to 12s. Driving
+// the real loop shows that is inert: the cap is never reached. The torch pool
+// releases in ~400ms while the DRIVER counter stays frozen at its pre-/free
+// value, and that torch movement satisfied the loop's change-then-plateau test,
+// so it returned the frozen driver number after ~780ms. Stillness cannot tell a
+// plateau from a release that has not begun — only a pre-/free BASELINE can,
+// and only if it ignores the torch pool.
+//
+// These tests drive the registered `clear_vram` handler against that timing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const mocks = vi.hoisted(() => ({
+  comfyApiFetch: vi.fn(),
+  getSystemStats: vi.fn(),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  comfyApiFetch: (...args: unknown[]) => mocks.comfyApiFetch(...args),
+  getSystemStats: (...args: unknown[]) => mocks.getSystemStats(...args),
+}));
+
+import {
+  CLEAR_VRAM_SETTLE_INTERVAL_MS,
+  CLEAR_VRAM_SETTLE_MIN_MS,
+  CLEAR_VRAM_SETTLE_TIMEOUT_MS,
+  registerMemoryManagementTools,
+} from "../../tools/memory-management.js";
+import type { SystemStats } from "../../comfyui/types.js";
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+interface Registered {
+  name: string;
+  shape: z.ZodRawShape;
+  handler: Handler;
+}
+
+function registered(): Registered[] {
+  const tools: Registered[] = [];
+  const server = {
+    tool: (name: string, _desc: string, shape: z.ZodRawShape, handler: Handler) => {
+      tools.push({ name, shape, handler });
+    },
+  };
+  registerMemoryManagementTools(server as never);
+  return tools;
+}
+
+function call(args: Record<string, unknown>) {
+  const tools = registered();
+  const [{ shape, handler }] = tools;
+  return handler(z.object(shape).parse(args) as Record<string, unknown>);
+}
+
+const textOf = (res: Awaited<ReturnType<Handler>>) =>
+  res.content.map((c) => c.text).join(" ");
+
+// The reporter's exact bytes.
+const TOTAL = 34_190_458_880;
+/** ~2805 MB — what CUDA still reported while the driver had not released. */
+const STALE_FREE = 2805 * 1024 * 1024;
+/** ~30 GB — the follow-up get_system_stats (action:"stats") reading. */
+const TRUE_FREE = 32_268_615_680;
+const TORCH_TOTAL = 100_663_296;
+/** Torch pool while the models were loaded... */
+const TORCH_BUSY = 8_388_608;
+/** ...and after torch hands it back, ~400ms in. Reported as `Torch: 78/96 MB`. */
+const TORCH_FREE_AFTER = 82_575_360;
+
+function gpuStats(vramFree: number, torchFree: number): SystemStats {
+  return {
+    system: { os: "win32", python_version: "3.12", embedded_python: false },
+    devices: [
+      {
+        name: "cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync",
+        type: "cuda",
+        index: 0,
+        vram_total: TOTAL,
+        vram_free: vramFree,
+        torch_vram_total: TORCH_TOTAL,
+        torch_vram_free: torchFree,
+      },
+    ],
+  };
+}
+
+function mb(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(0);
+}
+
+const STALE_LINE = `Current VRAM: ${mb(STALE_FREE)}/${mb(TOTAL)} MB free`;
+const TRUE_LINE = `Current VRAM: ${mb(TRUE_FREE)}/${mb(TOTAL)} MB free`;
+const UNSETTLED_CAVEAT = "had not finished releasing";
+
+function freeOk(): Response {
+  return new Response(null, { status: 200 });
+}
+
+/**
+ * Drive one clear_vram to completion. The mock answers as the reported card
+ * did: the torch pool is handed back at 400ms, while the DRIVER counter stays
+ * frozen at its pre-/free value until `driverReleasesAtMs`.
+ *
+ * Returns the sample times so a test can assert WHEN the loop gave up, not just
+ * what it printed.
+ */
+async function runClear(opts: {
+  driverReleasesAtMs: number;
+  baselineFree?: number;
+}) {
+  const sampledAt: number[] = [];
+  let freeAt: number | null = null;
+  mocks.comfyApiFetch.mockImplementation(async () => {
+    freeAt = Date.now();
+    return freeOk();
+  });
+  mocks.getSystemStats.mockImplementation(async () => {
+    const now = Date.now();
+    sampledAt.push(now);
+    // Before POST /free: the loaded card, torch pool occupied.
+    if (freeAt == null) return gpuStats(opts.baselineFree ?? STALE_FREE, TORCH_BUSY);
+    const since = now - freeAt;
+    return gpuStats(
+      since >= opts.driverReleasesAtMs ? TRUE_FREE : STALE_FREE,
+      since >= 400 ? TORCH_FREE_AFTER : TORCH_BUSY,
+    );
+  });
+
+  const pending = call({ unload_models: true, free_memory: true });
+  await vi.advanceTimersByTimeAsync(
+    CLEAR_VRAM_SETTLE_TIMEOUT_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS * 2,
+  );
+  return { res: await pending, sampledAt, freeAt: () => freeAt };
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("clear_vram against a driver that releases late (#2704)", () => {
+  it("waits out an 8s driver release instead of printing the frozen 2805 MB", async () => {
+    // The whole report in one case. Before the fix the loop returned at ~780ms
+    // with STALE_FREE, because the torch pool moving at 400ms counted as "the
+    // release happened" and the next equal pair looked like a plateau.
+    const { res, sampledAt, freeAt } = await runClear({ driverReleasesAtMs: 8_000 });
+
+    expect(textOf(res)).toContain("VRAM cleared successfully");
+    expect(textOf(res)).toContain(TRUE_LINE);
+    expect(textOf(res)).not.toContain(STALE_LINE);
+    // ...and it is reported as a measured figure, with no hedge attached.
+    expect(textOf(res)).not.toContain(UNSETTLED_CAVEAT);
+    // It really did keep polling past the release, rather than getting the
+    // right answer by luck on a single late read.
+    expect(sampledAt.at(-1)! - freeAt()!).toBeGreaterThanOrEqual(8_000);
+  });
+
+  it("samples the baseline BEFORE /free, since a later one is already stale", async () => {
+    // A baseline taken after /free is the frozen value itself, so it could
+    // never show the release land. Order is the whole point of the fix.
+    const order: string[] = [];
+    mocks.comfyApiFetch.mockImplementation(async () => {
+      order.push("free");
+      return freeOk();
+    });
+    mocks.getSystemStats.mockImplementation(async () => {
+      order.push("stats");
+      return gpuStats(STALE_FREE, TORCH_BUSY);
+    });
+
+    const pending = call({ unload_models: true, free_memory: true });
+    await vi.advanceTimersByTimeAsync(CLEAR_VRAM_SETTLE_TIMEOUT_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS);
+    await pending;
+
+    expect(order[0]).toBe("stats");
+    expect(order[1]).toBe("free");
+  });
+
+  it("prints the reading but says so when the release never lands inside the cap", async () => {
+    // Never releasing is indistinguishable from releasing at cap+1ms, so the
+    // number is still the best available — it just must not be presented as a
+    // measured post-release figure. Torch DOES move here, so this also pins
+    // that torch movement alone never counts as the driver releasing.
+    const { res } = await runClear({ driverReleasesAtMs: Number.MAX_SAFE_INTEGER });
+
+    expect(textOf(res)).toContain("VRAM cleared successfully");
+    expect(textOf(res)).toContain(STALE_LINE);
+    expect(textOf(res)).toContain(UNSETTLED_CAVEAT);
+  });
+
+  it("does not spend the cap on a card that was already mostly free", async () => {
+    // The cost of waiting for movement is paid only where movement is expected.
+    // An idle card has nothing to release, so clear_vram must stay as fast as
+    // it was before #2704 rather than blocking for the full 12s.
+    const { res, sampledAt, freeAt } = await runClear({
+      driverReleasesAtMs: Number.MAX_SAFE_INTEGER,
+      baselineFree: TRUE_FREE, // ~94% free: not occupied
+    });
+
+    const waited = sampledAt.at(-1)! - freeAt()!;
+    expect(waited).toBeLessThan(CLEAR_VRAM_SETTLE_MIN_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS * 3);
+    expect(waited).toBeLessThan(CLEAR_VRAM_SETTLE_TIMEOUT_MS);
+    expect(textOf(res)).toContain(STALE_LINE);
+  });
+});

--- a/src/__tests__/tools/clear-vram-driver-lag.test.ts
+++ b/src/__tests__/tools/clear-vram-driver-lag.test.ts
@@ -231,6 +231,32 @@ describe("clear_vram against a driver that releases late (#2704)", () => {
     expect(textOf(res)).not.toContain(UNSETTLED_CAVEAT);
   });
 
+  it("does not claim a reading is settled when the baseline could not be read", async () => {
+    // An unreadable baseline and an idle card both arrive at the settle loop
+    // with nothing to check. Collapsing them would publish an unprovable
+    // reading as a measured one — the exact failure this change exists to stop.
+    let freeAt: number | null = null;
+    mocks.comfyApiFetch.mockImplementation(async () => {
+      freeAt = Date.now();
+      return freeOk();
+    });
+    mocks.getSystemStats.mockImplementation(async () => {
+      // The pre-/free read fails; every read after /free succeeds and sits
+      // frozen on the pre-release value.
+      if (freeAt == null) throw new Error("ECONNRESET");
+      return gpuStats(STALE_FREE, TORCH_FREE_AFTER);
+    });
+
+    const pending = call({ unload_models: true, free_memory: true });
+    await vi.advanceTimersByTimeAsync(
+      CLEAR_VRAM_SETTLE_TIMEOUT_MS + CLEAR_VRAM_SETTLE_INTERVAL_MS * 2,
+    );
+    const res = await pending;
+
+    expect(textOf(res)).toContain(STALE_LINE);
+    expect(textOf(res)).toContain(UNSETTLED_CAVEAT);
+  });
+
   it("does not arm the wait on a device that reports no usable VRAM total", async () => {
     // `free / total` says nothing when total is 0 or tiny, and an occupancy
     // rule that reads such a device as "occupied" would block every clear_vram

--- a/src/__tests__/tools/clear-vram-stale-report.test.ts
+++ b/src/__tests__/tools/clear-vram-stale-report.test.ts
@@ -192,7 +192,12 @@ describe("clear_vram post-unload VRAM (#2050)", () => {
 
     const res = await runClear({ unload_models: true, free_memory: true });
 
-    expect(mocks.getSystemStats).not.toHaveBeenCalled();
+    // #2704 added ONE read before POST /free — the settle baseline, which must
+    // be sampled before the mutation to be worth anything. The polling this
+    // guards against is the settle LOOP, so the count is pinned exactly rather
+    // than loosened to "some": a loop leaking in behind a failed /free would
+    // run many more than one.
+    expect(mocks.getSystemStats).toHaveBeenCalledTimes(1);
     expect(textOf(res)).toMatch(/Failed to free VRAM/);
     expect(textOf(res)).not.toContain("Current VRAM:");
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -53,6 +53,7 @@ import { extname, isAbsolute, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { settleUntilStable } from "../services/vram-settle.js";
+import type { SettledRead } from "../services/vram-settle.js";
 import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
 import {
   findPackOnDisk,
@@ -4909,6 +4910,14 @@ function vramDevicesSignature(devices: VramDeviceSample[]): string {
     .join("|");
 }
 
+/** The DRIVER counters alone — the ones whose release lags. Torch hands its
+ *  pool back in ~400ms while `vram_free` can stay frozen for seconds, so
+ *  proving a release against the combined signature would certify the driver
+ *  as released on torch's schedule (#2704). */
+function vramDevicesReleaseSignature(devices: VramDeviceSample[]): string {
+  return devices.map((d) => `${d.index ?? d.name ?? ""}:${d.vram_free ?? ""}`).join("|");
+}
+
 /**
  * #2050 — POST /free returns when ComfyUI drops model refs; CUDA can still be
  * releasing. The 0.52.146 recurrence: panel_free_vram reported freed:true, a
@@ -4918,10 +4927,20 @@ function vramDevicesSignature(devices: VramDeviceSample[]): string {
 async function readSettledVramDevices(
   base: string,
   timeoutMs: number,
-): Promise<VramDeviceSample[] | null> {
+  before?: VramDeviceSample[] | null,
+): Promise<SettledRead<VramDeviceSample[]>> {
+  // #2704 — hold the poll against the PRE-/free counters, but only when the
+  // card was occupied enough that a release is expected to move them. A still
+  // reading is otherwise indistinguishable from a release that has not begun,
+  // which is how a frozen driver number was returned as settled at ~780ms.
+  const baseline =
+    before != null && occupiedVramDevices(before).length > 0
+      ? vramDevicesReleaseSignature(before)
+      : null;
   return settleUntilStable(
     () => readVramDevicesMaybe(base, timeoutMs),
     vramDevicesSignature,
+    { baseline, progressOf: vramDevicesReleaseSignature },
   );
 }
 
@@ -4932,6 +4951,9 @@ interface FreeVramDirectOutcome {
   reason?: string;
   before?: VramDeviceSample[] | null;
   after?: VramDeviceSample[] | null;
+  /** #2704 — false when `after` was returned at the settle cap without the
+   *  release ever being observed, i.e. the counters are reported unconfirmed. */
+  afterSettled?: boolean;
 }
 
 /** Issue ComfyUI's /free DIRECTLY against a proven-local base and read the
@@ -4962,8 +4984,8 @@ async function freeVramDirect(base: string): Promise<FreeVramDirectOutcome> {
   } finally {
     clearTimeout(timer);
   }
-  const after = await readSettledVramDevices(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
-  return { ok: true, before, after };
+  const after = await readSettledVramDevices(base, FREE_VRAM_DIRECT_TIMEOUT_MS, before);
+  return { ok: true, before, after: after.value, afterSettled: after.settled };
 }
 
 /** Test injection for the direct server-side /free, so the settle can be
@@ -5016,6 +5038,11 @@ async function settleFreeVramAfterAckTimeout(
     via: `POST ${base}/free`,
     ...(direct.before != null ? { vram_before: direct.before } : {}),
     ...(direct.after != null ? { vram_after: direct.after } : {}),
+    // #2704 — a card whose release never landed inside the settle cap is
+    // reported, but never as a confirmed post-release measurement.
+    ...(direct.after != null && direct.afterSettled === false
+      ? { vram_after_settled: false }
+      : {}),
   };
   // #1866 — a 2xx from /free is not a free GPU. Ray/CLIP workers can keep a
   // device pinned. When we have occupancy numbers, they are the verdict.
@@ -5079,7 +5106,10 @@ async function annotateFreeVramAck(ctx: PanelToolCtx, res: ToolResult): Promise<
       note: UNOBSERVED_OCCUPANCY_NOTE,
     });
   }
-  const devices = await readSettledVramDevices(base, FREE_VRAM_DIRECT_TIMEOUT_MS);
+  // No pre-/free sample exists on this path — the tab already posted /free
+  // before it acked — so this read keeps the best-effort plateau rule and
+  // cannot rule out a still-settling card the way freeVramDirect can (#2704).
+  const devices = (await readSettledVramDevices(base, FREE_VRAM_DIRECT_TIMEOUT_MS)).value;
   if (devices == null) return res;
   const pinned = pinnedVramDevices(devices);
   if (pinned.length > 0) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4925,12 +4925,25 @@ function vramDeviceReleaseKeys(
   only?: ReadonlySet<string>,
 ): ReadonlyMap<string, string> {
   const keys = new Map<string, string>();
+  const ambiguous = new Set<string>();
   for (const d of devices) {
     const id = vramDeviceKey(d);
     if (only != null && !only.has(id)) continue;
+    // A repeated identity cannot be attributed to one card, and `Map.set`
+    // would silently keep the last one — letting the second device's movement
+    // clear the first device's entry. Drop it instead: an unattributable key
+    // is absent, and absence never counts as a release.
+    if (keys.has(id)) ambiguous.add(id);
     keys.set(id, `${d.vram_free ?? ""}`);
   }
+  for (const id of ambiguous) keys.delete(id);
   return keys;
+}
+
+/** Do these devices have identities we can hold a per-card baseline against? */
+function vramDevicesAreIdentifiable(devices: VramDeviceSample[]): boolean {
+  const ids = devices.map(vramDeviceKey);
+  return !ids.includes("") && new Set(ids).size === ids.length;
 }
 
 /**
@@ -4950,7 +4963,10 @@ async function readSettledVramDevices(
   // how a frozen driver number was returned as settled at ~780ms. Cards that
   // were already free are excluded rather than waited on: they will never move.
   const occupiedBefore = before != null ? occupiedVramDevices(before) : [];
-  const watched = new Set(occupiedBefore.map(vramDeviceKey));
+  // Cards we cannot tell apart cannot be proven to have released individually,
+  // so we do not pretend to: no baseline, and the result is not confirmable.
+  const identifiable = vramDevicesAreIdentifiable(occupiedBefore);
+  const watched = identifiable ? new Set(occupiedBefore.map(vramDeviceKey)) : new Set<string>();
   const baselineKeys = watched.size > 0 ? vramDeviceReleaseKeys(before!, watched) : null;
   const baseline = baselineKeys != null && baselineKeys.size > 0 ? baselineKeys : null;
   return settleUntilStable(
@@ -4959,9 +4975,10 @@ async function readSettledVramDevices(
     {
       baseline,
       progressOf: (devices) => vramDeviceReleaseKeys(devices, watched),
-      // A `before` we could not read is not the same as a box with nothing to
-      // release; only the latter may be published as a measured figure.
-      confirmable: before != null,
+      // A `before` we could not read — or occupied cards we cannot tell apart —
+      // is not the same as a box with nothing to release. Only the latter may
+      // be published as a measured figure.
+      confirmable: before != null && identifiable,
     },
   );
 }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4910,12 +4910,23 @@ function vramDevicesSignature(devices: VramDeviceSample[]): string {
     .join("|");
 }
 
-/** The DRIVER counters alone — the ones whose release lags. Torch hands its
- *  pool back in ~400ms while `vram_free` can stay frozen for seconds, so
- *  proving a release against the combined signature would certify the driver
- *  as released on torch's schedule (#2704). */
-function vramDevicesReleaseSignature(devices: VramDeviceSample[]): string {
-  return devices.map((d) => `${d.index ?? d.name ?? ""}:${d.vram_free ?? ""}`).join("|");
+/** Stable per-device identity, so a baseline key and a live key line up. */
+function vramDeviceKey(d: VramDeviceSample): string {
+  return `${d.index ?? d.name ?? ""}`;
+}
+
+/** The DRIVER counter of each watched device, ONE KEY PER DEVICE. Torch hands
+ *  its pool back in ~400ms while `vram_free` can stay frozen for seconds, so
+ *  proving a release against the combined signature would certify the driver as
+ *  released on torch's schedule; and joining the devices into one string would
+ *  let card 0 releasing certify card 1, which never moved (#2704). */
+function vramDeviceReleaseKeys(
+  devices: VramDeviceSample[],
+  only?: ReadonlySet<string>,
+): readonly string[] {
+  return devices
+    .filter((d) => only == null || only.has(vramDeviceKey(d)))
+    .map((d) => `${vramDeviceKey(d)}:${d.vram_free ?? ""}`);
 }
 
 /**
@@ -4929,18 +4940,24 @@ async function readSettledVramDevices(
   timeoutMs: number,
   before?: VramDeviceSample[] | null,
 ): Promise<SettledRead<VramDeviceSample[]>> {
-  // #2704 — hold the poll against the PRE-/free counters, but only when the
-  // card was occupied enough that a release is expected to move them. A still
-  // reading is otherwise indistinguishable from a release that has not begun,
-  // which is how a frozen driver number was returned as settled at ~780ms.
-  const baseline =
-    before != null && occupiedVramDevices(before).length > 0
-      ? vramDevicesReleaseSignature(before)
-      : null;
+  // #2704 — hold the poll against the PRE-/free counters, but only for the
+  // cards that were occupied enough for a release to move them. A still reading
+  // is otherwise indistinguishable from a release that has not begun, which is
+  // how a frozen driver number was returned as settled at ~780ms. Cards that
+  // were already free are excluded rather than waited on: they will never move.
+  const occupiedBefore = before != null ? occupiedVramDevices(before) : [];
+  const watched = new Set(occupiedBefore.map(vramDeviceKey));
+  const baseline = watched.size > 0 ? vramDeviceReleaseKeys(before!, watched) : null;
   return settleUntilStable(
     () => readVramDevicesMaybe(base, timeoutMs),
     vramDevicesSignature,
-    { baseline, progressOf: vramDevicesReleaseSignature },
+    {
+      baseline,
+      progressOf: (devices) => vramDeviceReleaseKeys(devices, watched),
+      // A `before` we could not read is not the same as a box with nothing to
+      // release; only the latter may be published as a measured figure.
+      confirmable: before != null,
+    },
   );
 }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4923,10 +4923,14 @@ function vramDeviceKey(d: VramDeviceSample): string {
 function vramDeviceReleaseKeys(
   devices: VramDeviceSample[],
   only?: ReadonlySet<string>,
-): readonly string[] {
-  return devices
-    .filter((d) => only == null || only.has(vramDeviceKey(d)))
-    .map((d) => `${vramDeviceKey(d)}:${d.vram_free ?? ""}`);
+): ReadonlyMap<string, string> {
+  const keys = new Map<string, string>();
+  for (const d of devices) {
+    const id = vramDeviceKey(d);
+    if (only != null && !only.has(id)) continue;
+    keys.set(id, `${d.vram_free ?? ""}`);
+  }
+  return keys;
 }
 
 /**
@@ -4947,7 +4951,8 @@ async function readSettledVramDevices(
   // were already free are excluded rather than waited on: they will never move.
   const occupiedBefore = before != null ? occupiedVramDevices(before) : [];
   const watched = new Set(occupiedBefore.map(vramDeviceKey));
-  const baseline = watched.size > 0 ? vramDeviceReleaseKeys(before!, watched) : null;
+  const baselineKeys = watched.size > 0 ? vramDeviceReleaseKeys(before!, watched) : null;
+  const baseline = baselineKeys != null && baselineKeys.size > 0 ? baselineKeys : null;
   return settleUntilStable(
     () => readVramDevicesMaybe(base, timeoutMs),
     vramDevicesSignature,

--- a/src/services/vram-settle.ts
+++ b/src/services/vram-settle.ts
@@ -2,8 +2,64 @@
 export const VRAM_SETTLE_INTERVAL_MS = 250;
 /** Do not treat an unchanged first reading as settled — CUDA may not have started releasing yet. */
 export const VRAM_SETTLE_MIN_MS = 1_000;
-/** Hard cap so a card that never plateaus still returns a number. */
-export const VRAM_SETTLE_TIMEOUT_MS = 5_000;
+/**
+ * Hard cap so a card that never plateaus still returns a number.
+ *
+ * #2704 raised this from 5s. An RTX 5090 on cudaMallocAsync took ~8s for a
+ * ~29 GB unload to become visible in /system_stats, so 5s could not cover it.
+ * The cap is only ever REACHED when a `baseline` was supplied and the release
+ * never landed — a card that releases promptly returns as soon as it plateaus,
+ * so this costs nothing on hardware that already worked.
+ */
+export const VRAM_SETTLE_TIMEOUT_MS = 12_000;
+
+/**
+ * "This card is holding memory" — free/total at or below this ratio, on a card
+ * big enough for the ratio to mean anything. Mirrors the pin thresholds
+ * `panel-tools.ts` already applies to the same counters (#1895), so callers
+ * decide whether to wait for a release using one definition of occupied.
+ */
+export const VRAM_OCCUPIED_FREE_RATIO = 0.2;
+export const VRAM_OCCUPIED_MIN_TOTAL_BYTES = 1024 * 1024 * 1024;
+
+export interface SettledRead<T> {
+  /** The last reading taken, or null when the source never answered. */
+  value: T | null;
+  /**
+   * True only when the loop could JUSTIFY the plateau it returned: it saw the
+   * counters move off `baseline` and then hold. False means the value is
+   * returned unconfirmed (the cap was reached, or nothing was read) and the
+   * caller must not present it as a measured post-release figure.
+   */
+  settled: boolean;
+}
+
+export interface SettleOptions<T> {
+  /**
+   * `progressOf` of a reading taken BEFORE the mutation. Supply it and
+   * stillness stops being read as "settled": the release is only proven once
+   * the counters move away from this value.
+   *
+   * Omit it (or pass null) when no pre-mutation sample exists, or when the card
+   * was idle enough that no release is expected. The loop then accepts any
+   * reading that holds steady past the min wait — which cannot tell "released"
+   * from "not started yet", so `settled` is the only honest thing separating
+   * the two cases.
+   */
+  baseline?: string | null;
+  /**
+   * The projection whose movement PROVES the release landed, defaulting to
+   * `signatureOf`.
+   *
+   * #2704 — these must be allowed to differ. `signatureOf` covers everything
+   * the caller reports, so it includes the torch pool; but the torch pool
+   * releases in ~400ms while the driver number lags seconds behind it. Testing
+   * movement against the combined signature would let that torch movement stand
+   * in as proof the DRIVER released — which is the original bug wearing a
+   * baseline. Narrow this to the counter that actually lags.
+   */
+  progressOf?: (value: T) => string;
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -17,40 +73,65 @@ function sleep(ms: number): Promise<void> {
  * A failed or null read returns null rather than the previous sample: /free
  * may have released memory between the two, so returning the prior sample
  * would report a known-stale VRAM figure as if it were current.
+ *
+ * #2704 — WHY A `baseline` IS THE LOAD-BEARING PART, and not the cap.
+ * Waiting for the counters to "stop changing" cannot distinguish a plateau
+ * from a release that has not started, because both are perfectly still. On
+ * the reported RTX 5090 the torch pool released in ~400ms while the DRIVER
+ * number stayed frozen at its pre-/free value for ~8s; the torch movement
+ * satisfied the change-then-plateau test, so the loop returned the frozen
+ * driver number after ~780ms and never came close to the 5s cap. Raising the
+ * cap alone changes nothing — measured: both 5s and 12s returned the same
+ * stale 2805 MB at ~775ms. Comparing against a pre-mutation sample is what
+ * turns the unanswerable "is this still?" into the answerable "has anything
+ * been released yet?".
  */
 export async function settleUntilStable<T>(
   read: () => Promise<T | null>,
   signatureOf: (value: T) => string,
-): Promise<T | null> {
+  options: SettleOptions<T> = {},
+): Promise<SettledRead<T>> {
+  const baseline = options.baseline ?? null;
+  const progressOf = options.progressOf ?? signatureOf;
   const started = Date.now();
   const deadline = started + VRAM_SETTLE_TIMEOUT_MS;
   let lastSig: string | null = null;
-  let sawChange = false;
+  // Latched: a reading that moves off `baseline` proves the release landed even
+  // if a later sample happens to match `baseline` again.
+  let releaseSeen = false;
 
   for (;;) {
     let current: T | null;
     try {
       current = await read();
     } catch {
-      return null;
+      return { value: null, settled: false };
     }
-    if (current == null) return null;
+    if (current == null) return { value: null, settled: false };
 
     const sig = signatureOf(current);
     const elapsed = Date.now() - started;
-    if (lastSig !== null && sig !== lastSig) sawChange = true;
+    if (baseline !== null && progressOf(current) !== baseline) releaseSeen = true;
     const stable = lastSig !== null && sig === lastSig;
     lastSig = sig;
 
-    if (stable && (sawChange || elapsed >= VRAM_SETTLE_MIN_MS)) {
-      return current;
+    // With a baseline, stillness counts only AFTER the release is observed.
+    // Without one, keep the pre-#2704 rule — a reading that is stable past the
+    // min wait is accepted, because there is nothing available to prove it is
+    // anything better than a guess. `sawChange` no longer SHORTENS that wait:
+    // on the #2704 card the torch pool moving was enough to satisfy it, which
+    // is precisely how a frozen driver number got returned at ~780ms.
+    const releaseObserved = baseline !== null ? releaseSeen : true;
+
+    if (stable && releaseObserved && elapsed >= VRAM_SETTLE_MIN_MS) {
+      return { value: current, settled: true };
     }
     if (elapsed >= VRAM_SETTLE_TIMEOUT_MS) {
-      return current;
+      return { value: current, settled: false };
     }
 
     const wait = Math.min(VRAM_SETTLE_INTERVAL_MS, Math.max(0, deadline - Date.now()));
-    if (wait <= 0) return current;
+    if (wait <= 0) return { value: current, settled: false };
     await sleep(wait);
   }
 }

--- a/src/services/vram-settle.ts
+++ b/src/services/vram-settle.ts
@@ -36,14 +36,19 @@ export interface SettledRead<T> {
 
 export interface SettleOptions<T> {
   /**
-   * `progressOf` of a reading taken BEFORE the mutation — one key per unit that
-   * is expected to release. Supply it and stillness stops being read as
-   * "settled": the release is proven only once EVERY key has moved.
+   * Identity -> pre-mutation value, one entry per unit expected to release.
+   * Supply it and stillness stops being read as "settled": the release is
+   * proven only once EVERY entry has moved.
    *
-   * Per-key rather than one combined string because a joined signature changes
+   * Per-unit rather than one combined string because a joined signature changes
    * as soon as ANY unit moves. On a two-GPU box that lets card 0 releasing
    * certify card 1, whose driver counter never moved at all — the same
    * substitution the torch pool was making, one level up.
+   *
+   * Keyed by identity rather than position because a device list can REORDER
+   * between samples. Matching by index would then compare card 0's value
+   * against card 1's, read every watched card as moved, and certify a wholly
+   * unreleased box.
    *
    * Only include units a release is actually expected from: a card that was
    * already free will never move, and demanding movement from it would spend
@@ -51,10 +56,10 @@ export interface SettleOptions<T> {
    *
    * Omit it (or pass null) when nothing needs proving.
    */
-  baseline?: readonly string[] | null;
+  baseline?: ReadonlyMap<string, string> | null;
   /**
-   * The projection whose movement PROVES the release landed, defaulting to
-   * `signatureOf`'s value as a single key.
+   * Identity -> current value, using the same identities as `baseline`.
+   * Defaults to `signatureOf`'s value under a single fixed key.
    *
    * #2704 — this must be allowed to differ from `signatureOf`. `signatureOf`
    * covers everything the caller reports, so it includes the torch pool; but
@@ -62,10 +67,8 @@ export interface SettleOptions<T> {
    * behind it. Testing movement against the combined signature would let that
    * torch movement stand in as proof the DRIVER released — which is the
    * original bug wearing a baseline. Narrow this to the counters that lag.
-   *
-   * Must be index-aligned with `baseline`.
    */
-  progressOf?: (value: T) => readonly string[];
+  progressOf?: (value: T) => ReadonlyMap<string, string>;
   /**
    * False when the caller could not establish a baseline it TRUSTS — typically
    * the pre-mutation read failed. The loop still returns on a plateau (there is
@@ -111,15 +114,16 @@ export async function settleUntilStable<T>(
   options: SettleOptions<T> = {},
 ): Promise<SettledRead<T>> {
   const baseline = options.baseline ?? null;
-  const progressOf = options.progressOf ?? ((value: T) => [signatureOf(value)]);
+  const progressOf =
+    options.progressOf ?? ((value: T) => new Map([["", signatureOf(value)]]));
   const confirmable = options.confirmable ?? true;
   const started = Date.now();
   const deadline = started + VRAM_SETTLE_TIMEOUT_MS;
   let lastSig: string | null = null;
-  // Keys still sitting on their pre-mutation value. Emptying is LATCHED per
-  // key: a unit that moves has demonstrably released, even if a later sample
-  // happens to land back on the baseline value.
-  const unmoved = new Set<number>(baseline ? baseline.map((_, i) => i) : []);
+  // Identities still sitting on their pre-mutation value. Emptying is LATCHED
+  // per identity: a unit that moves has demonstrably released, even if a later
+  // sample happens to land back on the baseline value.
+  const unmoved = new Set<string>(baseline ? baseline.keys() : []);
 
   for (;;) {
     let current: T | null;
@@ -133,10 +137,13 @@ export async function settleUntilStable<T>(
     const sig = signatureOf(current);
     const elapsed = Date.now() - started;
     if (baseline !== null && unmoved.size > 0) {
-      const keys = progressOf(current);
-      for (const i of [...unmoved]) {
-        // A missing key is a changed key: the unit it described is gone.
-        if (keys[i] !== baseline[i]) unmoved.delete(i);
+      const now = progressOf(current);
+      for (const id of [...unmoved]) {
+        const seen = now.get(id);
+        // A device that VANISHED from the sample proves nothing — absence is
+        // not a release. Leave it unmoved and let the cap expire into an
+        // honest "unconfirmed" rather than certifying a value we cannot see.
+        if (seen !== undefined && seen !== baseline.get(id)) unmoved.delete(id);
       }
     }
     const stable = lastSig !== null && sig === lastSig;

--- a/src/services/vram-settle.ts
+++ b/src/services/vram-settle.ts
@@ -36,29 +36,48 @@ export interface SettledRead<T> {
 
 export interface SettleOptions<T> {
   /**
-   * `progressOf` of a reading taken BEFORE the mutation. Supply it and
-   * stillness stops being read as "settled": the release is only proven once
-   * the counters move away from this value.
+   * `progressOf` of a reading taken BEFORE the mutation — one key per unit that
+   * is expected to release. Supply it and stillness stops being read as
+   * "settled": the release is proven only once EVERY key has moved.
    *
-   * Omit it (or pass null) when no pre-mutation sample exists, or when the card
-   * was idle enough that no release is expected. The loop then accepts any
-   * reading that holds steady past the min wait — which cannot tell "released"
-   * from "not started yet", so `settled` is the only honest thing separating
-   * the two cases.
+   * Per-key rather than one combined string because a joined signature changes
+   * as soon as ANY unit moves. On a two-GPU box that lets card 0 releasing
+   * certify card 1, whose driver counter never moved at all — the same
+   * substitution the torch pool was making, one level up.
+   *
+   * Only include units a release is actually expected from: a card that was
+   * already free will never move, and demanding movement from it would spend
+   * the whole cap waiting for something that is not coming.
+   *
+   * Omit it (or pass null) when nothing needs proving.
    */
-  baseline?: string | null;
+  baseline?: readonly string[] | null;
   /**
    * The projection whose movement PROVES the release landed, defaulting to
-   * `signatureOf`.
+   * `signatureOf`'s value as a single key.
    *
-   * #2704 — these must be allowed to differ. `signatureOf` covers everything
-   * the caller reports, so it includes the torch pool; but the torch pool
-   * releases in ~400ms while the driver number lags seconds behind it. Testing
-   * movement against the combined signature would let that torch movement stand
-   * in as proof the DRIVER released — which is the original bug wearing a
-   * baseline. Narrow this to the counter that actually lags.
+   * #2704 — this must be allowed to differ from `signatureOf`. `signatureOf`
+   * covers everything the caller reports, so it includes the torch pool; but
+   * the torch pool releases in ~400ms while the driver number lags seconds
+   * behind it. Testing movement against the combined signature would let that
+   * torch movement stand in as proof the DRIVER released — which is the
+   * original bug wearing a baseline. Narrow this to the counters that lag.
+   *
+   * Must be index-aligned with `baseline`.
    */
-  progressOf?: (value: T) => string;
+  progressOf?: (value: T) => readonly string[];
+  /**
+   * False when the caller could not establish a baseline it TRUSTS — typically
+   * the pre-mutation read failed. The loop still returns on a plateau (there is
+   * nothing to be gained by waiting out the cap), but never reports it as
+   * confirmed.
+   *
+   * This is the difference between "idle card, nothing to release, the reading
+   * is good" and "we have no idea whether this released" — both arrive with no
+   * baseline, and collapsing them would let an unprovable reading be published
+   * as a measured one, which is the bug this whole change is about.
+   */
+  confirmable?: boolean;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -92,13 +111,15 @@ export async function settleUntilStable<T>(
   options: SettleOptions<T> = {},
 ): Promise<SettledRead<T>> {
   const baseline = options.baseline ?? null;
-  const progressOf = options.progressOf ?? signatureOf;
+  const progressOf = options.progressOf ?? ((value: T) => [signatureOf(value)]);
+  const confirmable = options.confirmable ?? true;
   const started = Date.now();
   const deadline = started + VRAM_SETTLE_TIMEOUT_MS;
   let lastSig: string | null = null;
-  // Latched: a reading that moves off `baseline` proves the release landed even
-  // if a later sample happens to match `baseline` again.
-  let releaseSeen = false;
+  // Keys still sitting on their pre-mutation value. Emptying is LATCHED per
+  // key: a unit that moves has demonstrably released, even if a later sample
+  // happens to land back on the baseline value.
+  const unmoved = new Set<number>(baseline ? baseline.map((_, i) => i) : []);
 
   for (;;) {
     let current: T | null;
@@ -111,20 +132,26 @@ export async function settleUntilStable<T>(
 
     const sig = signatureOf(current);
     const elapsed = Date.now() - started;
-    if (baseline !== null && progressOf(current) !== baseline) releaseSeen = true;
+    if (baseline !== null && unmoved.size > 0) {
+      const keys = progressOf(current);
+      for (const i of [...unmoved]) {
+        // A missing key is a changed key: the unit it described is gone.
+        if (keys[i] !== baseline[i]) unmoved.delete(i);
+      }
+    }
     const stable = lastSig !== null && sig === lastSig;
     lastSig = sig;
 
-    // With a baseline, stillness counts only AFTER the release is observed.
-    // Without one, keep the pre-#2704 rule — a reading that is stable past the
-    // min wait is accepted, because there is nothing available to prove it is
-    // anything better than a guess. `sawChange` no longer SHORTENS that wait:
-    // on the #2704 card the torch pool moving was enough to satisfy it, which
-    // is precisely how a frozen driver number got returned at ~780ms.
-    const releaseObserved = baseline !== null ? releaseSeen : true;
+    // With a baseline, stillness counts only AFTER every unit has released.
+    // Without one there is nothing available to prove, so a plateau past the
+    // min wait is accepted — and `confirmable` says whether that plateau may be
+    // reported as a measured result. The old rule let ANY change shorten the
+    // min wait, which is how the torch pool moving returned a frozen driver
+    // number at ~780ms.
+    const releaseObserved = baseline === null || unmoved.size === 0;
 
     if (stable && releaseObserved && elapsed >= VRAM_SETTLE_MIN_MS) {
-      return { value: current, settled: true };
+      return { value: current, settled: baseline !== null ? true : confirmable };
     }
     if (elapsed >= VRAM_SETTLE_TIMEOUT_MS) {
       return { value: current, settled: false };

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -105,6 +105,7 @@ async function readVramBaseline(): Promise<SystemStats | null> {
  */
 async function readSettledSystemStats(
   before: SystemStats | null,
+  releaseRequested: boolean,
 ): Promise<SettledRead<SystemStats>> {
   return settleUntilStable(
     async () => {
@@ -116,12 +117,16 @@ async function readSettledSystemStats(
     },
     vramSignature,
     {
-      baseline: settleBaselineOf(before),
+      // Only wait for movement we actually ASKED for. `/free` with both flags
+      // off releases nothing, so an occupied card would sit out the whole cap
+      // and then be told it "had not finished releasing" — a wait and a warning
+      // for an operation that was never going to move the number.
+      baseline: releaseRequested ? settleBaselineOf(before) : null,
       progressOf: vramReleaseSignature,
-      // A baseline we could not READ is not the same as a card with nothing to
-      // release. Both arrive here without keys to check, but only the second
-      // one may be published as a measured figure.
-      confirmable: before !== null,
+      // A baseline we could not READ is not the same as having nothing to
+      // prove. Both arrive here without keys to check, but only the second may
+      // be published as a measured figure.
+      confirmable: !releaseRequested || before !== null,
     },
   );
 }
@@ -183,7 +188,10 @@ export function registerMemoryManagementTools(server: McpServer): void {
         // Get updated stats — after CUDA release settles, not the first post-/free sample.
         let statsText = "";
         try {
-          const settledRead = await readSettledSystemStats(before);
+          const settledRead = await readSettledSystemStats(
+            before,
+            args.unload_models === true || args.free_memory === true,
+          );
           if (settledRead.value) {
             statsText = formatVramStats(settledRead.value, settledRead.settled);
           }

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -6,7 +6,12 @@ import type { SystemStats } from "../comfyui/types.js";
 import { ComfyUIError, errorToToolResult } from "../utils/errors.js";
 import { bodyPrefixOf, describeStatus } from "../comfyui/json-guard.js";
 import { logger } from "../utils/logger.js";
-import { settleUntilStable } from "../services/vram-settle.js";
+import {
+  settleUntilStable,
+  VRAM_OCCUPIED_FREE_RATIO,
+  VRAM_OCCUPIED_MIN_TOTAL_BYTES,
+} from "../services/vram-settle.js";
+import type { SettledRead } from "../services/vram-settle.js";
 
 export {
   VRAM_SETTLE_INTERVAL_MS as CLEAR_VRAM_SETTLE_INTERVAL_MS,
@@ -21,29 +26,92 @@ function vramSignature(stats: SystemStats): string {
   return `${gpu.vram_free}:${gpu.torch_vram_free}`;
 }
 
-function formatVramStats(stats: SystemStats): string {
+/**
+ * The DRIVER counter alone — the one whose release lags (#2704).
+ *
+ * Deliberately not `vramSignature`: torch gives its pool back in ~400ms while
+ * `vram_free` can stay frozen for seconds, so a combined signature moves on
+ * torch's schedule and would certify the driver as released while it is still
+ * holding ~29 GB. That is the reported bug, and testing movement against the
+ * combined signature would reintroduce it.
+ */
+function vramReleaseSignature(stats: SystemStats): string {
+  const gpu = stats.devices?.[0];
+  if (!gpu) return "";
+  return `${gpu.vram_free}`;
+}
+
+function formatVramStats(stats: SystemStats, settled = true): string {
   const gpu = stats.devices?.[0];
   if (!gpu) return "";
   const vramFreeMB = (gpu.vram_free / 1024 / 1024).toFixed(0);
   const vramTotalMB = (gpu.vram_total / 1024 / 1024).toFixed(0);
   const torchFreeMB = (gpu.torch_vram_free / 1024 / 1024).toFixed(0);
   const torchTotalMB = (gpu.torch_vram_total / 1024 / 1024).toFixed(0);
-  return `\n\nCurrent VRAM: ${vramFreeMB}/${vramTotalMB} MB free | Torch: ${torchFreeMB}/${torchTotalMB} MB free`;
+  // #2704 — the unconfirmed reading is the one that misleads: it UNDERSTATES
+  // free VRAM, so it reads as an imminent OOM on a card that is actually empty.
+  // Print it (it is the best number we have) but never as a measured result.
+  const caveat = settled
+    ? ""
+    : ` (the card had not finished releasing when this was read — re-check with` +
+      ` get_system_stats (action:"stats") before sizing a model load against it)`;
+  return `\n\nCurrent VRAM: ${vramFreeMB}/${vramTotalMB} MB free | Torch: ${torchFreeMB}/${torchTotalMB} MB free${caveat}`;
+}
+
+/**
+ * The signature the post-/free poll must move AWAY from, or null to skip the
+ * wait entirely.
+ *
+ * #2704 — a full unload is only EXPECTED to move the driver's number when the
+ * card is actually holding memory. On a card that is already mostly free there
+ * is nothing to wait for, and demanding movement that will never come would
+ * spend the whole settle cap on the common speculative `clear_vram`. So the
+ * wait is armed by the same "occupied" rule the panel applies to these very
+ * counters, and an idle card keeps exactly today's fast path.
+ */
+function settleBaselineOf(before: SystemStats | null): string | null {
+  const gpu = before?.devices?.[0];
+  if (!gpu) return null;
+  const free = gpu.vram_free;
+  const total = gpu.vram_total;
+  if (!Number.isFinite(free) || !Number.isFinite(total)) return null;
+  if (total < VRAM_OCCUPIED_MIN_TOTAL_BYTES) return null;
+  if (free > total * VRAM_OCCUPIED_FREE_RATIO) return null;
+  return vramReleaseSignature(before as SystemStats);
+}
+
+/** Best effort — a baseline we cannot read costs precision, never the clear. */
+async function readVramBaseline(): Promise<SystemStats | null> {
+  try {
+    return await getSystemStats();
+  } catch {
+    return null;
+  }
 }
 
 /**
  * /free answers when ComfyUI drops model refs; CUDA/driver release can lag.
  * Poll until the displayed counters stop changing (or we hit the cap) so the
  * printed value matches a follow-up get_system_stats (action:"stats") (#2050).
+ *
+ * #2704 — "stopped changing" is not on its own evidence of a release, because a
+ * release that has not STARTED is equally still. `baseline` is the pre-/free
+ * reading the poll must move away from before a plateau counts.
  */
-async function readSettledSystemStats(): Promise<SystemStats | null> {
-  return settleUntilStable(async () => {
-    try {
-      return await getSystemStats();
-    } catch {
-      return null;
-    }
-  }, vramSignature);
+async function readSettledSystemStats(
+  baseline: string | null,
+): Promise<SettledRead<SystemStats>> {
+  return settleUntilStable(
+    async () => {
+      try {
+        return await getSystemStats();
+      } catch {
+        return null;
+      }
+    },
+    vramSignature,
+    { baseline, progressOf: vramReleaseSignature },
+  );
 }
 
 export function registerMemoryManagementTools(server: McpServer): void {
@@ -64,6 +132,12 @@ export function registerMemoryManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
+        // Sample BEFORE the mutation (#2704). A baseline taken after /free is
+        // useless: on a lagging driver the first post-/free sample IS the stale
+        // pre-release value, so it can never show the release landing. Read
+        // failures degrade to null, which restores the pre-#2704 behaviour
+        // rather than failing the clear.
+        const before = await readVramBaseline();
 
         // ComfyUI's /free endpoint accepts POST with JSON body
         const res = await comfyApiFetch("/free", {
@@ -97,8 +171,10 @@ export function registerMemoryManagementTools(server: McpServer): void {
         // Get updated stats — after CUDA release settles, not the first post-/free sample.
         let statsText = "";
         try {
-          const stats = await readSettledSystemStats();
-          if (stats) statsText = formatVramStats(stats);
+          const settledRead = await readSettledSystemStats(settleBaselineOf(before));
+          if (settledRead.value) {
+            statsText = formatVramStats(settledRead.value, settledRead.settled);
+          }
         } catch {
           // Best effort
         }

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -35,10 +35,10 @@ function vramSignature(stats: SystemStats): string {
  * holding ~29 GB. That is the reported bug, and testing movement against the
  * combined signature would reintroduce it.
  */
-function vramReleaseSignature(stats: SystemStats): readonly string[] {
+function vramReleaseSignature(stats: SystemStats): ReadonlyMap<string, string> {
   const gpu = stats.devices?.[0];
-  if (!gpu) return [""];
-  return [`${gpu.vram_free}`];
+  if (!gpu) return new Map();
+  return new Map([[`${gpu.index ?? gpu.name ?? "0"}`, `${gpu.vram_free}`]]);
 }
 
 function formatVramStats(stats: SystemStats, settled = true): string {
@@ -73,7 +73,7 @@ function formatVramStats(stats: SystemStats, settled = true): string {
  * device 0's release is exactly what backs the number being reported. Proving a
  * second card released would not make the printed figure any more true.
  */
-function settleBaselineOf(before: SystemStats | null): readonly string[] | null {
+function settleBaselineOf(before: SystemStats | null): ReadonlyMap<string, string> | null {
   const gpu = before?.devices?.[0];
   if (!gpu) return null;
   const free = gpu.vram_free;
@@ -81,7 +81,8 @@ function settleBaselineOf(before: SystemStats | null): readonly string[] | null 
   if (!Number.isFinite(free) || !Number.isFinite(total)) return null;
   if (total < VRAM_OCCUPIED_MIN_TOTAL_BYTES) return null;
   if (free > total * VRAM_OCCUPIED_FREE_RATIO) return null;
-  return vramReleaseSignature(before as SystemStats);
+  const keys = vramReleaseSignature(before as SystemStats);
+  return keys.size > 0 ? keys : null;
 }
 
 /** Best effort — a baseline we cannot read costs precision, never the clear. */

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -35,10 +35,10 @@ function vramSignature(stats: SystemStats): string {
  * holding ~29 GB. That is the reported bug, and testing movement against the
  * combined signature would reintroduce it.
  */
-function vramReleaseSignature(stats: SystemStats): string {
+function vramReleaseSignature(stats: SystemStats): readonly string[] {
   const gpu = stats.devices?.[0];
-  if (!gpu) return "";
-  return `${gpu.vram_free}`;
+  if (!gpu) return [""];
+  return [`${gpu.vram_free}`];
 }
 
 function formatVramStats(stats: SystemStats, settled = true): string {
@@ -68,8 +68,12 @@ function formatVramStats(stats: SystemStats, settled = true): string {
  * spend the whole settle cap on the common speculative `clear_vram`. So the
  * wait is armed by the same "occupied" rule the panel applies to these very
  * counters, and an idle card keeps exactly today's fast path.
+ *
+ * Device 0 only, deliberately: `formatVramStats` prints device 0's counters, so
+ * device 0's release is exactly what backs the number being reported. Proving a
+ * second card released would not make the printed figure any more true.
  */
-function settleBaselineOf(before: SystemStats | null): string | null {
+function settleBaselineOf(before: SystemStats | null): readonly string[] | null {
   const gpu = before?.devices?.[0];
   if (!gpu) return null;
   const free = gpu.vram_free;
@@ -99,7 +103,7 @@ async function readVramBaseline(): Promise<SystemStats | null> {
  * reading the poll must move away from before a plateau counts.
  */
 async function readSettledSystemStats(
-  baseline: string | null,
+  before: SystemStats | null,
 ): Promise<SettledRead<SystemStats>> {
   return settleUntilStable(
     async () => {
@@ -110,7 +114,14 @@ async function readSettledSystemStats(
       }
     },
     vramSignature,
-    { baseline, progressOf: vramReleaseSignature },
+    {
+      baseline: settleBaselineOf(before),
+      progressOf: vramReleaseSignature,
+      // A baseline we could not READ is not the same as a card with nothing to
+      // release. Both arrive here without keys to check, but only the second
+      // one may be published as a measured figure.
+      confirmable: before !== null,
+    },
   );
 }
 
@@ -171,7 +182,7 @@ export function registerMemoryManagementTools(server: McpServer): void {
         // Get updated stats — after CUDA release settles, not the first post-/free sample.
         let statsText = "";
         try {
-          const settledRead = await readSettledSystemStats(settleBaselineOf(before));
+          const settledRead = await readSettledSystemStats(before);
           if (settledRead.value) {
             statsText = formatVramStats(settledRead.value, settledRead.settled);
           }


### PR DESCRIPTION
Closes #2704.

## The report's premise does not hold — measured, not read

The report diagnosed a 5s settle cap being hit, and prescribed raising
`CLEAR_VRAM_SETTLE_TIMEOUT_MS` to 12s. I drove the real `settleUntilStable` from
`origin/main` against the reported RTX 5090 timing before changing it. **The cap
is never reached, and raising it alone changes nothing:**

```
Driver releases 8s after /free (the reported case):
  origin/main (cap  5s)    2805 MB after 788ms   *** STALE ***
  cap raised to 12s only   2805 MB after 773ms   *** STALE ***
```

The loop exits at ~780ms, nowhere near either cap.

**Why.** The stability signature is `vram_free:torch_vram_free`. Torch hands its
pool back in ~400ms; the *driver* counter stays frozen at its pre-`/free` value
for ~8s. That torch movement satisfied the loop's change-then-plateau test, so
the next two equal samples looked like a settled plateau and the frozen driver
number was returned as a measured result.

The deeper problem: **stillness cannot distinguish a plateau from a release that
has not started** — both are perfectly still. No cap value fixes that. A 3s lag,
comfortably inside the *existing* 5s cap, is equally broken on `origin/main`
(returns stale at 778ms).

## The fix

Compare against a sample taken **before** the mutation. That turns the
unanswerable "is this still?" into the answerable "has anything been released
yet?".

- `settleUntilStable` takes an optional `baseline`; a plateau counts only once
  the reading has moved off it. It returns `{ value, settled }` rather than a
  bare value.
- **`progressOf` is separate from `signatureOf` on purpose.** The release test
  reads the *driver* counters alone. Testing movement against the combined
  signature would let torch's fast release stand in as proof the driver
  released — the original bug wearing a baseline. I wrote that bug into my own
  first draft; two tests pin it now.
- **Baseline and progress are identity-keyed maps, latched per device.** A joined
  signature would let card 0 releasing certify card 1; positional matching would
  let a *reordered* device list certify a box where nothing released. A device
  absent from a sample stays unmoved — absence is not a release. Devices whose
  identities collide yield no baseline at all rather than a silently-merged one.
- The cap moves 5s → 12s. Load-bearing only in combination: it is what lets an 8s
  release land before the loop gives up.
- An unconfirmed reading is still reported — it is the best number available —
  but never as a measured figure. `clear_vram` appends a caveat; the panel adds
  `vram_after_settled: false`.
- The wait is armed only when a release was actually **requested** and the card
  was **occupied** at baseline (the same free/total rule `panel-tools.ts` already
  applies to these counters). An idle card, or a `/free` with both flags off,
  keeps today's fast path instead of blocking for the cap.

Measured after the change:

```
Driver releases 8s:        30774 MB after 8381ms   settled=true   CORRECT
Driver releases 3s:        30774 MB after 3412ms   settled=true   CORRECT
Driver releases instantly: 30774 MB after 1047ms   settled=true   CORRECT
Driver never releases:      2805 MB after 12015ms  settled=false  (disclosed)
```

## Costs, stated plainly

- **A fast card costs +273ms** (774ms → 1047ms). The old rule let *any* change
  return before `VRAM_SETTLE_MIN_MS`; that shortcut is exactly what the #2704
  card exploited, so the min wait now always applies.
- **An occupied card whose release never lands blocks for the full 12s** and then
  reports the reading with a caveat. A deliberate trade: the old failure silently
  understated free VRAM by ~27 GB, which reads as an imminent OOM. A slow honest
  answer beats a fast wrong one.

## Risky parts — please look here first

1. **`progressOf` vs `signatureOf`** (`vram-settle.ts`). If these are ever
   collapsed into one function, the bug returns silently and the numbers still
   look plausible.
2. **I changed an existing assertion.** `clear-vram-stale-report.test.ts` → "does
   not poll /system_stats when /free fails" asserted `getSystemStats` was never
   called. The baseline read now happens *before* `POST /free`, so it is called
   exactly once. I pinned the count at exactly 1 rather than loosening it to
   "some", so a settle loop leaking in behind a failed `/free` still fails the
   test. Its intent — no VRAM figure reported when the free failed — is unchanged
   and still asserted.
3. **The occupancy gate is a threshold**, reusing the panel's existing
   `free/total <= 0.2` rule rather than a new number. It decides latency, never
   correctness: getting it wrong costs a wait we did not need, or today's
   behaviour.
4. **The baseline read is a new call before a throw path.** Wrapped so a failed
   read degrades to `null` (and to `confirmable: false`) rather than failing the
   clear.

## Deliberately NOT changed

- **`get_system_stats(action:"health")` keeps no settle loop.** The report asks
  whether it should have one. It is a point-in-time read and it is not
  miscalculating — it reported what the driver said at that moment. Adding a
  multi-second settle to every health call would tax the common path to correct a
  transient that only follows a `/free`.
- **`annotateFreeVramAck` keeps the old best-effort rule.** No pre-`/free` sample
  can exist there — the tab posted `/free` before it acked — so there is nothing
  to hold a baseline against. Called out in a comment at the site.

## Verification

- **Independent review: codex, 5 rounds.** Rounds 1–4 each returned
  NEEDS-REVISION with a real finding (baseline-vs-idle conflation; global release
  latching; positional key matching; colliding device identities; the wait armed
  regardless of the requested `/free` flags). Each was fixed and pinned. Round 5
  returned **VERDICT: PASS** on `a1f7781`, the SHA this merges.
- **18 mutations, 18 caught.** Every element deleted independently — the cap, the
  baseline, `progressOf` (both call sites), the disclosure (both), the occupancy
  gate (both), the min-total guard, `confirmable` (both), identity matching,
  absence handling, the collision guards, `releaseRequested`, and the baseline
  read's *ordering*. The one mutation that survived first time (the occupancy
  gate) exposed a fixture that changed the driver value across `/free` and so
  satisfied the movement test by accident; it was rebuilt as a genuine static
  control and now catches it.
- Full suite: **752 files, 13863 passed, 6 skipped, 0 failed.**
- `npm run lint` (tsc --noEmit + anti-slop): clean, no new findings.
- `check:vocabulary` and `check:unknown-collapse`: pass.
- Not browser-verified: this changes orchestrator/tool output and renders nothing
  in the panel sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
