### PR TITLE
fix(#925): acknowledge uncorrelatable completion frames

### DIFF
--- a/src/__tests__/orchestrator/completion-receipt.test.ts
+++ b/src/__tests__/orchestrator/completion-receipt.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { buildCompletionReceipt } from "../../orchestrator/completion-receipt.js";
+import { buildCompletionReceipt, canonicalPromptId } from "../../orchestrator/completion-receipt.js";
 
 const PROMPT_ID = "8812d3a2-75e8-4ae5-b4d8-0a5b1e7c9f20";
 const COMPLETION_KEY = JSON.stringify(["route-925", "conversation-925", PROMPT_ID, "nonce-1"]);
 
 describe("#2700 completion receipts", () => {
+  it("canonicalizes a padded prompt id to the key the Panel removes", () => {
+    const padded = ` \t${PROMPT_ID}\n`;
+    const receipt = buildCompletionReceipt(padded, COMPLETION_KEY, false);
+
+    expect(canonicalPromptId(padded)).toBe(PROMPT_ID);
+    expect(receipt?.prompt_id).toBe(PROMPT_ID);
+
+    // This is the Panel-facing operation: its completion ledger is keyed by the
+    // normalized prompt id, and the receipt must remove that exact key.
+    const panelPending = new Map([[PROMPT_ID, true]]);
+    panelPending.delete(receipt?.prompt_id ?? "");
+    expect(panelPending.size).toBe(0);
+  });
+
   it("negatively acknowledges a keyed frame that reached the journal but is uncorrelated", () => {
     expect(buildCompletionReceipt(PROMPT_ID, COMPLETION_KEY, false)).toEqual({
       type: "ack",
@@ -28,6 +42,8 @@ describe("#2700 completion receipts", () => {
 
   it("does not emit a receipt for an incomplete or oversized identity", () => {
     expect(buildCompletionReceipt("", COMPLETION_KEY, false)).toBeUndefined();
+    expect(buildCompletionReceipt(" \t\n ", COMPLETION_KEY, false)).toBeUndefined();
+    expect(canonicalPromptId(" \t\n ")).toBeUndefined();
     expect(buildCompletionReceipt(PROMPT_ID, "", false)).toBeUndefined();
     expect(buildCompletionReceipt(PROMPT_ID, "x".repeat(513), false)).toBeUndefined();
   });

--- a/src/__tests__/orchestrator/completion-receipt.test.ts
+++ b/src/__tests__/orchestrator/completion-receipt.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildCompletionReceipt } from "../../orchestrator/completion-receipt.js";
+
+const PROMPT_ID = "8812d3a2-75e8-4ae5-b4d8-0a5b1e7c9f20";
+const COMPLETION_KEY = JSON.stringify(["route-925", "conversation-925", PROMPT_ID, "nonce-1"]);
+
+describe("#2700 completion receipts", () => {
+  it("negatively acknowledges a keyed frame that reached the journal but is uncorrelated", () => {
+    expect(buildCompletionReceipt(PROMPT_ID, COMPLETION_KEY, false)).toEqual({
+      type: "ack",
+      ok: false,
+      kind: "completion",
+      prompt_id: PROMPT_ID,
+      completion_key: COMPLETION_KEY,
+      reason: "uncorrelated",
+    });
+  });
+
+  it("keeps accepted receipts unchanged and without a failure reason", () => {
+    expect(buildCompletionReceipt(PROMPT_ID, COMPLETION_KEY, true)).toEqual({
+      type: "ack",
+      ok: true,
+      kind: "completion",
+      prompt_id: PROMPT_ID,
+      completion_key: COMPLETION_KEY,
+    });
+  });
+
+  it("does not emit a receipt for an incomplete or oversized identity", () => {
+    expect(buildCompletionReceipt("", COMPLETION_KEY, false)).toBeUndefined();
+    expect(buildCompletionReceipt(PROMPT_ID, "", false)).toBeUndefined();
+    expect(buildCompletionReceipt(PROMPT_ID, "x".repeat(513), false)).toBeUndefined();
+  });
+});

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -308,6 +308,14 @@ describe("#1824 production keyed completion ingress", () => {
       conversation,
     );
     expect(stale.acked).toBe(false);
+    expect(stale.receipt).toEqual({
+      type: "ack",
+      ok: false,
+      kind: "completion",
+      prompt_id: PROMPT_A,
+      completion_key: keyA,
+      reason: "uncorrelated",
+    });
     expect(stale.entry?.correlation.status).toBe("foreign");
     expect(journal.outstanding(tab)).toHaveLength(1);
   });

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -30,6 +30,7 @@ import {
   describe as describeCorrelation,
   type CompletionPayload,
 } from "../../orchestrator/run-completion-journal.js";
+import { buildCompletionReceipt, canonicalPromptId } from "../../orchestrator/completion-receipt.js";
 import { AskAnswerJournalImpl } from "../../orchestrator/ask-answer-journal.js";
 
 let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
@@ -195,7 +196,18 @@ function makeHarness(backend: AgentBackend) {
       typeof payload.completion_key === "string" && payload.completion_key.length > 0
         ? payload.completion_key
         : null;
-    const promptId = typeof payload.prompt_id === "string" ? payload.prompt_id : null;
+    const promptId = canonicalPromptId(payload.prompt_id) ?? null;
+    const canonicalPayload =
+      promptId !== null
+        ? payload.prompt_id === promptId
+          ? payload
+          : { ...payload, prompt_id: promptId }
+        : typeof payload.prompt_id === "string"
+          ? (() => {
+              const { prompt_id: _whitespaceOnlyPromptId, ...withoutPromptId } = payload;
+              return withoutPromptId;
+            })()
+          : payload;
     const alreadyKnown =
       completionKey !== null &&
       promptId !== null &&
@@ -204,20 +216,70 @@ function makeHarness(backend: AgentBackend) {
       alreadyKnown || promptId === null
         ? alreadyKnown
           ? null
-          : journal.record(tab, payload, { conversation })
-        : journal.record(tab, payload, { conversation });
+          : journal.record(tab, canonicalPayload, { conversation })
+        : journal.record(tab, canonicalPayload, { conversation });
     if (entry?.alreadyDelivered) journal.suppressAlreadyDelivered(entry.token);
     const acked =
       completionKey !== null &&
       promptId !== null &&
       journal.acceptsCompletionReceipt(completionKey, promptId, tab, conversation);
+    const receipt = buildCompletionReceipt(promptId, completionKey, acked);
     flush(tab);
-    return { entry, acked };
+    return { entry, acked, receipt };
   };
   return { journal, manager, flush, arrive, arriveProduction };
 }
 
 describe("#1824 production keyed completion ingress", () => {
+  it("canonicalizes padded ingress IDs for journal dedupe and Panel receipt removal", () => {
+    const backend = new ContinuationBackend();
+    const { journal, arriveProduction } = makeHarness(backend);
+    const tab = "tab-padded-1824";
+    const conversation = "orchestrator::claude";
+    const key = JSON.stringify([tab, conversation, PROMPT_A, "generation-padded"]);
+
+    journal.openRun(PROMPT_A, { tabId: tab, conversation, completionKey: key });
+    const first = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: ` \t${PROMPT_A}\n`, completion_key: key },
+      conversation,
+    );
+    expect(first.acked).toBe(true);
+    expect(first.receipt?.prompt_id).toBe(PROMPT_A);
+    expect(first.entry?.payload.prompt_id).toBe(PROMPT_A);
+    expect(first.entry).toBeDefined();
+    journal.ack(first.entry!.token);
+
+    // The same completion replay must hit the acknowledged-key fence rather than
+    // create a second journal entry or require an untrimmed Panel map key.
+    const replay = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: ` ${PROMPT_A} `, completion_key: key },
+      conversation,
+    );
+    expect(replay.entry).toBeNull();
+    expect(replay.receipt?.prompt_id).toBe(PROMPT_A);
+    expect(journal.allOutstanding()).toHaveLength(0);
+  });
+
+  it("rejects a whitespace-only ingress ID without emitting a receipt", () => {
+    const backend = new ContinuationBackend();
+    const { journal, arriveProduction } = makeHarness(backend);
+    const tab = "tab-whitespace-1824";
+    const conversation = "orchestrator::claude";
+    const key = JSON.stringify([tab, conversation, PROMPT_A, "generation-whitespace"]);
+
+    const result = arriveProduction(
+      tab,
+      { kind: "executed", prompt_id: " \t\n ", completion_key: key },
+      conversation,
+    );
+    expect(result.acked).toBe(false);
+    expect(result.receipt).toBeUndefined();
+    expect(result.entry?.correlation.status).toBe("unidentified");
+    expect(journal.allOutstanding()).toHaveLength(1);
+  });
+
   it("ACKs a keyed completion only for the current ticket generation", () => {
     const backend = new ContinuationBackend();
     const { journal, arriveProduction } = makeHarness(backend);

--- a/src/__tests__/orchestrator/run-completion-race.test.ts
+++ b/src/__tests__/orchestrator/run-completion-race.test.ts
@@ -310,6 +310,21 @@ describe("WIRING: the orchestrator offers a completion the moment it arrives (#1
     // …and nothing opens a ticket in between — the whole point is that there is none.
     expect(src.slice(record, flush)).not.toContain("openRun");
   });
+
+  it("#2700: the executed ingress sends a negative receipt when ownership rejects the key", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const src = (await readFile(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8"))
+      .replace(/\r\n/g, "\n");
+    const branchAt = src.indexOf('if (ev.kind === "executed") {');
+    expect(branchAt).toBeGreaterThan(-1);
+    const branchEnd = src.indexOf("return;", branchAt);
+    expect(branchEnd).toBeGreaterThan(branchAt);
+    const branch = src.slice(branchAt, branchEnd);
+
+    expect(branch).toContain("const completionReceipt = buildCompletionReceipt(");
+    expect(branch).toContain("receiptAccepted,");
+    expect(branch).toContain("bridge.push(completionReceipt, event.tab_id)");
+  });
 });
 
 describe("WIRING: panel_run stamps the dispatch time before dispatching (#1327)", () => {

--- a/src/orchestrator/completion-receipt.ts
+++ b/src/orchestrator/completion-receipt.ts
@@ -1,0 +1,42 @@
+/**
+ * Build the panel receipt for a keyed run-completion frame.
+ *
+ * A negative receipt is still an acknowledgement of the panel-to-orchestrator
+ * delivery. It says the frame reached the journal, but its key cannot be
+ * accepted for the current ticket generation. The panel must retire its
+ * transport retry in that case; otherwise it spends its bounded replay budget
+ * repeating a frame the orchestrator already has (#2700, recurrence of #925).
+ */
+export type CompletionReceipt = {
+  type: "ack";
+  ok: boolean;
+  kind: "completion";
+  prompt_id: string;
+  completion_key: string;
+  reason?: "uncorrelated";
+};
+
+export function buildCompletionReceipt(
+  promptId: unknown,
+  completionKey: unknown,
+  accepted: boolean,
+): CompletionReceipt | undefined {
+  if (
+    typeof promptId !== "string" ||
+    promptId.length === 0 ||
+    typeof completionKey !== "string" ||
+    completionKey.length === 0 ||
+    completionKey.length > 512
+  ) {
+    return undefined;
+  }
+
+  return {
+    type: "ack",
+    ok: accepted,
+    kind: "completion",
+    prompt_id: promptId,
+    completion_key: completionKey,
+    ...(accepted ? {} : { reason: "uncorrelated" as const }),
+  };
+}

--- a/src/orchestrator/completion-receipt.ts
+++ b/src/orchestrator/completion-receipt.ts
@@ -16,14 +16,21 @@ export type CompletionReceipt = {
   reason?: "uncorrelated";
 };
 
+/** The prompt-id spelling shared by journal correlation and Panel map keys. */
+export function canonicalPromptId(promptId: unknown): string | undefined {
+  if (typeof promptId !== "string") return undefined;
+  const canonical = promptId.trim();
+  return canonical || undefined;
+}
+
 export function buildCompletionReceipt(
   promptId: unknown,
   completionKey: unknown,
   accepted: boolean,
 ): CompletionReceipt | undefined {
+  const canonicalId = canonicalPromptId(promptId);
   if (
-    typeof promptId !== "string" ||
-    promptId.length === 0 ||
+    canonicalId === undefined ||
     typeof completionKey !== "string" ||
     completionKey.length === 0 ||
     completionKey.length > 512
@@ -35,7 +42,7 @@ export function buildCompletionReceipt(
     type: "ack",
     ok: accepted,
     kind: "completion",
-    prompt_id: promptId,
+    prompt_id: canonicalId,
     completion_key: completionKey,
     ...(accepted ? {} : { reason: "uncorrelated" as const }),
   };

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -281,6 +281,7 @@ import {
   describe as describeCorrelation,
   type CompletionPayload,
 } from "./run-completion-journal.js";
+import { buildCompletionReceipt } from "./completion-receipt.js";
 import {
   RunCompletionIdempotencyFence,
   scheduleRunCompletion,
@@ -5617,17 +5618,17 @@ export async function runPanelOrchestrator(): Promise<void> {
             event.tab_id,
             agentKeyFor(event.tab_id),
           );
-        if (receiptAccepted) {
-          bridge.push(
-            {
-              type: "ack",
-              ok: true,
-              kind: "completion",
-              prompt_id: ev.prompt_id,
-              completion_key: completionKey,
-            },
-            event.tab_id,
-          );
+        // #2700 / Panel #925 recurrence — the frame has reached the journal
+        // even when the ownership gate refuses its receipt. Tell the panel
+        // that explicitly so it retires the transport retry instead of
+        // spending its bounded replay budget on a frame we already hold.
+        const completionReceipt = buildCompletionReceipt(
+          ev.prompt_id,
+          completionKey,
+          receiptAccepted,
+        );
+        if (completionReceipt) {
+          bridge.push(completionReceipt, event.tab_id);
         }
         logger.info(
           entry

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -5611,7 +5611,7 @@ export async function runPanelOrchestrator(): Promise<void> {
           });
         const entry = alreadyKnown
           ? null
-          : RunCompletions.record(event.tab_id, completionPayload as CompletionPayload, {
+          : RunCompletions.record(event.tab_id, blindStrippedCompletion(completionPayload as CompletionPayload), {
               conversation: agentKeyFor(event.tab_id),
             });
         // #2591 — `completion_key` is unavailable on older/replayed panel

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -281,7 +281,7 @@ import {
   describe as describeCorrelation,
   type CompletionPayload,
 } from "./run-completion-journal.js";
-import { buildCompletionReceipt } from "./completion-receipt.js";
+import { buildCompletionReceipt, canonicalPromptId } from "./completion-receipt.js";
 import {
   RunCompletionIdempotencyFence,
   scheduleRunCompletion,
@@ -5586,17 +5586,32 @@ export async function runPanelOrchestrator(): Promise<void> {
           ev.completion_key.length <= 512
             ? ev.completion_key
             : null;
+        const promptId = canonicalPromptId(ev.prompt_id);
+        // Correlation and Panel removal both use the trimmed spelling. Keep the
+        // journal payload on that same representation so a lost-ack replay can
+        // hit the duplicate fence instead of creating a second agent turn.
+        const completionPayload =
+          promptId !== undefined
+            ? ev.prompt_id === promptId
+              ? evForTab
+              : { ...evForTab, prompt_id: promptId }
+            : typeof ev.prompt_id === "string"
+              ? (() => {
+                  const { prompt_id: _whitespaceOnlyPromptId, ...withoutPromptId } = evForTab;
+                  return withoutPromptId;
+                })()
+              : evForTab;
         const alreadyKnown =
           completionKey !== null &&
-          typeof ev.prompt_id === "string" &&
+          promptId !== undefined &&
           RunCompletions.hasCompletionReceipt(completionKey, {
-            promptId: ev.prompt_id,
+            promptId,
             key: event.tab_id,
             conversation: agentKeyFor(event.tab_id),
           });
         const entry = alreadyKnown
           ? null
-          : RunCompletions.record(event.tab_id, evForTab as CompletionPayload, {
+          : RunCompletions.record(event.tab_id, completionPayload as CompletionPayload, {
               conversation: agentKeyFor(event.tab_id),
             });
         // #2591 — `completion_key` is unavailable on older/replayed panel
@@ -5610,11 +5625,10 @@ export async function runPanelOrchestrator(): Promise<void> {
         }
         const receiptAccepted =
           completionKey !== null &&
-          typeof ev.prompt_id === "string" &&
-          ev.prompt_id.length > 0 &&
+          promptId !== undefined &&
           RunCompletions.acceptsCompletionReceipt(
             completionKey,
-            ev.prompt_id,
+            promptId,
             event.tab_id,
             agentKeyFor(event.tab_id),
           );
@@ -5623,7 +5637,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // that explicitly so it retires the transport retry instead of
         // spending its bounded replay budget on a frame we already hold.
         const completionReceipt = buildCompletionReceipt(
-          ev.prompt_id,
+          promptId,
           completionKey,
           receiptAccepted,
         );


### PR DESCRIPTION
## Summary

- fix the current Panel #925 recurrence in the MCP executed-completion ingress
- send an explicit negative `kind:"completion"` receipt when the keyed frame is journaled but ownership correlation rejects it
- keep the existing positive receipt and invalid-identity behavior unchanged
- add executable receipt coverage and executed-path wiring coverage

Panel #925 is the reporter-facing recurrence. The owning defect is tracked upstream as MCP #2700: the Panel replay budget is intentionally bounded, but current MCP 0.52.169 still left a journaled, uncorrelatable keyed completion without any receipt. The negative receipt tells the Panel to retire that transport retry while MCP retains the completion for its normal undetermined delivery path.

## Validation

- focused Vitest: 4 files, 131 tests passed
- `npm run build`: passed
- `npm run test:vitest`: 13,910 passed, 6 skipped; 2 unrelated timing failures in `src/__tests__/orchestrator/late-mutation-e2e.test.ts` and `src/__tests__/services/panel-image-relay.test.ts`
- `npm run lint`: `tsc --noEmit` passed; anti-slop could not start because `oxlint/package.json` is absent from the resolved worktree dependencies

No merge performed.