### PR TITLE
fix(2068): bind Panel restart to dynamic local target

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -54,6 +54,12 @@ import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 // The orchestrator's immutable boot endpoint — what the decline-probe and the
 // refuse-safe preflight bind to when the tab provably fronts our boot instance.
 const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+const dynamicTargetUrl = new URL(BOOT_BASE);
+dynamicTargetUrl.port = String(
+  Number(dynamicTargetUrl.port || (dynamicTargetUrl.protocol === "https:" ? 443 : 80)) + 1,
+);
+dynamicTargetUrl.pathname = "";
+const DYNAMIC_PANEL_BASE = dynamicTargetUrl.toString().replace(/\/+$/, "");
 
 const text = (res: ToolResult): string =>
   res.content.find((c) => c.type === "text")!.text as string;
@@ -151,6 +157,7 @@ afterEach(() => {
   __panelToolsTestHooks.setPanelRebootTiming(null);
   __panelToolsTestHooks.setHealthProbe(null);
   __panelToolsTestHooks.setLocalRestartPreflight(null);
+  __panelToolsTestHooks.setVerifiedProxyRestartTarget(null);
   __panelToolsTestHooks.setDeclineProbeTiming(null);
   __processControlTestHooks.reset();
   hoistedConfig.configBase.value = null;
@@ -952,6 +959,50 @@ describe("panel_restart_comfyui — identity is resolved BEFORE the confirmation
     expect(out.rebooting).toBe(false);
     expect(out.confirmed_cycle).toBe(false);
     expect(String(out.note)).toMatch(/cannot tell which server the restart would stop/i);
+  });
+
+  it("#2068 authorizes a concrete local dynamic-port target through the Panel path", async () => {
+    // The Panel has already passed the hello target-resolution gate, so the
+    // mutable target and the server-observed WebSocket Origin identify the same
+    // concrete loopback instance. The immutable MCP boot endpoint is different;
+    // this must permit only the authenticated relative Panel reboot, without
+    // inventing a health-probe or headless-restart binding.
+    hoistedConfig.configBase.value = DYNAMIC_PANEL_BASE;
+    __panelToolsTestHooks.setVerifiedProxyRestartTarget(async () => undefined);
+    const preflight = vi.fn(async () => ({ ok: true }));
+    const healthProbe = vi.fn(async () => "healthy" as const);
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    __panelToolsTestHooks.setHealthProbe(healthProbe);
+    const { ctx, sends } = makeCtx({ confirm: "yes", serverOrigin: DYNAMIC_PANEL_BASE });
+    const confirm = vi.fn(async () => "yes" as const);
+    ctx.confirm = confirm;
+
+    const out = parse(await restartTool().handler({}, ctx));
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(preflight).toHaveBeenCalledOnce();
+    expect(healthProbe).not.toHaveBeenCalled();
+    expect(sends.filter((cmd) => cmd.cmd === "comfy_reboot")).toHaveLength(1);
+    expect(out.rebooting).toBe(true);
+    expect(out.ready).toBe(false);
+    expect(out.confirmed_cycle).toBe(false);
+    expect(out.note).toMatch(/no local boot endpoint/i);
+  });
+
+  it("#2068 keeps the dynamic exception fail-closed when the server Origin differs", async () => {
+    hoistedConfig.configBase.value = DYNAMIC_PANEL_BASE;
+    __panelToolsTestHooks.setVerifiedProxyRestartTarget(async () => undefined);
+    const preflight = vi.fn(async () => ({ ok: true }));
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    const { ctx, sends } = makeCtx({ confirm: "yes", serverOrigin: BOOT_BASE });
+    const confirm = vi.fn(async () => "yes" as const);
+    ctx.confirm = confirm;
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(preflight).not.toHaveBeenCalled();
+    expect(sends).toEqual([]);
+    expect(out.refused).toBe(true);
   });
 
   it("a refused restart keeps the live tab and reports one terminal state, not a reconnect", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3429,6 +3429,30 @@ function proxyTargetBindsPanel(
   );
 }
 
+/**
+ * A live local Panel can safely own a Manager reboot even when the MCP process
+ * started before the Panel selected a different loopback port (for example,
+ * ComfyUI Desktop's dynamic port). This is a DISPATCH-ONLY binding:
+ *
+ *  - the target must be a concrete loopback URL;
+ *  - the socket must have arrived on the server-trusted local listener; and
+ *  - the server-observed WebSocket Origin must identify the current target.
+ *
+ * The result must never be used as the MCP health-probe or headless-restart
+ * target. Those paths still require the immutable boot target from
+ * captureRebootHealthBase/configuredBootRestartBase. The Panel's own
+ * authenticated relative Manager request is the only reboot authority this
+ * exception grants (#2068).
+ */
+function currentPanelRestartTarget(ctx: PanelToolCtx): string | null {
+  if (ctx.bridge?.tabIsLocal?.(ctx.tabId) !== true) return null;
+  const target = getComfyUIBaseUrl().replace(/\/+$/, "");
+  if (!target || !isLoopbackOrigin(target)) return null;
+  const observedOrigin = ctx.bridge?.tabServerOrigin?.(ctx.tabId);
+  if (!sameHttpBase(observedOrigin, target)) return null;
+  return target;
+}
+
 /** Test injection for the #742 decline-probe recheck window, so tests don't
  *  wait the real ~6s. null → the DECLINE_PROBE_* constants. */
 let declineProbeTimingOverride: {
@@ -26507,6 +26531,11 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // awaits. The proxy is never treated as a ComfyUI process; it only lets
         // the tab-scoped Manager request be observed against the immutable backend.
         let proxyRestartTarget: VerifiedProxyRestartTarget | undefined;
+        // #2068: a Panel may front a concrete local Desktop port selected after
+        // this MCP process started. This binding authorizes only the Panel's
+        // authenticated relative Manager dispatch; it is never a health or
+        // headless-restart target.
+        let panelRestartTarget: string | undefined;
         // #1819: resolve instance identity BEFORE the confirmation card. Asking the
         // user to confirm a restart, then refusing because we cannot tell which
         // ComfyUI this tab fronts, is two contradictory outcomes (timeout vs refuse)
@@ -26526,11 +26555,14 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             if (proxyTargetBindsPanel(ctx, candidate)) {
               proxyRestartTarget = candidate;
             }
+            if (proxyRestartTarget == null) {
+              panelRestartTarget = currentPanelRestartTarget(ctx) ?? undefined;
+            }
             const tabStillHere =
               typeof ctx.bridge?.canReach === "function"
                 ? ctx.bridge.canReach(ctx.tabId) === true
                 : true;
-            if (tabStillHere && proxyRestartTarget == null) {
+            if (tabStillHere && proxyRestartTarget == null && panelRestartTarget == null) {
               return restartRefusedPreservingBinding(
                 ctx,
                 unboundLocalRestartRefusalNote(ctx, identityHealthBase, identityBinding.blocker),
@@ -27321,11 +27353,19 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             ? refreshedProxy
             : undefined;
         }
+        if (proxyRestartTarget == null && panelRestartTarget != null) {
+          const refreshedPanelTarget = currentPanelRestartTarget(ctx);
+          panelRestartTarget =
+            refreshedPanelTarget != null && sameHttpBase(refreshedPanelTarget, panelRestartTarget)
+              ? refreshedPanelTarget
+              : undefined;
+        }
         const preflightBinding = resolveRebootHealthBinding(ctx);
         const preflightHealthBase =
-          proxyRestartTarget?.backendBase ?? preflightBinding.base;
+          proxyRestartTarget?.backendBase ?? panelRestartTarget ?? preflightBinding.base;
         const preflightBound =
           proxyRestartTarget != null ||
+          panelRestartTarget != null ||
           (preflightHealthBase != null &&
             sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase));
         // #848: what the instance was OBSERVED running with, taken from the preflight
@@ -27392,10 +27432,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           }
           ctx.ensureReachable?.();
           const postPreflightHealthBase = captureRebootHealthBase(ctx);
+          const postPreflightPanelTarget =
+            panelRestartTarget != null ? currentPanelRestartTarget(ctx) : null;
           const tabFrontsSameInstance =
             proxyRestartTarget != null ||
-            (postPreflightHealthBase != null &&
-              sameHttpBase(preflightHealthBase, postPreflightHealthBase));
+            (panelRestartTarget != null
+              ? postPreflightPanelTarget != null &&
+                sameHttpBase(preflightHealthBase, postPreflightPanelTarget)
+              : postPreflightHealthBase != null &&
+                sameHttpBase(preflightHealthBase, postPreflightHealthBase));
           const configStable =
             proxyRestartTarget != null
               ? getComfyuiTargetGeneration() === proxyRestartTarget.generation
@@ -27488,6 +27533,13 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             preflightArgvGeneration = proxyRestartTarget.generation;
           }
         }
