### PR TITLE
fix(2714): a git install must be corroborated on disk, not by ComfyUI-Manager's own list

### DIFF
--- a/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
+++ b/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
@@ -86,8 +86,10 @@ vi.mock("../../services/live-interpreter.js", async (importOriginal) => {
 // ── ComfyUI-Manager v4: the queue ACCEPTS, drains "done", and the installed-pack
 //    list ANSWERS FOR the pack. Exactly the reporter's wire shape. ─────────────
 const manager = vi.hoisted(() => ({
-  /** Body served at /v2/customnode/installed. */
-  installed: {} as Record<string, unknown>,
+  /** Body served at /v2/customnode/installed. Manager serves the object-keyed
+   *  shape; the ARRAY shape is `parseInstalled`'s other branch, which is where a
+   *  human `title` can end up standing in for the module key. */
+  installed: {} as Record<string, unknown> | unknown[],
   calls: [] as string[],
 }));
 vi.mock("../../comfyui/fetch.js", () => {
@@ -296,7 +298,7 @@ describe("#2714 — a Manager-listed git install must be corroborated on disk", 
     // never happened, which is this issue's own bug wearing a different hat.
     manager.installed = [
       { title: "Shared Title", aux_id: `darksidewalker/${REPO_NAME}`, ver: "nightly", enabled: true },
-    ] as unknown as Record<string, unknown>;
+    ];
     makePackDir("Shared Title", { "__init__.py": "NODE_CLASS_MAPPINGS = {}\n" });
 
     const { ok, error } = await install({ id: REPO, source: "git" });

--- a/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
+++ b/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
@@ -1,0 +1,296 @@
+// #2714 — `install_custom_node` reported a git install that never happened.
+//
+// The reporter moved an existing Registry-ZIP pack out of `custom_nodes`, then
+// installed the same pack by git URL with `useCmCli:false` against ComfyUI-Manager
+// 4.2.2. The tool answered
+//
+//   Installed "ComfyUI-DaSiWa-Nodes" via ComfyUI-Manager. Restart may be required…
+//
+// with done_count 2, and `~/ComfyUI/custom_nodes/ComfyUI-DaSiWa-Nodes` did not exist.
+//
+// The whole proof behind that sentence was ONE question asked of ComfyUI-Manager:
+//
+//   const installed = await listInstalledNodesAt(managerBase).catch(() => []);
+//   if (nodeInstalledMatches(gitId, installed)) return { mechanism: "manager-http", … };
+//
+// `/v2/customnode/installed` is Manager's own bookkeeping. It is not a filesystem
+// read, and for a pack Manager previously tracked it keeps answering after the
+// directory is gone — while a v4 task that resolves nothing is still marked done.
+// The registry branch of the SAME function already crosses that list with a disk
+// scan (`resolvePackPresence`) and already refuses a marker-only husk
+// (`looksLikeAPack`, #900/#1816). The git branch had neither.
+//
+// These tests drive the REAL `installCustomNode` through the REAL resolvers against
+// a REAL directory tree, with the Manager LISTING the pack — the one shape the
+// existing #1765 coverage never produces (its `/customnode/installed` always
+// answers `[]`, so the list never had to be doubted).
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ── One REAL local install, which the server reports as its own root ───────────
+const SANDBOX = mkdtempSync(join(tmpdir(), "manager-listed-absent-2714-"));
+const CONNECTED = join(SANDBOX, "comfy");
+mkdirSync(join(CONNECTED, "custom_nodes"), { recursive: true });
+mkdirSync(join(CONNECTED, "models"), { recursive: true });
+writeFileSync(join(CONNECTED, "main.py"), "# ComfyUI\n");
+const WORKSPACE_JSON = join(SANDBOX, "workspace.json");
+writeFileSync(WORKSPACE_JSON, JSON.stringify({ defaultWorkspace: CONNECTED }));
+
+const cfg = vi.hoisted(() => ({
+  comfyuiPath: undefined as string | undefined,
+  comfyuiCodePath: undefined as string | undefined,
+  resolvedPort: 8188,
+  comfyuiHost: "127.0.0.1",
+  comfyuiSsl: false,
+  githubToken: undefined as string | undefined,
+}));
+vi.mock("../../config.js", () => ({
+  config: cfg,
+  getComfyUIBaseUrl: () => `http://${cfg.comfyuiHost}:${cfg.resolvedPort}`,
+  getComfyuiTargetGeneration: () => 0,
+  getComfyUIAuthHeaders: () => ({}),
+  isLoopbackHost: (host: string | undefined) =>
+    !host || ["127.0.0.1", "::1", "localhost", "0.0.0.0", "::"].includes(host),
+  isForceRemoteFlagSet: () => false,
+  isRemoteMode: () => false,
+  isLocalMode: () => true,
+  isCloudMode: () => false,
+}));
+
+// ── the LIVE server's self-report: this is how the custom_nodes scan root is
+//    established with COMFYUI_PATH unset. ──────────────────────────────────────
+const live = vi.hoisted(() => ({
+  argv: [] as string[],
+  reachable: true,
+}));
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: async () => {
+    if (!live.reachable) throw new Error("connect ECONNREFUSED 127.0.0.1:8188");
+    return { system: { argv: live.argv } };
+  },
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+// The OS process-table tier is not what this file measures; keep it silent so the
+// scan root comes from the server's own argv.
+vi.mock("../../services/live-interpreter.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/live-interpreter.js")>();
+  return { ...actual, observeLiveServerProcess: () => undefined };
+});
+
+// ── ComfyUI-Manager v4: the queue ACCEPTS, drains "done", and the installed-pack
+//    list ANSWERS FOR the pack. Exactly the reporter's wire shape. ─────────────
+const manager = vi.hoisted(() => ({
+  /** Body served at /v2/customnode/installed. */
+  installed: {} as Record<string, unknown>,
+  calls: [] as string[],
+}));
+vi.mock("../../comfyui/fetch.js", () => {
+  const json = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  return {
+    comfyuiFetch: async (url: string) => {
+      manager.calls.push(url);
+      const { pathname } = new URL(url);
+      if (pathname === "/v2/manager/queue/task") return json({ ui_id: "queued" });
+      if (pathname === "/v2/manager/queue/start") return json({});
+      if (pathname === "/v2/manager/queue/status") {
+        // done_count 2 — the reporter's own number. A drained queue.
+        return json({ is_processing: false, done_count: 2, total_count: 2 });
+      }
+      if (pathname === "/v2/customnode/installed") return json(manager.installed);
+      return new Response("no such route", { status: 404, statusText: "Not Found" });
+    },
+  };
+});
+
+// ── `git clone` stands in as a directory creation: no network, and the
+//    destination it was handed is observable. ─────────────────────────────────
+const git = vi.hoisted(() => ({ calls: [] as string[][] }));
+vi.mock("node:child_process", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  return {
+    execFile: vi.fn(),
+    spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "" })),
+    execFileSync: vi.fn((file: string, args: string[]) => {
+      git.calls.push([file, ...args]);
+      if (file === "git" && args[0] === "clone") {
+        const dest = args[args.length - 1];
+        fs.mkdirSync(dest, { recursive: true });
+        fs.writeFileSync(path.join(dest, "__init__.py"), "NODE_CLASS_MAPPINGS = {}\n");
+      }
+      return "";
+    }),
+  };
+});
+
+const { installCustomNode, setQueueTimingForTests } = await import(
+  "../../services/node-management.js"
+);
+const { configureWorkspace, resetWorkspaceConfig } = await import(
+  "../../services/workspace-env.js"
+);
+const { setManagerApiCacheForTests } = await import("../../services/manager-api-cache.js");
+setQueueTimingForTests({ pollIntervalMs: 1, startupGraceMs: 0, timeoutMs: 5_000 });
+
+/** The reporter's own repository, verbatim from the issue. */
+const REPO = "https://github.com/darksidewalker/ComfyUI-DaSiWa-Nodes";
+const REPO_NAME = "ComfyUI-DaSiWa-Nodes";
+const PACK_DIR = join(CONNECTED, "custom_nodes", REPO_NAME);
+
+/** The Manager entry that vouches for the pack — keyed by folder name, as v4 serves it. */
+const LISTED_BY_REPO_NAME = {
+  [REPO_NAME]: { ver: "nightly", aux_id: "darksidewalker/ComfyUI-DaSiWa-Nodes", enabled: true },
+};
+
+function clonedInto(): string | undefined {
+  const clone = git.calls.find((c) => c[0] === "git" && c[1] === "clone");
+  return clone?.[clone.length - 1];
+}
+
+/** Create a directory under custom_nodes with the given top-level entries. */
+function makePackDir(name: string, entries: Record<string, string>): string {
+  const dir = join(CONNECTED, "custom_nodes", name);
+  mkdirSync(dir, { recursive: true });
+  for (const [file, body] of Object.entries(entries)) {
+    const target = join(dir, file);
+    mkdirSync(join(target, ".."), { recursive: true });
+    writeFileSync(target, body);
+  }
+  return dir;
+}
+
+async function install(
+  opts: Parameters<typeof installCustomNode>[0],
+): Promise<{ ok?: { mechanism: string; message: string }; error?: string }> {
+  try {
+    return { ok: (await installCustomNode(opts)) as { mechanism: string; message: string } };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+let priorEnvPath: string | undefined;
+
+beforeEach(() => {
+  git.calls = [];
+  manager.calls = [];
+  manager.installed = LISTED_BY_REPO_NAME;
+  live.reachable = true;
+  live.argv = [join(CONNECTED, "main.py"), "--port", "8188"];
+  cfg.comfyuiPath = undefined;
+  priorEnvPath = process.env.COMFYUI_PATH;
+  delete process.env.COMFYUI_PATH;
+  configureWorkspace({ configPath: WORKSPACE_JSON });
+  setManagerApiCacheForTests("http://127.0.0.1:8188", "v2");
+});
+
+afterEach(() => {
+  resetWorkspaceConfig();
+  if (priorEnvPath === undefined) delete process.env.COMFYUI_PATH;
+  else process.env.COMFYUI_PATH = priorEnvPath;
+  rmSync(join(CONNECTED, "custom_nodes"), { recursive: true, force: true });
+  mkdirSync(join(CONNECTED, "custom_nodes"), { recursive: true });
+});
+
+afterAll(() => rmSync(SANDBOX, { recursive: true, force: true }));
+
+describe("#2714 — a Manager-listed git install must be corroborated on disk", () => {
+  it("does not report an install ComfyUI-Manager only CLAIMS: the pack is absent, so it clones", async () => {
+    // THE REPORT, REPRODUCED. Manager lists the pack; custom_nodes does not have it.
+    expect(existsSync(PACK_DIR)).toBe(false);
+
+    const { ok, error } = await install({ id: REPO, source: "git", ref: "main", useCmCli: false });
+
+    expect(error).toBeUndefined();
+    // The shipped code answered `manager-http` here, with the reporter's exact
+    // sentence, having written nothing. Deleting the #2714 corroboration in
+    // node-management.ts turns this line red and every other line in this file green.
+    expect(ok?.mechanism).toBe("git-clone");
+    expect(ok?.message).not.toMatch(/Installed "ComfyUI-DaSiWa-Nodes" via ComfyUI-Manager/);
+    // And the pack the caller asked for is now actually there.
+    expect(clonedInto()).toBe(PACK_DIR);
+    expect(existsSync(join(PACK_DIR, "__init__.py"))).toBe(true);
+  });
+
+  it("names the real reason for the clone — not 'not in the registry', which is false here", async () => {
+    const { ok } = await install({ id: REPO, source: "git" });
+
+    // cloneCustomNodeFallback's DEFAULT explanation would be a wrong cause for a
+    // correct action: Manager did list this pack. The fall-through has to carry
+    // what was actually observed.
+    expect(ok?.message).toMatch(/installed-pack list/i);
+    expect(ok?.message).toMatch(/NO matching pack exists/i);
+    expect(ok?.message).not.toMatch(/is not in the ComfyUI-Manager registry/);
+  });
+
+  it("KEEPS the Manager result when the disk corroborates it — no needless clone", async () => {
+    makePackDir(REPO_NAME, { "__init__.py": "NODE_CLASS_MAPPINGS = {}\n" });
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok?.mechanism).toBe("manager-http");
+    expect(ok?.message).toMatch(/verified present on disk/);
+    expect(clonedInto()).toBeUndefined();
+  });
+
+  it("corroborates through the MANAGER ENTRY's own id, not just the URL's repo name", async () => {
+    // Manager v4 is registry-first: it can resolve a git URL to a CNR record and
+    // unpack it under the CNR id, which is NOT the repo name we derived. A check
+    // that only asked for `<repo>` would call that a false success and clone a
+    // DUPLICATE pack next to the working one.
+    manager.installed = {
+      "dasiwa-nodes": { ver: "1.2.0", cnr_id: "dasiwa-nodes", aux_id: "darksidewalker/ComfyUI-DaSiWa-Nodes", enabled: true },
+    };
+    makePackDir("dasiwa-nodes", { "pyproject.toml": '[project]\nname = "dasiwa-nodes"\n' });
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok?.mechanism).toBe("manager-http");
+    expect(clonedInto()).toBeUndefined();
+    expect(existsSync(PACK_DIR)).toBe(false);
+  });
+
+  it("refuses a marker-only HUSK instead of reporting it as installed (#900 on the git route)", async () => {
+    // The directory exists and Manager vouches for it, but ComfyUI cannot import
+    // it — it will log a failure on every start. A success here is the same lie
+    // in a different disguise.
+    const husk = makePackDir(REPO_NAME, { ".git/HEAD": "ref: refs/heads/main\n" });
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(ok).toBeUndefined();
+    expect(error).toMatch(/holds nothing ComfyUI can import/);
+    expect(error).toContain(husk);
+    // Not ours to delete: this call is not the proven author of that directory.
+    expect(existsSync(husk)).toBe(true);
+    expect(clonedInto()).toBeUndefined();
+  });
+
+  it("still succeeds — and SAYS the disk was not checked — when no scan root can be established", async () => {
+    // COMFYUI_PATH unset and the server unreachable: `resolveInstallLocalWorkspace`
+    // refuses to fall back to the saved default, so there is no custom_nodes root
+    // to scan. "Could not look" is not absence, and the Manager list is then the
+    // only witness there is — which the message must admit rather than imply.
+    live.reachable = false;
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok?.mechanism).toBe("manager-http");
+    expect(ok?.message).toMatch(/presence on disk was NOT verified/i);
+    expect(ok?.message).toMatch(/only witness/i);
+    expect(clonedInto()).toBeUndefined();
+  });
+});

