### PR TITLE
fix(codex): retry graph read after panel_open_workflow

### DIFF
--- a/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
+++ b/src/__tests__/orchestrator/codex-mcp-reconnect.test.ts
@@ -120,6 +120,7 @@ interface Drive {
       | "scrubbed-transport"
       | "event-notification-transport"
       | "unrelated-transport"
+      | "panel-read-retry-after-open-workflow-success"
       | "panel-read-retry-outline-success"
       | "panel-read-retry-query-success"
       | "panel-read-retry-find-success"
@@ -271,14 +272,25 @@ function startDrive(opts: {
         const notify = (method: string, params: Record<string, unknown>) =>
           client.notificationHandler?.({ method, params: { threadId: "thread-1", turnId, ...params } });
         const enter = { type: "mcpToolCall", id: "enter-1", server: "panel", tool: "panel_enter_subgraph" };
+        const openWorkflow = {
+          type: "mcpToolCall",
+          id: "open-workflow-1",
+          server: "panel",
+          tool: "panel_open_workflow",
+        };
         if (
           kind !== "panel-read-no-enter-no-retry" &&
+          kind !== "panel-read-retry-after-open-workflow-success" &&
           kind !== "panel-read-retry-after-run-find-success" &&
           kind !== "panel-run-no-retry" &&
           kind !== "panel-run-worker-transport-no-retry"
         ) {
           notify("item/started", { item: enter });
           notify("item/completed", { item: { ...enter, status: "completed" } });
+        }
+        if (kind === "panel-read-retry-after-open-workflow-success") {
+          notify("item/started", { item: openWorkflow });
+          notify("item/completed", { item: { ...openWorkflow, status: "completed" } });
         }
         if (kind === "panel-mutation-no-retry") {
           const mutation = { type: "mcpToolCall", id: "mutation-1", server: "panel", tool: "panel_set_property" };
@@ -389,6 +401,7 @@ function startDrive(opts: {
               willRetry: true,
             });
             if (
+              kind === "panel-read-retry-after-open-workflow-success" ||
               kind === "panel-read-retry-outline-success" ||
               kind === "panel-read-retry-query-success" ||
               kind === "panel-read-retry-find-success"
@@ -493,8 +506,25 @@ describe("Codex mid-session MCP drop reconnects panel tools (#1524)", () => {
     );
     expect([...PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS]).toEqual([
       "panel_enter_subgraph",
+      "panel_open_workflow",
       "panel_run",
     ]);
+  });
+
+  it("retries a live panel_graph_outline once after panel_open_workflow (#2286)", async () => {
+    const drive = startDrive({ listings: [PANEL_UP] });
+    await drive.endTurn("panel-read-retry-after-open-workflow-success");
+
+    expect(drive.reloadCalls).toBe(0);
+    expect(drive.interruptCalls).toBe(0);
+    expect(drive.events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(
+      drive.events.filter(
+        (e) => e.type === "error" && !(e as { sessionNotice?: boolean }).sessionNotice,
+      ),
+    ).toHaveLength(0);
+
+    await drive.finish();
   });
 
   it("retries a live panel_graph_outline once after panel_enter_subgraph (#2395)", async () => {

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -636,11 +636,13 @@ export const PANEL_OUTER_TRANSPORT_RETRY_SAFE_TOOLS = new Set([
   "panel_get_errors",
 ]);
 
-// Completing these can leave the Codex HTTP MCP client in a racy state.
+// Completing these can leave the Codex HTTP MCP client in a racy state (notably
+// the read immediately following a successful panel_open_workflow).
 // Arm a one-shot window for the immediate next allowlisted read. The tools
-// themselves stay off the retry allowlist so a failed enter or run is fenced.
+// themselves stay off the retry allowlist so a failed arm operation is fenced.
 export const PANEL_OUTER_TRANSPORT_RETRY_ARM_TOOLS = new Set([
   "panel_enter_subgraph",
+  "panel_open_workflow",
   "panel_run",
 ]);
 
@@ -1755,11 +1757,12 @@ export class CodexBackend implements AgentBackend {
     let immediatePanelReadAfterArm: string | null = null;
 
     // Retry contract: only the next panel request after a successful
-    // panel_enter_subgraph or panel_run completion can be an eligible graph
-    // read. The one-shot sequence is consumed at request start; a mutation or
-    // unrelated panel request therefore invalidates it before a later read can
-    // qualify. Correlation must resolve the transport error to that request;
-    // ambiguity is fail-closed. Mutations and unrelated reads use normal fencing.
+    // panel_enter_subgraph, panel_open_workflow, or panel_run completion can be
+    // an eligible graph read. The one-shot sequence is consumed at request
+    // start; a mutation or unrelated panel request therefore invalidates it
+    // before a later read can qualify. Correlation must resolve the transport
+    // error to that request; ambiguity is fail-closed. Mutations and unrelated
+    // reads use normal fencing.
 
     // LIVENESS (watchdog re-arm): re-arm PanelAgent's idle watchdog ONLY for
     // notifications that represent work or an outcome for THIS active turn. A


### PR DESCRIPTION
## Summary

- Arm the existing one-shot outer Codex HTTP-MCP retry window after a successful panel_open_workflow.
- Retry only the immediate idempotent panel_graph_outline read when Codex reports the correlated transport failure.
- Keep panel_open_workflow itself outside the retry allowlist, so an opaque failed workflow switch is never replayed.

The current recurrence was reproduced in the Codex backend test seam: without this guard, the exact open-workflow -> graph-outline sequence took the reload/fence path; with it, the read completes without reload or turn replay. This is an MCP-side fix; no Panel companion is needed.

## Validation

- Focused + adjacent: 48 passed (codex-mcp-reconnect.test.ts, panel-mcp-stale-session.test.ts)
- Build: passed
- git diff --check: passed
- Full npm test: 13/14 checks passed; Vitest 13,915 passed, 6 skipped, with two unrelated pre-existing failures in late-mutation-e2e.test.ts and panel-image-relay.test.ts
- npm run lint: TypeScript passed; anti-slop/YARA-parity step blocked because this worktree lacks the oxlint package
- Protected Python files unchanged

Fixes #2286