### PR TITLE
chore: release v0.52.171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.171] - 2026-09-02
+
+### MCP
+
+#### Fixed
+- recover full-graph `panel_run` queued-unknown responses from an exact rid-correlated Panel receipt without inferring a foreign queue prompt (#2143, #2732)
+
+
 ## [0.52.170] - 2026-09-01
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.170",
+  "version": "0.52.171",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.170",
+      "version": "0.52.171",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.170",
+  "version": "0.52.171",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Summary

Release-only bump for v0.52.171 based on merged PR #2732 at origin/main 6728343f73a4b5955f36197305a2dd32e14643de.

- Bump package.json and package-lock.json to 0.52.171.
- Add the MCP changelog entry for exact rid-correlated full-graph Panel receipt recovery in #2143 / #2732.
- No tool-surface, docs, vocabulary, source, init.py, or pps_routes.py changes.

## Validation

Passed locally: 
pm ci, 
pm run lint (including anti-slop), 
pm run build, 
pm run docs:gen (no content delta), direct changelog guard, i18n/docs/blog checks, asset counts, vocabulary, unknown-collapse, and vocabulary export.

Known blocker: 
pm test completed with 754 Vitest files passed and 1 failed (13,915 passed, 6 skipped): src/__tests__/services/panel-image-relay.test.ts:466 observed 	imeoutMs === 0 where the unchanged baseline test expects a positive value. 
pm test exited 1; no unrelated fix is included.

Not run locally at checkpoint: 
ode scripts/smoke-install.mjs (Pack & install smoke; GitHub CI is pending). No MCP-local YARA executable or YARA workflow/check exists in this repository; that gate is unavailable here and is not claimed as passed.

Scope audit: exactly CHANGELOG.md, package.json, and package-lock.json differ from origin/main. No merge, tag, or publish performed.