### PR TITLE
U20 director agent tools: every editor drive command reachable as an ACTION

### DIFF
--- a/src/__tests__/orchestrator/director-calliope-tools.test.ts
+++ b/src/__tests__/orchestrator/director-calliope-tools.test.ts
@@ -29,6 +29,38 @@ const run = async (name: string, args: Record<string, unknown>, reply?: unknown)
   return { res, frames };
 };
 
+/**
+ * The same rig for an action that sends MORE THAN ONE frame, where the second frame's arguments
+ * are read out of the first frame's reply. One fixed reply cannot express that: the create has to
+ * answer with a row id and the patch with the patched row, and a test that fed both the same body
+ * would pass even if the handler read the wrong one.
+ */
+function fakeCtxSeq(replyFor: (cmd: Frame) => unknown) {
+  const frames: Frame[] = [];
+  const call = vi.fn(async (cmd: Frame): Promise<ToolResult> => {
+    frames.push(cmd);
+    return { content: [{ type: "text", text: JSON.stringify(replyFor(cmd)) }] };
+  });
+  return { ctx: { call } as unknown as PanelToolCtx, frames };
+}
+
+const runSeq = async (name: string, args: Record<string, unknown>, replyFor: (cmd: Frame) => unknown) => {
+  const { ctx, frames } = fakeCtxSeq(replyFor);
+  const res = await tool(name).handler(args, ctx);
+  const raw = (res.content[0] as { text?: string }).text ?? "";
+  // A refusal is prose, not JSON — parse leniently so the refusal cases can use this rig too.
+  let body: Record<string, unknown> = {};
+  try {
+    body = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    /* not JSON: the caller asserts on res.content instead */
+  }
+  return { res, frames, body };
+};
+
+/** An outline reply in the shape the pane sends it, with `cal-sc-<id>` node ids. */
+const outlineWith = (nodes: Array<Record<string, unknown>>) => ({ ok: true, result: { nodes, edges: [] } });
+
 describe("Calliope tools — every action maps to one client call through the pane", () => {
   it("all five are mounted with the director group, and the ledger names them", () => {
     for (const name of ["panel_director_project", "panel_director_story", "panel_director_scene", "panel_director_workflow", "panel_director_render"]) {
@@ -77,12 +109,14 @@ describe("Calliope tools — every action maps to one client call through the pa
   });
 
   it("render: videos_generate carries explicit prompts — the surest way to keep Calliope's model out of the loop", async () => {
+    // Two frames now: the bypass check reads the outline first (nothing bypassed here), then enqueues.
     expect((await run("panel_director_render", { action: "videos_generate", project_id: 1, scene_ids: [1, 2], prompts: { "1": "a", "2": "b" } })).frames).toEqual([
+      { cmd: "director_outline" },
       { cmd: "director_calliope", ns: "jobs", op: "generateVideos", args: [1, { scene_ids: [1, 2], prompts: { "1": "a", "2": "b" } }] },
     ]);
     expect((await run("panel_director_render", { action: "export", project_id: 1 })).frames).toEqual([{ cmd: "director_calliope", ns: "jobs", op: "exportFilm", args: [1] }]);
-    expect((await run("panel_director_render", { action: "attach", path: "/x.png", target: "character", character_id: 3 })).frames).toEqual([
-      { cmd: "director_calliope", ns: "playground", op: "attach", args: [{ path: "/x.png", target: "character", character_id: 3 }] },
+    expect((await run("panel_director_render", { action: "attach", path: "/x.png", project_id: 1, target: "character_sheet", character_id: 3 })).frames).toEqual([
+      { cmd: "director_calliope", ns: "playground", op: "attach", args: [{ path: "/x.png", project_id: 1, target: "character_sheet", character_id: 3 }] },
     ]);
   });
 
@@ -107,6 +141,209 @@ describe("Calliope tools — every action maps to one client call through the pa
       expect(res.isError, name).toBe(true);
       expect(frames, name).toHaveLength(0);
     }
+  });
+});
+
+// U20 — the editor's drive vocabulary reaches the agent as ACTIONS, never as new tool names.
+// The arg NAMES are frozen in ComfyUI_BenjiDirector/docs/drive-commands.md: a rename on either
+// side is a command the editor does not recognise, and the panel answers "unknown cmd" rather
+// than failing loudly at the call site. So every one is pinned frame-for-frame here.
+describe("Director drive commands — one editor frame per action, with the frozen arg names", () => {
+  it("graph: node chrome, clipboard, selection, notes, reroute and the inspector", async () => {
+    const cases: Array<[Record<string, unknown>, Frame]> = [
+      [{ action: "set_bypassed", id: "sc-01", bypassed: true }, { cmd: "director_set_bypassed", id: "sc-01", bypassed: true }],
+      [{ action: "set_node_color", id: "sc-01", color: "#34d399" }, { cmd: "director_set_node_color", id: "sc-01", color: "#34d399" }],
+      // null is a VALUE here (clear the tint), so it must survive `need` and reach the editor.
+      [{ action: "set_node_color", id: "sc-01", color: null }, { cmd: "director_set_node_color", id: "sc-01", color: null }],
+      [{ action: "set_node_collapsed", id: "sc-01", collapsed: true }, { cmd: "director_set_node_collapsed", id: "sc-01", collapsed: true }],
+      [{ action: "duplicate", ids: ["sc-01", "sc-02"] }, { cmd: "director_duplicate", ids: ["sc-01", "sc-02"] }],
+      // An EMPTY selection is the documented way to clear it, not a missing argument.
+      [{ action: "select", ids: [] }, { cmd: "director_select", ids: [] }],
+      [{ action: "fit_view" }, { cmd: "director_fit_view" }],
+      [{ action: "fit_view", ids: ["sc-01"] }, { cmd: "director_fit_view", ids: ["sc-01"] }],
+      [{ action: "add_note", x: 10, y: 20, text: "beat sheet" }, { cmd: "director_add_note", x: 10, y: 20, text: "beat sheet" }],
+      [{ action: "set_note", id: "note-1", text: "rewrite" }, { cmd: "director_set_note", id: "note-1", text: "rewrite" }],
+      [{ action: "reroute", edge_id: "e-7", x: 5, y: 6 }, { cmd: "director_reroute", edge_id: "e-7", x: 5, y: 6 }],
+      [{ action: "inspect", id: "sc-01" }, { cmd: "director_inspect", id: "sc-01" }],
+    ];
+    for (const [args, frame] of cases) {
+      expect((await run("panel_director_graph", args)).frames, String(args.action)).toEqual([frame]);
+    }
+  });
+
+  it("graph: whole-graph persistence — export/import, named saves, clear and reset", async () => {
+    const cases: Array<[Record<string, unknown>, Frame]> = [
+      [{ action: "export_graph" }, { cmd: "director_export_graph" }],
+      [{ action: "import_graph", json: '{"nodes":[]}' }, { cmd: "director_import_graph", json: '{"nodes":[]}' }],
+      [{ action: "save_named", name: "take-1" }, { cmd: "director_save_named", name: "take-1" }],
+      [{ action: "load_named", name: "take-1" }, { cmd: "director_load_named", name: "take-1" }],
+      [{ action: "list_saves" }, { cmd: "director_list_saves" }],
+      [{ action: "delete_save", name: "take-1" }, { cmd: "director_delete_save", name: "take-1" }],
+      [{ action: "clear" }, { cmd: "director_clear" }],
+      [{ action: "reset_demo" }, { cmd: "director_reset_demo" }],
+    ];
+    for (const [args, frame] of cases) {
+      expect((await run("panel_director_graph", args)).frames, String(args.action)).toEqual([frame]);
+    }
+  });
+
+  it("subgraph: container deletion carries its mode, and a blueprint can be updated or dropped", async () => {
+    const cases: Array<[Record<string, unknown>, Frame]> = [
+      [{ action: "delete_container", id: "beat-1", mode: "all" }, { cmd: "director_delete_container", id: "beat-1", mode: "all" }],
+      [{ action: "delete_container", id: "beat-1", mode: "shell" }, { cmd: "director_delete_container", id: "beat-1", mode: "shell" }],
+      [{ action: "update_blueprint", blueprint_id: "bp-1", id: "beat-1" }, { cmd: "director_update_blueprint", blueprint_id: "bp-1", id: "beat-1" }],
+      [{ action: "update_blueprint", blueprint_id: "bp-1" }, { cmd: "director_update_blueprint", blueprint_id: "bp-1" }],
+      [{ action: "delete_blueprint", blueprint_id: "bp-1" }, { cmd: "director_delete_blueprint", blueprint_id: "bp-1" }],
+    ];
+    for (const [args, frame] of cases) {
+      expect((await run("panel_director_subgraph", args)).frames, String(args.action)).toEqual([frame]);
+    }
+  });
+
+  it("render: the playground's own jobs, and the composer on one scene", async () => {
+    // `playground.jobs(limit = 50)` takes a POSITIONAL scalar: an omitted limit must be an
+    // ABSENT argument, not `undefined` or a query object, or the client's default never applies.
+    expect((await run("panel_director_render", { action: "playground_jobs" })).frames).toEqual([{ cmd: "director_calliope", ns: "playground", op: "jobs", args: [] }]);
+    expect((await run("panel_director_render", { action: "playground_jobs", limit: 5 })).frames).toEqual([{ cmd: "director_calliope", ns: "playground", op: "jobs", args: [5] }]);
+    expect((await run("panel_director_render", { action: "playground_delete", job_id: 12 })).frames).toEqual([{ cmd: "director_calliope", ns: "playground", op: "deleteJob", args: [12] }]);
+    // render_scene is an EDITOR command (it opens the composer), not a client call.
+    expect((await run("panel_director_render", { action: "render_scene", scene_id: 4 })).frames).toEqual([{ cmd: "director_render_scene", scene_id: 4 }]);
+  });
+
+  it("render: attach without project_id is refused before any frame — the endpoint requires it", async () => {
+    const { res, frames } = await run("panel_director_render", { action: "attach", path: "/x.png", target: "scene", scene_id: 2 });
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain("project_id");
+    expect(frames).toHaveLength(0);
+  });
+
+  it("project: set_cover clears with an EXPLICIT null, and never by omission", async () => {
+    expect((await run("panel_director_project", { action: "set_cover", project_id: 3, cover_path: "/out/poster.png" })).frames).toEqual([
+      { cmd: "director_calliope", ns: "projects", op: "patch", args: [3, { cover_path: "/out/poster.png" }] },
+    ]);
+    expect((await run("panel_director_project", { action: "set_cover", project_id: 3, cover_path: null })).frames).toEqual([
+      { cmd: "director_calliope", ns: "projects", op: "patch", args: [3, { cover_path: null }] },
+    ]);
+    // Omitting cover_path is refused rather than treated as "clear it".
+    const { res, frames } = await run("panel_director_project", { action: "set_cover", project_id: 3 });
+    expect(res.isError).toBe(true);
+    expect(frames).toHaveLength(0);
+  });
+
+  it("scene add: chain_from_prev is a SECOND frame — SceneCreate has no such field", async () => {
+    const { frames, body } = await runSeq(
+      "panel_director_scene",
+      { action: "add", project_id: 1, heading: "SC-03 · Rooftop", duration_sec: 6, chain_from_prev: true },
+      (cmd) => (cmd.op === "create" ? { id: 42, heading: "SC-03 · Rooftop" } : { id: 42, chain_from_prev: true }),
+    );
+    expect(frames).toEqual([
+      // The create body must NOT carry chain_from_prev: the endpoint drops it silently, so a
+      // one-frame version would report the flag set while Calliope stored nothing.
+      { cmd: "director_calliope", ns: "scenes", op: "create", args: [1, { heading: "SC-03 · Rooftop", duration_sec: 6 }] },
+      { cmd: "director_calliope", ns: "scenes", op: "patch", args: [1, 42, { chain_from_prev: true }] },
+    ]);
+    expect(body.scene_id).toBe(42);
+    expect(body.chain_from_prev).toBe(true);
+  });
+
+  it("scene add: without chain_from_prev it stays ONE frame, and an id-less reply says the flag did not land", async () => {
+    expect((await run("panel_director_scene", { action: "add", project_id: 1, heading: "SC-04" })).frames).toEqual([
+      { cmd: "director_calliope", ns: "scenes", op: "create", args: [1, { heading: "SC-04" }] },
+    ]);
+    // A create reply the tool cannot read an id out of must SAY so — the alternative is a
+    // scene that quietly is not chained and an agent that believes it is.
+    const { res, frames } = await run("panel_director_scene", { action: "add", project_id: 1, heading: "SC-05", chain_from_prev: true }, { ok: true });
+    expect(frames).toHaveLength(1);
+    expect(res.content.map((c) => (c.type === "text" ? c.text : "")).join(" ")).toContain("chain_from_prev was NOT applied");
+  });
+
+  it("scene patch still sends chain_from_prev inline — only CREATE lacks the field", async () => {
+    expect((await run("panel_director_scene", { action: "patch", project_id: 1, scene_id: 2, chain_from_prev: false })).frames).toEqual([
+      { cmd: "director_calliope", ns: "scenes", op: "patch", args: [1, 2, { chain_from_prev: false }] },
+    ]);
+  });
+
+  it("videos_generate drops the scenes whose node is bypassed, and names them in the reply", async () => {
+    const { frames, body } = await runSeq(
+      "panel_director_render",
+      { action: "videos_generate", project_id: 1, scene_ids: [1, 2, 3] },
+      (cmd) =>
+        cmd.cmd === "director_outline"
+          ? outlineWith([
+              { id: "cal-sc-1", kind: "scene", bypassed: false },
+              { id: "cal-sc-2", kind: "scene", bypassed: true },
+              { id: "cal-sc-3", kind: "scene" },
+              { id: "cal-beat-1", kind: "beat" },
+            ])
+          : { ok: true, jobs: [{ id: 9 }] },
+    );
+    expect(frames).toEqual([
+      { cmd: "director_outline" },
+      { cmd: "director_calliope", ns: "jobs", op: "generateVideos", args: [1, { scene_ids: [1, 3] }] },
+    ]);
+    expect(body.skipped_bypassed).toEqual([2]);
+    expect(body.scene_ids).toEqual([1, 3]);
+    // The queue's own answer survives the annotation.
+    expect(body.result).toMatchObject({ ok: true });
+  });
+
+  it("skip_bypassed false renders exactly what was asked and never reads the outline", async () => {
+    expect((await run("panel_director_render", { action: "videos_generate", project_id: 1, scene_ids: [1, 2], skip_bypassed: false })).frames).toEqual([
+      { cmd: "director_calliope", ns: "jobs", op: "generateVideos", args: [1, { scene_ids: [1, 2] }] },
+    ]);
+  });
+
+  it("every scene bypassed is a REFUSAL, not an empty enqueue", async () => {
+    const { res, frames } = await runSeq("panel_director_render", { action: "videos_generate", project_id: 1, scene_ids: [2] }, () =>
+      outlineWith([{ id: "cal-sc-2", kind: "scene", bypassed: true }]),
+    );
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain("bypassed");
+    // Only the outline read went out: nothing was queued.
+    expect(frames).toEqual([{ cmd: "director_outline" }]);
+  });
+
+  it("an unreadable outline still renders, and says the bypass check did not run", async () => {
+    const frames: Frame[] = [];
+    const call = vi.fn(async (cmd: Frame): Promise<ToolResult> => {
+      frames.push(cmd);
+      return cmd.cmd === "director_outline"
+        ? { content: [{ type: "text", text: "no connected tab" }], isError: true }
+        : { content: [{ type: "text", text: JSON.stringify({ ok: true }) }] };
+    });
+    const res = await tool("panel_director_render").handler({ action: "videos_generate", project_id: 1, scene_ids: [1, 2] }, { call } as unknown as PanelToolCtx);
+    expect(frames).toHaveLength(2);
+    expect(frames[1]).toEqual({ cmd: "director_calliope", ns: "jobs", op: "generateVideos", args: [1, { scene_ids: [1, 2] }] });
+    expect((res.content[0] as { text: string }).text).toContain("bypass_check");
+  });
+
+  it("a missing required field on a NEW action is refused before any frame is sent", async () => {
+    for (const [name, args] of [
+      ["panel_director_graph", { action: "set_bypassed", id: "sc-01" }],
+      ["panel_director_graph", { action: "set_node_color", id: "sc-01" }],
+      ["panel_director_graph", { action: "duplicate" }],
+      ["panel_director_graph", { action: "select" }],
+      ["panel_director_graph", { action: "add_note", x: 1, y: 2 }],
+      ["panel_director_graph", { action: "set_note", id: "note-1" }],
+      ["panel_director_graph", { action: "reroute", edge_id: "e-1", x: 1 }],
+      ["panel_director_graph", { action: "inspect" }],
+      ["panel_director_graph", { action: "import_graph" }],
+      ["panel_director_graph", { action: "save_named" }],
+      ["panel_director_subgraph", { action: "delete_container", id: "beat-1" }],
+      ["panel_director_subgraph", { action: "update_blueprint", id: "beat-1" }],
+      ["panel_director_subgraph", { action: "delete_blueprint" }],
+      ["panel_director_render", { action: "render_scene" }],
+      ["panel_director_render", { action: "playground_delete" }],
+    ] as const) {
+      const { res, frames } = await run(name, args as Record<string, unknown>);
+      expect(res.isError, `${name} ${String((args as Record<string, unknown>).action)}`).toBe(true);
+      expect(frames, `${name} ${String((args as Record<string, unknown>).action)}`).toHaveLength(0);
+    }
+  });
+
+  it("adds ACTIONS only — the tool vocabulary is still the same ten names", () => {
+    expect(DIRECTOR_TOOL_NAMES).toHaveLength(10);
+    expect(buildDirectorToolDefs().map((d) => d.name).sort()).toEqual([...DIRECTOR_TOOL_NAMES].sort());
   });
 });
 

--- a/src/orchestrator/director-tools.ts
+++ b/src/orchestrator/director-tools.ts
@@ -90,6 +90,67 @@ function jobsFromReply(res: ToolResult): Array<Record<string, unknown>> {
   return Array.isArray(v) ? (v as Array<Record<string, unknown>>) : [];
 }
 
+/** The `cal-sc-<id>` node ids the editor mints for Calliope scenes — the one bridge from a graph node back to its row. */
+const CAL_SCENE_PREFIX = "cal-sc-";
+
+/** The raw text half of a panel reply, for quoting an error back to the caller. */
+function textOf(res: ToolResult): string {
+  const first = res.content[0];
+  return first && first.type === "text" ? first.text : "";
+}
+
+/** The text half of a panel reply, parsed when it is JSON and left as text when it is not. */
+function bodyOfReply(res: ToolResult): unknown {
+  const raw = textOf(res);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/** The nodes array out of an `outline` reply, however the pane wrapped it. */
+function nodesFromOutline(res: ToolResult): Array<Record<string, unknown>> {
+  let v = bodyOfReply(res);
+  for (let hop = 0; hop < 3; hop += 1) {
+    if (Array.isArray(v)) return v as Array<Record<string, unknown>>;
+    if (!v || typeof v !== "object") return [];
+    const o = v as Record<string, unknown>;
+    if (Array.isArray(o.nodes)) return o.nodes as Array<Record<string, unknown>>;
+    v = o.result ?? o.outline ?? null;
+  }
+  return [];
+}
+
+/**
+ * The Calliope scene ids whose Director node is BYPASSED.
+ *
+ * Bypass is a graph-side fact — the editor mutes a node, nothing in Calliope knows — so the only
+ * way a render tool can honour it is to read the outline and map `cal-sc-12` back to scene 12.
+ */
+function bypassedSceneIds(outline: ToolResult): Set<number> {
+  const out = new Set<number>();
+  for (const n of nodesFromOutline(outline)) {
+    if (n.kind !== "scene" || n.bypassed !== true) continue;
+    const raw = typeof n.id === "string" && n.id.startsWith(CAL_SCENE_PREFIX) ? Number(n.id.slice(CAL_SCENE_PREFIX.length)) : Number.NaN;
+    if (Number.isInteger(raw)) out.add(raw);
+  }
+  return out;
+}
+
+/** The row id in a create reply, however the pane wrapped it. Null when the reply carried none. */
+function rowIdFromReply(res: ToolResult): number | null {
+  let v = bodyOfReply(res);
+  for (let hop = 0; hop < 3; hop += 1) {
+    if (!v || typeof v !== "object" || Array.isArray(v)) return null;
+    const o = v as Record<string, unknown>;
+    if (typeof o.id === "number" && Number.isInteger(o.id)) return o.id;
+    v = o.result ?? null;
+  }
+  return null;
+}
+
 /**
  * Block until none of a project's jobs is active, or the budget runs out. Bounded on purpose:
  * an agent that wants to follow a render calls this, not an event stream it would have to be
@@ -107,6 +168,47 @@ async function waitForJobs(ctx: PanelToolCtx, projectId: number, timeoutS: numbe
     if (Date.now() - started > budget) return { settled: false, waited_ms: Date.now() - started, active: active.length, jobs };
     await new Promise((r) => setTimeout(r, 2000));
   }
+}
+
+/**
+ * Enqueue a project's videos, honouring the graph's bypass flags.
+ *
+ * A bypassed node is the user saying "not this shot" on the surface they are looking at, and
+ * Calliope cannot see it — the flag lives on the Director's node, not on the scene row. So the
+ * skip is done HERE, against the outline read at dispatch time, and the reply says which ids
+ * were dropped: a scene that silently did not render is indistinguishable from a queue failure.
+ */
+async function renderVideos(ctx: PanelToolCtx, args: A): Promise<ToolResult> {
+  const pid = args.project_id;
+  const requested = (args.scene_ids as number[]) ?? [];
+  const body = pick(args, ["scene_ids", "workflow_id", "input_values", "prompts"]);
+  if (args.skip_bypassed === false) return calliope(ctx, "jobs", "generateVideos", [pid, body]);
+
+  const outline = await forward(ctx, "director_outline", {}, DIRECTOR_READ_MS);
+  if (outline.isError) {
+    // Unreadable outline: render what was asked for rather than refuse, and SAY the check
+    // did not run — a silent fallback would look exactly like "nothing was bypassed".
+    const res = await calliope(ctx, "jobs", "generateVideos", [pid, body]);
+    return annotate(res, { bypass_check: "skipped — the outline could not be read", scene_ids: requested });
+  }
+  const bypassed = bypassedSceneIds(outline);
+  const skipped = requested.filter((id) => bypassed.has(id));
+  if (!skipped.length) return calliope(ctx, "jobs", "generateVideos", [pid, body]);
+
+  const keep = requested.filter((id) => !bypassed.has(id));
+  if (!keep.length) return refuse(`every scene requested is bypassed on the graph (${skipped.join(", ")}) — un-bypass one with panel_director_graph set_bypassed, or pass skip_bypassed false`);
+  const res = await calliope(ctx, "jobs", "generateVideos", [pid, { ...body, scene_ids: keep }]);
+  return annotate(res, { skipped_bypassed: skipped, scene_ids: keep });
+}
+
+/** Wrap a reply with what the tool decided before sending it, keeping the reply's own body intact. */
+function annotate(res: ToolResult, note: Record<string, unknown>): ToolResult {
+  // A fresh result rather than a spread: rewriting `content` while carrying the original
+  // `structuredContent` would leave a machine half that describes the UN-annotated reply.
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ...note, result: bodyOfReply(res) }, null, 2) }],
+    ...(res.isError ? { isError: true } : {}),
+  };
 }
 
 /** Where Calliope answers — the same default the pane uses; override with CALLIOPE_BASE_URL. */