+        if (proxyRestartTarget == null && panelRestartTarget != null) {
+          const dispatchPanelTarget = currentPanelRestartTarget(ctx);
+          panelRestartTarget =
+            dispatchPanelTarget != null && sameHttpBase(dispatchPanelTarget, panelRestartTarget)
+              ? dispatchPanelTarget
+              : undefined;
+        }
         const healthBase =
           proxyRestartTarget?.backendBase ?? captureRebootHealthBase(ctx);
         // THE BINDING RULE APPLIES AT THE DISPATCH POINT, NOT ONLY BEFORE THE AWAIT.
@@ -27504,7 +27556,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // instance this server accounts for is refused.
         const dispatchBound =
           proxyRestartTarget != null ||
-          (healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase));
+          (healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase)) ||
+          (panelRestartTarget != null &&
+            sameHttpBase(getComfyUIBaseUrl(), panelRestartTarget));
         if (!dispatchBound && !isRemoteMode() && !isCloudMode()) {
           return restartRefusedPreservingBinding(
             ctx,


### PR DESCRIPTION
## Summary

- Fixes the Panel #2068 recurrence where MCP's immutable boot target differs from the concrete local ComfyUI Desktop port selected by Panel.
- Binds the exception only to the current server-observed WebSocket Origin and local loopback target, revalidating after confirmation, preflight, and immediately before dispatch.
- Keeps confirmation, authenticated Panel-relative Manager reboot, immutable boot-target health/headless binding, generation fences, and fail-closed refusal behavior intact.
- Adds acceptance and mismatched-Origin regression coverage.

## Validation

- Focused restart suites: 4 files, 91 tests passed.
- `npm run build` passed.
- `npm run lint` passed: 785 known anti-slop findings, none added.
- Vocabulary, unknown-collapse, i18n, docs-links, changelog, diff, and Python scope guards passed.
- Full Vitest was attempted; it encountered unrelated baseline failures in `late-mutation-e2e.test.ts` and `package-hooks.test.ts` and was stopped after continuing through long-running tests.
- YARA executable is not installed in this environment; no Python files changed, including `__init__.py` and `py/apps_routes.py`.

References: artokun/comfyui-mcp-panel#2068