### PR TITLE
chore: ignore root agent scratch and vendored node packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,15 @@ orch.err.log
 # Local Discord watchdog/notifier toolkit (token read from ~/.claude.json at runtime; not committed)
 /.discord/
 codex-kp-smoke-orch.log
+
+# Agent scratch at the repo root. A stray `git add -A` once swept 291 of these
+# into a single commit (3ef895f, local-only — never reached any pushed ref).
+# Ignore them so a wide `add` can't sweep them in again.
+/.tmp-*
+/.playwright-mcp/
+
+# Third-party custom-node packs unpacked into the repo root for inspection.
+# They ship their own licenses (Impact Pack is GPL-3.0) and must never land in
+# this MIT-licensed repo. Clone them under the ComfyUI install, not here.
+/ComfyUI-Impact-Pack-Main/
+/ComfyUI-*-Main/


### PR DESCRIPTION
## What this is — and what it is *not*

This PR was opened while investigating a report that commit `3ef895f`
("refactor(1869): simplify tests…") had leaked a GPL-3.0 node pack and ~36 MB of
scratch into the public repo.

**That did not happen.** The investigation is written up below; the only real,
actionable residue is this `.gitignore` hardening.

## Findings

`3ef895f` is a **single orphaned commit**, reachable only from the detached HEAD of
the local main checkout:

- `git for-each-ref --contains 3ef895f` → **no ref**
- `git ls-remote origin` → **0 of 3443 remote refs** point at it
- `git merge-base --is-ancestor 3ef895f origin/main` → **not an ancestor**
- `origin/main` (`b8944fd`) tracks **zero** `ComfyUI-Impact-Pack-Main/` or `.tmp-*` paths

So nothing was ever pushed: no license misrepresentation in the public tree, and no
clone bloat. A fresh clone of `main` is clean. There is nothing to `git rm --cached`.

What *is* true about that commit's tree: 291 unrelated files (102 pack + 189 scratch,
36.4 MB), and `ComfyUI-Impact-Pack-Main/LICENSE.txt` genuinely is GNU GPL v3.

## Why this PR still exists

None of those paths were ignored, so the same wide-`add` accident could recur — and
next time it might land on a branch that gets pushed. This adds root-anchored rules:

| Pattern | Covers |
| --- | --- |
| `/.tmp-*` | agent scratch dirs and files |
| `/.playwright-mcp/` | browser console-log dumps |
| `/ComfyUI-Impact-Pack-Main/`, `/ComfyUI-*-Main/` | third-party packs unpacked for inspection |

The pack rule is the one that matters beyond tidiness: Impact Pack is GPL-3.0 and
this repo is MIT, so a vendored copy would misstate the license of the tree.

## Verification

- `git check-ignore` over the **305** offending paths from `3ef895f` → all 305 ignored.
- `git check-ignore` over all **2026** currently tracked paths → **none** matched, so no
  tracked file changes status.
- Ignore rules never affect already-tracked files, so this is behaviour-neutral for `main`.

## Not done here (owner's call)

History rewrite is **not** needed and is not proposed — there is no published history
containing these files. See the accompanying report for the two things that do want an
owner decision: the main checkout parked in detached HEAD on this orphan commit, and
whether `3ef895f` is worth salvaging or discarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)