--- a/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
+++ b/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
@@ -290,14 +290,21 @@ describe("#2714 — a Manager-listed git install must be corroborated on disk", 
     expect(existsSync(PACK_DIR)).toBe(false);
   });
 
-  it("will not let a human TITLE vouch for the filesystem", async () => {
-    // The ARRAY payload shape: `parseInstalled` prefers `title` over the real module
-    // key, so `module` here is prose. ComfyUI imports a custom_nodes directory as a
-    // PYTHON MODULE NAME, so a value with a space in it cannot be a pack folder —
-    // scanning for one lets an unrelated same-named directory certify an install that
-    // never happened, which is this issue's own bug wearing a different hat.
+  it("will not let a human TITLE stand in for the module key", async () => {
+    // codex gate round 2, P1. The ARRAY payload branch of `parseInstalled` used to
+    // prefer `title` — prose — over the entry's own `module`. That put a label in a
+    // slot every consumer reads as an IDENTITY (Manager's `node_name` on
+    // uninstall/disable, findInstalledNode's matching, and this disk scan), so an
+    // unrelated `custom_nodes/Shared Title` could certify an install that never
+    // happened: this issue's own bug wearing a different hat.
     manager.installed = [
-      { title: "Shared Title", aux_id: `darksidewalker/${REPO_NAME}`, ver: "nightly", enabled: true },
+      {
+        title: "Shared Title",
+        module: REPO_NAME,
+        aux_id: `darksidewalker/${REPO_NAME}`,
+        ver: "nightly",
+        enabled: true,
+      },
     ];
     makePackDir("Shared Title", { "__init__.py": "NODE_CLASS_MAPPINGS = {}\n" });
 
@@ -306,6 +313,27 @@ describe("#2714 — a Manager-listed git install must be corroborated on disk", 
     expect(error).toBeUndefined();
     expect(ok?.mechanism).toBe("git-clone");
     expect(clonedInto()).toBe(PACK_DIR);
+  });
+
+  it("a pack folder with a SPACE in its name still corroborates", async () => {
+    // codex gate round 2, P1. Round 1 dropped whitespace-bearing aliases on the
+    // reasoning that ComfyUI imports a pack directory as a Python module name so it
+    // cannot contain a space. MEASURED FALSE: ComfyUI loads packs via
+    // `importlib.util.spec_from_file_location`, which accepts any string as the
+    // module name. The heuristic would have read a real, working pack as absent and
+    // cloned a SECOND copy beside it.
+    manager.installed = {
+      "Foo Bar": { ver: "1.0.0", cnr_id: "foo-bar", aux_id: "someone/foo-bar", enabled: true },
+    };
+    makePackDir("Foo Bar", { "__init__.py": "NODE_CLASS_MAPPINGS = {}\n" });
+
+    const { ok, error } = await install({ id: "https://github.com/someone/Foo-Bar", source: "git" });
+
+    // The install id resolves to `Foo-Bar`, which is NOT on disk; only the Manager
+    // entry's own module key ("Foo Bar") names the directory that is.
+    expect(error).toBeUndefined();
+    expect(ok?.mechanism).toBe("manager-http");
+    expect(clonedInto()).toBeUndefined();
   });
 
   it("refuses a marker-only HUSK instead of reporting it as installed (#900 on the git route)", async () => {

--- a/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
+++ b/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
@@ -315,6 +315,30 @@ describe("#2714 — a Manager-listed git install must be corroborated on disk", 
     expect(clonedInto()).toBe(PACK_DIR);
   });
 
+  it("a TITLE-ONLY entry contributes no folder name at all", async () => {
+    // codex gate round 3. This entry states NO `module`, so `parseInstalled` promotes
+    // its human `title` into that slot — which is why the corroboration reads
+    // `moduleKey` (the key the payload actually stated) and not `module`. Reading
+    // `module` here would send the scan looking for a directory called "Friendly
+    // Label", and an unrelated pack that happens to be named that would certify an
+    // install that never happened.
+    manager.installed = [
+      {
+        title: "Friendly Label",
+        cnr_id: `someone/${REPO_NAME}`,
+        ver: "1.0.0",
+        enabled: true,
+      },
+    ];
+    makePackDir("Friendly Label", { "__init__.py": "NODE_CLASS_MAPPINGS = {}\n" });
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok?.mechanism).toBe("git-clone");
+    expect(clonedInto()).toBe(PACK_DIR);
+  });
+
   it("a pack folder with a SPACE in its name still corroborates", async () => {
     // codex gate round 2, P1. Round 1 dropped whitespace-bearing aliases on the
     // reasoning that ComfyUI imports a pack directory as a Python module name so it

--- a/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
+++ b/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
@@ -262,6 +262,50 @@ describe("#2714 — a Manager-listed git install must be corroborated on disk", 
     expect(existsSync(PACK_DIR)).toBe(false);
   });
 
+  // ---- codex gate round 1: the identity set itself was wrong in both directions --
+
+  it("corroborates through the aux id's REPO HALF — a raw \"owner/repo\" vouches for nothing", async () => {
+    // `packDirNameCandidates` drops any path-shaped id (traversal defence), so passing
+    // `aux_id` straight through silently contributes NO candidate. Manager matched this
+    // entry by its cnr_id while the real checkout sits under the aux id's repo half, so
+    // without the basename this reads as absent and clones a SECOND copy of a pack that
+    // is already installed and working.
+    manager.installed = {
+      "ComfyUI-DaSiWa-Nodes-title": {
+        ver: "1.2.0",
+        cnr_id: "ComfyUI-DaSiWa-Nodes",
+        aux_id: "darksidewalker/dasiwa-nodes-src",
+        enabled: true,
+      },
+    };
+    makePackDir("dasiwa-nodes-src", { "__init__.py": "NODE_CLASS_MAPPINGS = {}\n" });
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok?.mechanism).toBe("manager-http");
+    expect(clonedInto()).toBeUndefined();
+    expect(existsSync(PACK_DIR)).toBe(false);
+  });
+
+  it("will not let a human TITLE vouch for the filesystem", async () => {
+    // The ARRAY payload shape: `parseInstalled` prefers `title` over the real module
+    // key, so `module` here is prose. ComfyUI imports a custom_nodes directory as a
+    // PYTHON MODULE NAME, so a value with a space in it cannot be a pack folder —
+    // scanning for one lets an unrelated same-named directory certify an install that
+    // never happened, which is this issue's own bug wearing a different hat.
+    manager.installed = [
+      { title: "Shared Title", aux_id: `darksidewalker/${REPO_NAME}`, ver: "nightly", enabled: true },
+    ] as unknown as Record<string, unknown>;
+    makePackDir("Shared Title", { "__init__.py": "NODE_CLASS_MAPPINGS = {}\n" });
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok?.mechanism).toBe("git-clone");
+    expect(clonedInto()).toBe(PACK_DIR);
+  });
+
   it("refuses a marker-only HUSK instead of reporting it as installed (#900 on the git route)", async () => {
     // The directory exists and Manager vouches for it, but ComfyUI cannot import
     // it — it will log a failure on every start. A success here is the same lie

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -4081,6 +4081,20 @@ describe("node-management service", () => {
       expect(nodes[0].module).toBe("PackA");
     });
 
+    it("#2714 — an entry that states its own module is not overridden by a title", async () => {
+      // `module` is an IDENTITY here: it is sent to Manager as `node_name` on the
+      // uninstall/disable routes, matched by findInstalledNode, and scanned for on
+      // disk by the git-install corroboration. A label must not displace a module
+      // key the entry stated outright.
+      stubFetch({
+        installedBody: [
+          { title: "Pack A", module: "ComfyUI-PackA", ver: "1.0.0", cnr_id: "packa", enabled: true },
+        ],
+      });
+      const nodes = await listInstalledNodes();
+      expect(nodes[0].module).toBe("ComfyUI-PackA");
+    });
+
     it("missing enabled/is_disabled is UNKNOWN, never defaulted to a definite state", async () => {
       stubFetch({
         installedBody: {

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -3969,6 +3969,9 @@ describe("node-management service", () => {
         expect(nodes).toEqual([
           {
             module: "ComfyUI-Manager",
+            // #2714 — the object payload's key is a folder key, carried explicitly
+            // so the on-disk corroboration never has to guess whether it is one.
+            moduleKey: "ComfyUI-Manager",
             cnrId: "comfyui-manager",
             version: "3.1",
             enabled: true,
@@ -4081,18 +4084,31 @@ describe("node-management service", () => {
       expect(nodes[0].module).toBe("PackA");
     });
 
-    it("#2714 — an entry that states its own module is not overridden by a title", async () => {
-      // `module` is an IDENTITY here: it is sent to Manager as `node_name` on the
-      // uninstall/disable routes, matched by findInstalledNode, and scanned for on
-      // disk by the git-install corroboration. A label must not displace a module
-      // key the entry stated outright.
+    it("#2714 — a title-derived module carries NO folder key", async () => {
+      // `module` keeps its precedence (title first) because that is what this list
+      // displays and what Manager is sent back as `node_name`. But #2714's on-disk
+      // corroboration reads a module as a PATH, and prose is not one — so the key
+      // the payload actually stated is carried separately, and is absent when the
+      // payload stated none.
       stubFetch({
         installedBody: [
-          { title: "Pack A", module: "ComfyUI-PackA", ver: "1.0.0", cnr_id: "packa", enabled: true },
+          { title: "Friendly Label", ver: "1.0.0", cnr_id: "packa", enabled: true },
+          { title: "Pack A", module: "ComfyUI-PackA", ver: "1.0.0", enabled: true },
         ],
       });
       const nodes = await listInstalledNodes();
-      expect(nodes[0].module).toBe("ComfyUI-PackA");
+      expect(nodes[0].module).toBe("Friendly Label");
+      expect(nodes[0].moduleKey).toBeUndefined();
+      expect(nodes[1].module).toBe("Pack A");
+      expect(nodes[1].moduleKey).toBe("ComfyUI-PackA");
+    });
+
+    it("#2714 — the object shape's KEY is a folder key", async () => {
+      stubFetch({
+        installedBody: { "ComfyUI-PackB": { ver: "1.0.0", cnr_id: "packb", enabled: true } },
+      });
+      const nodes = await listInstalledNodes();
+      expect(nodes[0].moduleKey).toBe("ComfyUI-PackB");
     });
 
     it("missing enabled/is_disabled is UNKNOWN, never defaulted to a definite state", async () => {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -137,6 +137,16 @@ export type ManagerMode = "remote" | "local" | "cache";
 export interface InstalledNode {
   /** Custom-node module/folder name (the key Manager uses internally). */
   module: string;
+  /**
+   * The module/folder KEY the payload actually stated, when it stated one.
+   *
+   * `module` above is a DISPLAY-or-identity blend: the array shape prefers the
+   * entry's human `title`, so a value there may be prose. Anything that reads a
+   * module as a PATH — the #2714 on-disk corroboration of a git install — must
+   * use this field instead, and treat `undefined` as "the payload named no
+   * folder key", not as a name to go looking for.
+   */
+  moduleKey?: string;
   /** ComfyUI Node Registry id, if the pack is CNR-registered. */
   cnrId?: string;
   /** GitHub/aux id for git-based packs. */
@@ -2101,8 +2111,13 @@ function runCmCli(args: string[], workspace?: string): string {
 function parseInstalled(raw: unknown): InstalledNode[] {
   if (!raw || typeof raw !== "object") return [];
 
-  const toNode = (module: string, v: Record<string, unknown>): InstalledNode => ({
+  const toNode = (
+    module: string,
+    v: Record<string, unknown>,
+    moduleKey?: string,
+  ): InstalledNode => ({
     module,
+    ...(moduleKey ? { moduleKey } : {}),
     cnrId:
       typeof v.cnr_id === "string" && v.cnr_id.length > 0 ? v.cnr_id : undefined,
     auxId:
@@ -2125,27 +2140,22 @@ function parseInstalled(raw: unknown): InstalledNode[] {
         Boolean(entry && typeof entry === "object"),
       )
       .map((entry) => {
-        // #2714 — AN EXPLICIT `module` OUTRANKS A TITLE. This branch preferred
-        // `title` — prose — even when the entry stated its own `module` key, and
-        // every consumer of this field wants the module: it is sent to
-        // ComfyUI-Manager as `node_name` on the uninstall/disable/enable routes,
-        // matched by findInstalledNode, and (as of #2714) scanned for on disk. An
-        // entry that named its module and was overridden by a label could let an
-        // unrelated same-named directory certify an install that never happened.
-        // The title→cnr_id order BELOW it is unchanged: for an entry that states
-        // no module, the title is still the name Manager displays it under.
         const module =
-          (typeof entry.module === "string" && entry.module) ||
           (typeof entry.title === "string" && entry.title) ||
+          (typeof entry.module === "string" && entry.module) ||
           (typeof entry.cnr_id === "string" && entry.cnr_id) ||
           "unknown";
-        return toNode(module, entry);
+        // #2714 — `module` above may be a human TITLE, so it is NOT safe to read as
+        // a directory name. Carry the key the payload actually stated separately;
+        // `module`'s own precedence is left exactly as it was, because it is what
+        // Manager is sent back as `node_name` and what this list displays.
+        return toNode(module, entry, typeof entry.module === "string" ? entry.module : undefined);
       });
   }
 
   return Object.entries(raw as Record<string, unknown>)
     .filter(([, v]) => Boolean(v && typeof v === "object"))
-    .map(([module, v]) => toNode(module, v as Record<string, unknown>));
+    .map(([module, v]) => toNode(module, v as Record<string, unknown>, module));
 }
 
 function stripUrlSuffix(value: string): string {
@@ -3222,6 +3232,12 @@ type ManagerClaimCorroboration =
  * as, and `packDirNameCandidates` deliberately drops any path-shaped id, so the
  * raw value would silently vouch for nothing. Take its basename.
  *
+ * It reads `moduleKey`, NEVER `module`: the array payload puts a human `title` in
+ * the latter whenever the entry has one, so a Manager record of
+ * `{title:"Friendly Label", cnr_id:"owner/repo"}` would send this scan looking for
+ * a directory called "Friendly Label" — and an unrelated pack that happens to be
+ * named that would then certify an install that never happened (gate round 3).
+ *
  * NO NAME-SHAPE HEURISTIC BEYOND THAT. Round 1 of the gate rejected values with
  * whitespace here on the reasoning that ComfyUI imports a pack directory as a
  * Python module name so it cannot contain a space. That reasoning is FALSE —
@@ -3233,7 +3249,7 @@ type ManagerClaimCorroboration =
  */
 function packDirAliases(node: InstalledNode): string[] {
   const aliases: string[] = [];
-  for (const raw of [node.module, node.cnrId, node.auxId]) {
+  for (const raw of [node.moduleKey, node.cnrId, node.auxId]) {
     if (typeof raw !== "string") continue;
     const name = basename(raw.trim().replace(/[\\/]+$/, ""));
     if (name.length === 0 || name === "." || name === "..") continue;

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2125,10 +2125,17 @@ function parseInstalled(raw: unknown): InstalledNode[] {
         Boolean(entry && typeof entry === "object"),
       )
       .map((entry) => {
+        // #2714 — `module` IS AN IDENTITY, NOT A LABEL. This branch preferred
+        // `title` — prose — over the entry's own `module` key, and every consumer
+        // wants the module: it is sent to ComfyUI-Manager as `node_name` on the
+        // uninstall/disable/enable routes, matched by findInstalledNode, and (as
+        // of #2714) scanned for on disk. A title in that slot is wrong for all
+        // three. It stays as the LAST resort so an entry that carries nothing
+        // else still matches by the only name it has.
         const module =
-          (typeof entry.title === "string" && entry.title) ||
           (typeof entry.module === "string" && entry.module) ||
           (typeof entry.cnr_id === "string" && entry.cnr_id) ||
+          (typeof entry.title === "string" && entry.title) ||
           "unknown";
         return toNode(module, entry);
       });
@@ -3213,12 +3220,14 @@ type ManagerClaimCorroboration =
  * as, and `packDirNameCandidates` deliberately drops any path-shaped id, so the
  * raw value would silently vouch for nothing. Take its basename.
  *
- * A value carrying whitespace is dropped instead. ComfyUI imports a custom_nodes
- * directory AS A PYTHON MODULE NAME, so a pack folder cannot have a space in it —
- * such a value is a human TITLE, which `parseInstalled`'s array branch prefers
- * over the real `module` key. A title is not evidence about the filesystem, and
- * letting one scan for a same-named directory is how an unrelated pack ends up
- * vouching for an install that never happened (codex gate, round 1).
+ * NO NAME-SHAPE HEURISTIC BEYOND THAT. Round 1 of the gate rejected values with
+ * whitespace here on the reasoning that ComfyUI imports a pack directory as a
+ * Python module name so it cannot contain a space. That reasoning is FALSE —
+ * ComfyUI loads packs through `importlib.util.spec_from_file_location`, which
+ * takes any string as the module name — and the filter it justified would have
+ * dropped a real `custom_nodes/Foo Bar` and cloned a duplicate beside it (round 2).
+ * The contamination it was actually defending against was `parseInstalled` putting
+ * a human `title` in the `module` slot; that is fixed at its source instead.
  */
 function packDirAliases(node: InstalledNode): string[] {
   const aliases: string[] = [];
@@ -3226,7 +3235,7 @@ function packDirAliases(node: InstalledNode): string[] {
     if (typeof raw !== "string") continue;
     const name = basename(raw.trim().replace(/[\\/]+$/, ""));
     if (name.length === 0 || name === "." || name === "..") continue;
-    if (/[\s/\\]/.test(name) || /[\x00-\x1F\x7F]/.test(name)) continue;
+    if (/[\x00-\x1F\x7F]/.test(name)) continue;
     aliases.push(name);
   }
   return aliases;
@@ -4350,8 +4359,11 @@ async function installCustomNodeImpl(
     // VERIFY: the Manager's installed-pack list is the FIRST witness — but it is
     // Manager's own bookkeeping, not the filesystem, so #2714 crosses it with a
     // disk scan before any success wording (see diskCorroboratesManagerInstall).
-    // A list hit that the disk does not corroborate is not an install; it falls
-    // through to the same direct clone an unregistered pack takes.
+    // Three outcomes, and only one of them writes: a scan that finds the pack
+    // ABSENT falls through to the same direct clone an unregistered pack takes; a
+    // HUSK throws; a scan that could not answer (remote, no proven scan root, an
+    // unreadable custom_nodes) keeps the Manager result and says the disk was not
+    // checked. "Could not look" is never folded into "not there".
     const installed = await listInstalledNodesAt(managerBase).catch(
       () => [] as InstalledNode[],
     );

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3185,10 +3185,11 @@ function looksLikeAPack(dir: string): boolean {
  * evidence, applied to the git route.
  *
  * CORROBORATION IS PER-IDENTITY, NOT PER-NAME. Manager may hold the pack under
- * its CNR id or its own module key rather than the repo name we derived from the
- * URL, so every identity the matched entry offers gets to vouch for the pack;
- * ONE hit is enough. Only when they ALL scan clean is the claim uncorroborated —
- * an "absent" that has to survive every spelling before it can retract a success.
+ * its CNR id, its own module key, or the repo half of its aux id rather than the
+ * repo name we derived from the URL, so every identity the matched entry offers
+ * that could be a DIRECTORY (see packDirAliases) gets to vouch for the pack; ONE
+ * hit is enough. Only when they ALL scan clean is the claim uncorroborated — an
+ * "absent" that has to survive every spelling before it can retract a success.
  *
  * NOT the `.git`-must-exist check the report proposed: the v4 route is
  * registry-first by construction, so a pack it resolved and unpacked from the
@@ -3204,16 +3205,42 @@ type ManagerClaimCorroboration =
   /** The disk could not answer — never treated as absence. */
   | { state: "unreadable" };
 
+/**
+ * The alias identities a matched Manager entry offers, reduced to values that
+ * could actually BE a directory under custom_nodes.
+ *
+ * `aux_id` is "owner/repo" — the repo half is what Manager checks the pack out
+ * as, and `packDirNameCandidates` deliberately drops any path-shaped id, so the
+ * raw value would silently vouch for nothing. Take its basename.
+ *
+ * A value carrying whitespace is dropped instead. ComfyUI imports a custom_nodes
+ * directory AS A PYTHON MODULE NAME, so a pack folder cannot have a space in it —
+ * such a value is a human TITLE, which `parseInstalled`'s array branch prefers
+ * over the real `module` key. A title is not evidence about the filesystem, and
+ * letting one scan for a same-named directory is how an unrelated pack ends up
+ * vouching for an install that never happened (codex gate, round 1).
+ */
+function packDirAliases(node: InstalledNode): string[] {
+  const aliases: string[] = [];
+  for (const raw of [node.module, node.cnrId, node.auxId]) {
+    if (typeof raw !== "string") continue;
+    const name = basename(raw.trim().replace(/[\\/]+$/, ""));
+    if (name.length === 0 || name === "." || name === "..") continue;
+    if (/[\s/\\]/.test(name) || /[\x00-\x1F\x7F]/.test(name)) continue;
+    aliases.push(name);
+  }
+  return aliases;
+}
+
 function diskCorroboratesManagerInstall(
   gitId: string,
   node: InstalledNode,
   diskRoot: string,
 ): ManagerClaimCorroboration {
-  const identities = [gitId, node.module, node.cnrId].filter(
-    (v): v is string => typeof v === "string" && v.trim().length > 0,
-  );
+  const identities = [gitId, ...packDirAliases(node)];
   let husk: string | undefined;
   let scanned: string | undefined;
+  let unreadable = false;
   for (const identity of identities) {
     const found = findPackOnDisk(identity, diskRoot);
     if (found.state === "found") {
@@ -3222,11 +3249,18 @@ function diskCorroboratesManagerInstall(
       continue;
     }
     if (found.state === "not-found") scanned ??= found.scanned;
+    else unreadable = true;
   }
-  // A husk is a POSITIVE observation about a real directory and outranks the
-  // other identities coming back clean: the pack the caller asked for is that
-  // directory, and it is broken.
+  // A husk is a POSITIVE observation of a real directory. A scan that could not
+  // answer cannot explain it away, so it is reported first — and it only ever
+  // produces a refusal, never a write.
   if (husk !== undefined) return { state: "husk", dir: husk };
+  // UNREADABLE OUTRANKS ABSENT, and this ordering is the whole point (codex gate,
+  // round 1): "absent" is the one verdict here that retracts a success AND
+  // authorizes a filesystem write, so it may only be reached when EVERY identity
+  // was conclusively scanned. One `not-found` beside one unanswerable scan is not
+  // proof of absence — it is the #796/#797 fold this file exists to avoid.
+  if (unreadable) return { state: "unreadable" };
   if (scanned !== undefined) return { state: "absent", scanned };
   return { state: "unreadable" };
 }

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3244,8 +3244,9 @@ type ManagerClaimCorroboration =
  * ComfyUI loads packs through `importlib.util.spec_from_file_location`, which
  * takes any string as the module name — and the filter it justified would have
  * dropped a real `custom_nodes/Foo Bar` and cloned a duplicate beside it (round 2).
- * The contamination it was actually defending against was `parseInstalled` putting
- * a human `title` in the `module` slot; that is fixed at its source instead.
+ * The contamination it was actually defending against is the title-in-`module`
+ * problem above, which `moduleKey` removes outright — so the heuristic bought
+ * nothing that reading the right field does not already give.
  */
 function packDirAliases(node: InstalledNode): string[] {
   const aliases: string[] = [];

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2125,17 +2125,19 @@ function parseInstalled(raw: unknown): InstalledNode[] {
         Boolean(entry && typeof entry === "object"),
       )
       .map((entry) => {
-        // #2714 — `module` IS AN IDENTITY, NOT A LABEL. This branch preferred
-        // `title` — prose — over the entry's own `module` key, and every consumer
-        // wants the module: it is sent to ComfyUI-Manager as `node_name` on the
-        // uninstall/disable/enable routes, matched by findInstalledNode, and (as
-        // of #2714) scanned for on disk. A title in that slot is wrong for all
-        // three. It stays as the LAST resort so an entry that carries nothing
-        // else still matches by the only name it has.
+        // #2714 — AN EXPLICIT `module` OUTRANKS A TITLE. This branch preferred
+        // `title` — prose — even when the entry stated its own `module` key, and
+        // every consumer of this field wants the module: it is sent to
+        // ComfyUI-Manager as `node_name` on the uninstall/disable/enable routes,
+        // matched by findInstalledNode, and (as of #2714) scanned for on disk. An
+        // entry that named its module and was overridden by a label could let an
+        // unrelated same-named directory certify an install that never happened.
+        // The title→cnr_id order BELOW it is unchanged: for an entry that states
+        // no module, the title is still the name Manager displays it under.
         const module =
           (typeof entry.module === "string" && entry.module) ||
-          (typeof entry.cnr_id === "string" && entry.cnr_id) ||
           (typeof entry.title === "string" && entry.title) ||
+          (typeof entry.cnr_id === "string" && entry.cnr_id) ||
           "unknown";
         return toNode(module, entry);
       });

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3167,6 +3167,71 @@ function looksLikeAPack(dir: string): boolean {
 }
 
 /**
+ * #2714 — DOES THE DISK CORROBORATE THE MANAGER'S "IT IS INSTALLED"?
+ *
+ * The git branch of installCustomNodeImpl used to accept ComfyUI-Manager's
+ * installed-pack list as the whole proof: queue drained, `nodeInstalledMatches`
+ * true, report `Installed "<repo>" via ComfyUI-Manager`. On Manager 4.2.2 a
+ * reporter got exactly that string (done_count 2) for
+ * `https://github.com/darksidewalker/ComfyUI-DaSiWa-Nodes` while
+ * `custom_nodes/ComfyUI-DaSiWa-Nodes` did not exist at all. The list is
+ * Manager's OWN bookkeeping — for a pack it previously tracked it keeps
+ * answering after the directory is gone, and a v4 task that resolves nothing is
+ * still marked done. Neither the list nor done_count observes the filesystem.
+ *
+ * The registry branch below already crosses the list with a disk scan
+ * (`resolvePackPresence`) and already refuses a marker-only husk
+ * (`looksLikeAPack`, #900/#1816). The git branch had neither. This is that same
+ * evidence, applied to the git route.
+ *
+ * CORROBORATION IS PER-IDENTITY, NOT PER-NAME. Manager may hold the pack under
+ * its CNR id or its own module key rather than the repo name we derived from the
+ * URL, so every identity the matched entry offers gets to vouch for the pack;
+ * ONE hit is enough. Only when they ALL scan clean is the claim uncorroborated —
+ * an "absent" that has to survive every spelling before it can retract a success.
+ *
+ * NOT the `.git`-must-exist check the report proposed: the v4 route is
+ * registry-first by construction, so a pack it resolved and unpacked from the
+ * registry has no `.git` and is working exactly as designed. What matters is
+ * whether ComfyUI can import the directory, which is what `looksLikeAPack` asks.
+ */
+type ManagerClaimCorroboration =
+  | { state: "corroborated"; dir: string }
+  /** The directory is there but holds no importable pack (#900's husk). */
+  | { state: "husk"; dir: string }
+  /** Every identity was scanned for and none is on disk. */
+  | { state: "absent"; scanned: string }
+  /** The disk could not answer — never treated as absence. */
+  | { state: "unreadable" };
+
+function diskCorroboratesManagerInstall(
+  gitId: string,
+  node: InstalledNode,
+  diskRoot: string,
+): ManagerClaimCorroboration {
+  const identities = [gitId, node.module, node.cnrId].filter(
+    (v): v is string => typeof v === "string" && v.trim().length > 0,
+  );
+  let husk: string | undefined;
+  let scanned: string | undefined;
+  for (const identity of identities) {
+    const found = findPackOnDisk(identity, diskRoot);
+    if (found.state === "found") {
+      if (looksLikeAPack(found.dir)) return { state: "corroborated", dir: found.dir };
+      husk ??= found.dir;
+      continue;
+    }
+    if (found.state === "not-found") scanned ??= found.scanned;
+  }
+  // A husk is a POSITIVE observation about a real directory and outranks the
+  // other identities coming back clean: the pack the caller asked for is that
+  // directory, and it is broken.
+  if (husk !== undefined) return { state: "husk", dir: husk };
+  if (scanned !== undefined) return { state: "absent", scanned };
+  return { state: "unreadable" };
+}
+
+/**
  * Registry-zip post-verify: the target directory exists but holds no pack code.
  * Look up the registry entry's repository so the error can name the git-clone
  * fallback that actually works; a lookup failure must not hide the empty dir.
@@ -4248,19 +4313,64 @@ async function installCustomNodeImpl(
     }
     assertInstallTargetStable(targetGeneration, managerBase);
 
-    // VERIFY: /v2/customnode/installed reflects on-disk custom_nodes, so a
-    // freshly-cloned pack shows up even before a reboot. If the Manager actually
-    // installed it, we're done; otherwise it's unregistered → clone it directly.
+    // VERIFY: the Manager's installed-pack list is the FIRST witness — but it is
+    // Manager's own bookkeeping, not the filesystem, so #2714 crosses it with a
+    // disk scan before any success wording (see diskCorroboratesManagerInstall).
+    // A list hit that the disk does not corroborate is not an install; it falls
+    // through to the same direct clone an unregistered pack takes.
     const installed = await listInstalledNodesAt(managerBase).catch(
       () => [] as InstalledNode[],
     );
     assertInstallTargetStable(targetGeneration, managerBase);
-    if (nodeInstalledMatches(gitId, installed)) {
-      return withCliNote({
-        mechanism: "manager-http",
-        message: `Installed "${repoName}" via ComfyUI-Manager. Restart may be required to load new nodes.`,
-        details: status,
-      });
+    const listedNode = findInstalledNode(gitId, installed);
+    /** #2714 — why the Manager's own "installed" verdict was not taken. */
+    let uncorroboratedNote: string | undefined;
+    if (listedNode) {
+      // The disk is only consulted when it can answer ABOUT THIS SERVER: in
+      // remote mode the tree we could read is not the host's, and with no local
+      // root captured there is nothing to scan. In both cases the list is the
+      // only witness there is, and saying so is the honest report — not silence.
+      const corroboration =
+        presenceCtx.remote || !presenceCtx.diskRoot
+          ? undefined
+          : diskCorroboratesManagerInstall(gitId, listedNode, presenceCtx.diskRoot);
+      if (corroboration?.state === "absent") {
+        uncorroboratedNote =
+          `ComfyUI-Manager drained the install task and still lists "${repoName}" in its ` +
+          `installed-pack list, but NO matching pack exists under ${corroboration.scanned} ` +
+          `— so that list is describing its own bookkeeping, not this filesystem, and a ` +
+          `drained queue proves nothing landed (#2714). Nothing was installed by that route.`;
+      } else if (corroboration?.state === "husk") {
+        // Same class as #900/#1816, reached from the git route: a directory the
+        // install left behind that ComfyUI cannot import. This call is not the
+        // proven author of it, so it is named and left untouched rather than
+        // deleted, and no success is claimed over it.
+        throw new NodeManagementError(
+          `ComfyUI-Manager drained the install task and lists "${repoName}" as installed, but ` +
+            `${corroboration.dir} holds nothing ComfyUI can import — only metadata/marker files, ` +
+            `the husk of an install that did not complete. ComfyUI loads DIRECTORIES, so it will ` +
+            `fail to import that on every start. NOT reporting success: nothing usable was ` +
+            `installed. Delete ${corroboration.dir} by hand and retry the install.`,
+          status,
+        );
+      } else {
+        return withCliNote({
+          mechanism: "manager-http",
+          message:
+            `Installed "${repoName}" via ComfyUI-Manager` +
+            (corroboration?.state === "corroborated"
+              ? `, verified present on disk at ${corroboration.dir}`
+              : `. Its presence on disk was NOT verified from here (${
+                  presenceCtx.remote
+                    ? "this session targets a REMOTE ComfyUI, so the local filesystem is not the host's"
+                    : !presenceCtx.diskRoot
+                      ? "no local custom_nodes scan root could be established for the connected server"
+                      : "the local custom_nodes scan could not answer"
+                }), so ComfyUI-Manager's installed-pack list is the only witness`) +
+            `. Restart may be required to load new nodes.`,
+          details: status,
+        });
+      }
     }
     if (localWriteMismatch) {
       throw new ProcessControlError(
@@ -4272,6 +4382,10 @@ async function installCustomNodeImpl(
     const clone = () => cloneCustomNodeFallback(gitId, repoName, gitRef, status, cliWorkspace, {
       refFromVersion,
       allowSharedWorkspaceFallback: cliWorkspace !== undefined,
+      // #2714 — the default reason ("not in the ComfyUI-Manager registry") is the
+      // wrong explanation when Manager DID list the pack; state what was actually
+      // observed instead, so a subsequent refusal from here is not misattributed.
+      ...(uncorroboratedNote ? { managerRefusalNote: uncorroboratedNote } : {}),
     });
     // An accepted remote Manager task that resolves no pack still reaches this
     // helper only for its authoritative remote-target refusal; it is not a


### PR DESCRIPTION
Fixes #2714

## The report, reproduced

`install_custom_node` (`source:"git"`, `ref:"main"`, `useCmCli:false`) answered

> Installed "ComfyUI-DaSiWa-Nodes" via ComfyUI-Manager. Restart may be required to load new nodes.

with `done_count 2`, and `~/ComfyUI/custom_nodes/ComfyUI-DaSiWa-Nodes` did not exist. Manager 4.2.2.

The whole proof behind that sentence, on `origin/main`, was one question asked of ComfyUI-Manager:

```ts
const installed = await listInstalledNodesAt(managerBase).catch(() => []);
if (nodeInstalledMatches(gitId, installed)) {
  return { mechanism: "manager-http", message: `Installed "${repoName}" via ComfyUI-Manager. …` };
}
```

`/v2/customnode/installed` is Manager's **own bookkeeping**, not a filesystem read. For a pack it previously tracked it keeps answering after the directory is gone (the reporter moved a Registry ZIP pack out), and a v4 task that resolves nothing is still marked done. Neither the list nor `done_count` observes the disk.

The **registry** branch of the same function already crosses that list with a disk scan (`resolvePackPresence`, #797) and already refuses a marker-only husk (`looksLikeAPack`, #900/#1816). The **git** branch had neither.

## What changed — `src/services/node-management.ts`

- **`diskCorroboratesManagerInstall(gitId, listedNode, diskRoot)`** asks `findPackOnDisk` for every identity the matched Manager entry offers that could actually *be* a directory: the URL-derived repo name, the entry's stated folder key, its `cnrId`, and the repo half of its `auxId`. One hit corroborates. Returns `corroborated` / `husk` / `absent` / `unreadable`.
- **The git success gate** consumes it:
  - **corroborated** — the same `manager-http` success, now naming the verified directory.
  - **absent** — no success. Falls through to the *existing* direct-clone path, carrying a `managerRefusalNote` stating what was observed. `cloneCustomNodeFallback`'s default reason ("not in the ComfyUI-Manager registry") would be a wrong cause for a correct action, since Manager *did* list it.
  - **husk** — refuses, names the directory, leaves it untouched (this call is not its proven author).
  - **unreadable / remote / no proven scan root** — unchanged success, but the message now *says* the disk was not checked and that Manager's list is the only witness.
- **`InstalledNode.moduleKey`** (new, optional). `module` is a display-or-identity blend: `parseInstalled`'s array branch prefers the entry's human `title`. `module`'s value and precedence are **unchanged** — it is still what Manager is sent back as `node_name` and what the installed list displays — but anything reading a module as a *path* now uses `moduleKey`, which holds the key the payload actually stated (the object payload's key; the array entry's `module`) and is `undefined` when the payload stated none.

## Where the load-bearing claims are

1. **The `absent` verdict retracts a success AND authorizes a filesystem write.** It is therefore the strictest branch: every identity must have been *conclusively* scanned. One `not-found` beside one unanswerable scan yields `unreadable`, not `absent`.
2. **The husk branch is a new throw where a success used to be.** `looksLikeAPack` returns `true` on an unreadable directory and on any top-level `.py`/`pyproject.toml`, and it is already the gate on the other two paths in this same function.
3. **I did NOT implement the `.git`-must-exist check the report prescribes.** The v4 route is registry-first by construction: a pack Manager resolved and unpacked from the registry has no `.git` and is working as designed. Requiring `.git` would false-refuse it. The property that matters is whether ComfyUI can import the directory. The report's *premise* (false success) is right; that one clause of its prescribed fix is not.
4. **Disclosed and accepted:** a pack installed under an `extra_model_paths`-style second `custom_nodes` root is not seen by `findPackOnDisk`, so it could be cloned again into the primary root. The same exposure already exists on this function's pre-existing not-listed fall-through. `moduleKey` is `undefined` for the cm-cli `show installed` table path; that path is not used by the install verification.
5. **Not covered by a test:** the `unreadable`-outranks-`absent` ordering. `findPackOnDisk` returns `unreadable` only for root-level failures, so all identities scanned against one root share that outcome and a mixed state is reachable only under a mid-scan race. It is ordering hardening, not a demonstrated failure — claiming coverage for it would be false.

## Evidence

New pin: `src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts` (10 tests) drives the REAL `installCustomNode` through the REAL resolvers against a REAL temp tree, with Manager accepting the task, draining `done_count 2`, and **listing** the pack. The existing #1765 coverage never produces this shape (its `/customnode/installed` always answers `[]`), which is why the list never had to be doubted.

**Deleting the fix** (`git checkout origin/main -- src/services/node-management.ts`) turned 5 of the original 6 red, the first with the reporter's outcome verbatim (`expected 'manager-http' to be 'git-clone'`).

**Every clause is pinned independently.** Each mutation turns exactly the named test(s) red and leaves the rest green:

| mutation | red |
| --- | --- |
| identity list reduced to `[gitId]` | corroborates through the MANAGER ENTRY's own id |
| `basename()` removed from `packDirAliases` | corroborates through the aux id's REPO HALF |
| whitespace filter re-added | a pack folder with a SPACE in its name still corroborates |
| alias scan reads `node.module` instead of `moduleKey` | will not let a human TITLE stand in… + a TITLE-ONLY entry contributes no folder name |
| `parseInstalled` precedence moved | a title-derived module carries NO folder key |

The over-refusal control (`corroborates through the MANAGER ENTRY's own id`) **survives** the fix-deletion mutation, as a control must.

Full suite: **754/754 files, 13894 passed, 6 skipped**. `tsc --noEmit` clean; anti-slop gate `none added`.

**Browser gate not run, and not claimed:** nothing here touches panel rendering or the `panel_install_node` bridge path — the change is confined to the MCP-side `install_custom_node` service.

## Review

`codex-gate.mjs` returned the known Windows wrapper failure (`CreateProcessAsUserW failed: 5 (Access is denied)` — an indeterminate, not a finding), so the review ran through direct `codex exec` with the diff supplied inline. **Four rounds**; the first three each found a real defect in this change, and all are fixed above:

- **R1** — `aux_id`'s repo half was never scanned (duplicate clone); a human title could vouch for an unrelated directory; one `not-found` beside one `unreadable` returned `absent`, authorizing a write on an unproven absence.
- **R2** — an entry stating its own `module` had it overridden by `title`; **R1's whitespace filter rested on a false claim of mine** (I asserted ComfyUI imports a pack directory as a Python module name so it cannot contain a space — it loads packs via `importlib.util.spec_from_file_location`, which accepts any string), and would have read a real `custom_nodes/Foo Bar` as absent and cloned a duplicate beside it; a call-site comment overstated the fall-through.
- **R3** — R2's fix was both too wide and incomplete: it moved `module`'s precedence (a field sent to Manager as `node_name`) while an entry of `{title, cnr_id}` still promoted its title into `module`. Reverted the precedence change; added `moduleKey`.
- **R4 — `VERDICT: PASS`** on `1d61cf7`: *"No behavior-changing defect remains in the supplied diff. `module` precedence is unchanged; `moduleKey` is threaded correctly, corroboration ordering is safe under the stated helper contract, and `uncorroboratedNote` is scoped only to the relevant fallback clone."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
