### PR TITLE
fix(2705): settle an unacked workflow_new against the panel's own rid-correlated receipt

### DIFF
--- a/src/__tests__/orchestrator/fence-trusts-own-reply.test.ts
+++ b/src/__tests__/orchestrator/fence-trusts-own-reply.test.ts
@@ -188,12 +188,30 @@ describe("#814 WIRING: both call sites route through refreshFenceFromOwnReply fi
     );
 
     const saveIdx = src.indexOf('"panel_save_workflow"');
-    const newIdx = src.indexOf('"panel_new_workflow"');
+    // #2705 — panel_new_workflow's body MOVED. It grew a verify-after-timeout
+    // path (like panel_open_workflow's) and now lives in `newWorkflowWithVerify`,
+    // so a slice taken from the `def("panel_new_workflow"` literal no longer
+    // contains the wiring line and this pin went red on a refactor that changed
+    // nothing about the wiring. Anchor on the function the tool delegates TO, and
+    // pin the delegation separately — together those are the same claim
+    // ("panel_new_workflow reaches this line") without depending on the two
+    // halves sitting next to each other.
+    const newIdx = src.indexOf("async function newWorkflowWithVerify(");
     expect(saveIdx).toBeGreaterThan(0);
     expect(newIdx).toBeGreaterThan(0);
+    expect(src).toMatch(/async \(_args, ctx\) => newWorkflowWithVerify\(ctx\),/);
 
     const saveBlock = src.slice(saveIdx, saveIdx + 8000);
-    const newBlock = src.slice(newIdx, newIdx + 5000);
+    // Bounded by the top-level closing brace, not by a character count: a
+    // function that grows past an arbitrary slice would silently stop being
+    // checked, which is how a source pin turns into a green no-op.
+    // `\r?\n` on purpose: this tree checks out CRLF on Windows, and a literal
+    // "\n}\n" finds nothing there — the slice would be empty and the assertion
+    // below would fail for a reason that has nothing to do with the wiring.
+    const fromNew = src.slice(newIdx);
+    const newEnd = fromNew.search(/\r?\n\}\r?\n/);
+    expect(newEnd).toBeGreaterThan(0);
+    const newBlock = fromNew.slice(0, newEnd);
     const wired = /const fenceRebind = refreshFenceFromOwnReply\(ctx, res\) \?\? \(await rebindWorkflowFence\(ctx\)\);/;
     expect(saveBlock).toMatch(wired);
     expect(newBlock).toMatch(wired);

