### PR TITLE
chore: release v0.52.173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.173] - 2026-09-02
+
 ### MCP
 
 #### Fixed
-- artokun-flow installs the SAM3 checkpoint its REPLACEMENT MODE subgraph requires, saves with VHS_VideoCombine (an OUTPUT_NODE), and honors the requested artokun/comfyui-teskors-utils git origin instead of Manager teskor-hub alias (#2523)
+- artokun-flow installs the SAM3 checkpoint its REPLACEMENT MODE subgraph requires, saves with VHS_VideoCombine (an OUTPUT_NODE), and honors the requested artokun/comfyui-teskors-utils git origin instead of Manager teskor-hub alias (#2523, #2657)
+- panel restart binds to the dynamic local target instead of a stale fixed origin (#2068, #2737)
 
 ## [0.52.172] - 2026-09-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.172",
+  "version": "0.52.173",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.172",
+      "version": "0.52.173",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.172",
+  "version": "0.52.173",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Summary

- Bump package metadata to 0.52.173.
- Publish changelog entries for merged fixes #2523/#2657 and #2068/#2737.
- Release base is origin/main at 14d617ba953ef9c75319257a867ca5bd5476d2ca.

## Validation

- npm ci
- npm run lint
- npm run build
- npm test (756 files passed; 13,931 tests passed; 6 skipped)
- npm run check:vocabulary
- npm run check:unknown-collapse
- npm run vocab:export -- --check
- node scripts/asset-counts.mjs --check
- node scripts/validate-manifests.mjs
- node scripts/check-pack-models.mjs (0 errors; 102 baseline warnings)
- node scripts/check-model-urls.mjs (407/407)
- npm run docs:gen freshness check
- npm run packs:gen freshness check
- node scripts/smoke-install.mjs
- node scripts/check-changelog.mjs

## Known local baseline/tool gaps

- npm audit reports 5 existing vulnerabilities (1 low, 1 moderate, 3 high).
- scripts/test-packs.sh stops at ernie-combo because the generated installer invokes real python3 -m pip install librosa in this Windows environment.
- shellcheck is not installed on this Windows host.
- No __init__.py or py/apps_routes.py files exist in the release tree; no such files were changed.

Do not merge automatically; this PR is for hosted release validation.