@@ -222,40 +324,100 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
       mountGroup: "director",
       description:
         "The Director's scene graph — nodes. `outline` returns every node (Scenes, assets, Beats with their rails) and every wire; read it first, ids come from here. " +
-        "`read_node` one node in full. `add_node` places a Scene / Character / Location / Item at Director graph x,y (dropping inside a Beat joins it) and returns the id the EDITOR minted. " +
-        "`remove_node`, `move_node`, `set_title`, `set_color` (hex, Beats only), `set_collapsed` (subgraphs only), " +
-        "`set_parent` (move a node into a Beat, or out with parent_id null), `set_pin` (show a node on its subgraph's collapsed face — only meaningful inside a subgraph). " +
+        "`read_node` one node in full; `inspect` opens the editor's inspector on it for the user. `add_node` places a Scene / Character / Location / Item at Director graph x,y (dropping inside a Beat joins it) and returns the id the EDITOR minted. " +
+        "`remove_node`, `move_node`, `duplicate` (ids → the new ids), `select` (ids, empty clears), `fit_view` (frame ids, or everything), `set_title`, `set_color` (hex, Beats only), " +
+        "`set_node_color` (one leaf's tint; null clears it), `set_collapsed` (subgraphs only), `set_node_collapsed` (collapse a leaf to its header), `set_bypassed` (mute a node: drawn faded and skipped by renders), " +
+        "`set_parent` (move a node into a Beat, or out with parent_id null), `set_pin` (show a node on its subgraph's collapsed face — only meaningful inside a subgraph), " +
+        "`add_note` / `set_note` (a sticky note at x,y), `reroute` (drop a pass-through dot on a wire at x,y). " +
+        "Whole-graph persistence: `export_graph` / `import_graph` (json), `save_named` / `load_named` / `list_saves` / `delete_save` (name), `clear` (empty it), `reset_demo` (back to the demo project). " +
         "The user can be editing the same graph by hand at the same time; re-read the outline rather than assuming your last write is the whole story.",
       schema: {
-        action: z.enum(["outline", "read_node", "add_node", "remove_node", "move_node", "set_title", "set_color", "set_collapsed", "set_parent", "set_pin"]).describe("What to do."),
-        id: z.string().optional().describe("Node id (from outline). Required for everything but outline/add_node."),
+        action: z
+          .enum([
+            "outline",
+            "read_node",
+            "inspect",
+            "add_node",
+            "remove_node",
+            "move_node",
+            "duplicate",
+            "select",
+            "fit_view",
+            "set_title",
+            "set_color",
+            "set_node_color",
+            "set_collapsed",
+            "set_node_collapsed",
+            "set_bypassed",
+            "set_parent",
+            "set_pin",
+            "add_note",
+            "set_note",
+            "reroute",
+            "export_graph",
+            "import_graph",
+            "save_named",
+            "load_named",
+            "list_saves",
+            "delete_save",
+            "clear",
+            "reset_demo",
+          ])
+          .describe("What to do."),
+        id: z.string().optional().describe("Node id (from outline). Required for read_node/inspect/remove_node/move_node/set_note and every set_*."),
+        ids: z.array(z.string()).optional().describe("duplicate/select/fit_view: node ids. select with [] clears the selection; fit_view without ids frames the whole graph."),
         kind: z.enum(["scene", "character", "location", "item"]).optional().describe("add_node: what to add."),
-        x: z.number().optional().describe("add_node/move_node: Director graph x."),
-        y: z.number().optional().describe("add_node/move_node: Director graph y."),
+        x: z.number().optional().describe("add_node/move_node/add_note/reroute: Director graph x."),
+        y: z.number().optional().describe("add_node/move_node/add_note/reroute: Director graph y."),
         label: z.string().optional().describe("add_node/set_title: title text."),
-        color: z.string().optional().describe("set_color: hex like #34d399."),
-        collapsed: z.boolean().optional().describe("set_collapsed."),
+        color: z.string().nullable().optional().describe("set_color: hex like #34d399. set_node_color: the same, or null to clear the tint."),
+        collapsed: z.boolean().optional().describe("set_collapsed / set_node_collapsed."),
+        bypassed: z.boolean().optional().describe("set_bypassed: muted or not."),
         parent_id: z.string().nullable().optional().describe("set_parent: Beat id, or null to move to the top level."),
         promoted: z.boolean().optional().describe("set_pin: pinned or not."),
+        text: z.string().optional().describe("add_note/set_note: the note's text (markdown)."),
+        edge_id: z.string().optional().describe("reroute: the wire to drop the dot onto (from outline)."),
+        json: z.string().optional().describe("import_graph: a graph as export_graph returned it."),
+        name: z.string().optional().describe("save_named/load_named/delete_save: the save's name."),
       },
       handler: async (args: A, ctx) => {
         const action = args.action as string;
         const required: Record<string, string[]> = {
           outline: [],
           read_node: ["id"],
+          inspect: ["id"],
           add_node: ["kind", "x", "y"],
           remove_node: ["id"],
           move_node: ["id", "x", "y"],
+          duplicate: ["ids"],
+          select: ["ids"],
+          fit_view: [],
           set_title: ["id", "label"],
           set_color: ["id", "color"],
+          set_node_color: ["id", "color"],
           set_collapsed: ["id", "collapsed"],
+          set_node_collapsed: ["id", "collapsed"],
+          set_bypassed: ["id", "bypassed"],
           set_parent: ["id", "parent_id"],
           set_pin: ["id", "promoted"],
+          add_note: ["x", "y", "text"],
+          set_note: ["id", "text"],
+          reroute: ["edge_id", "x", "y"],
+          export_graph: [],
+          import_graph: ["json"],
+          save_named: ["name"],
+          load_named: ["name"],
+          list_saves: [],
+          delete_save: ["name"],
+          clear: [],
+          reset_demo: [],
         };
         const miss = need(args, action, ...(required[action] ?? []));
         if (miss) return miss;
         const { action: _a, ...rest } = args;
-        return forward(ctx, `director_${action}`, rest, action === "outline" || action === "read_node" ? DIRECTOR_READ_MS : DIRECTOR_WRITE_MS);
+        // Reads are cheap and must not sit on the write budget; everything else can redraw the graph.
+        const READS = new Set(["outline", "read_node", "export_graph", "list_saves"]);
+        return forward(ctx, `director_${action}`, rest, READS.has(action) ? DIRECTOR_READ_MS : DIRECTOR_WRITE_MS);
       },
     },
     {
@@ -289,18 +451,35 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
       description:
         "The Director's Beats. A Beat is a container: `group` wraps node_ids in a new Beat; `promote` turns a Beat into a SUBGRAPH, which exposes every wire crossing its boundary as a named rail; " +
         "`dissolve` turns it back into a plain group; `reconcile` re-derives one Beat's rails. Rails are user-labelled: `set_rail_label` and `reorder_rail` (side in/out, from → to index). " +
-        "Blueprints are reusable Beats: `save_blueprint` a subgraph under a name, `list_blueprints`, `apply_blueprint` to stamp a copy at x,y.",
+        "`delete_container` removes a Beat: mode `all` takes everything inside with it, mode `shell` keeps the children and lifts them out. " +
+        "Blueprints are reusable Beats: `save_blueprint` a subgraph under a name, `list_blueprints`, `apply_blueprint` to stamp a copy at x,y, `update_blueprint` to re-save one from a Beat (id), `delete_blueprint` to drop it.",
       schema: {
-        action: z.enum(["group", "promote", "dissolve", "reconcile", "set_rail_label", "reorder_rail", "save_blueprint", "list_blueprints", "apply_blueprint"]).describe("What to do."),
-        id: z.string().optional().describe("Beat id. Required for promote/dissolve/reconcile/set_rail_label/reorder_rail/save_blueprint."),
+        action: z
+          .enum([
+            "group",
+            "promote",
+            "dissolve",
+            "reconcile",
+            "delete_container",
+            "set_rail_label",
+            "reorder_rail",
+            "save_blueprint",
+            "list_blueprints",
+            "apply_blueprint",
+            "update_blueprint",
+            "delete_blueprint",
+          ])
+          .describe("What to do."),
+        id: z.string().optional().describe("Beat id. Required for promote/dissolve/reconcile/delete_container/set_rail_label/reorder_rail/save_blueprint; optional for update_blueprint (the Beat to re-save from)."),
         node_ids: z.array(z.string()).optional().describe("group: nodes to wrap."),
         label: z.string().optional().describe("group: the new Beat's title; set_rail_label: the new label."),
         port_id: z.string().optional().describe("set_rail_label: the rail's id (from outline)."),
         side: z.enum(["in", "out"]).optional().describe("reorder_rail: which rail."),
         from: z.number().int().optional().describe("reorder_rail: current index."),
         to: z.number().int().optional().describe("reorder_rail: new index."),
+        mode: z.enum(["all", "shell"]).optional().describe("delete_container: `all` deletes the children too, `shell` keeps them."),
         name: z.string().optional().describe("save_blueprint: blueprint name."),
-        blueprint_id: z.string().optional().describe("apply_blueprint: id from list_blueprints."),
+        blueprint_id: z.string().optional().describe("apply_blueprint/update_blueprint/delete_blueprint: id from list_blueprints."),
         x: z.number().optional().describe("apply_blueprint: Director graph x."),
         y: z.number().optional().describe("apply_blueprint: Director graph y."),
       },
@@ -311,11 +490,14 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
           promote: ["id"],
           dissolve: ["id"],
           reconcile: ["id"],
+          delete_container: ["id", "mode"],
           set_rail_label: ["id", "port_id", "label"],
           reorder_rail: ["id", "side", "from", "to"],
           save_blueprint: ["id", "name"],
           list_blueprints: [],
           apply_blueprint: ["blueprint_id", "x", "y"],
+          update_blueprint: ["blueprint_id"],
+          delete_blueprint: ["blueprint_id"],
         };
         const miss = need(args, action, ...(required[action] ?? []));
         if (miss) return miss;
