### PR TITLE
chore(release): 0.52.169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.169] - 2026-09-01
+
 ### MCP
 
 #### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.168",
+  "version": "0.52.169",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.168",
+      "version": "0.52.169",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.168",
+  "version": "0.52.169",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Release preparation\n\n- Bumped package.json and package-lock.json to 0.52.169 without creating a tag.\n- Generated CHANGELOG.md section for #1474 (list_local_models removal and live Desktop shared roots).\n- npm ci passed; prepare TypeScript build passed.\n- npm run lint passed (TypeScript plus anti-slop: 785 known findings, none added).\n- npm run build passed.\n- npm test passed: 754 files, 13,908 tests passed, 6 skipped; all auxiliary checks passed, including i18n, docs links/locale/MDX, blog checks, asset counts, vocabulary, unknown-collapse, vocab export, and changelog integrity.\n- docs:gen was a no-op; exact staged diff was limited to CHANGELOG.md, package.json, and package-lock.json.\n- Protected-file and scope checks passed: no init.py or apps_routes.py changes, no source or generated-doc changes.\n\nThe first full test attempt had one intermittent panel-image-relay timing failure; the isolated suite passed 45/45 and the complete rerun passed.\n\nNo merge, tag, or publish action has been performed.