--- a/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
@@ -216,6 +216,9 @@ describe("#2705: an unacked workflow_new is settled by the panel's own receipt",
     expect(res.isError).toBeFalsy();
     expect(jsonOf(res).applied_but_ack_timed_out).toBe(true);
     expect(fence).toBe(NEW_UUID);
+    // …but does not tell the user their tab was SLOW when it disconnected.
+    expect(String(jsonOf(res).note)).toMatch(/disconnected mid-command/);
+    expect(String(jsonOf(res).note)).not.toMatch(/within the 15s window/);
   });
 
   it("never claims the recovered tab is BLANK, and never invites a retry", async () => {

--- a/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
@@ -187,6 +187,10 @@ describe("#2705: an unacked workflow_new is settled by the panel's own receipt",
     const body = jsonOf(res);
     expect(body.created).toBe(true);
     // The machine-readable verdict the issue asked for — no prose parsing.
+    // Always present: the acknowledgement did not arrive. The issue's own field
+    // name rides along ONLY where it is literally true (see the drop test below).
+    expect(body.applied_but_unacknowledged).toBe(true);
+    expect(body.unacknowledged_cause).toBe("ack_timeout");
     expect(body.applied_but_ack_timed_out).toBe(true);
     expect(body.recovered).toBe(true);
     expect(body.routing_key).toBe(NEW_KEY);
@@ -214,7 +218,11 @@ describe("#2705: an unacked workflow_new is settled by the panel's own receipt",
       makeCtx({ newReply: reconnectDrop, listReplies: [listWithActiveNewTab(appliedReceipt())] }),
     );
     expect(res.isError).toBeFalsy();
-    expect(jsonOf(res).applied_but_ack_timed_out).toBe(true);
+    expect(jsonOf(res).applied_but_unacknowledged).toBe(true);
+    expect(jsonOf(res).unacknowledged_cause).toBe("reconnect_drop");
+    // A disconnect is NOT a timeout, so the timeout-named field must be absent —
+    // not present-and-false, which would still read as "this field applies here".
+    expect(jsonOf(res)).not.toHaveProperty("applied_but_ack_timed_out");
     expect(fence).toBe(NEW_UUID);
     // …but does not tell the user their tab was SLOW when it disconnected.
     expect(String(jsonOf(res).note)).toMatch(/disconnected mid-command/);

--- a/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
@@ -1,0 +1,442 @@
+// #2705 — `panel_new_workflow` timed out AFTER the new tab was already created.
+//
+// The reporter's sequence, verbatim from the issue:
+//
+//   1. bound to a saved workflow tab
+//   2. panel_new_workflow({})  ->  15s ack timeout, "may have been applied"
+//   3. panel_graph_outline     ->  refused: "workflow instance mismatch …
+//                                  issued for 3b86446a…, tab reported d2d3e6f4…"
+//   4. panel_set_workflow_target({mode:"current"})  ->  binds, blank graph
+//
+// So the mutation reached the panel and APPLIED; only the acknowledgement was
+// lost. Two consequences, and the old code had neither:
+//
+//   * the OUTCOME stayed unknown, even though the panel journals a rid-correlated
+//     receipt for exactly this command (#402/#514 `last_open`), and
+//   * the session's workflow-instance FENCE was never re-pointed, so every graph
+//     call afterwards was refused against the workflow the user had just left.
+//
+// `panel_open_workflow` has had this recovery since #215/#319/#496. The whole of
+// `panel_new_workflow` was `ctx.call(...)` then `if (res.isError) return res` —
+// which returns before the fence refresh below it and never asks the panel what
+// happened.
+//
+// WHAT MAKES A RECOVERY SAFE HERE. `workflow_new` is NOT idempotent: a blind
+// retry leaves a second blank tab. So nothing may be inferred from `active`
+// matching (after a reconnect the frontend restores a tab by itself), and nothing
+// may say "safe to retry" unless the panel journaled a clean negative. The only
+// evidence used is the receipt for THIS exact rid AND this exact command name,
+// corroborated — for the identity adoption — against the live active record still
+// naming the routing key the receipt says this command minted.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __openWorkflowTestHooks,
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const textOf = (res: ToolResult): string =>
+  res.content.find((c) => c.type === "text")?.text ?? "";
+const jsonOf = (res: ToolResult): Record<string, unknown> => JSON.parse(textOf(res));
+
+/** RFC-shaped: the fence regex requires a [1-5] version and an [89ab] variant. */
+const NEW_UUID = "d2d3e6f4-d810-4149-a496-c6ff47bca22e";
+const PRIOR_UUID = "3b86446a-94c7-4f6f-94ff-086df603b568";
+const RID = "new-rid-1";
+/** The per-instance routing handle the panel mints for the tab it just created. */
+const NEW_KEY = "tmp:9f2c1a";
+
+const newWorkflow = () => buildPanelToolDefs().find((d) => d.name === "panel_new_workflow")!;
+
+/** The bridge's own ack-timeout text for `workflow_new` — the exact message the
+ *  reporter quoted, which is what `isAckTimeout(res, "workflow_new")` keys on. */
+const ackTimeout = (): ToolResult => ({
+  content: [
+    {
+      type: "text" as const,
+      text:
+        `Error: Panel tab wf:workflows/mine.json did not reply to "workflow_new" within 15000 ms — ` +
+        `the ComfyUI tab may be backgrounded or frozen. This command MUTATES and was already ` +
+        `delivered to the tab, so it may have been applied despite the missing reply`,
+    },
+  ],
+  isError: true,
+});
+
+/** The #402 mid-command reconnect drop — the other outcome-unknown shape. */
+const reconnectDrop = (): ToolResult => ({
+  content: [{ type: "text" as const, text: "Error: tab disconnected mid-command — OUTCOME UNKNOWN" }],
+  isError: true,
+});
+
+/** A receipt for THIS rid, applied, naming the tab it created. */
+const appliedReceipt = (over: Record<string, unknown> = {}) => ({
+  rid: RID,
+  answers_only_command_rid: RID,
+  cmd: "workflow_new",
+  requested: null,
+  resolved: { path: null, filename: null, routing_key: NEW_KEY },
+  applied: true,
+  ...over,
+});
+
+/** `workflow_list` reporting the created tab as the live active canvas. */
+const listWithActiveNewTab = (receipt: Record<string, unknown>) => ({
+  active_confirmed: true,
+  active: {
+    path: null,
+    filename: null,
+    title: "Unsaved Workflow",
+    key: NEW_KEY,
+    routing_key: NEW_KEY,
+    workflow_uuid: NEW_UUID,
+  },
+  workflows: [{ path: null, filename: null, key: NEW_KEY, routing_key: NEW_KEY, active: true }],
+  last_open: receipt,
+});
+
+let fence: string | undefined;
+let stamps: string[];
+let cmds: string[];
+
+/**
+ * Programmable ctx. `newReply` decides what `workflow_new` answers; each
+ * `workflow_list` yields the next entry in `listReplies` (the last repeats).
+ * `rid: null` models a bridge/panel pair that exposes no request id at all.
+ */
+function makeCtx(opts: {
+  newReply: () => ToolResult;
+  listReplies?: Array<Record<string, unknown> | null>;
+  rid?: string | null;
+  canMutate?: boolean;
+}): PanelToolCtx {
+  let listIdx = 0;
+  const refreshWorkflowUuid = vi.fn((_tabId: string, uuid: string) => {
+    fence = uuid;
+    stamps.push(uuid);
+    return true;
+  });
+  const bridge: Pick<
+    PanelToolCtx["bridge"],
+    "workflowUuidFor" | "refreshWorkflowUuid" | "isHeadless"
+  > = {
+    workflowUuidFor: () => ({ known: true, uuid: fence }),
+    refreshWorkflowUuid,
+    isHeadless: () => false,
+  };
+  const ctx: Pick<PanelToolCtx, "call" | "confirm" | "tabId" | "tabGraphMutationCapability"> & {
+    bridge: typeof bridge;
+  } = {
+    call: async (
+      cmd: Record<string, unknown>,
+      _timeoutMs?: number,
+      onDispatchedRid?: (rid: string) => void,
+    ) => {
+      cmds.push(cmd.cmd as string);
+      if (cmd.cmd === "workflow_new") {
+        if (opts.rid !== null) onDispatchedRid?.(opts.rid ?? RID);
+        return opts.newReply();
+      }
+      if (cmd.cmd === "workflow_list") {
+        const replies = opts.listReplies ?? [];
+        const reply = replies.length ? replies[Math.min(listIdx, replies.length - 1)] : null;
+        listIdx++;
+        return { content: [{ type: "text" as const, text: JSON.stringify(reply ?? {}) }] };
+      }
+      return { content: [{ type: "text" as const, text: "{}" }] };
+    },
+    confirm: async () => "yes" as const,
+    tabId: "tab-1",
+    tabGraphMutationCapability: () => ({ known: true, canMutate: opts.canMutate ?? true }),
+    bridge,
+  };
+  // ONE assertion, and the members above are TYPE-CHECKED against the real
+  // interfaces by the `Pick`s — so a signature drift in PanelToolCtx or UiBridge
+  // still breaks this harness instead of being papered over by `as unknown as`.
+  // The cast only supplies the members these handlers never touch.
+  return ctx as PanelToolCtx;
+}
+
+beforeAll(() => {
+  // Fast, deterministic verify timing so these don't wait the real ~6s budget.
+  __openWorkflowTestHooks.setOpenVerifyTiming({ budgetMs: 200, intervalMs: 1, probeTimeoutMs: 50 });
+});
+afterAll(() => {
+  __openWorkflowTestHooks.setOpenVerifyTiming(null);
+});
+beforeEach(() => {
+  fence = PRIOR_UUID; // the wedge: still stamped with the workflow we just left
+  stamps = [];
+  cmds = [];
+});
+
+describe("#2705: an unacked workflow_new is settled by the panel's own receipt", () => {
+  it("reports the creation as applied-but-unacked instead of an unknown outcome", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({ newReply: ackTimeout, listReplies: [listWithActiveNewTab(appliedReceipt())] }),
+    );
+    expect(res.isError).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.created).toBe(true);
+    // The machine-readable verdict the issue asked for — no prose parsing.
+    expect(body.applied_but_ack_timed_out).toBe(true);
+    expect(body.recovered).toBe(true);
+    expect(body.routing_key).toBe(NEW_KEY);
+    // It actually asked the panel; the old code returned before any probe.
+    expect(cmds).toEqual(["workflow_new", "workflow_list"]);
+  });
+
+  // THE fix, stated directly: step 3 of the report must stop happening.
+  it("re-points the session fence at the canvas the timed-out command created", async () => {
+    const ctx = makeCtx({
+      newReply: ackTimeout,
+      listReplies: [listWithActiveNewTab(appliedReceipt())],
+    });
+    const res = await newWorkflow().handler({}, ctx);
+    expect(stamps).toEqual([NEW_UUID]);
+    expect(fence).toBe(NEW_UUID);
+    expect(fence).not.toBe(PRIOR_UUID);
+    expect(jsonOf(res).workflow_instance_adopted).toBe(true);
+    expect(jsonOf(res).graph_binding).toBe("bound");
+  });
+
+  it("recovers a mid-command reconnect drop the same way", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({ newReply: reconnectDrop, listReplies: [listWithActiveNewTab(appliedReceipt())] }),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(jsonOf(res).applied_but_ack_timed_out).toBe(true);
+    expect(fence).toBe(NEW_UUID);
+  });
+
+  it("never claims the recovered tab is BLANK, and never invites a retry", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({ newReply: ackTimeout, listReplies: [listWithActiveNewTab(appliedReceipt())] }),
+    );
+    const body = jsonOf(res);
+    // The panel journals the receipt BEFORE deciding the tab is provably empty
+    // (#708), so `applied:true` proves created-and-active, never blank.
+    expect(body.empty).toBe("unknown");
+    expect(String(body.note)).toMatch(/NOT PROVEN BLANK/);
+    expect(String(body.note)).toMatch(/panel_graph_outline/);
+    expect(String(body.note)).toMatch(/Do NOT call panel_new_workflow again/i);
+  });
+});
+
+describe("#2705: what the recovery refuses to conclude", () => {
+  it("does not adopt an identity when the created tab is no longer active", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        listReplies: [
+          {
+            active_confirmed: true,
+            // A DIFFERENT canvas is in view now — its uuid must never fence us.
+            active: {
+              path: "workflows/other.json",
+              routing_key: "wf:workflows/other.json",
+              workflow_uuid: "11111111-2222-4333-8444-555555555555",
+            },
+            last_open: appliedReceipt(),
+          },
+        ],
+      }),
+    );
+    // The creation still HAPPENED — retracting that would be the worse lie.
+    expect(res.isError).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.created).toBe(true);
+    expect(body.workflow_instance_adopted).toBe(false);
+    expect(body.graph_binding).toBe("not_recovered");
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+    expect(String(body.note)).toMatch(/panel_set_workflow_target/);
+  });
+
+  it("does not adopt when the active record carries no usable instance identity", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        listReplies: [
+          {
+            active_confirmed: true,
+            // Right tab, but the panel withheld the uuid (#716 fail-closed).
+            active: { path: null, key: NEW_KEY, routing_key: NEW_KEY },
+            last_open: appliedReceipt(),
+          },
+        ],
+      }),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(jsonOf(res).workflow_instance_adopted).toBe(false);
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("does not read an EARLIER command's receipt as an answer about this one", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        listReplies: [listWithActiveNewTab(appliedReceipt({ rid: "older-rid", answers_only_command_rid: "older-rid" }))],
+      }),
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/outcome is undetermined/i);
+    expect(textOf(res)).not.toMatch(/safe to call panel_new_workflow again/i);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("does not accept a workflow_OPEN receipt that happens to carry this rid", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        listReplies: [listWithActiveNewTab(appliedReceipt({ cmd: "workflow_open" }))],
+      }),
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/outcome is undetermined/i);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it('says "safe to retry" ONLY for a journaled clean negative', async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        listReplies: [
+          {
+            active_confirmed: true,
+            last_open: appliedReceipt({ applied: false, error: "command service unavailable" }),
+          },
+        ],
+      }),
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/confirmed NOT applied/);
+    expect(textOf(res)).toMatch(/safe to call panel_new_workflow again/);
+    expect(textOf(res)).toMatch(/command service unavailable/);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it('treats applied:"unknown" as undetermined — never as a clean negative', async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        listReplies: [
+          {
+            active_confirmed: true,
+            // The panel's own wording for "it may have got partway".
+            last_open: appliedReceipt({
+              applied: "unknown",
+              error: "workflow_new created a tab but lost ownership",
+            }),
+          },
+        ],
+      }),
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/outcome is undetermined/i);
+    expect(textOf(res)).toMatch(/lost ownership/);
+    // The cost of getting this wrong is a SECOND blank tab, so the message must
+    // not merely omit the retry advice — it must forbid it.
+    expect(textOf(res)).toMatch(/Do NOT re-issue/);
+    expect(textOf(res)).not.toMatch(/safe to call panel_new_workflow again/i);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("identifies an older panel that cannot make receipt claims at all", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      // No `active_confirmed`, no `last_open` — the #514 capability probe.
+      makeCtx({ newReply: ackTimeout, listReplies: [{ active: { path: null, routing_key: NEW_KEY } }] }),
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/does not provide request-id-correlated open receipts/);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("stays undetermined when the bridge exposed no request id to correlate on", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        rid: null,
+        listReplies: [listWithActiveNewTab(appliedReceipt())],
+      }),
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/did not expose a request id/);
+    // No rid means no correlation is possible, so it must not even probe.
+    expect(cmds).toEqual(["workflow_new"]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("names the STALE FENCE on every undetermined exit, not just the unknown outcome", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({ newReply: ackTimeout, listReplies: [{ active_confirmed: true }] }),
+    );
+    expect(res.isError).toBe(true);
+    // An agent that reads only "outcome unknown" and then meets a mismatch has no
+    // way to know the two are the same event.
+    expect(textOf(res)).toMatch(/workflow instance mismatch/);
+    expect(textOf(res)).toMatch(/panel_set_workflow_target/);
+  });
+});
+
+describe("#2705: a genuine acked failure is NOT a candidate for recovery", () => {
+  it("returns the panel's own executor error verbatim, with no receipt probe", async () => {
+    const panelError = (): ToolResult => ({
+      content: [
+        {
+          type: "text" as const,
+          text:
+            "Error: workflow_new could not take the workflow switch/reload section because " +
+            "another workflow operation is still in flight. Retry in a moment.",
+        },
+      ],
+      isError: true,
+    });
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({ newReply: panelError, listReplies: [listWithActiveNewTab(appliedReceipt())] }),
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/still in flight/);
+    expect(cmds).toEqual(["workflow_new"]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("does not fire on another command's ack timeout wearing the same preamble", async () => {
+    // The command name lives INSIDE the anchored pattern. A workflow_OPEN timeout
+    // surfacing here must not open workflow_new's recovery — that is what would
+    // let one command's receipt settle a different command's outcome.
+    const otherTimeout = (): ToolResult => ({
+      content: [
+        {
+          type: "text" as const,
+          text: `Error: Panel tab abcd1234 did not reply to "workflow_open" within 15000 ms`,
+        },
+      ],
+      isError: true,
+    });
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({ newReply: otherTimeout, listReplies: [listWithActiveNewTab(appliedReceipt())] }),
+    );
+    expect(res.isError).toBe(true);
+    expect(cmds).toEqual(["workflow_new"]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+});

--- a/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
@@ -392,6 +392,23 @@ describe("#2705: what the recovery refuses to conclude", () => {
     expect(fence).toBe(PRIOR_UUID);
   });
 
+  // Codex gate: the test above moves BOTH correlation fields at once, so deleting
+  // either check on its own would leave it green. This moves exactly one — the
+  // panel's own "this receipt answers only for rid X" self-declaration — while
+  // `rid` still matches, which is the shape a half-correlated reply would have.
+  it.each([
+    ["answers_only_command_rid", { answers_only_command_rid: "other-rid" }],
+    ["rid", { rid: "other-rid" }],
+  ])("requires %s to agree on its own, not just its twin", async (_field, over) => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({ newReply: ackTimeout, listReplies: [listWithActiveNewTab(appliedReceipt(over))] }),
+    );
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/outcome is undetermined/i);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
   it("does not accept a workflow_OPEN receipt that happens to carry this rid", async () => {
     const res = await newWorkflow().handler(
       {},

--- a/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
@@ -234,6 +234,21 @@ describe("#2705: an unacked workflow_new is settled by the panel's own receipt",
     expect(String(body.note)).toMatch(/panel_graph_outline/);
     expect(String(body.note)).toMatch(/Do NOT call panel_new_workflow again/i);
   });
+
+  // Codex gate: `empty:"unknown"` next to prose that says "the blank workflow WAS
+  // created" is a reply that contradicts itself, and an agent acts on the prose.
+  // Asserting the FIELD alone left that contradiction green, so pin the words too.
+  it("does not contradict empty:\"unknown\" in the prose it ships beside it", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({ newReply: ackTimeout, listReplies: [listWithActiveNewTab(appliedReceipt())] }),
+    );
+    const note = String(jsonOf(res).note);
+    expect(note).not.toMatch(/blank workflow WAS created/i);
+    expect(note).toMatch(/NEW WORKFLOW TAB WAS created and made active/);
+    // Nor may it assert whose nodes they are — nothing here has read that graph.
+    expect(note).not.toMatch(/belong to another workflow/i);
+  });
 });
 
 describe("#2705: what the recovery refuses to conclude", () => {
@@ -264,6 +279,7 @@ describe("#2705: what the recovery refuses to conclude", () => {
     expect(body.graph_binding).toBe("not_recovered");
     expect(stamps).toEqual([]);
     expect(fence).toBe(PRIOR_UUID);
+    expect(String(body.note)).toMatch(/DIFFERENT canvas/);
     expect(String(body.note)).toMatch(/panel_set_workflow_target/);
   });
 
@@ -285,6 +301,52 @@ describe("#2705: what the recovery refuses to conclude", () => {
     expect(res.isError).toBeFalsy();
     expect(jsonOf(res).workflow_instance_adopted).toBe(false);
     expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  // Codex gate: `resolved: null` is a shape the PANEL really produces (several of
+  // its workflow_new failure paths journal it), and folding it into "a different
+  // workflow is active" would state drift that was never observed AND tell the
+  // caller to reopen by a routing key that does not exist.
+  it("says which canvas is in view is UNESTABLISHED when the receipt carries no routing identity", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        listReplies: [listWithActiveNewTab(appliedReceipt({ resolved: null }))],
+      }),
+    );
+    expect(res.isError).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.created).toBe(true);
+    expect(body.workflow_instance_adopted).toBe(false);
+    expect(body.routing_key).toBeUndefined();
+    const note = String(body.note);
+    expect(note).toMatch(/which canvas is in view was NOT established/);
+    expect(note).toMatch(/the receipt carried no routing identity/);
+    // Never the drift wording, and never "open it with its routing key".
+    expect(note).not.toMatch(/DIFFERENT canvas/);
+    expect(note).not.toMatch(/panel_open_workflow with/);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("says the same when the panel reports no readable ACTIVE record", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        // A receipt naming the tab it created, but nothing active to compare to.
+        listReplies: [{ active_confirmed: true, active: null, last_open: appliedReceipt() }],
+      }),
+    );
+    expect(res.isError).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.workflow_instance_adopted).toBe(false);
+    expect(body.routing_key).toBe(NEW_KEY);
+    const note = String(body.note);
+    expect(note).toMatch(/which canvas is in view was NOT established/);
+    expect(note).toMatch(/no readable routing identity for the active canvas/);
+    expect(note).not.toMatch(/DIFFERENT canvas/);
     expect(fence).toBe(PRIOR_UUID);
   });
 