@@ -334,21 +516,32 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
       description:
         "Calliope projects behind the Director. `list` them; `create` one (title, optional idea/genre/tone/target_duration) — then `open` it so the Director's graph shows it; " +
         "`current` says which project the Director's graph has loaded and whether Calliope is reachable; `refresh` re-reads it; `patch` edits title/idea/genre/tone/target_duration/status; `delete` removes a project and everything in it. " +
+        "`set_cover` sets the project's poster image to a produced file's cover_path, or clears it with an explicit null. " +
         "`settings_get` / `settings_set` read and write Calliope's own settings (its ComfyUI URL, queue concurrency, dry_run) — its LLM settings are dead config here: this agent is the only model in the loop.",
       schema: {
-        action: z.enum(["list", "create", "open", "current", "refresh", "patch", "delete", "settings_get", "settings_set"]).describe("What to do."),
-        project_id: z.number().int().optional().describe("open/patch/delete: which project."),
+        action: z.enum(["list", "create", "open", "current", "refresh", "patch", "set_cover", "delete", "settings_get", "settings_set"]).describe("What to do."),
+        project_id: z.number().int().optional().describe("open/patch/set_cover/delete: which project."),
         title: z.string().optional(),
         idea: z.string().optional().describe("The premise, in a sentence or a paragraph."),
         genre: z.string().optional(),
         tone: z.string().optional(),
         target_duration: z.string().optional().describe("e.g. '2 min'."),
         status: z.string().optional().describe("patch: project status."),
+        cover_path: z.string().nullable().optional().describe("set_cover: the poster image's path, or null to clear it."),
         settings: z.record(z.string(), z.unknown()).optional().describe("settings_set: the keys to change."),
       },
       handler: async (args: A, ctx) => {
         const action = args.action as string;
-        const required: Record<string, string[]> = { create: ["title"], open: ["project_id"], patch: ["project_id"], delete: ["project_id"], settings_set: ["settings"] };
+        const required: Record<string, string[]> = {
+          create: ["title"],
+          open: ["project_id"],
+          patch: ["project_id"],
+          // cover_path is required so CLEARING is something the caller said, not something an
+          // omitted field did: `null` is the clear, and there is no way to reach it by accident.
+          set_cover: ["project_id", "cover_path"],
+          delete: ["project_id"],
+          settings_set: ["settings"],
+        };
         const miss = need(args, action, ...(required[action] ?? []));
         if (miss) return miss;
         const body = pick(args, ["title", "idea", "genre", "tone", "target_duration", "status"]);
@@ -365,6 +558,9 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
             return forward(ctx, "director_project_refresh", {}, DIRECTOR_WRITE_MS);
           case "patch":
             return calliope(ctx, "projects", "patch", [args.project_id, body]);
+          case "set_cover":
+            // Explicitly `cover_path`, never `pick`: an omitted key does not clear a column, a null does.
+            return calliope(ctx, "projects", "patch", [args.project_id, { cover_path: args.cover_path ?? null }]);
           case "delete":
             return calliope(ctx, "projects", "delete", [args.project_id]);
           case "settings_get":
@@ -421,7 +617,7 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
       name: "panel_director_scene",
       mountGroup: "director",
       description:
-        "Scenes — the shots. `list` them (with the estimated total duration); `add` one (heading, action, dialog, duration_sec, beat_id, location_id, character_ids, workflow_id, chain_from_prev); `patch` any of those by scene_id; `delete`; " +
+        "Scenes — the shots. `list` them (with the estimated total duration); `add` one (heading, action, dialog, duration_sec, beat_id, location_id, character_ids, workflow_id, chain_from_prev — the create endpoint has no continuity field, so `add` sets it with a follow-up patch and reports the new scene_id); `patch` any of those by scene_id; `delete`; " +
         "`reorder` with the full scene_ids list — order_index IS the timeline, so this is the cut order. `set_prompt` stores the exact video prompt a scene will render with (this agent authors prompts; the draft is stamped against the scene's current text so Calliope honours it — edit the scene text and you must set the prompt again).",
       schema: {
         action: z.enum(["list", "add", "patch", "delete", "reorder", "set_prompt"]).describe("What to do."),
@@ -446,15 +642,35 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
         const required: Record<string, string[]> = { add: ["heading"], patch: ["scene_id"], delete: ["scene_id"], reorder: ["scene_ids"], set_prompt: ["scene_id", "prompt"] };
         const miss = need(args, action, ...(required[action] ?? []));
         if (miss) return miss;
-        const body = pick(args, ["heading", "dialog", "duration_sec", "beat_id", "location_id", "character_ids", "workflow_id", "chain_from_prev", "order_index"]);
+        // `chain_from_prev` is deliberately NOT in this list: Calliope's SceneCreate has no such
+        // field (only SceneUpdate does), so sending it on create is silently dropped by the
+        // endpoint — the continuity flag would read as set and never be.
+        const body = pick(args, ["heading", "dialog", "duration_sec", "beat_id", "location_id", "character_ids", "workflow_id", "order_index"]);
         if (args.action_text !== undefined) body.action = args.action_text;
         switch (action) {
           case "list":
             return calliope(ctx, "scenes", "list", [pid], DIRECTOR_READ_MS);
-          case "add":
-            return calliope(ctx, "scenes", "create", [pid, body]);
+          case "add": {
+            const created = await calliope(ctx, "scenes", "create", [pid, body]);
+            if (created.isError || args.chain_from_prev === undefined) return created;
+            // Two frames, on purpose: create, then patch the one field create cannot carry.
+            const newId = rowIdFromReply(created);
+            if (newId === null) {
+              return {
+                ...created,
+                content: [
+                  ...created.content,
+                  { type: "text" as const, text: 'note: chain_from_prev was NOT applied — the create reply carried no scene id. Set it with action "patch" once you know the id.' },
+                ],
+              };
+            }
+            const chained = await calliope(ctx, "scenes", "patch", [pid, newId, { chain_from_prev: args.chain_from_prev }]);
+            // The scene EXISTS either way — say so, or the agent retries `add` and gets a duplicate.
+            if (chained.isError) return refuse(`scene ${newId} was created, but chain_from_prev could not be set: ${textOf(chained)}`);
+            return text({ scene_id: newId, created: bodyOfReply(created), chain_from_prev: args.chain_from_prev, chained: bodyOfReply(chained) });
+          }
           case "patch":
-            return calliope(ctx, "scenes", "patch", [pid, args.scene_id, body]);
+            return calliope(ctx, "scenes", "patch", [pid, args.scene_id, { ...body, ...pick(args, ["chain_from_prev"]) }]);
           case "delete":
             return calliope(ctx, "scenes", "delete", [pid, args.scene_id]);
           case "reorder":
@@ -505,11 +721,30 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
       name: "panel_director_render",
       mountGroup: "director",
       description:
-        "Rendering through Calliope's queue. `videos_generate` enqueues scene_ids (optionally a workflow_id, input_values, and `prompts` keyed by scene id — the surest way to render exactly the text you wrote); `preview_prompt` shows what a scene would send; `assets_generate` renders portraits and environment images for character_ids/location_ids/item_ids (missing_only by default). " +
-        "`jobs_list` (filter by project_id/status), `job_get`, `job_retry`, `job_cancel`; `queue_status`, `queue_pause`, `queue_resume`. `wait` blocks until the project's jobs settle or timeout_s passes and returns them. `export` concatenates the finished clips into the film. `attach` puts a produced file (path) on a scene, character, location or item.",
+        "Rendering through Calliope's queue. `videos_generate` enqueues scene_ids (optionally a workflow_id, input_values, and `prompts` keyed by scene id — the surest way to render exactly the text you wrote), skipping any scene whose node the user has bypassed unless you pass skip_bypassed false; " +
+        "`render_scene` opens the editor's composer on one scene instead of enqueuing it; `preview_prompt` shows what a scene would send; `assets_generate` renders portraits and environment images for character_ids/location_ids/item_ids (missing_only by default). " +
+        "`jobs_list` (filter by project_id/status), `job_get`, `job_retry`, `job_cancel`; `queue_status`, `queue_pause`, `queue_resume`. `wait` blocks until the project's jobs settle or timeout_s passes and returns them. `export` concatenates the finished clips into the film. " +
+        "`attach` puts a produced file (path) on a scene, character, location or item — it needs the project_id. `playground_jobs` lists the playground's own renders and `playground_delete` removes one with its files.",
       schema: {
         action: z
-          .enum(["videos_generate", "preview_prompt", "assets_generate", "jobs_list", "job_get", "job_retry", "job_cancel", "queue_status", "queue_pause", "queue_resume", "wait", "export", "attach"])
+          .enum([
+            "videos_generate",
+            "render_scene",
+            "preview_prompt",
+            "assets_generate",
+            "jobs_list",
+            "job_get",
+            "job_retry",
+            "job_cancel",
+            "queue_status",
+            "queue_pause",
+            "queue_resume",
+            "wait",
+            "export",
+            "attach",
+            "playground_jobs",
+            "playground_delete",
+          ])
           .describe("What to do."),
         project_id: z.number().int().optional().describe("Required for videos_generate/preview_prompt/assets_generate/wait/export; filters jobs_list."),
         scene_ids: z.array(z.number().int()).optional(),
@@ -527,8 +762,9 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
         status: z.string().optional().describe("jobs_list: filter."),
         limit: z.number().int().optional(),
         timeout_s: z.number().optional().describe("wait: how long to block (default 120, max 600)."),
+        skip_bypassed: z.boolean().optional().describe("videos_generate: leave out scenes whose Director node is bypassed (default true)."),
         path: z.string().optional().describe("attach: the produced file."),
-        target: z.string().optional().describe("attach: scene | character | location | item."),
+        target: z.string().optional().describe("attach: the endpoint's own names — character_sheet | location | item | scene."),
         character_id: z.number().int().optional(),
         location_id: z.number().int().optional(),
         item_id: z.number().int().optional(),
@@ -538,6 +774,7 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
         const action = args.action as string;
         const required: Record<string, string[]> = {
           videos_generate: ["project_id", "scene_ids"],
+          render_scene: ["scene_id"],
           preview_prompt: ["project_id", "scene_id"],
           assets_generate: ["project_id"],
           job_get: ["job_id"],
@@ -545,14 +782,18 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
           job_cancel: ["job_id"],
           wait: ["project_id"],
           export: ["project_id"],
-          attach: ["path", "target"],
+          // PlaygroundAttach declares project_id REQUIRED; omitting it is a 422, not a default.
+          attach: ["path", "target", "project_id"],
+          playground_delete: ["job_id"],
         };
         const miss = need(args, action, ...(required[action] ?? []));
         if (miss) return miss;
         const pid = args.project_id;
         switch (action) {
           case "videos_generate":
-            return calliope(ctx, "jobs", "generateVideos", [pid, pick(args, ["scene_ids", "workflow_id", "input_values", "prompts"])]);
+            return renderVideos(ctx, args);
+          case "render_scene":
+            return forward(ctx, "director_render_scene", { scene_id: args.scene_id }, DIRECTOR_WRITE_MS);
           case "preview_prompt":
             return calliope(ctx, "jobs", "previewPrompt", [pid, pick(args, ["scene_id", "workflow_id"])], DIRECTOR_READ_MS);
           case "assets_generate":
@@ -575,6 +816,12 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
             return calliope(ctx, "jobs", "exportFilm", [pid]);
           case "attach":
             return calliope(ctx, "playground", "attach", [pick(args, ["path", "project_id", "target", "character_id", "location_id", "item_id", "scene_id", "name"])]);
+          case "playground_jobs":
+            // `jobs(limit = 50)` takes a POSITIONAL scalar, not a query object — an omitted
+            // limit must be an absent argument so the client's own default applies.
+            return calliope(ctx, "playground", "jobs", args.limit === undefined ? [] : [args.limit], DIRECTOR_READ_MS);
+          case "playground_delete":
+            return calliope(ctx, "playground", "deleteJob", [args.job_id]);
           default:
             return text(await waitForJobs(ctx, pid as number, typeof args.timeout_s === "number" ? args.timeout_s : 120));
         }

--- a/src/orchestrator/director-tools.ts
+++ b/src/orchestrator/director-tools.ts
@@ -74,22 +74,6 @@ const pick = (args: A, keys: string[]): Record<string, unknown> => {
 
 const ACTIVE_JOB = /^(queued|pending|running|in_progress|processing)$/i;
 
-/** ctx.call wraps the panel's reply as text; the job list is inside it, bare or under `result`/`jobs`. */
-function jobsFromReply(res: ToolResult): Array<Record<string, unknown>> {
-  const first = res.content[0];
-  if (!first || first.type !== "text") return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(first.text);
-  } catch {
-    return [];
-  }
-  const unwrap = (v: unknown): unknown => (v && typeof v === "object" && !Array.isArray(v) ? ((v as Record<string, unknown>).result ?? (v as Record<string, unknown>).jobs ?? v) : v);
-  let v = unwrap(parsed);
-  if (!Array.isArray(v)) v = unwrap(v);
-  return Array.isArray(v) ? (v as Array<Record<string, unknown>>) : [];
-}
-
 /** The `cal-sc-<id>` node ids the editor mints for Calliope scenes — the one bridge from a graph node back to its row. */
 const CAL_SCENE_PREFIX = "cal-sc-";
 
@@ -108,6 +92,15 @@ function bodyOfReply(res: ToolResult): unknown {
   } catch {
     return raw;
   }
+}
+
+/** ctx.call wraps the panel's reply as text; the job list is inside it, bare or under `result`/`jobs`. */
+function jobsFromReply(res: ToolResult): Array<Record<string, unknown>> {
+  const parsed = bodyOfReply(res);
+  const unwrap = (v: unknown): unknown => (v && typeof v === "object" && !Array.isArray(v) ? ((v as Record<string, unknown>).result ?? (v as Record<string, unknown>).jobs ?? v) : v);
+  let v = unwrap(parsed);
+  if (!Array.isArray(v)) v = unwrap(v);
+  return Array.isArray(v) ? (v as Array<Record<string, unknown>>) : [];
 }
 
 /** The nodes array out of an `outline` reply, however the pane wrapped it. */
@@ -326,7 +319,7 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
         "The Director's scene graph — nodes. `outline` returns every node (Scenes, assets, Beats with their rails) and every wire; read it first, ids come from here. " +
         "`read_node` one node in full; `inspect` opens the editor's inspector on it for the user. `add_node` places a Scene / Character / Location / Item at Director graph x,y (dropping inside a Beat joins it) and returns the id the EDITOR minted. " +
         "`remove_node`, `move_node`, `duplicate` (ids → the new ids), `select` (ids, empty clears), `fit_view` (frame ids, or everything), `set_title`, `set_color` (hex, Beats only), " +
-        "`set_node_color` (one leaf's tint; null clears it), `set_collapsed` (subgraphs only), `set_node_collapsed` (collapse a leaf to its header), `set_bypassed` (mute a node: drawn faded and skipped by renders), " +
+        "`set_node_color` (one leaf's tint; null clears it), `set_collapsed` (any Beat — a plain group collapses to a header card with proxy handles), `set_node_collapsed` (collapse a leaf to its header), `set_bypassed` (mute a node: drawn faded and skipped by renders), " +
         "`set_parent` (move a node into a Beat, or out with parent_id null), `set_pin` (show a node on its subgraph's collapsed face — only meaningful inside a subgraph), " +
         "`add_note` / `set_note` (a sticky note at x,y), `reroute` (drop a pass-through dot on a wire at x,y). " +
         "Whole-graph persistence: `export_graph` / `import_graph` (json), `save_named` / `load_named` / `list_saves` / `delete_save` (name), `clear` (empty it), `reset_demo` (back to the demo project). " +
@@ -371,7 +364,7 @@ export function buildDirectorToolDefs(): Array<PanelToolDef & { mountGroup?: Mou
         y: z.number().optional().describe("add_node/move_node/add_note/reroute: Director graph y."),
         label: z.string().optional().describe("add_node/set_title: title text."),
         color: z.string().nullable().optional().describe("set_color: hex like #34d399. set_node_color: the same, or null to clear the tint."),
-        collapsed: z.boolean().optional().describe("set_collapsed / set_node_collapsed."),
+        collapsed: z.boolean().optional().describe("set_collapsed (a Beat) / set_node_collapsed (a leaf)."),
         bypassed: z.boolean().optional().describe("set_bypassed: muted or not."),
         parent_id: z.string().nullable().optional().describe("set_parent: Beat id, or null to move to the top level."),
         promoted: z.boolean().optional().describe("set_pin: pinned or not."),


### PR DESCRIPTION
The editor's drive vocabulary (`ComfyUI_BenjiDirector/docs/drive-commands.md`) grew past what the MCP seam exposed: node chrome, clipboard, selection, notes, reroute, the inspector, whole-graph persistence, container deletion and blueprint edits were reachable by mouse and unreachable by tool. Every one of them lands here as an **action on a tool that already exists** — `DIRECTOR_TOOL_NAMES` stays at ten, `docs/design/panel-surface.txt` is untouched, and the vocabulary ratchet is green.

## What the agent can now drive

**`panel_director_graph`** — `set_bypassed`, `set_node_color` (null clears the tint), `set_node_collapsed`, `duplicate`, `select` (empty clears), `fit_view`, `add_note`, `set_note`, `reroute`, `inspect`, plus whole-graph persistence: `export_graph` / `import_graph` / `save_named` / `load_named` / `list_saves` / `delete_save` / `clear` / `reset_demo`. Each forwards `director_<action>` with the arg names frozen in the editor's doc.

**`panel_director_subgraph`** — `delete_container` (`mode: all | shell`), `update_blueprint` (`blueprint_id`, optional `id`), `delete_blueprint`.

**`panel_director_render`** — `playground_jobs` (`playground.jobs`), `playground_delete` (`playground.deleteJob`), `render_scene` (forwards `director_render_scene`, the composer).

**`panel_director_project`** — `set_cover`.

## Three defects fixed on the way

- **`attach` sent a call the endpoint 422s.** `PlaygroundAttach` declares `project_id` **required**; the tool did not. It is now required, refused before any frame. The `target` describe also now names the endpoint's own enum (`character_sheet | location | item | scene`) instead of a guess that would round-trip as a validation error.
- **`scene add` reported a continuity flag it never set.** Calliope's `SceneCreate` has no `chain_from_prev` — only `SceneUpdate` does — so the field was silently dropped by the endpoint while the tool's reply looked like a success. `add` now creates, reads the minted id out of the reply, and patches the flag in a **second frame**; when the reply carries no id it says the flag did not land rather than implying it did. `patch` still sends it inline, which is where it belongs.
- **`set_cover` could not clear.** `pick()` drops `undefined`, so an omitted field cannot express "clear the column". `set_cover` requires `cover_path` and sends an **explicit null**.

## Bypass is a graph-side fact

`videos_generate` gains `skip_bypassed` (default **true**). A muted node is the user saying "not this shot" on the surface they are looking at, and Calliope cannot see it — the flag lives on the Director's node, not the scene row — so the skip happens at this seam: read `director_outline`, map `cal-sc-<id>` back to the row, drop the muted ids, and **name them in the reply**. A scene that silently did not render is indistinguishable from a queue failure, hence the annotation rather than a quiet filter. Every scene bypassed is a refusal, not an empty enqueue. An unreadable outline renders what was asked and says the check did not run.

## Verification

- `src/__tests__/orchestrator/director-calliope-tools.test.ts` — one frame assertion per new action (25 tests), both frames of the chained `add`, the bypass skip against a mocked outline, the all-bypassed refusal, the unreadable-outline fallback, and the `attach` refusal without `project_id`. A ratchet test pins that the surface is still the same ten tool names.
- **Five mutations, five caught**: the bypass filter neutered; `project_id` dropped from `attach`'s requirements; the chained `add` collapsed to one frame; `playground_jobs` passing `[undefined]` instead of `[]` (the client method takes a positional scalar, so an omitted limit must be an *absent* argument); `set_node_color`'s `color` requirement removed.
- Green: the five targeted vitest files (227 tests), `npm run check:vocabulary`, `npx tsc --noEmit`.
- **Browser e2e skipped for this unit, per the recipe.** The wire these actions ride is already proven end-to-end by `mountable-tools.test.ts`, which drives a real MCP client over an in-memory transport against the real registration pass; what is new here is the *mapping* from (tool, action, args) to one bridge frame, and that is exactly what the frame-pinning tests measure. The editor side of each command is another unit's to land.

## Note for the panel side

`docs/drive-commands.md` changed under this branch while it was being written (U6 widened `set_collapsed` from subgraphs to any Beat); the tool description follows the current doc. Nothing here registers an editor command — if a `director_*` command has not landed yet, the panel answers "unknown cmd" and the tool reports it verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
