### PR TITLE
chore: release v0.52.174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.174] - 2026-09-02
+
 ### MCP
 
 #### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.173",
+  "version": "0.52.174",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.173",
+      "version": "0.52.174",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.173",
+  "version": "0.52.174",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Summary
- prepare MCP v0.52.174 from origin/main
- document merged #2526 / PR #2655 get_image relative-subfolder filename fix
- bump package.json and package-lock.json consistently

## Validation
- docs:gen: no-op
- npm run lint: passed
- npm run build: passed
- npm test: passed (756 files; 13,937 passed, 6 skipped)
- node scripts/check-changelog.mjs 0.52.174: passed
- npm run packs:validate: passed
- node scripts/smoke-install.mjs: passed
- no changes to init.py or apps_routes.py

Do not merge/tag/publish from this PR.