### PR TITLE
fix-panel-run-recover-full-graph-queued-receipts

### DIFF
--- a/src/__tests__/orchestrator/run-late-ack-reconcile.test.ts
+++ b/src/__tests__/orchestrator/run-late-ack-reconcile.test.ts
@@ -29,6 +29,7 @@ import {
   buildPanelToolDefs,
   makePanelToolCtx,
   RETRY_TOKEN_CMDS,
+  __panelRunTestHooks,
   __panelToolsTestHooks,
   type PanelToolCtx,
   type ToolResult,
@@ -81,6 +82,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  __panelRunTestHooks.setGotPromptLinesProbe(null);
   __panelToolsTestHooks.setRunLateAckGraceMs(null);
   for (const s of sockets.splice(0)) s.close();
   await bridge.stop();
@@ -147,6 +149,49 @@ function scriptRunPanel(
   return { rids, lateReplySent };
 }
 
+/** A current Panel full-graph shape: the bounded command returns queued_unknown,
+ * then the at-least-once receipt outbox reports the exact /prompt id later. */
+function scriptQueuedUnknownThenReceipt(
+  sock: WebSocket,
+  receiptDelayMs: number,
+): { rids: string[]; receiptSent: Promise<void> } {
+  const rids: string[] = [];
+  let markSent: () => void = () => {};
+  const receiptSent = new Promise<void>((resolve) => (markSent = resolve));
+  sock.on("message", (buf) => {
+    const msg = JSON.parse(buf.toString()) as { rid?: string; cmd?: string };
+    if (typeof msg.rid !== "string" || msg.cmd !== "graph_run") return;
+    const rid = msg.rid;
+    rids.push(rid);
+    setTimeout(() => {
+      sock.send(
+        JSON.stringify({
+          rid,
+          ok: true,
+          result: {
+            queued_unknown: true,
+            indeterminate_count: 1,
+            inFlight: 1,
+            error: "queuePrompt did not answer within the Panel command budget",
+          },
+        }),
+      );
+    }, 0);
+    setTimeout(() => {
+      sock.send(
+        JSON.stringify({
+          type: "run_receipt",
+          run_rid: rid,
+          prompt_id: "p-full-late-receipt",
+          completion_key: JSON.stringify(["tab-full-late-receipt", "prompt-full-late-receipt"]),
+        }),
+      );
+      markSent();
+    }, receiptDelayMs);
+  });
+  return { rids, receiptSent };
+}
+
 /**
  * The REAL ctx with one property shortened: panel_run passes an EXPLICIT 20 000 ms
  * to ctx.call, so unlike the #694 e2e a default cannot be lowered — the value is
@@ -175,6 +220,27 @@ async function settle(): Promise<void> {
 }
 
 describe("panel_run reconciles a late graph_run acknowledgement (#1175)", () => {
+  it("full-graph queued_unknown waits for the exact Panel receipt (#2143)", async () => {
+    // A Panel full-graph command can answer with this uncertainty body before
+    // its run_receipt outbox has delivered the prompt id.
+    // There is no safe queue-id inference here: only the rid-correlated Panel
+    // receipt may turn this into a queued run.
+    __panelRunTestHooks.setGotPromptLinesProbe(async () => []);
+    const sock = await connectPanel("tab-full-late-receipt");
+    const panel = scriptQueuedUnknownThenReceipt(sock, 250);
+    const ctx = fastCtx("tab-full-late-receipt");
+
+    const res = await panelRun().handler({}, ctx);
+    const text = textOf(res);
+
+    expect(res.isError, `expected the exact receipt to recover the run, got: ${text}`).toBeFalsy();
+    expect(text).toContain("p-full-late-receipt");
+    expect(text).toContain("[RECOVERED]");
+    expect(text).toContain("notified automatically");
+    expect(panel.rids).toHaveLength(1);
+    await panel.receiptSent;
+  });
+
   it("THE REPORT: a run acked after the bound is reported as queued, not unknown", async () => {
     const sock = await connectPanel("tab-late-run");
     const panel = scriptRunPanel(sock, { queued: true, prompt_id: "p-late-1" }, 250);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -19026,9 +19026,11 @@ function runLateAckGraceMs(): number {
  *
  * Returns null when there is nothing to reconcile. The negatives are deliberate:
  *
- *  - NOT an unacked post-write (timeout or disconnect), or the Panel's explicit
- *    id-less queued_unknown receipt (#1728) ⇒ nothing to wait for.
- *    Gated on the bridge's own typed marks, never on message text: an acked
+ *  - A `queued_unknown` with no exact receipt and no scoped queue-attribution
+ *    contract ⇒ nothing to claim. Full-graph uncertainty waits only for the
+ *    bridge's rid-correlated `run_receipt`; scoped uncertainty may additionally
+ *    use its existing bounded queue observation. Gated on the bridge's own typed
+ *    marks, never on message text: an acked
  *    panel error can quote our timeout/OUTCOME UNKNOWN sentence verbatim
  *    (#1468 round 2), and the difference is whether the tab answered, which
  *    only the bridge knows.
@@ -19076,9 +19078,10 @@ async function reconcileLateRunAck(
   res: ToolResult,
   rid: string | undefined,
   preRunningPromptId?: string | null,
-  allowPanelQueueUnknown = false,
+  allowPanelQueueUnknownReceipt = false,
   expectedTabId?: string,
   expectedPromptCount = 1,
+  allowQueueUnknownInference = false,
 ): Promise<{
   result: unknown;
   lateByMs: number;
@@ -19094,10 +19097,15 @@ async function reconcileLateRunAck(
   // id-less-only below.
   const receiptEligible =
     Boolean(rid) &&
-    ((allowPanelQueueUnknown && isPanelQueueUncertainty(parsed)) ||
+    ((allowPanelQueueUnknownReceipt && isPanelQueueUncertainty(parsed)) ||
       isReplyTimeoutResult(res) ||
       isMidCommandDisconnectResult(res));
-  const queueEligible = isUnackedGraphRunResult(res, allowPanelQueueUnknown);
+  // A run_receipt is exact Panel evidence for BOTH full and scoped runs. Queue
+  // observation is weaker: only the scoped Panel contract makes a new queue id
+  // attributable to this dispatch. Keep those authorities separate so enabling
+  // full-graph receipt recovery cannot turn a foreign back-to-back render into
+  // this run's prompt id.
+  const queueEligible = isUnackedGraphRunResult(res, allowQueueUnknownInference);
   if (!receiptEligible && !queueEligible) return null;
   const fromQueue = (): {
     result: unknown;
@@ -23280,11 +23288,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             res,
             runRid,
             pre.runningPromptId,
-            typeof args.to_node_id === "number",
+            // #2143 — queued_unknown is receipt-recoverable for full graph runs
+            // too. Only exact run_receipt evidence is allowed there; the weaker
+            // QueueMonitor inference remains scoped-run-only below.
+            true,
             runTicketTab,
             typeof args.batch_count === "number"
               ? Math.max(1, Math.min(64, Math.floor(args.batch_count)))
               : 1,
+            typeof args.to_node_id === "number",
           );
           if (!recovered) return;
           for (const entry of recovered.completionKeys ?? []) {


### PR DESCRIPTION
Fixes #2143. Allow exact rid-correlated Panel run_receipt recovery for full-graph queued_unknown responses while keeping queue observation inference scoped-only. Adds a real UiBridge regression covering receipt recovery and no redispatch.
