### PR TITLE
Release v0.52.177

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.177] - 2026-09-02
+
+### MCP
+
+#### Fixed
+- **`node_pack` accepts documented pack-relative paths for git operations (#2716).**
+  Paths are now resolved against the selected pack before the existing jail
+  containment checks, so entries such as `preset_core.py` no longer resolve
+  from `custom_nodes/` and get rejected as outside the pack.
+
 ## [0.52.176] - 2026-09-02
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.176",
+  "version": "0.52.177",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.176",
+      "version": "0.52.177",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.176",
+  "version": "0.52.177",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Release v0.52.177\n\n- Base: 47a610b6fc40930e323f8d9ed6b108f40774edc4 (origin/main)\n- Release commit: 9dd43b4\n- Includes the #2716 changelog entry for documented pack-relative node_pack git paths.\n- Changes are limited to package.json, package-lock.json, and CHANGELOG.md.\n\nValidation: npm ci, lint, build, docs generation/no-op, changelog/version guards, vocabulary/assets/unknown-collapse checks, pack validation/generation/no-op, npm pack dry-run, pack/install smoke, and focused panel-image-relay tests passed. The full local npm test run had 13,985 passing tests and 6 skipped, with one timing-sensitive pre-existing panel-image-relay failure under the concurrent Windows run; the focused file rerun passed 45/45.\n\nDo not merge or tag as part of this PR preparation.