--- a/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
+++ b/src/__tests__/orchestrator/new-workflow-ack-timeout.test.ts
@@ -112,9 +112,13 @@ function makeCtx(opts: {
   listReplies?: Array<Record<string, unknown> | null>;
   rid?: string | null;
   canMutate?: boolean;
+  refuseStamp?: boolean;
 }): PanelToolCtx {
   let listIdx = 0;
   const refreshWorkflowUuid = vi.fn((_tabId: string, uuid: string) => {
+    // `refuseStamp` models the bridge declining the stamp (no routable tab for
+    // this session): a uuid was published and STILL nothing was adopted.
+    if (opts.refuseStamp) return false;
     fence = uuid;
     stamps.push(uuid);
     return true;
@@ -278,6 +282,26 @@ describe("#2705: what the recovery refuses to conclude", () => {
     expect(res.isError).toBeFalsy();
     expect(jsonOf(res).workflow_instance_adopted).toBe(false);
     expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("reports NOT-adopted when the bridge itself declines the stamp", async () => {
+    const res = await newWorkflow().handler(
+      {},
+      makeCtx({
+        newReply: ackTimeout,
+        listReplies: [listWithActiveNewTab(appliedReceipt())],
+        refuseStamp: true,
+      }),
+    );
+    expect(res.isError).toBeFalsy();
+    const body = jsonOf(res);
+    expect(body.created).toBe(true);
+    // A uuid WAS published; the adoption still did not happen. Saying "the panel
+    // published no identity" here would name the wrong cause.
+    expect(body.workflow_instance_adopted).toBe(false);
+    expect(body.graph_binding).toBe("not_recovered");
+    expect(String(body.note)).toMatch(/this bridge did not accept the stamp/);
     expect(fence).toBe(PRIOR_UUID);
   });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14280,9 +14280,17 @@ interface NewWorkflowVerifyResult extends ReceiptPollCost {
   error?: string;
   /** The routing handle of the tab the receipt says this command created. */
   routingKey?: string;
-  /** The live `active` record still names that exact tab (so its identity is ours). */
-  activeIsCreatedTab?: boolean;
-  /** #716 shape-gated fence identity, and ONLY when `activeIsCreatedTab`. */
+  /** The routing handle the live `workflow_list` reports as the active canvas. */
+  activeKey?: string;
+  /**
+   * THREE states, not two (codex gate). "The active record names a different
+   * canvas" and "one of the two identities could not be read at all" are opposite
+   * facts with opposite remedies, and folding the second into the first is the
+   * absence-of-evidence collapse this repo keeps auditing for: it would tell a
+   * caller another workflow is in view when nothing was observed about what is.
+   */
+  corroboration?: "matched" | "different" | "unreadable";
+  /** #716 shape-gated fence identity, and ONLY when `corroboration === "matched"`. */
   workflowUuid?: string;
 }
 
@@ -14327,14 +14335,19 @@ async function waitForNewWorkflowReceipt(
   const error = typeof receipt.error === "string" ? receipt.error : undefined;
   if (receipt.applied === false) return { receipt: "not_applied", error, waited_ms, attempts };
   if (receipt.applied !== true) return { receipt: "unknown", error, waited_ms, attempts };
+  // The panel sets `resolved: null` on several failure paths and can report no
+  // active record at all, so EITHER side of this comparison can be missing. A
+  // missing side is `unreadable` — not `different`.
   const routingKey = routingKeyOf(receipt.resolved);
   const activeKey = routingKeyOf(parsed.active);
-  const activeIsCreatedTab = !!routingKey && routingKey === activeKey;
+  const corroboration: "matched" | "different" | "unreadable" =
+    !routingKey || !activeKey ? "unreadable" : routingKey === activeKey ? "matched" : "different";
   return {
     receipt: "applied",
     routingKey,
-    activeIsCreatedTab,
-    workflowUuid: activeIsCreatedTab ? responseWorkflowUuid(parsed.active) : undefined,
+    activeKey,
+    corroboration,
+    workflowUuid: corroboration === "matched" ? responseWorkflowUuid(parsed.active) : undefined,
     waited_ms,
     attempts,
   };
@@ -14708,26 +14721,42 @@ async function recoverTimedOutNewWorkflow(
   // #708's caveat rides EVERY recovered creation. The panel journals the receipt
   // BEFORE it decides whether the new tab is provably empty, so `applied:true`
   // proves the tab was created and is active — never that it is blank. Claiming
-  // "blank" here would be the exact fabrication the direct reply refuses to make.
+  // "blank" here would be the exact fabrication the direct reply refuses to make,
+  // and an earlier draft made it TWICE (codex gate): the lead said "the blank
+  // workflow WAS created" and this caveat then said the opposite, while the last
+  // clause asserted any nodes found "belong to another workflow" — a second
+  // unobserved claim about a graph nothing here has read.
   const blankCaveat =
     ` NOT PROVEN BLANK: the receipt records that the tab was created and made active; it does ` +
     `not carry the panel's zero-node proof, which the lost reply was going to. Call ` +
-    `panel_graph_outline before building — if it already has nodes they belong to another ` +
-    `workflow (#708) and you should open the one you actually want instead.`;
+    `panel_graph_outline before building — if it already holds nodes, this is not the fresh ` +
+    `canvas you asked for (a reconnect/tab-restore can leave the previously active graph on the ` +
+    `shared canvas — #708), so open the workflow you actually want rather than building here.`;
   const fenceNote = adopted
     ? ` This session's workflow-instance fence has been RE-POINTED at the new canvas` +
       `${verify.workflowUuid ? ` (${verify.workflowUuid})` : ""}, so graph tools target it rather ` +
       `than the workflow you were on.${fence ? fence.note : ""}`
-    : verify.activeIsCreatedTab
+    : verify.corroboration === "matched"
       ? ` This session's fence was NOT re-pointed: the panel reports the new tab as active, but ` +
         `${verify.workflowUuid ? `this bridge did not accept the stamp` : `it published no usable ` +
         `workflow-instance identity for that tab`}, so graph commands keep the stamp they had. ` +
         `Call panel_set_workflow_target({mode:"current"}) to bind onto it.`
-      : ` This session's fence was NOT re-pointed: the panel's live active record does NOT name ` +
-        `the tab this command created${verify.routingKey ? ` (${verify.routingKey})` : ""}, so ` +
-        `another workflow is in view now and adopting an identity from it would fence you to the ` +
-        `wrong canvas. Switch to the new tab (panel_open_workflow with its routing key), then ` +
-        `call panel_set_workflow_target({mode:"current"}).`;
+      : verify.corroboration === "different"
+        ? ` This session's fence was NOT re-pointed: the panel's live active record names a ` +
+          `DIFFERENT canvas (${verify.activeKey}) than the tab this command created ` +
+          `(${verify.routingKey}), so adopting an identity from it would fence you to the wrong ` +
+          `workflow. Switch to the new tab (panel_open_workflow with ${verify.routingKey}), then ` +
+          `call panel_set_workflow_target({mode:"current"}).`
+        : // UNREADABLE — one of the two identities was missing, so NOTHING was
+          // observed about which canvas is in view. Do not narrate that as drift.
+          ` This session's fence was NOT re-pointed, and which canvas is in view was NOT ` +
+          `established: ${
+            verify.routingKey
+              ? `the panel reported no readable routing identity for the active canvas`
+              : `the receipt carried no routing identity for the tab it created`
+          }, so there was nothing to compare and adopting an identity would have been a guess. ` +
+          `Call panel_list_workflows to see the open tabs, then ` +
+          `panel_set_workflow_target({mode:"current"}) once you know which one you are on.`;
   return ok({
     created: true,
     empty: "unknown",
@@ -14749,9 +14778,9 @@ async function recoverTimedOutNewWorkflow(
           ? "panel_new_workflow did not receive its acknowledgement within the 15s window"
           : "panel_new_workflow lost its acknowledgement — the tab disconnected mid-command"
       }, but the ` +
-      `panel's request-id-correlated receipt confirms the blank workflow WAS created (found after ` +
-      `${waited}). Do NOT call panel_new_workflow again — it is not idempotent and a retry would ` +
-      `leave a second blank tab.${fenceNote}${blankCaveat}`,
+      `panel's request-id-correlated receipt confirms a NEW WORKFLOW TAB WAS created and made ` +
+      `active (found after ${waited}). Do NOT call panel_new_workflow again — it is not ` +
+      `idempotent and a retry would leave a second blank tab.${fenceNote}${blankCaveat}`,
   });
 }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3717,8 +3717,15 @@ async function awaitTabWhileContinuingRecovery(args: {
  * workflow matching …") comes back as a normal error REPLY the bridge received
  * and relayed, NOT a timeout, so it is never treated as a candidate for recovery
  * and still fails clearly. Defensive: non-error results are never a timeout.
+ *
+ * #2705 — `cmd` is a PARAMETER, not a widened pattern. The command name stays
+ * INSIDE the anchored form, so `workflow_new`'s recovery cannot be opened by a
+ * `workflow_open` timeout and vice versa; the union type is what keeps a caller
+ * from passing a name the bridge never writes. The two accepted values contain no
+ * regex metacharacters, so they are interpolated as-is — a `RegExp` built from an
+ * arbitrary string would be the thing to avoid here, and the type forbids it.
  */
-function isAckTimeout(res: ToolResult): boolean {
+function isAckTimeout(res: ToolResult, cmd: "workflow_open" | "workflow_new" = "workflow_open"): boolean {
   if (!res?.isError) return false;
   const text = res?.content?.find((c) => c.type === "text")?.text ?? "";
   // Match the CANONICAL bridge ack-timeout SPECIFICALLY (ui-bridge.ts): a
@@ -3752,7 +3759,10 @@ function isAckTimeout(res: ToolResult): boolean {
   // isReplyTimeoutError documents). The bridge message never carries leading
   // whitespace, so trimming buys nothing and only lets a whitespace/newline-
   // prefixed acked error reach the receipt-recovery path.
-  return /^(?:Error: )?Panel tab .+? did not reply to "workflow_open" within \d+\s*ms/i.test(text);
+  return new RegExp(
+    `^(?:Error: )?Panel tab .+? did not reply to "${cmd}" within \\d+\\s*ms`,
+    "i",
+  ).test(text);
 }
 
 /**
@@ -14128,16 +14138,44 @@ function resolvedOpenPathMatches(receipt: Record<string, unknown>, path: string)
 }
 
 /**
- * Poll `workflow_list` for the #514 `last_open` receipt for this exact bridge rid.
- * Active workflow state is deliberately ignored as recovery proof. Older panels
- * without receipt fields are identified promptly and remain undetermined.
+ * How much of the poll was spent, for the caller's message. Carried on every
+ * outcome so a recovery can say how long it looked, not just what it found.
  */
-async function waitForOpenReceipt(
+interface ReceiptPollCost {
+  waited_ms: number;
+  attempts: number;
+}
+
+/**
+ * The TRANSPORT half of receipt recovery: poll `workflow_list` until the #514
+ * `last_open` receipt minted for THIS exact bridge rid AND this exact command
+ * name appears, the panel proves itself too old to have receipts, or the budget
+ * runs out. It reads the correlation and nothing else — every judgement about
+ * what the receipt MEANS belongs to the caller, because `workflow_open` and
+ * `workflow_new` corroborate an applied receipt against different things (a
+ * caller-supplied path vs the tab the command itself minted).
+ *
+ * Extracted from `waitForOpenReceipt` (#2705) rather than copied: the
+ * correlation rule — rid, `answers_only_command_rid`, AND `cmd` — is the load-
+ * bearing guard on both paths, and two copies of it would be two chances for one
+ * to drift into accepting a receipt for someone else's command.
+ *
+ * Active workflow state is deliberately ignored as recovery proof here. Older
+ * panels without receipt fields are identified promptly and remain undetermined.
+ */
+type CorrelatedReceiptProbe = ReceiptPollCost &
+  (
+    | { kind: "matched"; parsed: Record<string, unknown>; receipt: Record<string, unknown> }
+    | { kind: "unsupported" }
+    | { kind: "missing" }
+  );
+
+async function waitForCorrelatedOpenReceipt(
   ctx: PanelToolCtx,
-  path: string,
+  cmd: "workflow_open" | "workflow_new",
   rid: string,
   timing: OpenVerifyTiming,
-): Promise<OpenVerifyResult> {
+): Promise<CorrelatedReceiptProbe> {
   const start = Date.now();
   const deadline = start + timing.budgetMs;
   const intervalMs = openVerifyTimingOverride
@@ -14154,49 +14192,13 @@ async function waitForOpenReceipt(
       // #514 always includes active_confirmed, including when last_open is null.
       // Its absence identifies an older panel which cannot make recovery claims.
       if (!("active_confirmed" in parsed) && !("last_open" in parsed)) {
-        return { receipt: "unsupported", waited_ms: Date.now() - start, attempts };
+        return { kind: "unsupported", waited_ms: Date.now() - start, attempts };
       }
       const lastOpen = parsed.last_open;
       if (lastOpen && typeof lastOpen === "object") {
         const receipt = lastOpen as Record<string, unknown>;
-        if (receipt.rid === rid && receipt.answers_only_command_rid === rid && receipt.cmd === "workflow_open") {
-          // The exact RID identifies this command. Keep a target check as an
-          // accidental wrong-workflow guard; active itself is never proof.
-          if (!resolvedOpenPathMatches(receipt, path)) {
-            return { receipt: "unknown", waited_ms: Date.now() - start, attempts };
-          }
-          if (receipt.applied === true) {
-            // A receipt proves this open applied, but a later user switch could
-            // have made another canvas active before this probe.  Refresh only
-            // when the current active object still names this exact target.
-            const active = parsed.active;
-            const resolved = receipt.resolved as Record<string, unknown>;
-            const resolvedPath = resolved.path as string;
-            // The receipt has already proved the command's exact resolved path.
-            // Still require its routing claim and the live active record to
-            // corroborate the ORIGINAL request identity before refreshing.
-            const requestedIdentity = canonicalRequestedSavedIdentity(path);
-            const resolvedIdentity = canonicalSavedRecordIdentity({
-              path: resolvedPath,
-              routing_key: resolved.routing_key,
-            });
-            const workflowUuid =
-              requestedIdentity &&
-              requestedIdentity === resolvedIdentity &&
-              activeMatchesOpenRefreshTarget(active, path)
-              ? responseWorkflowUuid(active)
-              : undefined;
-            return { receipt: "applied", workflowUuid, waited_ms: Date.now() - start, attempts };
-          }
-          if (receipt.applied === false) {
-            return {
-              receipt: "not_applied",
-              error: typeof receipt.error === "string" ? receipt.error : undefined,
-              waited_ms: Date.now() - start,
-              attempts,
-            };
-          }
-          return { receipt: "unknown", waited_ms: Date.now() - start, attempts };
+        if (receipt.rid === rid && receipt.answers_only_command_rid === rid && receipt.cmd === cmd) {
+          return { kind: "matched", parsed, receipt, waited_ms: Date.now() - start, attempts };
         }
       }
     }
@@ -14204,7 +14206,138 @@ async function waitForOpenReceipt(
     if (left <= 0) break;
     await sleep(Math.min(intervalMs, left));
   }
-  return { receipt: "missing", waited_ms: Date.now() - start, attempts };
+  return { kind: "missing", waited_ms: Date.now() - start, attempts };
+}
+
+/**
+ * Poll `workflow_list` for the #514 `last_open` receipt for this exact bridge rid,
+ * then decide what it says about THIS `workflow_open`.
+ */
+async function waitForOpenReceipt(
+  ctx: PanelToolCtx,
+  path: string,
+  rid: string,
+  timing: OpenVerifyTiming,
+): Promise<OpenVerifyResult> {
+  const probe = await waitForCorrelatedOpenReceipt(ctx, "workflow_open", rid, timing);
+  const { waited_ms, attempts } = probe;
+  if (probe.kind === "unsupported") return { receipt: "unsupported", waited_ms, attempts };
+  if (probe.kind === "missing") return { receipt: "missing", waited_ms, attempts };
+  const { parsed, receipt } = probe;
+  // The exact RID identifies this command. Keep a target check as an
+  // accidental wrong-workflow guard; active itself is never proof.
+  if (!resolvedOpenPathMatches(receipt, path)) {
+    return { receipt: "unknown", waited_ms, attempts };
+  }
+  if (receipt.applied === true) {
+    // A receipt proves this open applied, but a later user switch could
+    // have made another canvas active before this probe.  Refresh only
+    // when the current active object still names this exact target.
+    const active = parsed.active;
+    const resolved = receipt.resolved as Record<string, unknown>;
+    const resolvedPath = resolved.path as string;
+    // The receipt has already proved the command's exact resolved path.
+    // Still require its routing claim and the live active record to
+    // corroborate the ORIGINAL request identity before refreshing.
+    const requestedIdentity = canonicalRequestedSavedIdentity(path);
+    const resolvedIdentity = canonicalSavedRecordIdentity({
+      path: resolvedPath,
+      routing_key: resolved.routing_key,
+    });
+    const workflowUuid =
+      requestedIdentity &&
+      requestedIdentity === resolvedIdentity &&
+      activeMatchesOpenRefreshTarget(active, path)
+      ? responseWorkflowUuid(active)
+      : undefined;
+    return { receipt: "applied", workflowUuid, waited_ms, attempts };
+  }
+  if (receipt.applied === false) {
+    return {
+      receipt: "not_applied",
+      error: typeof receipt.error === "string" ? receipt.error : undefined,
+      waited_ms,
+      attempts,
+    };
+  }
+  return { receipt: "unknown", waited_ms, attempts };
+}
+
+/** A `routing_key` from a receipt's `resolved` block, or from a `workflow_list`
+ *  record — the per-instance handle (`tmp:<uuid>` unsaved, `wf:<path>` saved) that
+ *  is the ONLY thing that distinguishes two unsaved tabs from each other. Empty,
+ *  absent, or non-string reads as "no identity", never as a match. */
+function routingKeyOf(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const key = (value as { routing_key?: unknown }).routing_key;
+  return typeof key === "string" && key.trim() ? key.trim() : undefined;
+}
+
+/** What the panel's rid-correlated receipt says about ONE `workflow_new`. */
+interface NewWorkflowVerifyResult extends ReceiptPollCost {
+  receipt: "applied" | "not_applied" | "unknown" | "unsupported" | "missing";
+  /** The panel's own error text, when it journaled one. */
+  error?: string;
+  /** The routing handle of the tab the receipt says this command created. */
+  routingKey?: string;
+  /** The live `active` record still names that exact tab (so its identity is ours). */
+  activeIsCreatedTab?: boolean;
+  /** #716 shape-gated fence identity, and ONLY when `activeIsCreatedTab`. */
+  workflowUuid?: string;
+}
+
+/**
+ * #2705 — the `workflow_new` half of receipt recovery.
+ *
+ * `panel_new_workflow` timed out after 15s, the blank tab HAD been created, and
+ * the tool returned the raw ack-timeout: no receipt lookup, and — the part that
+ * wedged the session — no fence refresh, so the next `panel_graph_outline` was
+ * refused with `workflow instance mismatch` naming the workflow the user had just
+ * left. The panel already journals this command (`noteOpenAttempt({cmd:
+ * "workflow_new", …})` on every exit, `applied:true` only where the tab exists and
+ * is active), so the evidence is a STRUCTURED, rid-correlated receipt rather than
+ * a re-read of `active` — which after a reconnect names a tab the frontend
+ * restored by itself and proves nothing about our command.
+ *
+ * CORROBORATION IS DIFFERENT FROM THE OPEN PATH, because the identity is. An open
+ * has a caller-supplied path to check the receipt against; a new workflow has no
+ * caller target at all — the command MINTS its target. So the check is: the
+ * receipt names the routing key its own execution created, and the live `active`
+ * record still names that same key. That is what makes `active.workflow_uuid`
+ * safe to adopt: the two fields come from one observation of one tab
+ * (`liveWorkflowListActive`), so a matching routing key means the uuid belongs to
+ * the tab this rid created, not to whatever happens to be in view.
+ *
+ * Nothing is adopted without that match. `applied:"unknown"` — which the panel
+ * uses for every branch where creation may have got partway, or where it
+ * deliberately RETIRED the binding proof — never adopts either: taking a fence
+ * from a live record the panel just invalidated would re-assert exactly the proof
+ * it withdrew.
+ */
+async function waitForNewWorkflowReceipt(
+  ctx: PanelToolCtx,
+  rid: string,
+  timing: OpenVerifyTiming,
+): Promise<NewWorkflowVerifyResult> {
+  const probe = await waitForCorrelatedOpenReceipt(ctx, "workflow_new", rid, timing);
+  const { waited_ms, attempts } = probe;
+  if (probe.kind === "unsupported") return { receipt: "unsupported", waited_ms, attempts };
+  if (probe.kind === "missing") return { receipt: "missing", waited_ms, attempts };
+  const { parsed, receipt } = probe;
+  const error = typeof receipt.error === "string" ? receipt.error : undefined;
+  if (receipt.applied === false) return { receipt: "not_applied", error, waited_ms, attempts };
+  if (receipt.applied !== true) return { receipt: "unknown", error, waited_ms, attempts };
+  const routingKey = routingKeyOf(receipt.resolved);
+  const activeKey = routingKeyOf(parsed.active);
+  const activeIsCreatedTab = !!routingKey && routingKey === activeKey;
+  return {
+    receipt: "applied",
+    routingKey,
+    activeIsCreatedTab,
+    workflowUuid: activeIsCreatedTab ? responseWorkflowUuid(parsed.active) : undefined,
+    waited_ms,
+    attempts,
+  };
 }
 
 /**
@@ -14451,6 +14584,210 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
     `${toolResultText(res)}\n\nworkflow_open outcome is undetermined: ${reason}. ` +
       `Do not assume the workflow was opened; inspect the current workflow before deciding whether to retry.`,
   );
+}
+
+/**
+ * The tab's graph-MUTATION capability, in the tri-state `describeFenceRebind`
+ * consumes: `true` permitted, `false` refused (with the cause that decides which
+ * remedy is printed), `undefined` NOT KNOWN.
+ *
+ * Shared by `panel_new_workflow`'s normal and recovered paths (#2705) so both
+ * report the same `graph_binding` vocabulary for the same tab state — a recovery
+ * that invented its own binding words would be a second dialect for the one fact
+ * the caller acts on.
+ */
+function readGraphMutationCapability(ctx: PanelToolCtx): {
+  canMutate: boolean | undefined;
+  refusalCause?: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement";
+} {
+  try {
+    if (ctx.tabGraphMutationCapability) {
+      const cap = ctx.tabGraphMutationCapability();
+      return {
+        canMutate: cap.known ? cap.canMutate : undefined,
+        refusalCause: cap.known && !cap.canMutate ? cap.because : undefined,
+      };
+    }
+    return { canMutate: ctx.tabCanMutateGraph?.() };
+  } catch {
+    // unknown-ok: a guard that can throw is not a guard. A probe that threw has
+    // OBSERVED nothing, and `undefined` is exactly that state for this renderer —
+    // it prints "not verified", not the refusal wording a collapsed `false` would.
+    return { canMutate: undefined };
+  }
+}
+
+/**
+ * #2705 — what to report when `workflow_new` did not ACK.
+ *
+ * The reporter's sequence: a 15s ack timeout that said the mutation "may have
+ * been applied", a blank tab that HAD in fact been created, and a session still
+ * fenced to the workflow it had just left — so the next `panel_graph_outline` was
+ * refused with `workflow instance mismatch` and the only way out was a manual
+ * `panel_set_workflow_target({mode:"current"})`.
+ *
+ * Both halves are answered from ONE structured source: the panel's #402/#514
+ * rid-correlated receipt. `applied:true` settles the outcome the timeout could
+ * not, and the routing key it names — matched against the live `active` record —
+ * is what licenses re-pointing the fence at the canvas this command created.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO. It never adopts an identity the receipt did
+ * not correlate, and it never tells the caller to retry unless the panel
+ * journaled a clean negative: `workflow_new` is not idempotent, so a wrong
+ * "safe to retry" costs the user a second blank tab — which is the failure the
+ * panel's own `applied:"unknown"` branches exist to prevent.
+ */
+async function recoverTimedOutNewWorkflow(
+  ctx: PanelToolCtx,
+  res: ToolResult,
+  dispatchedRid: string | undefined,
+): Promise<ToolResult> {
+  // The stale fence is the SECOND half of this report, so every undetermined exit
+  // names it too: an agent that reads only "outcome unknown" then meets a
+  // `workflow instance mismatch` has no way to know the two are the same event.
+  const undetermined = (reason: string): ToolResult =>
+    fail(
+      `${toolResultText(res)}\n\nworkflow_new outcome is undetermined: ${reason}. Do NOT re-issue ` +
+        `panel_new_workflow — it is NOT idempotent, so if the tab was in fact created a retry ` +
+        `leaves a SECOND blank tab behind. Call panel_list_workflows to see whether a new blank ` +
+        `tab exists. This session's workflow-instance fence was NOT re-pointed either, so a graph ` +
+        `call that now fails with "workflow instance mismatch" is that same stale fence rather ` +
+        `than a second fault — once you know which canvas you are on, clear it with ` +
+        `panel_set_workflow_target({mode:"current"}).`,
+    );
+
+  if (!dispatchedRid) {
+    return undetermined(
+      "this bridge/panel combination did not expose a request id for receipt correlation",
+    );
+  }
+  const verify = await waitForNewWorkflowReceipt(ctx, dispatchedRid, getOpenVerifyTiming());
+  const waited =
+    `${(verify.waited_ms / 1000).toFixed(1)}s (${verify.attempts} probe` +
+    `${verify.attempts === 1 ? "" : "s"})`;
+
+  if (verify.receipt === "not_applied") {
+    // The ONE branch that may say "retry": the panel journaled that nothing ran.
+    return fail(
+      `workflow_new was confirmed NOT applied by the panel's request-id-correlated receipt` +
+        `${verify.error ? `: ${verify.error}` : "."} No blank tab was created, and this session's ` +
+        `workflow target is unchanged — it is safe to call panel_new_workflow again.`,
+    );
+  }
+  if (verify.receipt !== "applied") {
+    return undetermined(
+      verify.receipt === "unsupported"
+        ? "this panel version does not provide request-id-correlated open receipts"
+        : verify.receipt === "unknown"
+          ? `the matching panel receipt did not confirm that the command was applied` +
+            `${verify.error ? ` (${verify.error})` : ""}`
+          : `no request-id-correlated panel receipt was observed in ${waited}`,
+    );
+  }
+
+  // APPLIED. The tab exists. Adopt its identity only if the receipt's routing key
+  // is still what the panel reports as active — see waitForNewWorkflowReceipt.
+  const before = currentWorkflowFence(ctx);
+  const adopted = verify.workflowUuid
+    ? refreshWorkflowUuid(ctx, { workflow_uuid: verify.workflowUuid })
+    : false;
+  const cap = readGraphMutationCapability(ctx);
+  const fence =
+    adopted && verify.workflowUuid
+      ? describeFenceRebind(
+          { status: "refreshed", uuid: verify.workflowUuid, before },
+          cap.canMutate,
+          cap.refusalCause,
+          panelTooOldNote(ctx),
+        )
+      : null;
+  // #708's caveat rides EVERY recovered creation. The panel journals the receipt
+  // BEFORE it decides whether the new tab is provably empty, so `applied:true`
+  // proves the tab was created and is active — never that it is blank. Claiming
+  // "blank" here would be the exact fabrication the direct reply refuses to make.
+  const blankCaveat =
+    ` NOT PROVEN BLANK: the receipt records that the tab was created and made active; it does ` +
+    `not carry the panel's zero-node proof, which the lost reply was going to. Call ` +
+    `panel_graph_outline before building — if it already has nodes they belong to another ` +
+    `workflow (#708) and you should open the one you actually want instead.`;
+  const fenceNote = adopted
+    ? ` This session's workflow-instance fence has been RE-POINTED at the new canvas` +
+      `${verify.workflowUuid ? ` (${verify.workflowUuid})` : ""}, so graph tools target it rather ` +
+      `than the workflow you were on.${fence ? fence.note : ""}`
+    : verify.activeIsCreatedTab
+      ? ` This session's fence was NOT re-pointed: the panel reports the new tab as active but ` +
+        `published no usable workflow-instance identity for it, so graph commands will keep the ` +
+        `stamp they had. Call panel_set_workflow_target({mode:"current"}) to bind onto it.`
+      : ` This session's fence was NOT re-pointed: the panel's live active record does NOT name ` +
+        `the tab this command created${verify.routingKey ? ` (${verify.routingKey})` : ""}, so ` +
+        `another workflow is in view now and adopting an identity from it would fence you to the ` +
+        `wrong canvas. Switch to the new tab (panel_open_workflow with its routing key), then ` +
+        `call panel_set_workflow_target({mode:"current"}).`;
+  return ok({
+    created: true,
+    empty: "unknown",
+    recovered: true,
+    // The machine-readable form of "the mutation landed, the acknowledgement did
+    // not" — so a caller never has to parse the prose to learn that (#2705).
+    applied_but_ack_timed_out: true,
+    ...(verify.routingKey ? { key: verify.routingKey, routing_key: verify.routingKey } : {}),
+    workflow_instance_adopted: adopted,
+    graph_binding: fence ? fence.binding : "not_recovered",
+    note:
+      `panel_new_workflow did not receive its acknowledgement within the 15s window, but the ` +
+      `panel's request-id-correlated receipt confirms the blank workflow WAS created (found after ` +
+      `${waited}). Do NOT call panel_new_workflow again — it is not idempotent and a retry would ` +
+      `leave a second blank tab.${fenceNote}${blankCaveat}`,
+  });
+}
+
+/**
+ * `panel_new_workflow` body. Forwards `workflow_new`, and on an ACK-TIMEOUT or a
+ * mid-command reconnect drop settles the outcome against the panel's own
+ * rid-correlated receipt instead of handing the caller an unknown (#2705).
+ */
+async function newWorkflowWithVerify(ctx: PanelToolCtx): Promise<ToolResult> {
+  let dispatchedRid: string | undefined;
+  const res = await ctx.call({ cmd: "workflow_new" }, 15000, (rid) => {
+    dispatchedRid = rid;
+  });
+  // Checked BEFORE `res.isError`: a genuine acked executor error (the panel's own
+  // "could not take the workflow switch/reload section", a thrown creation) must
+  // still surface verbatim, and only a no-reply is a candidate for recovery.
+  if (isAckTimeout(res, "workflow_new") || isReconnectDrop(res)) {
+    return recoverTimedOutNewWorkflow(ctx, res, dispatchedRid);
+  }
+  if (res.isError) return res;
+  // #932 (recurrence on 0.50.6) — a NEW canvas needs a NEW fence.
+  //
+  // workflow_new authoritatively re-points the active workflow, exactly as
+  // workflow_open does — but only the open path re-derived the command
+  // fence afterwards (openWorkflowWithVerify). So this session kept the
+  // PREVIOUS workflow's instance stamp while the user was now looking at a
+  // brand-new blank canvas, and every stamped command after it failed with
+  // "workflow instance mismatch". The reporter created a workflow and could
+  // not add a single node to it.
+  //
+  // Refresh from the panel's own live active record, the same way the open
+  // path does. The panel mints the new canvas's identity EAGERLY at
+  // creation ("so the key exists BEFORE the first edit").
+  //
+  // #814/#812 — this reply DOES carry workflow_uuid directly (#762), and the
+  // stale comment that used to stand here said otherwise. Trust it first,
+  // before ever attempting rebindWorkflowFence's independent workflow_list
+  // round trip, which can be refused by the exact fence being repaired
+  // (#1071) — the same trap a reporter hit via panel_new_workflow's own
+  // recovery attempt.
+  //
+  // NEVER fails the call on a rebind miss: the workflow WAS created, and
+  // retracting that would be the worse lie. Disclose instead, so the agent
+  // learns the graph tools are not yet usable here rather than discovering
+  // it one confusing mismatch at a time.
+  const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
+  const cap = readGraphMutationCapability(ctx);
+  const fence = describeFenceRebind(fenceRebind, cap.canMutate, cap.refusalCause, panelTooOldNote(ctx));
+  if (!fence || fence.binding === "bound") return res;
+  return appendNote(res, `The blank workflow WAS created.${fence.note}`);
 }
 
 /** True when a ToolResult is a MID-COMMAND reconnect drop ("disconnected
@@ -25397,56 +25734,11 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
       "panel_new_workflow",
       "Open a brand-new BLANK workflow in a NEW TAB. Use this whenever the user wants a 'new workflow' / 'fresh canvas' / 'start over for a new project'. This does NOT touch their current workflow — it opens a separate tab. NEVER use panel_clear for a new workflow (panel_clear wipes the CURRENT graph and is only for 'clear/reset this canvas').",
       {},
-      async (_args, ctx) => {
-        const res = await ctx.call({ cmd: "workflow_new" }, 15000);
-        if (res.isError) return res;
-        // #932 (recurrence on 0.50.6) — a NEW canvas needs a NEW fence.
-        //
-        // workflow_new authoritatively re-points the active workflow, exactly as
-        // workflow_open does — but only the open path re-derived the command
-        // fence afterwards (openWorkflowWithVerify). So this session kept the
-        // PREVIOUS workflow's instance stamp while the user was now looking at a
-        // brand-new blank canvas, and every stamped command after it failed with
-        // "workflow instance mismatch". The reporter created a workflow and could
-        // not add a single node to it.
-        //
-        // Refresh from the panel's own live active record, the same way the open
-        // path does. The panel mints the new canvas's identity EAGERLY at
-        // creation ("so the key exists BEFORE the first edit").
-        //
-        // #814/#812 — this reply DOES carry workflow_uuid directly (#762), and the
-        // stale comment that used to stand here said otherwise. Trust it first,
-        // before ever attempting rebindWorkflowFence's independent workflow_list
-        // round trip, which can be refused by the exact fence being repaired
-        // (#1071) — the same trap a reporter hit via panel_new_workflow's own
-        // recovery attempt.
-        //
-        // NEVER fails the call on a rebind miss: the workflow WAS created, and
-        // retracting that would be the worse lie. Disclose instead, so the agent
-        // learns the graph tools are not yet usable here rather than discovering
-        // it one confusing mismatch at a time.
-        const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
-        let canMutateNow: boolean | undefined;
-        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | "target_disagreement" | undefined;
-        try {
-          if (ctx.tabGraphMutationCapability) {
-            const cap = ctx.tabGraphMutationCapability();
-            canMutateNow = cap.known ? cap.canMutate : undefined;
-            if (cap.known && !cap.canMutate) refusalCause = cap.because;
-          } else {
-            canMutateNow = ctx.tabCanMutateGraph?.();
-          }
-        } catch {
-          canMutateNow = undefined; // a guard that can throw is not a guard
-          refusalCause = undefined;
-        }
-        const fence = describeFenceRebind(fenceRebind, canMutateNow, refusalCause, panelTooOldNote(ctx));
-        if (!fence || fence.binding === "bound") return res;
-        return appendNote(
-          res,
-          `The blank workflow WAS created.${fence.note}`,
-        );
-      },
+      // Verify-after-timeout (#2705), the same mechanism panel_open_workflow uses:
+      // a backgrounded/frozen tab can create the blank workflow and still miss the
+      // 15s ack window, and returning that raw timeout left the session fenced to
+      // the PREVIOUS canvas — see newWorkflowWithVerify.
+      async (_args, ctx) => newWorkflowWithVerify(ctx),
     ),
     def(
       "panel_open_workflow",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14757,24 +14757,33 @@ async function recoverTimedOutNewWorkflow(
           }, so there was nothing to compare and adopting an identity would have been a guess. ` +
           `Call panel_list_workflows to see the open tabs, then ` +
           `panel_set_workflow_target({mode:"current"}) once you know which one you are on.`;
+  // Two shapes reach here and they are NOT the same event: an ack TIMEOUT is a tab
+  // that never answered inside the window; a reconnect DROP is the tab going away
+  // mid-command. What they share is that no acknowledgement arrived — which is the
+  // fact a caller acts on — so that is what the always-present field asserts, and
+  // the cause rides beside it. An earlier draft set `applied_but_ack_timed_out` on
+  // both and explained in a comment why that was fine (codex gate round 2): it is
+  // not, because the name says "timed out" and a disconnect did not.
+  const ackTimedOut = isAckTimeout(res, "workflow_new");
   return ok({
     created: true,
     empty: "unknown",
     recovered: true,
     // The machine-readable form of "the mutation landed, the acknowledgement did
     // not" — so a caller never has to parse the prose to learn that (#2705).
-    applied_but_ack_timed_out: true,
+    applied_but_unacknowledged: true,
+    unacknowledged_cause: ackTimedOut ? "ack_timeout" : "reconnect_drop",
+    // #2705's own vocabulary, kept for the case it was written about — and ONLY
+    // for that case, so a caller keying on it is never told a disconnect was a
+    // timeout. Absent on the reconnect-drop path rather than false: this field
+    // has always meant "the thing named happened".
+    ...(ackTimedOut ? { applied_but_ack_timed_out: true } : {}),
     ...(verify.routingKey ? { key: verify.routingKey, routing_key: verify.routingKey } : {}),
     workflow_instance_adopted: adopted,
     graph_binding: fence ? fence.binding : "not_recovered",
     note:
-      // Both shapes reach here and they are not the same event: an ack TIMEOUT is
-      // a tab that never answered inside the window, a reconnect DROP is the tab
-      // going away mid-command. `applied_but_ack_timed_out` covers both (in each
-      // case no acknowledgement arrived, which is the fact a caller acts on), but
-      // the prose must not tell someone their tab was slow when it disconnected.
       `${
-        isAckTimeout(res, "workflow_new")
+        ackTimedOut
           ? "panel_new_workflow did not receive its acknowledgement within the 15s window"
           : "panel_new_workflow lost its acknowledgement — the tab disconnected mid-command"
       }, but the ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14719,9 +14719,10 @@ async function recoverTimedOutNewWorkflow(
       `${verify.workflowUuid ? ` (${verify.workflowUuid})` : ""}, so graph tools target it rather ` +
       `than the workflow you were on.${fence ? fence.note : ""}`
     : verify.activeIsCreatedTab
-      ? ` This session's fence was NOT re-pointed: the panel reports the new tab as active but ` +
-        `published no usable workflow-instance identity for it, so graph commands will keep the ` +
-        `stamp they had. Call panel_set_workflow_target({mode:"current"}) to bind onto it.`
+      ? ` This session's fence was NOT re-pointed: the panel reports the new tab as active, but ` +
+        `${verify.workflowUuid ? `this bridge did not accept the stamp` : `it published no usable ` +
+        `workflow-instance identity for that tab`}, so graph commands keep the stamp they had. ` +
+        `Call panel_set_workflow_target({mode:"current"}) to bind onto it.`
       : ` This session's fence was NOT re-pointed: the panel's live active record does NOT name ` +
         `the tab this command created${verify.routingKey ? ` (${verify.routingKey})` : ""}, so ` +
         `another workflow is in view now and adopting an identity from it would fence you to the ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14692,13 +14692,17 @@ async function recoverTimedOutNewWorkflow(
     ? refreshWorkflowUuid(ctx, { workflow_uuid: verify.workflowUuid })
     : false;
   const cap = readGraphMutationCapability(ctx);
+  // No `panelTooOldNote` here, deliberately (#1043's gate counts its call sites
+  // and this would be a third). It is printed ONLY in the `not_recovered` branch,
+  // for a fence read that could not be made — and this call always passes
+  // `status:"refreshed"`, because it is reached only when the adoption already
+  // succeeded. Passing it would be an argument that provably cannot be read.
   const fence =
     adopted && verify.workflowUuid
       ? describeFenceRebind(
           { status: "refreshed", uuid: verify.workflowUuid, before },
           cap.canMutate,
           cap.refusalCause,
-          panelTooOldNote(ctx),
         )
       : null;
   // #708's caveat rides EVERY recovered creation. The panel journals the receipt

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -14739,7 +14739,16 @@ async function recoverTimedOutNewWorkflow(
     workflow_instance_adopted: adopted,
     graph_binding: fence ? fence.binding : "not_recovered",
     note:
-      `panel_new_workflow did not receive its acknowledgement within the 15s window, but the ` +
+      // Both shapes reach here and they are not the same event: an ack TIMEOUT is
+      // a tab that never answered inside the window, a reconnect DROP is the tab
+      // going away mid-command. `applied_but_ack_timed_out` covers both (in each
+      // case no acknowledgement arrived, which is the fact a caller acts on), but
+      // the prose must not tell someone their tab was slow when it disconnected.
+      `${
+        isAckTimeout(res, "workflow_new")
+          ? "panel_new_workflow did not receive its acknowledgement within the 15s window"
+          : "panel_new_workflow lost its acknowledgement — the tab disconnected mid-command"
+      }, but the ` +
       `panel's request-id-correlated receipt confirms the blank workflow WAS created (found after ` +
       `${waited}). Do NOT call panel_new_workflow again — it is not idempotent and a retry would ` +
       `leave a second blank tab.${fenceNote}${blankCaveat}`,


### PR DESCRIPTION
Fixes #2705

## What was wrong

`panel_new_workflow({})` returned an outcome-unknown ack timeout after 15s, but the blank tab **had** been created. Two consequences, and the handler had neither remedy:

- the **outcome** stayed unknown, and
- the session's **workflow-instance fence** was never re-pointed — so the next `panel_graph_outline` was refused with `workflow instance mismatch … issued for 3b86446a…, tab reported d2d3e6f4…`, and only a manual `panel_set_workflow_target({mode:"current"})` cleared it.

The whole handler was:

```ts
const res = await ctx.call({ cmd: "workflow_new" }, 15000);
if (res.isError) return res;      // <- returns BEFORE the #932 fence refresh below it
```

`panel_open_workflow` has had verify-after-timeout since #215/#319/#496 (`openWorkflowWithVerify`). `panel_new_workflow` never got it.

## The evidence used — a receipt, not a re-read

The panel **already journals this command**. Verified against `comfyui-mcp-panel` `origin/main`, `workflow_new` calls `noteOpenAttempt({cmd:"workflow_new", rid, resolved:{path,filename,routing_key}, applied:true})`, and every failure path journals `applied:false` (nothing ran) or `applied:"unknown"` (may have got partway) *deliberately*. `workflow_list` publishes the latest as `last_open` with `answers_only_command_rid`.

So the recovery is a structured, rid-correlated receipt — never parsed prose, and never a re-read of `active` (after a reconnect the frontend restores a tab by itself, which is exactly why #661 exists).

## What it does

- `waitForCorrelatedOpenReceipt` — the polling shell **extracted** from `waitForOpenReceipt`, parameterised by command name. The correlation rule (`rid` + `answers_only_command_rid` + `cmd`) is load-bearing on both paths; two copies would be two chances for one to drift.
- `isAckTimeout(res, cmd)` — the command name stays **inside** the anchored pattern, so one command's timeout cannot open another's recovery. The parameter is a two-member union, not a string.
- `newWorkflowWithVerify` / `recoverTimedOutNewWorkflow`:
  - `applied:true` → `ok({created:true, applied_but_ack_timed_out:true, recovered:true, routing_key, workflow_instance_adopted, graph_binding, …})`
  - the fence is re-pointed **only** when the receipt's `resolved.routing_key` still equals the live `active` record's `routing_key`. Both fields come from one observation of one tab (`liveWorkflowListActive`), so a match means `active.workflow_uuid` belongs to the tab *this rid* created.
  - `applied:false` → the one branch allowed to say "safe to retry".
  - `applied:"unknown"` / no receipt / older panel → undetermined, and explicitly **forbids** a retry.

## Where the load-bearing claims are (please look here)

1. **`workflow_new` is not idempotent.** A wrong "safe to retry" costs the user a second blank tab. Only a journaled `applied:false` says it. `applied:"unknown"` — which the panel uses for *every* branch where creation may have got partway, and for the branch where it deliberately RETIRES the binding proof — is undetermined and adopts nothing. Adopting there would re-assert proof the panel just withdrew.
2. **The corroboration is a routing key, not a path.** An open has a caller-supplied target; a new workflow *mints* its target, so there is nothing to compare against except what the command itself created.
3. **It never claims the tab is blank.** The panel journals the receipt *before* deciding the tab is provably empty (#708), so `applied:true` proves created-and-active, never blank. Every recovered reply carries `empty:"unknown"` and a `NOT PROVEN BLANK` caveat pointing at `panel_graph_outline`.
4. **Every undetermined exit also names the stale fence** — an agent that reads only "outcome unknown" and then meets a `workflow instance mismatch` has no way to know the two are the same event.
5. **The extraction touches the open path.** `waitForOpenReceipt` is now a thin interpreter over the shared shell; the early-return points (unsupported on the first probe, matched receipt stops the poll) are preserved exactly. The existing open-verify tests in `panel-tools.test.ts` and `panel-session-rebind-residuals.test.ts` cover it and stay green.

## Evidence

Full suite: `Test Files 753 | Tests 13877 passed | 6 skipped`, with one pre-existing failure (`panel-version-gap.test.ts`) caused by this branch and fixed in the second commit — see below. `late-mutation-e2e.test.ts` fails only under full-suite load and passes in isolation (5/5), a known wall-clock flake.

**Mutation testing — I deleted the fix and watched named tests fail** (`new-workflow-ack-timeout.test.ts`, 15 tests):

| mutation | result |
|---|---|
| remove the recovery (restore `if (res.isError) return res`) | **13 failed** / 2 passed — the 2 survivors are the controls asserting a genuine acked error is *not* recovered |
| drop `receipt.cmd === cmd` from the correlation | **1 failed**: "does not accept a workflow_OPEN receipt that happens to carry this rid" |
| drop the routing-key corroboration | **1 failed**: "does not adopt an identity when the created tab is no longer active" |
| collapse `applied:"unknown"` into a clean negative | **1 failed**: 'treats applied:"unknown" as undetermined' |
| un-parameterise `isAckTimeout` (workflow_open only) | **13 failed** |

The first attempt at mutation 1 **did not apply** (this tree is CRLF and the pattern used `\n`); it read as "survived". The re-run with `\r?\n` is the one above — the applied-hit count is checked in each row.

Two existing **source pins** needed re-anchoring, both because code MOVED rather than changed:

- `fence-trusts-own-reply.test.ts` sliced from the `def("panel_new_workflow"` literal; the body now lives in `newWorkflowWithVerify`. Re-anchored on the function, brace-bounded rather than character-counted (a function that outgrows a fixed slice silently stops being checked), plus a separate pin on the delegation.
- `panel-version-gap.test.ts` counts `panelTooOldNote(ctx)` call sites (`save + new only`). The recovery's `describeFenceRebind` call always passes `status:"refreshed"`, and the note is printed only in the `not_recovered` branch — so the argument was provably unreadable and was removed rather than the gate loosened.

## Deliberately not done

- **No `awaitReachable` pre-send guard** on `panel_new_workflow` (the open path has one). It would reduce how often this fires, but it is a *new refusal surface* on a tool that currently always dispatches, which is a different change with its own risk. Worth a separate look.
- **No panel-side change.** The panel's receipt is already correct and complete for this; the gap was entirely on the MCP side.
- **No browser/Playwright run.** Nothing here reaches the sidebar's rendering — it changes what the MCP tool returns to an agent, and the panel-side `workflow_new`/`workflow_list` handlers are untouched. Stating that rather than implying coverage I do not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review gate — codex, 4 rounds, PASS on `7aa9b2f`

`codex-gate.mjs` could not launch codex (`CreateProcessAsUserW failed: 5 (Access is denied.)`) — the known wrapper sandbox failure, which is INDETERMINATE, not a verdict. Ran codex directly with the diff supplied inline, per the documented fallback:

```
cat prompt.txt | codex exec -s read-only --skip-git-repo-check -C <worktree> -o /tmp/codex-2705r<N>-<ts>.txt -
```

| round | verdict | findings |
|---|---|---|
| 1 | NEEDS-REVISION | the reply overclaimed blankness ("the blank workflow WAS created" beside `empty:"unknown"`, plus asserting whose nodes any found nodes were); `activeIsCreatedTab` was a boolean over three states, so a null `receipt.resolved` read as "a DIFFERENT workflow is in view"; the tests pinned the field but not the prose, and covered no null identity fields |
| 2 | NEEDS-REVISION | `applied_but_ack_timed_out` was set for reconnect drops too — the name says "timed out" and a disconnect did not |
| 3 | NEEDS-REVISION | **the round-2 code was not actually in the commit** — only its tests were; plus the earlier-receipt test moved both `rid` and `answers_only_command_rid` at once, so deleting either check would have stayed green |
| 4 | **PASS** | none |

**Round 3 is the one worth reading.** I edited the fix, ran the tests green, then ran mutation controls — and each control's `git checkout -- panel-tools.ts` restored the file to the last commit, which did not yet contain the edit. I committed and pushed tests without their fix, and `git status` showing only the test file modified is what I misread as "clean". Codex caught it from the diff. The head was genuinely red for one commit; `7aa9b2f` has the code, and I re-ran every mutation control against the **committed** tree afterwards:

| mutation | detected by |
|---|---|
| set `applied_but_ack_timed_out` unconditionally | "recovers a mid-command reconnect drop the same way" |
| always report `ack_timeout` as the cause | same |
| drop the `rid` check, keep its twin | "requires rid to agree on its own" |
| drop `answers_only_command_rid`, keep `rid` | "requires answers_only_command_rid to agree on its own" |
| collapse `unreadable` into `different` | both unreadable-identity tests |
| collapse `unreadable` into `matched` (adopt on no evidence) | both unreadable-identity tests |
| restore the blankness overclaim | the non-contradiction pin |

Final green on `7aa9b2f`: `npx vitest run` → **753 files, 13883 passed, 6 skipped**, one load flake (`console-secrets.test.ts`, 49s under full-suite load, 11/11 in isolation, and it touches nothing in this diff). `npm test`'s other 12 checks pass; `asset-counts` needs `npm run build` first in a fresh worktree.
