### PR TITLE
chore(release): comfyui-mcp 0.52.168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.168] - 2026-09-01
+
+### MCP
+
+#### Fixed
+- resolve train refs from one live snapshot (#2720)
+- a git install must be corroborated on disk, not by ComfyUI-Manager's own list (#2715)
+- settle an unacked workflow_new against the panel's own rid-correlated receipt (#2710)
+- prove a VRAM release landed before reporting the reading as settled (#2708)
+- a PANEL_FETCH_FAILED panel read now names its cause (#2706)
+
+
 ## [0.52.167] - 2026-09-01
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.167",
+  "version": "0.52.168",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.167",
+      "version": "0.52.168",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.167",
+  "version": "0.52.168",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Release 0.52.168\n\nVersion and changelog generated from current main after merged #1052.\n\nValidation:\n- npm.cmd run lint\n- npm.cmd run build\n- npm.cmd run check:vocabulary\n- npm.cmd run vocab:export\n- node scripts/check-changelog.mjs\n- git diff --check\n- anti-slop: 785 known findings, none added\n\nBase: e7667ab118ce79244c3def88aacd52406a96b26b\nHead: 40bb1e4\n\nNo init.py/apps_routes.py network operations.