### PR TITLE
chore: release v0.52.176

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.176] - 2026-09-02
+
+### MCP
+
+#### Fixed
+- make wan-multitalk workflow runnable (#2702)
+
+
 ## [0.52.175] - 2026-09-02
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.175",
+  "version": "0.52.176",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.175",
+      "version": "0.52.176",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.175",
+  "version": "0.52.176",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Release v0.52.176\n\n- Bump package.json and package-lock.json to 0.52.176.\n- Add the generated CHANGELOG.md entry for #2702 (wan-multitalk workflow).\n\nValidation completed in the isolated release worktree:\n- npm ci\n- npm run lint\n- npm run build\n- npm test (all checks passed; exit 0)\n- npm run packs:validate\n- npm run check:vocabulary\n- npm run check:unknown-collapse\n- npm run check:anti-slop\n- npm run vocab:export -- --check\n- node scripts/asset-counts.mjs --check\n- npm run docs:gen (no substantive docs diff)\n- node scripts/smoke-install.mjs\n- node scripts/check-changelog.mjs\n- git diff --check\n\nDo not merge or tag as part of this PR.