### PR TITLE
chore: release v0.52.172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.172] - 2026-09-02
+
+### MCP
+
+#### Fixed
+- retry graph reads after `panel_open_workflow` when the initial panel response is incomplete (#2286, #2734)
+
+
 ## [0.52.171] - 2026-09-02
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.171",
+  "version": "0.52.172",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.171",
+      "version": "0.52.172",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.171",
+  "version": "0.52.172",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release-only version bump and changelog for 0.52.172. Includes the post-0.52.171 panel_open_workflow graph-read fix (#2286, #2734). Local build, lint, release checks, artifact checks, and pack/install smoke passed. Full Vitest parallel run had 2 timing-sensitive failures, but the two affected files passed on targeted rerun (50/50). npm audit reports existing dependency advisories; no dependencies changed. Do not merge until hosted CI completes.