### PR TITLE
fix(#1052): resolve train refs from one live snapshot

### DIFF
--- a/src/__tests__/services/image-convert.test.ts
+++ b/src/__tests__/services/image-convert.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../config.js", () => ({
 // consults the SAVED DEFAULT WORKSPACE, and this rig has one.
 vi.mock("../../services/workspace-env.js", () => ({
   resolveEffectiveComfyUIBase: () => cfgRef.config.comfyuiPath,
+  getLiveServerSnapshot: async () => ({ reachable: false }),
 }));
 
 const getOutputImageMock = vi.fn();

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -165,18 +165,9 @@ vi.mock("../../services/workspace-env.js", async () => {
     // live-root rung is exercised end to end rather than stubbed away. This is
     // deliberately one snapshot: explicit I/O flags and the inferred live root
     // must describe the same server instance.
-    getLiveServerSnapshot: async () => {
-      try {
-        const stats = await getSystemStats();
-        return {
-          reachable: true,
-          argv: stats?.system?.argv,
-          cwd: stats?.system?.cwd,
-        };
-      } catch {
-        return { reachable: false };
-      }
-    },
+    // Use the real snapshot boundary so a production-shaped malformed response
+    // cannot bypass its runtime argv/cwd validation in this resolver suite.
+    getLiveServerSnapshot: () => actual.getLiveServerSnapshot(),
     liveRootFromArgv: actual.liveRootFromArgv,
     hasComfyUIEntrypoint: (dir: string) =>
       hasEntrypointFor ? hasEntrypointFor(dir) : baseHasEntrypoint,
@@ -1366,6 +1357,12 @@ describe("#1052: I/O dirs follow the CONNECTED server, not a second install", ()
   it("falls back when the live argv identifies no root", async () => {
     getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
     expect(await resolveOutputDir()).toBe(resolve(DESKTOP, "output"));
+  });
+
+  it("fails closed on a production-shaped malformed argv response", async () => {
+    getSystemStats.mockResolvedValue({ system: { argv: [1] } });
+    await expect(resolveOutputDir()).resolves.toBe(resolve(DESKTOP, "output"));
+    expect(getSystemStats).toHaveBeenCalledTimes(1);
   });
 
   // #2539 — ComfyUI Desktop / Windows portable report a RELATIVE

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -162,13 +162,19 @@ vi.mock("../../services/workspace-env.js", async () => {
   return {
     resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
     // #1052 — backed by the REAL argv parsing, like the resolvers above, so the
-    // live-root rung is exercised end to end rather than stubbed away.
-    resolveLiveComfyUIBase: async () => {
+    // live-root rung is exercised end to end rather than stubbed away. This is
+    // deliberately one snapshot: explicit I/O flags and the inferred live root
+    // must describe the same server instance.
+    getLiveServerSnapshot: async () => {
       try {
         const stats = await getSystemStats();
-        return actual.liveRootFromArgv(stats?.system?.argv, stats?.system?.cwd);
+        return {
+          reachable: true,
+          argv: stats?.system?.argv,
+          cwd: stats?.system?.cwd,
+        };
       } catch {
-        return undefined;
+        return { reachable: false };
       }
     },
     liveRootFromArgv: actual.liveRootFromArgv,
@@ -1328,11 +1334,13 @@ describe("#1052: I/O dirs follow the CONNECTED server, not a second install", ()
     const got = await resolveOutputDir();
     expect(got).toBe(join(CONNECTED, "output"));
     expect(got).not.toBe(resolve(DESKTOP, "output")); // the reported failure
+    expect(getSystemStats).toHaveBeenCalledTimes(1);
   });
 
   it("resolves the INPUT dir the same way", async () => {
     connectedServerNoExplicitDirs();
     expect(await resolveInputDir()).toBe(join(CONNECTED, "input"));
+    expect(getSystemStats).toHaveBeenCalledTimes(1);
   });
 
   // An EXPLICIT --output-directory is the server telling us outright; it must

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -112,6 +112,7 @@ import {
   resolveLocalWorkspaceBase,
   resolveInstallInterpreter,
   resolveLiveComfyUIBase,
+  getLiveServerSnapshot,
   resolveLiveServerRoot,
   resolveRootInterpreter,
   torchVersionsAgree,
@@ -2048,6 +2049,15 @@ describe("resolveLiveComfyUIBase (#490 / #463 — live connected install root)",
   it("returns undefined (never throws) when the server is unreachable", async () => {
     mockGetSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
     await expect(resolveLiveComfyUIBase()).resolves.toBeUndefined();
+  });
+
+  it("sanitizes malformed argv and cwd from the production JSON response", async () => {
+    mockGetSystemStats.mockResolvedValue({ system: { argv: [1], cwd: 42 } });
+    await expect(getLiveServerSnapshot()).resolves.toEqual({
+      reachable: true,
+      argv: undefined,
+      cwd: undefined,
+    });
   });
 });
 

--- a/src/__tests__/tools/get-image-local-fallback.test.ts
+++ b/src/__tests__/tools/get-image-local-fallback.test.ts
@@ -11,7 +11,6 @@ const mocks = vi.hoisted(() => ({
   fetchImage: vi.fn(),
   getSystemStats: vi.fn(),
   comfyApiFetch: vi.fn(),
-  liveRoot: vi.fn(),
   readFile: vi.fn(),
   realpath: vi.fn(),
   stat: vi.fn(),
@@ -44,7 +43,18 @@ vi.mock("../../services/workspace-env.js", async () => {
   const actual = await vi.importActual<typeof import("../../services/workspace-env.js")>("../../services/workspace-env.js");
   return {
     ...actual,
-    resolveLiveComfyUIBase: (...args: unknown[]) => mocks.liveRoot(...args),
+    getLiveServerSnapshot: async () => {
+      try {
+        const stats = await mocks.getSystemStats();
+        return {
+          reachable: true,
+          argv: stats?.system?.argv,
+          cwd: stats?.system?.cwd,
+        };
+      } catch {
+        return { reachable: false };
+      }
+    },
     // #1263 — this file pins the #2194 argv live-root rung. The OS process table
     // is not a fixture; observed-process for relative ComfyUI/main.py lives in
     // output-dir.test.ts (#2539).
@@ -122,7 +132,6 @@ beforeEach(() => {
   mocks.config.comfyuiPath = resolve("test-fixtures", "configured-comfyui");
   mocks.getSystemStats.mockResolvedValue({ system: { argv: ["python", "main.py"] } });
   mocks.comfyApiFetch.mockResolvedValue(new Response("{}", { status: 200 }));
-  mocks.liveRoot.mockResolvedValue(undefined);
   mocks.fetchImage.mockRejectedValue(view400());
   mocks.readFile.mockResolvedValue(mp4);
   mocks.realpath.mockImplementation(async (path: string) => path);
@@ -167,7 +176,9 @@ describe("get_image — canonical local input fallback (#2194)", () => {
   it("uses the connected live install input directory when no input flag is present", async () => {
     const liveBase = resolve("test-fixtures", "connected-live-comfyui");
     const localPath = join(liveBase, "input", filename);
-    mocks.liveRoot.mockResolvedValue(liveBase);
+    mocks.getSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(liveBase, "main.py")] },
+    });
 
     const out = await getHandler("get_image")({
       action: "get",
@@ -177,7 +188,7 @@ describe("get_image — canonical local input fallback (#2194)", () => {
     });
 
     expect(out.isError).toBeUndefined();
-    expect(mocks.liveRoot).toHaveBeenCalled();
+    expect(mocks.getSystemStats).toHaveBeenCalledTimes(1);
     expect(mocks.open).toHaveBeenCalledWith(localPath, "r");
     expect(mocks.open).not.toHaveBeenCalledWith(
       join(resolve(mocks.config.comfyuiPath), "input", filename),

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -4,7 +4,7 @@ import { config, isRemoteMode } from "../config.js";
 import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import {
   resolveEffectiveComfyUIBase,
-  resolveLiveComfyUIBase,
+  getLiveServerSnapshot,
   resolveLiveServerRoot,
   hasComfyUIEntrypoint,
 } from "./workspace-env.js";
@@ -1341,49 +1341,41 @@ export function localTempDirFallback(): string {
  * An explicit --output-directory still wins above, and the configured install
  * still catches everything below.
  */
-async function liveIoDirFallback(kind: "input" | "output" | "temp"): Promise<string | undefined> {
-  try {
-    // #2194 — get_image action:get type:input when no --input-directory is set.
-    const fromArgv = await resolveLiveComfyUIBase();
-    if (fromArgv) return join(fromArgv, kind);
+function liveIoDirFromSnapshot(
+  kind: "input" | "output" | "temp",
+  snapshot: { reachable: boolean; argv?: string[]; cwd?: string },
+): string | undefined {
+  if (!snapshot.reachable) return undefined;
 
-    // #2539 — relative ComfyUI/main.py with no cwd cannot be derived from argv.
-    const stats = await getSystemStats();
-    const live = resolveLiveServerRoot(
-      stats.system?.argv,
-      (stats.system as { cwd?: string } | undefined)?.cwd,
-      { remote: isRemoteMode() },
-    );
-    // A Docker/forwarded server reports a container-side path that is not
-    // host-local. Same gate resolveModelsDir uses for this root.
-    if (!live.root || !existsSync(live.root)) return undefined;
-    return join(live.root, kind);
-  } catch {
-    return undefined; // never let a probe failure outrank the configured install
-  }
+  // #2539 — relative ComfyUI/main.py with no cwd cannot be derived from argv;
+  // resolveLiveServerRoot may use the correlated local process observation for
+  // that shape. The snapshot is passed through unchanged so the explicit-dir
+  // and live-root answers can never describe different server instances.
+  const live = resolveLiveServerRoot(snapshot.argv, snapshot.cwd, { remote: false });
+  if (!live.root) return undefined;
+  // A Docker/forwarded server reports a container-side path that is not
+  // host-local. Same gate resolveModelsDir uses for an observed root. An argv
+  // root remains the server's direct claim, preserving the existing not-found
+  // behavior when that claimed path is unavailable locally.
+  if (live.source !== "argv" && !existsSync(live.root)) return undefined;
+  return join(live.root, kind);
 }
 
 export async function resolveInputDir(): Promise<string> {
-  try {
-    const stats = await getSystemStats();
-    const serverCwd = (stats.system as { cwd?: string } | undefined)?.cwd;
-    const fromArgv = parseInputDirFromArgv(stats.system?.argv, serverCwd);
+  const snapshot = await getLiveServerSnapshot();
+  if (snapshot.reachable) {
+    const fromArgv = parseInputDirFromArgv(snapshot.argv, snapshot.cwd);
     if (fromArgv) {
       logger.debug("Resolved ComfyUI input directory from launch argv", {
         inputDir: fromArgv,
       });
       return fromArgv;
     }
-  } catch (err) {
-    logger.debug(
-      "Could not resolve input dir from /system_stats; using COMFYUI_PATH/input",
-      { error: err instanceof Error ? err.message : String(err) },
-    );
   }
   // #1052 — before the CONFIGURED install, try the one that is actually
   // running. With two ComfyUIs on a machine these differ, and the connected
   // server is the one whose files the caller means.
-  const live = await liveIoDirFallback("input");
+  const live = liveIoDirFromSnapshot("input", snapshot);
   if (live) {
     logger.debug("Resolved ComfyUI input directory from the LIVE server's install root", {
       dir: live,
@@ -1398,25 +1390,20 @@ export async function resolveInputDir(): Promise<string> {
  * ComfyUI (/system_stats argv) first; falls back to <COMFYUI_PATH>/output.
  */
 export async function resolveOutputDir(): Promise<string> {
-  try {
-    const stats = await getSystemStats();
-    const fromArgv = parseOutputDirFromArgv(stats.system?.argv);
+  const snapshot = await getLiveServerSnapshot();
+  if (snapshot.reachable) {
+    const fromArgv = parseOutputDirFromArgv(snapshot.argv);
     if (fromArgv) {
       logger.debug("Resolved ComfyUI output directory from launch argv", {
         outputDir: fromArgv,
       });
       return fromArgv;
     }
-  } catch (err) {
-    logger.debug(
-      "Could not resolve output dir from /system_stats; using COMFYUI_PATH/output",
-      { error: err instanceof Error ? err.message : String(err) },
-    );
   }
   // #1052 — before the CONFIGURED install, try the one that is actually
   // running. With two ComfyUIs on a machine these differ, and the connected
   // server is the one whose files the caller means.
-  const live = await liveIoDirFallback("output");
+  const live = liveIoDirFromSnapshot("output", snapshot);
   if (live) {
     logger.debug("Resolved ComfyUI output directory from the LIVE server's install root", {
       dir: live,
@@ -1431,23 +1418,17 @@ export async function resolveOutputDir(): Promise<string> {
  * running ComfyUI (/system_stats argv) first; falls back to <COMFYUI_PATH>/temp.
  */
 export async function resolveTempDir(): Promise<string> {
-  try {
-    const stats = await getSystemStats();
-    const serverCwd = (stats.system as { cwd?: string } | undefined)?.cwd;
-    const fromArgv = parseTempDirFromArgv(stats.system?.argv, serverCwd);
+  const snapshot = await getLiveServerSnapshot();
+  if (snapshot.reachable) {
+    const fromArgv = parseTempDirFromArgv(snapshot.argv, snapshot.cwd);
     if (fromArgv) {
       logger.debug("Resolved ComfyUI temp directory from launch argv", {
         tempDir: fromArgv,
       });
       return fromArgv;
     }
-  } catch (err) {
-    logger.debug(
-      "Could not resolve temp dir from /system_stats; using COMFYUI_PATH/temp",
-      { error: err instanceof Error ? err.message : String(err) },
-    );
   }
-  const live = await liveIoDirFallback("temp");
+  const live = liveIoDirFromSnapshot("temp", snapshot);
   if (live) {
     logger.debug("Resolved ComfyUI temp directory from the LIVE server's install root", {
       dir: live,

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -614,6 +614,22 @@ export async function resolveLiveComfyUIBase(): Promise<string | undefined> {
 }
 
 /**
+ * Keep values from the server's JSON response at the runtime boundary. The
+ * SystemStats TypeScript type describes the normal ComfyUI response, but the
+ * response is still untrusted JSON at runtime; a shape such as `argv: [1]`
+ * must not reach the string-only launch-argv parsers.
+ */
+function validatedLaunchArgv(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((token): token is string => typeof token === "string")
+    ? value
+    : undefined;
+}
+
+function validatedServerCwd(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
  * ONE `/system_stats` snapshot for callers that need to derive several things from the
  * SAME server state (the launch flags AND the install root), rather than issuing two
  * calls that could straddle a restart — the same invariant `resolveModelsDirWithBases`
@@ -628,10 +644,14 @@ export async function getLiveServerSnapshot(): Promise<{
   if (isRemoteMode()) return { reachable: false };
   try {
     const stats = await getSystemStats();
+    const system =
+      stats && typeof stats === "object" && stats.system && typeof stats.system === "object"
+        ? (stats.system as Record<string, unknown>)
+        : undefined;
     return {
       reachable: true,
-      argv: stats.system?.argv,
-      cwd: (stats.system as { cwd?: string })?.cwd,
+      argv: validatedLaunchArgv(system?.argv),
+      cwd: validatedServerCwd(system?.cwd),
     };
   } catch {
     return { reachable: false };


### PR DESCRIPTION
Closes #1052

## Summary
- resolve train_prepare_dataset ref roots from one live `/system_stats` snapshot
- keep connected-server live-root precedence over stale COMFYUI_PATH
- preserve explicit directory precedence, remote refusal, observed-root host check, and ref containment
- update affected resolver test seams for the single-snapshot API

## Validation
- `npm run build`
- `npm run test:vitest -- src/__tests__/services/output-dir.test.ts src/__tests__/tools/train-dataset-refs.test.ts src/__tests__/services/image-convert.test.ts src/__tests__/tools/get-image-local-fallback.test.ts` — 135 passed
- `npm run lint`
- `npm run check:vocabulary`
- `node scripts/asset-counts.mjs --check`
- `git diff --check`

The full local `npm test` reached 13,894 passing tests but had unrelated environment/baseline failures in `late-mutation-e2e.test.ts`, `console-secrets.test.ts`, and an asset-count run before the final rebuild; the standalone asset-count check passes after rebuilding.