### PR TITLE
fix: support IPv6-only ComfyUI loopback targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- support IPv6-only loopback ComfyUI listeners when `COMFYUI_URL` uses `127.0.0.1` (#2719)
+
 ## [0.52.177] - 2026-09-02
 
 ### MCP

--- a/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
+++ b/src/__tests__/comfyui/fetch-image-panel-fallback.test.ts
@@ -59,7 +59,9 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         calls.push({ input, init });
         const url = String(input);
-        if (url.startsWith(HEADLESS)) throw transportFailure();
+        if (url.startsWith(HEADLESS) || url.startsWith("http://localhost:8000")) {
+          throw transportFailure();
+        }
         return imageResponse();
       }),
     );
@@ -68,11 +70,34 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
       base64: "AQID",
       mimeType: "image/jpeg",
     });
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(3);
     expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
-    expect(String(calls[1].input)).toContain(`${PANEL}/comfyapi/view?`);
+    expect(String(calls[1].input)).toContain("http://localhost:8000/comfyapi/view?");
+    expect(String(calls[2].input)).toContain(`${PANEL}/comfyapi/view?`);
     expect(new Headers(calls[0].init?.headers).get("authorization")).toBe("Bearer headless-token");
-    expect(calls[1].init?.headers).toBeUndefined();
+    expect(calls[2].init?.headers).toBeUndefined();
+  });
+
+  it("retries a refused manual /view request at IPv6-capable localhost", async () => {
+    setConnectedPanelFallbackOrigins(() => []);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({ input, init });
+        if (String(input).startsWith(HEADLESS)) throw transportFailure();
+        const response = imageResponse();
+        Object.defineProperty(response, "url", { value: String(input) });
+        return response;
+      }),
+    );
+
+    await expect(fetchImage("render.png")).resolves.toEqual({
+      base64: "AQID",
+      mimeType: "image/jpeg",
+    });
+    expect(calls).toHaveLength(2);
+    expect(String(calls[1].input)).toContain("http://localhost:8000/comfyapi/view?");
+    expect(calls[1].init?.redirect).toBe("manual");
   });
 
   it("does not guess when multiple different panel origins are connected", async () => {
@@ -89,10 +114,10 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     expect(err.message).toContain("I did NOT retry against a connected panel");
     expect(err.message).toContain("127.0.0.1:8188");
     expect(err.message).toContain("localhost:8189");
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
   });
 
-  it("does not retry a loopback alias of the failed target", async () => {
+  it("does not use a connected panel that is only the loopback alias", async () => {
     setConnectedPanelFallbackOrigins(() => ["http://localhost:8000"]);
     vi.stubGlobal(
       "fetch",
@@ -103,7 +128,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     );
 
     await expect(fetchImage("render.png")).rejects.toThrow(/fetch failed/);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
   });
 
   it("keeps a panel response's HTTP error classified as an image error", async () => {
@@ -112,7 +137,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
         calls.push({ input });
-        if (calls.length === 1) throw transportFailure();
+        if (calls.length <= 2) throw transportFailure();
         return imageResponse(404);
       }),
     );
@@ -122,7 +147,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     );
     expect(err.code).toBe("IMAGE_NOT_FOUND");
     expect(err.message).toContain(`at ${PANEL}`);
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(3);
   });
 
   it("does not retry a timeout as if it were a dead target", async () => {
@@ -158,7 +183,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     );
 
     await expect(fetchImage("render.png")).rejects.toThrow(/malformed, unsupported, remote, or otherwise unsafe/);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
   });
 
   it("does not follow a cross-origin redirect from the panel", async () => {
@@ -167,7 +192,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         calls.push({ input, init });
-        if (calls.length === 1) throw transportFailure();
+        if (calls.length <= 2) throw transportFailure();
         return new Response(null, {
           status: 302,
           headers: { location: "https://evil.example/collect" },
@@ -176,9 +201,9 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     );
 
     await expect(fetchImage("render.png")).rejects.toMatchObject({ code: "VIEW_REDIRECT_UNSAFE" });
-    expect(calls).toHaveLength(2);
-    expect(calls[1].init?.redirect).toBe("manual");
-    expect(calls[1].init?.signal).toBeInstanceOf(AbortSignal);
+    expect(calls).toHaveLength(3);
+    expect(calls[2].init?.redirect).toBe("manual");
+    expect(calls[2].init?.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("uses manual redirects for the configured target too", async () => {
@@ -252,7 +277,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     );
 
     await expect(fetchImage("forged.png")).rejects.toThrow(/fetch failed/);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
     expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
   });
 
@@ -270,7 +295,7 @@ describe("fetchImage connected-panel fallback (#2149)", () => {
     );
 
     await expect(fetchImage("render.png", "output", "shots")).rejects.toThrow(/fetch failed/);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
     expect(String(calls[0].input)).toContain(`${HEADLESS}/comfyapi/view?`);
   });
 });

--- a/src/__tests__/comfyui/fetch.test.ts
+++ b/src/__tests__/comfyui/fetch.test.ts
@@ -107,6 +107,35 @@ describe("comfyuiFetch", () => {
     await expect(retry.text()).resolves.toBe(JSON.stringify({ prompt: "p" }));
   });
 
+  it("tees a stream body so a refused literal attempt can be retried", async () => {
+    authHeaders.mockReturnValue({});
+    const response = new Response("ok");
+    fetchMock.mockImplementationOnce(async () => {
+      const firstInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      await new Response(firstInit.body as BodyInit).text();
+      throw undiciFailure("ECONNREFUSED");
+    });
+    fetchMock.mockResolvedValueOnce(response);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"prompt":"stream"}'));
+        controller.close();
+      },
+    });
+
+    await expect(
+      comfyuiFetch("http://127.0.0.1:8188/prompt", {
+        method: "POST",
+        body,
+      }),
+    ).resolves.toBe(response);
+
+    const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    await expect(new Response(retryInit.body as BodyInit).text()).resolves.toBe(
+      '{"prompt":"stream"}',
+    );
+  });
+
   it.each([
     ["localhost", "http://localhost:8188/view", undiciFailure("ECONNREFUSED")],
     ["a different loopback address", "http://127.0.0.2:8188/view", undiciFailure("ECONNREFUSED")],

--- a/src/__tests__/comfyui/fetch.test.ts
+++ b/src/__tests__/comfyui/fetch.test.ts
@@ -87,6 +87,26 @@ describe("comfyuiFetch", () => {
     expect((retryInit as RequestInit).signal).toBe((firstInit as RequestInit).signal);
   });
 
+  it("replays a Request body only after the literal target is refused", async () => {
+    authHeaders.mockReturnValue({});
+    const response = new Response("ok");
+    fetchMock.mockRejectedValueOnce(undiciFailure("ECONNREFUSED")).mockResolvedValueOnce(response);
+    const input = new Request("http://127.0.0.1:8188/prompt", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "p" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await expect(comfyuiFetch(input)).resolves.toBe(response);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const first = fetchMock.mock.calls[0]?.[0] as Request;
+    const retry = fetchMock.mock.calls[1]?.[0] as Request;
+    expect(first.url).toBe("http://127.0.0.1:8188/prompt");
+    expect(retry.url).toBe("http://localhost:8188/prompt");
+    await expect(retry.text()).resolves.toBe(JSON.stringify({ prompt: "p" }));
+  });
+
   it.each([
     ["localhost", "http://localhost:8188/view", undiciFailure("ECONNREFUSED")],
     ["a different loopback address", "http://127.0.0.2:8188/view", undiciFailure("ECONNREFUSED")],

--- a/src/__tests__/comfyui/fetch.test.ts
+++ b/src/__tests__/comfyui/fetch.test.ts
@@ -8,6 +8,12 @@ vi.mock("../../config.js", () => ({
 
 import { comfyuiFetch } from "../../comfyui/fetch.js";
 
+function undiciFailure(code: string): TypeError {
+  return new TypeError("fetch failed", {
+    cause: Object.assign(new Error(`connect ${code}`), { code }),
+  });
+}
+
 describe("comfyuiFetch", () => {
   const fetchMock = vi.fn(async () => new Response("ok"));
 
@@ -60,5 +66,39 @@ describe("comfyuiFetch", () => {
     });
     const [, init] = fetchMock.mock.calls[0];
     expect(new Headers((init as RequestInit).headers).get("Authorization")).toBe("Bearer explicit");
+  });
+
+  it("retries a manual redirect request through localhost after a bare IPv4 refusal", async () => {
+    authHeaders.mockReturnValue({});
+    const response = new Response("ok");
+    fetchMock.mockRejectedValueOnce(undiciFailure("ECONNREFUSED")).mockResolvedValueOnce(response);
+
+    await expect(
+      comfyuiFetch("http://127.0.0.1:8188/view?filename=out.png", { redirect: "manual" }),
+    ).resolves.toBe(response);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [firstUrl, firstInit] = fetchMock.mock.calls[0];
+    const [retryUrl, retryInit] = fetchMock.mock.calls[1];
+    expect(firstUrl).toBe("http://127.0.0.1:8188/view?filename=out.png");
+    expect(retryUrl).toBe("http://localhost:8188/view?filename=out.png");
+    expect((firstInit as RequestInit).redirect).toBe("manual");
+    expect((retryInit as RequestInit).redirect).toBe("manual");
+    expect((retryInit as RequestInit).signal).toBe((firstInit as RequestInit).signal);
+  });
+
+  it.each([
+    ["localhost", "http://localhost:8188/view", undiciFailure("ECONNREFUSED")],
+    ["a different loopback address", "http://127.0.0.2:8188/view", undiciFailure("ECONNREFUSED")],
+    ["a remote target", "https://comfy.example/view", undiciFailure("ECONNREFUSED")],
+    ["a non-refused transport error", "http://127.0.0.1:8188/view", undiciFailure("ECONNRESET")],
+    ["a non-bare fetch error", "http://127.0.0.1:8188/view", new Error("fetch failed after sending")],
+  ])("does not retry %s when the manual request is outside the narrow gate", async (_label, target, failure) => {
+    authHeaders.mockReturnValue({});
+    fetchMock.mockRejectedValueOnce(failure);
+
+    await comfyuiFetch(target, { redirect: "manual" }).catch(() => undefined);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_PANEL_BRIDGE_PORT } from "../services/bridge-ports.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 
 // config.ts has top-level await (port auto-detect). Use vi.resetModules() so
 // each test re-evaluates it with a fresh process.env.
@@ -129,6 +131,67 @@ describe("config mode detection", () => {
     process.env.COMFYUI_PORT = "8188";
     const mod = await import("../config.js");
     expect(mod.getInstanceSlug()).toBe("comfy-cloud");
+  });
+});
+
+describe("IPv6 loopback ComfyUI targets (#2719)", () => {
+  const OLD_ENV = process.env;
+  const OLD_ARGV = process.argv;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    process.argv = [...OLD_ARGV];
+    process.env.COMFYUI_API_KEY = "";
+    process.env.COMFYUI_PATH = "";
+    process.env.COMFYUI_CODE_PATH = "";
+    process.env.COMFYUI_HOST = "";
+    process.env.COMFYUI_MCP_FORCE_REMOTE = "";
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    process.argv = OLD_ARGV;
+    vi.restoreAllMocks();
+  });
+
+  async function listenIPv6Only(): Promise<{ server: ReturnType<typeof createServer>; port: number }> {
+    const server = createServer((_req, res) => res.end("ipv6-only-ok"));
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "::1", () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("IPv6 server did not expose an address");
+    return { server, port: address.port };
+  }
+
+  it("uses a dual-family localhost connection for a legacy IPv4 loopback URL", async () => {
+    const { server, port } = await listenIPv6Only();
+    try {
+      process.env.COMFYUI_URL = `http://127.0.0.1:${port}`;
+      const mod = await import("../config.js");
+
+      expect(mod.getComfyUIApiHost()).toBe(`127.0.0.1:${port}`);
+      expect(mod.getComfyUIBaseUrl()).toBe(`http://127.0.0.1:${port}`);
+      await expect(comfyuiFetch(`${mod.getComfyUIBaseUrl()}/system_stats`)).resolves.toMatchObject({ status: 200 });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("keeps an explicit IPv6 loopback target valid for URL consumers", async () => {
+    const { server, port } = await listenIPv6Only();
+    try {
+      process.env.COMFYUI_URL = `http://[::1]:${port}`;
+      const mod = await import("../config.js");
+
+      expect(mod.getComfyUIApiHost()).toBe(`[::1]:${port}`);
+      expect(mod.getComfyUIBaseUrl()).toBe(`http://[::1]:${port}`);
+      await expect(fetch(`${mod.getComfyUIBaseUrl()}/system_stats`)).resolves.toMatchObject({ status: 200 });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });
 
@@ -471,7 +534,7 @@ describe("getLocalComfyuiUrl (#269 LAN fallback)", () => {
     expect(mod.setComfyuiTarget("http://192.168.1.50:8188")).toBe(true);
     expect(mod.setComfyuiTarget("http://127.0.0.1:8188")).toBe(true);
     expect(mod.getComfyuiTargetGeneration()).toBe(g0 + 2);
-    expect(mod.getComfyUIBaseUrl()).toBe("http://127.0.0.1:8188"); // base looks "unchanged"
+    expect(mod.getComfyUIBaseUrl()).toBe("http://127.0.0.1:8188"); // base keeps configured identity
     // A rejected (malformed) retarget does NOT bump.
     expect(mod.setComfyuiTarget("not a url")).toBe(false);
     expect(mod.getComfyuiTargetGeneration()).toBe(g0 + 2);
@@ -535,7 +598,7 @@ describe("rescopeLocalTargetFile (#1909 non-default loopback port)", () => {
     expect(mod.getLocalComfyuiUrl()).toBe(configured);
     // Restart identity reads these — they must name the configured instance
     // or panel_restart_comfyui still refuses a panel that is on that port.
-    expect(mod.getBootLocalComfyUIBaseUrl()).toBe(configured);
+    expect(mod.getBootLocalComfyUIBaseUrl()).toBe("http://127.0.0.1:18188");
     expect(mod.getComfyUIBaseUrl()).toBe(configured);
   });
 
@@ -556,7 +619,7 @@ describe("rescopeLocalTargetFile (#1909 non-default loopback port)", () => {
     const scoped = join(fakeHome, `local-target-${DEFAULT_PANEL_BRIDGE_PORT}.json`);
     mod.rescopeLocalTargetFile(scoped);
     expect(writtenUrl(scoped)).toBe(configured);
-    expect(mod.getBootLocalComfyUIBaseUrl()).toBe(configured);
+    expect(mod.getBootLocalComfyUIBaseUrl()).toBe("http://127.0.0.1:18188");
   });
 
   it("keeps :8188 when that is the configured loopback URL", async () => {

--- a/src/__tests__/orchestrator/probeok-hoisting.test.ts
+++ b/src/__tests__/orchestrator/probeok-hoisting.test.ts
@@ -3,8 +3,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { probeOk } from "../../orchestrator/probe-ok.js";
 import { judgeHelloRetarget } from "../../services/hello-retarget.js";
-import * as cfg from "../../config.js";
-import { formatComfyUIUrl } from "../../transport/comfyui-url.js";
+import { comfyuiFetch } from "../../comfyui/fetch.js";
 
 const INDEX = readFileSync(
   fileURLToPath(new URL("../../orchestrator/index.ts", import.meta.url)),
@@ -17,6 +16,7 @@ const PROBE_SRC = readFileSync(
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -57,18 +57,14 @@ function asJsDeclaration(tsFn: string): string {
 }
 
 type HelloOrdering = (
-  fetchImpl: typeof fetch,
-  headers: () => Record<string, string>,
-  formatUrl: (url: string) => string,
+  comfyuiFetchImpl: typeof comfyuiFetch,
 ) => Promise<boolean>;
 
 function helloOrdering(declarationJs: string): HelloOrdering {
   // Same order as the bug: the hello path builds `probe: (u) => probeOk(u, 3_000)`
   // and invokes it BEFORE source evaluation would reach a later `const`.
   return new Function(
-    "fetch",
-    "getComfyUIAuthHeaders",
-    "formatComfyUIUrl",
+    "comfyuiFetch",
     `"use strict";
      const probe = (u) => probeOk(u, 3_000);
      const pending = probe("http://example.test/system_stats");
@@ -118,9 +114,9 @@ describe("probeOk hoisting (#2425)", () => {
   });
 
   it("returns true when the URL answers, and forwards configured auth headers", async () => {
-    vi.spyOn(cfg, "getComfyUIAuthHeaders").mockReturnValue({ Authorization: "Bearer t" });
+    vi.stubEnv("COMFYUI_AUTH_TOKEN", "t");
     const fetch = vi.fn(async (_url: string, init?: RequestInit) => {
-      expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer t");
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer t");
       return { ok: true };
     });
     vi.stubGlobal("fetch", fetch);
@@ -147,9 +143,10 @@ describe("probeOk hoisting (#2425)", () => {
     const tsFn = extractAsyncFunction(PROBE_SRC, "probeOk");
     const fnJs = asJsDeclaration(tsFn);
     const okFetch = (async () => ({ ok: true })) as typeof fetch;
-    const headers = () => ({});
+    const comfyuiFetchImpl = (async (url: string, init?: RequestInit) =>
+      okFetch(url, init)) as typeof comfyuiFetch;
 
-    await expect(helloOrdering(fnJs)(okFetch, headers, formatComfyUIUrl)).resolves.toBe(true);
+    await expect(helloOrdering(fnJs)(comfyuiFetchImpl)).resolves.toBe(true);
 
     const constJs = fnJs.replace(
       /^async function probeOk\s*\(([^)]*)\)\s*/,
@@ -158,7 +155,7 @@ describe("probeOk hoisting (#2425)", () => {
     expect(constJs, "mutant must be the const-arrow form that shipped in 0.52.139").toMatch(
       /^const probeOk = async \(/,
     );
-    expect(() => helloOrdering(constJs)(okFetch, headers)).toThrow(
+    expect(() => helloOrdering(constJs)(comfyuiFetchImpl)).toThrow(
       /Cannot access 'probeOk' before initialization/,
     );
   });

--- a/src/__tests__/orchestrator/probeok-hoisting.test.ts
+++ b/src/__tests__/orchestrator/probeok-hoisting.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { probeOk } from "../../orchestrator/probe-ok.js";
 import { judgeHelloRetarget } from "../../services/hello-retarget.js";
 import * as cfg from "../../config.js";
+import { formatComfyUIUrl } from "../../transport/comfyui-url.js";
 
 const INDEX = readFileSync(
   fileURLToPath(new URL("../../orchestrator/index.ts", import.meta.url)),
@@ -58,6 +59,7 @@ function asJsDeclaration(tsFn: string): string {
 type HelloOrdering = (
   fetchImpl: typeof fetch,
   headers: () => Record<string, string>,
+  formatUrl: (url: string) => string,
 ) => Promise<boolean>;
 
 function helloOrdering(declarationJs: string): HelloOrdering {
@@ -66,6 +68,7 @@ function helloOrdering(declarationJs: string): HelloOrdering {
   return new Function(
     "fetch",
     "getComfyUIAuthHeaders",
+    "formatComfyUIUrl",
     `"use strict";
      const probe = (u) => probeOk(u, 3_000);
      const pending = probe("http://example.test/system_stats");
@@ -146,7 +149,7 @@ describe("probeOk hoisting (#2425)", () => {
     const okFetch = (async () => ({ ok: true })) as typeof fetch;
     const headers = () => ({});
 
-    await expect(helloOrdering(fnJs)(okFetch, headers)).resolves.toBe(true);
+    await expect(helloOrdering(fnJs)(okFetch, headers, formatComfyUIUrl)).resolves.toBe(true);
 
     const constJs = fnJs.replace(
       /^async function probeOk\s*\(([^)]*)\)\s*/,

--- a/src/__tests__/services/instance-witness.test.ts
+++ b/src/__tests__/services/instance-witness.test.ts
@@ -49,7 +49,7 @@ describe("acquireInstanceWitness", () => {
     const witness = await acquireInstanceWitness(`http://127.0.0.1:${port}`);
 
     expect(witness).toBeDefined();
-    expect(witness?.url.startsWith(`ws://localhost:${port}/ws?clientId=`)).toBe(true);
+    expect(witness?.url.startsWith(`ws://127.0.0.1:${port}/ws?clientId=`)).toBe(true);
     expect(witness?.alive()).toBe(true);
     witness?.close();
   });

--- a/src/__tests__/services/instance-witness.test.ts
+++ b/src/__tests__/services/instance-witness.test.ts
@@ -22,13 +22,13 @@ afterEach(async () => {
   );
 });
 
-async function startServer(): Promise<{ wss: WebSocketServer; base: string }> {
-  const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+async function startServer(host = "127.0.0.1"): Promise<{ wss: WebSocketServer; base: string; port: number }> {
+  const wss = new WebSocketServer({ port: 0, host });
   servers.push(wss);
   await new Promise<void>((resolve) => wss.on("listening", resolve));
   const address = wss.address();
   if (typeof address === "string" || !address) throw new Error("no address");
-  return { wss, base: `http://127.0.0.1:${address.port}` };
+  return { wss, base: `http://${host === "::1" ? "[::1]" : host}:${address.port}`, port: address.port };
 }
 
 describe("acquireInstanceWitness", () => {
@@ -40,6 +40,17 @@ describe("acquireInstanceWitness", () => {
     expect(witness).toBeDefined();
     expect(witness?.alive()).toBe(true);
     expect(witness?.closedAt()).toBeUndefined();
+    witness?.close();
+  });
+
+  it("connects a legacy IPv4 loopback URL to an IPv6-only listener", async () => {
+    const { port } = await startServer("::1");
+
+    const witness = await acquireInstanceWitness(`http://127.0.0.1:${port}`);
+
+    expect(witness).toBeDefined();
+    expect(witness?.url.startsWith(`ws://localhost:${port}/ws?clientId=`)).toBe(true);
+    expect(witness?.alive()).toBe(true);
     witness?.close();
   });
 

--- a/src/__tests__/services/panel-status-base-path.test.ts
+++ b/src/__tests__/services/panel-status-base-path.test.ts
@@ -52,7 +52,7 @@ describe("fetchPanelBasePath (#296)", () => {
     expect(out).toBe("C:/Users/me/ComfyUI");
     const call = statusCall(fetchMock);
     expect(call, "status GET should have been made").toBeTruthy();
-    expect(String(call?.[0])).toBe("http://localhost:8188/comfyui_mcp_panel/status");
+    expect(String(call?.[0])).toBe("http://127.0.0.1:8188/comfyui_mcp_panel/status");
     // A GET (no explicit method / no POST body), not a mutation.
     const init = (call as [string, RequestInit | undefined])[1];
     expect(init?.method ?? "GET").toBe("GET");
@@ -108,7 +108,7 @@ describe("fetchPanelBasePath (#296)", () => {
     await fetchPanelBasePath("http://127.0.0.1:8188");
 
     const init = (statusCall(fetchMock) as [string, RequestInit])[1];
-    expect(init.headers).toMatchObject({ Authorization: "Bearer abc123" });
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer abc123");
   });
 
   it("returns undefined on a non-2xx status (no consumer error)", async () => {

--- a/src/__tests__/services/panel-status-base-path.test.ts
+++ b/src/__tests__/services/panel-status-base-path.test.ts
@@ -52,6 +52,7 @@ describe("fetchPanelBasePath (#296)", () => {
     expect(out).toBe("C:/Users/me/ComfyUI");
     const call = statusCall(fetchMock);
     expect(call, "status GET should have been made").toBeTruthy();
+    expect(String(call?.[0])).toBe("http://localhost:8188/comfyui_mcp_panel/status");
     // A GET (no explicit method / no POST body), not a mutation.
     const init = (call as [string, RequestInit | undefined])[1];
     expect(init?.method ?? "GET").toBe("GET");

--- a/src/__tests__/services/secure-bridge-auth.test.ts
+++ b/src/__tests__/services/secure-bridge-auth.test.ts
@@ -44,11 +44,10 @@ describe("advertiseBridge auth headers", () => {
 
     expect(ok).toBe(true);
     const [, init] = advertiseCall(fetchMock);
-    expect(init.headers).toMatchObject({
-      "Content-Type": "application/json",
-      "CF-Access-Client-Id": "cid.access",
-      "CF-Access-Client-Secret": "csecret",
-    });
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("CF-Access-Client-Id")).toBe("cid.access");
+    expect(headers.get("CF-Access-Client-Secret")).toBe("csecret");
   });
 
   it("also forwards COMFYUI_AUTH_TOKEN alongside CF Access", async () => {
@@ -62,11 +61,10 @@ describe("advertiseBridge auth headers", () => {
     await advertiseBridge("https://podid-3000.proxy.runpod.net", "wss://relay/?token=t");
 
     const [, init] = advertiseCall(fetchMock);
-    expect(init.headers).toMatchObject({
-      Authorization: "Bearer abc123",
-      "CF-Access-Client-Id": "cid.access",
-      "CF-Access-Client-Secret": "csecret",
-    });
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer abc123");
+    expect(headers.get("CF-Access-Client-Id")).toBe("cid.access");
+    expect(headers.get("CF-Access-Client-Secret")).toBe("csecret");
   });
 
   it("no auth configured → advertise POST carries only Content-Type (no regression)", async () => {
@@ -77,7 +75,7 @@ describe("advertiseBridge auth headers", () => {
     await advertiseBridge("https://podid-3000.proxy.runpod.net", "wss://relay/?token=t");
 
     const [, init] = advertiseCall(fetchMock);
-    expect(init.headers).toEqual({ "Content-Type": "application/json" });
+    expect([...new Headers(init.headers).entries()]).toEqual([["content-type", "application/json"]]);
   });
 
   it("carries local_url so the pack can follow the bound loopback port (#2030)", async () => {

--- a/src/__tests__/transport/comfyui-url.test.ts
+++ b/src/__tests__/transport/comfyui-url.test.ts
@@ -1,7 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { parseComfyUIUrl } from "../../transport/comfyui-url.js";
+import {
+  formatComfyUIConnectionHost,
+  formatComfyUIHost,
+  formatComfyUIUrl,
+  parseComfyUIUrl,
+} from "../../transport/comfyui-url.js";
 
 describe("parseComfyUIUrl", () => {
+  it("formats URL authorities without changing configured identity", () => {
+    expect(formatComfyUIHost("127.0.0.1")).toBe("127.0.0.1");
+    expect(formatComfyUIConnectionHost("127.0.0.1")).toBe("localhost");
+    expect(formatComfyUIHost("[::1]")).toBe("[::1]");
+    expect(formatComfyUIHost("2001:db8::1")).toBe("[2001:db8::1]");
+    expect(formatComfyUIUrl("http://127.0.0.1:8189/api")).toBe("http://localhost:8189/api");
+    expect(formatComfyUIUrl("http://192.168.1.50:8189/api")).toBe("http://192.168.1.50:8189/api");
+  });
+
+  it("parses an IPv6 loopback URL", () => {
+    expect(parseComfyUIUrl("http://[::1]:8189")).toEqual({
+      host: "[::1]",
+      port: 8189,
+      ssl: false,
+      basePath: "",
+    });
+  });
+
   it("parses http with explicit port", () => {
     expect(parseComfyUIUrl("http://127.0.0.1:8188")).toEqual({
       host: "127.0.0.1",

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1,4 +1,5 @@
 import { Client } from "@stable-canvas/comfyui-client";
+import { formatComfyUIUrl } from "../transport/comfyui-url.js";
 import {
   config,
   getComfyUIApiHost,
@@ -109,15 +110,29 @@ function requireLocalComfyUI(op: string): void {
 
 let clientInstance: Client | null = null;
 
+/** Keep the SDK's HTTP URL/diagnostic target literal while making its WS dial
+ * follow the same IPv6-only loopback fallback as the direct WS clients. */
+function connectionWebSocket(): typeof WebSocket | undefined {
+  const NativeWebSocket = globalThis.WebSocket;
+  if (!NativeWebSocket) return undefined;
+  return class ComfyUIConnectionWebSocket extends NativeWebSocket {
+    constructor(url: string | URL, protocols?: string | string[] | WebSocketInit) {
+      super(formatComfyUIUrl(String(url)), protocols);
+    }
+  };
+}
+
 export function getClient(): Client {
   requireLocalMode("getClient");
   if (!clientInstance) {
+    const ws = connectionWebSocket();
     clientInstance = new Client({
       api_host: getComfyUIApiHost(),
       // Path prefix for reverse-proxied / gateway'd ComfyUI (e.g. "/comfyapi").
       api_base: getComfyUIBasePath(),
       ssl: config.comfyuiSsl,
       clientId: "comfyui-mcp",
+      ...(ws ? { WebSocket: ws } : {}),
       // Inject generic auth headers (COMFYUI_AUTH_*) on the library's own HTTP
       // calls; a no-op when unset. Node 22+ provides global WebSocket.
       //

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1,5 +1,5 @@
 import { Client } from "@stable-canvas/comfyui-client";
-import { formatComfyUIUrl } from "../transport/comfyui-url.js";
+import { LoopbackWebSocket } from "../transport/loopback-websocket.js";
 import {
   config,
   getComfyUIApiHost,
@@ -111,16 +111,11 @@ function requireLocalComfyUI(op: string): void {
 
 let clientInstance: Client | null = null;
 
-/** Keep the SDK's HTTP URL/diagnostic target literal while making its WS dial
- * follow the same IPv6-only loopback fallback as the direct WS clients. */
+/** Keep the SDK's configured URL literal until a refused loopback dial proves
+ * that Node should retry through its IPv6-capable localhost resolver. */
 function connectionWebSocket(): typeof WebSocket | undefined {
-  const NativeWebSocket = globalThis.WebSocket;
-  if (!NativeWebSocket) return undefined;
-  return class ComfyUIConnectionWebSocket extends NativeWebSocket {
-    constructor(url: string | URL, protocols?: string | string[] | WebSocketInit) {
-      super(formatComfyUIUrl(String(url)), protocols);
-    }
-  };
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- the SDK's DOM WebSocket type is wider than this Node adapter's runtime-compatible surface
+  return LoopbackWebSocket as unknown as typeof WebSocket;
 }
 
 export function getClient(): Client {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -26,6 +26,7 @@ import {
   raceAbort,
 } from "./fetch.js";
 import { isKnownLoaderInput } from "./loader-asset-inputs.js";
+import { sameOrigin } from "../utils/origin.js";
 import {
   choosePanelFallbackOrigin,
   describeDeclinedPanelFallback,
@@ -1567,7 +1568,10 @@ export const MAX_VIEW_RESPONSE_BYTES = SHARED_MAX_VIEW_RESPONSE_BYTES;
 function validateViewResponseOrigin(res: Response, expectedOrigin: string, label: string): void {
   if (res.url) {
     const actualOrigin = httpOriginOf(res.url);
-    if (actualOrigin !== expectedOrigin) {
+    // The transport may retry exact 127.0.0.1 at localhost for an IPv6-only
+    // loopback listener. The comparator folds only those known loopback aliases;
+    // remote origins remain an exact scheme/host/port match.
+    if (!sameOrigin(actualOrigin, expectedOrigin)) {
       throw new ComfyUIError(
         `ComfyUI /view response from ${label} changed origin unexpectedly; the response was refused.`,
         "VIEW_RESPONSE_ORIGIN",

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -2,6 +2,7 @@ import { getComfyUIAuthHeaders } from "../config.js";
 import { describeFetchFailure, isBareFetchFailure } from "../utils/errors.js";
 import { sameOrigin } from "../utils/origin.js";
 import { readPublishedPanelOrigins } from "../services/panel-origin-channel.js";
+import { formatComfyUIUrl } from "../transport/comfyui-url.js";
 
 /** The request target, for the diagnostic. Never throws on an odd input. */
 export function targetOf(input: string | URL | Request): string {
@@ -687,19 +688,44 @@ export async function comfyuiFetch(
   // and it always wins — this only covers the ones that passed none, which
   // otherwise wait forever.
   const signal = init.signal ?? defaultComfyTimeoutSignal();
-  let request: Promise<Response>;
-  if (Object.keys(auth).length === 0) {
-    request = fetch(input, { ...init, signal });
-  } else {
+  const request = (target: string | URL | Request): Promise<Response> => {
+    if (Object.keys(auth).length === 0) return fetch(target, { ...init, signal });
     const headers = new Headers(init.headers);
     for (const [name, value] of Object.entries(auth)) {
       if (!headers.has(name)) headers.set(name, value);
     }
-    request = fetch(input, { ...init, headers, signal });
-  }
+    return fetch(target, { ...init, headers, signal });
+  };
   try {
-    return await request;
+    return await request(input);
   } catch (err) {
+    // Preserve the configured literal as the primary target. Only a refused
+    // exact IPv4 loopback connection is safe to retry: ECONNREFUSED proves no
+    // request reached the server, while reset/timeout errors can follow a
+    // delivered mutation. `localhost` lets Node select an IPv6-only listener
+    // without changing the configured target or any identity comparison.
+    const retryUrl =
+      typeof input === "string"
+        ? formatComfyUIUrl(input)
+        : input instanceof URL
+          ? new URL(formatComfyUIUrl(input.href))
+          : undefined;
+    if (
+      // /view uses its own authenticated/validated panel-origin fallback.
+      // Retrying a loopback alias first would change that fail-closed choice
+      // and make the panel transport tests observe an extra target.
+      init.redirect !== "manual" &&
+      retryUrl &&
+      String(retryUrl) !== String(input) &&
+      isBareFetchFailure(err) &&
+      describeFetchFailure(err).code === "ECONNREFUSED"
+    ) {
+      try {
+        return await request(retryUrl);
+      } catch (retryError) {
+        err = retryError;
+      }
+    }
     // Our own ceiling firing is not the same event as a caller's abort, and it
     // must not be reported as one. Only rewrite when WE supplied the signal.
     if (init.signal === undefined && isTimeoutAbort(err)) {

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -688,6 +688,18 @@ export async function comfyuiFetch(
   // and it always wins — this only covers the ones that passed none, which
   // otherwise wait forever.
   const signal = init.signal ?? defaultComfyTimeoutSignal();
+  // Keep a pristine body for a Request input. A failed network fetch may have
+  // disturbed the original Request body before the refusal is surfaced, while
+  // ECONNREFUSED still permits the one safe retry.
+  let retrySource: Request | undefined;
+  if (input instanceof Request) {
+    try {
+      retrySource = input.clone();
+    } catch {
+      // A caller may pass an already-disturbed Request. The literal attempt
+      // still runs; without a replayable body there is no safe retry.
+    }
+  }
   const request = (target: string | URL | Request): Promise<Response> => {
     if (Object.keys(auth).length === 0) return fetch(target, { ...init, signal });
     const headers = new Headers(init.headers);
@@ -704,20 +716,28 @@ export async function comfyuiFetch(
     // request reached the server, while reset/timeout errors can follow a
     // delivered mutation. `localhost` lets Node select an IPv6-only listener
     // without changing the configured target or any identity comparison.
+    const inputUrl =
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     const retryUrl =
       typeof input === "string"
         ? formatComfyUIUrl(input)
         : input instanceof URL
           ? new URL(formatComfyUIUrl(input.href))
-          : undefined;
+          : input instanceof Request
+            ? formatComfyUIUrl(input.url)
+            : undefined;
+    const retryInput =
+      input instanceof Request && retryUrl && retrySource
+        ? new Request(retryUrl, retrySource)
+        : retryUrl;
     if (
-      retryUrl &&
-      String(retryUrl) !== String(input) &&
+      retryInput &&
+      String(retryUrl) !== inputUrl &&
       isBareFetchFailure(err) &&
       describeFetchFailure(err).code === "ECONNREFUSED"
     ) {
       try {
-        return await request(retryUrl);
+        return await request(retryInput);
       } catch (retryError) {
         err = retryError;
       }

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -700,16 +700,26 @@ export async function comfyuiFetch(
       // still runs; without a replayable body there is no safe retry.
     }
   }
-  const request = (target: string | URL | Request): Promise<Response> => {
-    if (Object.keys(auth).length === 0) return fetch(target, { ...init, signal });
-    const headers = new Headers(init.headers);
+  let firstInit: RequestInit = { ...init, signal };
+  let retryInit: RequestInit = firstInit;
+  if (typeof ReadableStream !== "undefined" && init.body instanceof ReadableStream) {
+    const [firstBody, retryBody] = init.body.tee();
+    firstInit = { ...firstInit, body: firstBody };
+    retryInit = { ...firstInit, body: retryBody };
+  }
+  const request = (
+    target: string | URL | Request,
+    requestInit: RequestInit,
+  ): Promise<Response> => {
+    if (Object.keys(auth).length === 0) return fetch(target, requestInit);
+    const headers = new Headers(requestInit.headers);
     for (const [name, value] of Object.entries(auth)) {
       if (!headers.has(name)) headers.set(name, value);
     }
-    return fetch(target, { ...init, headers, signal });
+    return fetch(target, { ...requestInit, headers });
   };
   try {
-    return await request(input);
+    return await request(input, firstInit);
   } catch (err) {
     // Preserve the configured literal as the primary target. Only a refused
     // exact IPv4 loopback connection is safe to retry: ECONNREFUSED proves no
@@ -737,7 +747,7 @@ export async function comfyuiFetch(
       describeFetchFailure(err).code === "ECONNREFUSED"
     ) {
       try {
-        return await request(retryInput);
+        return await request(retryInput, retryInit);
       } catch (retryError) {
         err = retryError;
       }

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -711,10 +711,6 @@ export async function comfyuiFetch(
           ? new URL(formatComfyUIUrl(input.href))
           : undefined;
     if (
-      // /view uses its own authenticated/validated panel-origin fallback.
-      // Retrying a loopback alias first would change that fail-closed choice
-      // and make the panel transport tests observe an extra target.
-      init.redirect !== "manual" &&
       retryUrl &&
       String(retryUrl) !== String(input) &&
       isBareFetchFailure(err) &&

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,12 @@ import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSy
 import { homedir, networkInterfaces } from "node:os";
 import { isIP } from "node:net";
 import { normalizeInstallPathEnv } from "./utils/install-path-env.js";
-import { parseComfyUIUrl, type ComfyUITarget } from "./transport/comfyui-url.js";
+import {
+  formatComfyUIConnectionHost,
+  formatComfyUIHost,
+  parseComfyUIUrl,
+  type ComfyUITarget,
+} from "./transport/comfyui-url.js";
 import { resetManagerApiCache } from "./services/manager-api-cache.js";
 import { comfyuiEnvFilePath, freshSecretValue, loadEnvFileIntoProcess } from "./env-file.js";
 import { localComfyuiPort } from "./services/advertised-origin.js";
@@ -415,7 +420,7 @@ async function detectComfyUIPort(host: string): Promise<number> {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 1000);
       const protocol = parsedConfig.comfyuiSsl ? "https" : "http";
-      const res = await fetch(`${protocol}://${host}:${port}/system_stats`, {
+      const res = await fetch(`${protocol}://${formatComfyUIConnectionHost(host)}:${port}/system_stats`, {
         signal: controller.signal,
       });
       clearTimeout(timeout);
@@ -1033,7 +1038,7 @@ export function setComfyuiTarget(url: string): boolean {
 }
 
 export function getComfyUIApiHost(): string {
-  return `${config.comfyuiHost}:${config.resolvedPort}`;
+  return `${formatComfyUIHost(config.comfyuiHost)}:${config.resolvedPort}`;
 }
 
 export function getComfyUIProtocol(): "http" | "https" {
@@ -1051,7 +1056,7 @@ export function getComfyUIBasePath(): string {
  * this so reverse-proxied / path-prefixed instances route correctly.
  */
 export function getComfyUIBaseUrl(): string {
-  return `${getComfyUIProtocol()}://${getComfyUIApiHost()}${config.comfyuiBasePath}`;
+  return `${getComfyUIProtocol()}://${formatComfyUIHost(config.comfyuiHost)}:${config.resolvedPort}${config.comfyuiBasePath}`;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,11 +6,12 @@ import { homedir, networkInterfaces } from "node:os";
 import { isIP } from "node:net";
 import { normalizeInstallPathEnv } from "./utils/install-path-env.js";
 import {
-  formatComfyUIConnectionHost,
   formatComfyUIHost,
+  formatComfyUIUrl,
   parseComfyUIUrl,
   type ComfyUITarget,
 } from "./transport/comfyui-url.js";
+import { describeFetchFailure, isBareFetchFailure } from "./utils/errors.js";
 import { resetManagerApiCache } from "./services/manager-api-cache.js";
 import { comfyuiEnvFilePath, freshSecretValue, loadEnvFileIntoProcess } from "./env-file.js";
 import { localComfyuiPort } from "./services/advertised-origin.js";
@@ -416,20 +417,40 @@ async function detectComfyUIPort(host: string): Promise<number> {
   const ports = [...new Set([localComfyuiPort(), 8188, 8000])];
 
   for (const port of ports) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 1000);
+    const protocol = parsedConfig.comfyuiSsl ? "https" : "http";
+    const target = `${protocol}://${formatComfyUIHost(host)}:${port}/system_stats`;
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 1000);
-      const protocol = parsedConfig.comfyuiSsl ? "https" : "http";
-      const res = await fetch(`${protocol}://${formatComfyUIConnectionHost(host)}:${port}/system_stats`, {
-        signal: controller.signal,
-      });
-      clearTimeout(timeout);
+      let res: Response;
+      try {
+        // Probe the configured literal first. Only a bare ECONNREFUSED proves
+        // that no HTTP request reached it and permits the IPv6-capable alias.
+        res = await fetch(target, {
+          signal: controller.signal,
+        });
+      } catch (err) {
+        const fallback = formatComfyUIUrl(target);
+        if (
+          fallback === target ||
+          !isBareFetchFailure(err) ||
+          describeFetchFailure(err).code !== "ECONNREFUSED"
+        ) {
+          throw err;
+        }
+        res = await fetch(fallback, {
+          signal: controller.signal,
+        });
+      }
       if (res.ok) {
+        clearTimeout(timeout);
         console.error(`[comfyui-mcp] Found ComfyUI on port ${port}`);
         return port;
       }
     } catch {
       // Port not responding, try next
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/src/orchestrator/probe-ok.ts
+++ b/src/orchestrator/probe-ok.ts
@@ -1,4 +1,5 @@
 import { getComfyUIAuthHeaders } from "../config.js";
+import { formatComfyUIUrl } from "../transport/comfyui-url.js";
 
 /**
  * Boolean URL probe with a timeout — hello-retarget and pending-pod connect.
@@ -18,7 +19,7 @@ export async function probeOk(url: string, timeoutMs = 8_000): Promise<boolean> 
     // Carry configured auth (COMFYUI_AUTH_TOKEN / custom header) — a
     // protected pod's ComfyUI 401s otherwise and connect:true always times
     // out (codex finding).
-    const res = await fetch(url, { signal: ctl.signal, headers: getComfyUIAuthHeaders() });
+    const res = await fetch(formatComfyUIUrl(url), { signal: ctl.signal, headers: getComfyUIAuthHeaders() });
     return res.ok;
   } catch {
     return false;

--- a/src/orchestrator/probe-ok.ts
+++ b/src/orchestrator/probe-ok.ts
@@ -1,5 +1,4 @@
-import { getComfyUIAuthHeaders } from "../config.js";
-import { formatComfyUIUrl } from "../transport/comfyui-url.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 
 /**
  * Boolean URL probe with a timeout — hello-retarget and pending-pod connect.
@@ -16,10 +15,9 @@ export async function probeOk(url: string, timeoutMs = 8_000): Promise<boolean> 
   const ctl = new AbortController();
   const t = setTimeout(() => ctl.abort(), timeoutMs);
   try {
-    // Carry configured auth (COMFYUI_AUTH_TOKEN / custom header) — a
-    // protected pod's ComfyUI 401s otherwise and connect:true always times
-    // out (codex finding).
-    const res = await fetch(formatComfyUIUrl(url), { signal: ctl.signal, headers: getComfyUIAuthHeaders() });
+    // comfyuiFetch carries configured auth and the literal-first loopback
+    // fallback used by every ComfyUI HTTP caller.
+    const res = await comfyuiFetch(url, { signal: ctl.signal });
     return res.ok;
   } catch {
     return false;

--- a/src/services/bridge-port-reclaim.ts
+++ b/src/services/bridge-port-reclaim.ts
@@ -25,7 +25,7 @@ import { DEFAULT_PANEL_BRIDGE_PORT, LEGACY_PANEL_BRIDGE_PORT } from "./bridge-po
 import { detectInstallMode } from "./self-update.js";
 import { logger } from "../utils/logger.js";
 import type { UiBridge } from "./ui-bridge.js";
-import { formatComfyUIUrl } from "../transport/comfyui-url.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 
 const PORT_PROBE_TIMEOUT_MS = 5000;
 
@@ -198,8 +198,8 @@ export async function probeComfyUi(url: string, timeoutMs = 3000): Promise<boole
   try {
     const ctl = new AbortController();
     const timer = setTimeout(() => ctl.abort(), timeoutMs);
-    const target = formatComfyUIUrl(url);
-    const res = await fetch(new URL("system_stats", target.endsWith("/") ? target : `${target}/`), {
+    const target = new URL("system_stats", url.endsWith("/") ? url : `${url}/`);
+    const res = await comfyuiFetch(target, {
       signal: ctl.signal,
     });
     clearTimeout(timer);

--- a/src/services/bridge-port-reclaim.ts
+++ b/src/services/bridge-port-reclaim.ts
@@ -25,6 +25,7 @@ import { DEFAULT_PANEL_BRIDGE_PORT, LEGACY_PANEL_BRIDGE_PORT } from "./bridge-po
 import { detectInstallMode } from "./self-update.js";
 import { logger } from "../utils/logger.js";
 import type { UiBridge } from "./ui-bridge.js";
+import { formatComfyUIUrl } from "../transport/comfyui-url.js";
 
 const PORT_PROBE_TIMEOUT_MS = 5000;
 
@@ -197,7 +198,8 @@ export async function probeComfyUi(url: string, timeoutMs = 3000): Promise<boole
   try {
     const ctl = new AbortController();
     const timer = setTimeout(() => ctl.abort(), timeoutMs);
-    const res = await fetch(new URL("system_stats", url.endsWith("/") ? url : `${url}/`), {
+    const target = formatComfyUIUrl(url);
+    const res = await fetch(new URL("system_stats", target.endsWith("/") ? target : `${target}/`), {
       signal: ctl.signal,
     });
     clearTimeout(timer);

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -339,7 +339,7 @@ async function detectAttentionFromComfyLog(
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   timer.unref?.();
   try {
-    const res = await fetch(`${base}/internal/logs`, { signal: controller.signal });
+    const res = await comfyuiFetch(`${base}/internal/logs`, { signal: controller.signal });
     if (!res.ok) return {};
     const data = (await res.json()) as unknown;
     // /internal/logs returns { entries: [{ t, m }] } (m = message) on recent

--- a/src/services/instance-witness.ts
+++ b/src/services/instance-witness.ts
@@ -23,11 +23,10 @@
 // holds client connections alive while swapping backends would mask a
 // replacement, and no handshake this server can perform rules that out.
 
-import WebSocket from "ws";
 import { randomUUID } from "node:crypto";
 import { getComfyUIAuthHeaders } from "../config.js";
 import { logger } from "../utils/logger.js";
-import { formatComfyUIUrl } from "../transport/comfyui-url.js";
+import { LoopbackWebSocket } from "../transport/loopback-websocket.js";
 
 export interface InstanceWitness {
   /** The WS URL the witness is connected to (diagnostics only). */
@@ -64,16 +63,16 @@ export async function acquireInstanceWitness(
   timeoutMs = 3000,
 ): Promise<InstanceWitness | undefined> {
   const url =
-    `${formatComfyUIUrl(baseUrl).replace(/^http/, "ws").replace(/\/+$/, "")}` +
+    `${baseUrl.replace(/^http/, "ws").replace(/\/+$/, "")}` +
     `/ws?clientId=comfyui-mcp-instance-witness-${randomUUID()}`;
-  let ws: WebSocket;
+  let ws: LoopbackWebSocket;
   try {
     // Ride the same auth as HTTP (COMFYUI_AUTH_* + Cloudflare Access service
     // token) so the witness reaches a ComfyUI behind a gateway — the queue
     // monitor's established pattern. undefined when unauth'd → identical to
     // `new WebSocket(url)`.
     const authHeaders = getComfyUIAuthHeaders();
-    ws = new WebSocket(
+    ws = new LoopbackWebSocket(
       url,
       Object.keys(authHeaders).length ? { headers: authHeaders } : undefined,
     );

--- a/src/services/instance-witness.ts
+++ b/src/services/instance-witness.ts
@@ -27,6 +27,7 @@ import WebSocket from "ws";
 import { randomUUID } from "node:crypto";
 import { getComfyUIAuthHeaders } from "../config.js";
 import { logger } from "../utils/logger.js";
+import { formatComfyUIUrl } from "../transport/comfyui-url.js";
 
 export interface InstanceWitness {
   /** The WS URL the witness is connected to (diagnostics only). */
@@ -63,7 +64,7 @@ export async function acquireInstanceWitness(
   timeoutMs = 3000,
 ): Promise<InstanceWitness | undefined> {
   const url =
-    `${baseUrl.replace(/^http/, "ws").replace(/\/+$/, "")}` +
+    `${formatComfyUIUrl(baseUrl).replace(/^http/, "ws").replace(/\/+$/, "")}` +
     `/ws?clientId=comfyui-mcp-instance-witness-${randomUUID()}`;
   let ws: WebSocket;
   try {

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -28,10 +28,10 @@
 // is simply "inactive" and nothing in the orchestrator changes. It must never
 // throw into the main path.
 
-import WebSocket from "ws";
+import { type RawData } from "ws";
 import { logger } from "../utils/logger.js";
 import { getComfyUIAuthHeaders } from "../config.js";
-import { formatComfyUIUrl } from "../transport/comfyui-url.js";
+import { LoopbackWebSocket } from "../transport/loopback-websocket.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { sameOrigin } from "../utils/origin.js";
 
@@ -230,7 +230,7 @@ const TRAINING_NODE_CLASS_TYPES = new Set([
 ]);
 
 class QueueMonitorImpl {
-  private ws: WebSocket | null = null;
+  private ws: LoopbackWebSocket | null = null;
   private url: string | null = null;
   private stopped = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -517,19 +517,19 @@ class QueueMonitorImpl {
 
   private wsUrl(): string {
     // http(s)://host:port  →  ws(s)://host:port/ws?clientId=...
-    const base = formatComfyUIUrl(this.url ?? "http://127.0.0.1:8188").replace(/^http/, "ws").replace(/\/+$/, "");
+    const base = (this.url ?? "http://127.0.0.1:8188").replace(/^http/, "ws").replace(/\/+$/, "");
     return `${base}/ws?clientId=comfyui-mcp-watchdog`;
   }
 
   private connect(): void {
     if (this.stopped) return;
-    let ws: WebSocket;
+    let ws: LoopbackWebSocket;
     try {
       // Ride the same auth as HTTP (COMFYUI_AUTH_* + Cloudflare Access service
       // token) on the WS handshake, so the watchdog reaches a ComfyUI behind a
       // proxy / CF Access. undefined when unauth'd → identical to `new WebSocket(url)`.
       const authHeaders = getComfyUIAuthHeaders();
-      ws = new WebSocket(
+      ws = new LoopbackWebSocket(
         this.wsUrl(),
         Object.keys(authHeaders).length ? { headers: authHeaders } : undefined,
       );
@@ -548,7 +548,7 @@ class QueueMonitorImpl {
       this.state.connected = true;
       logger.debug("[queue-monitor] watchdog WS connected");
     });
-    ws.on("message", (raw: WebSocket.RawData, isBinary: boolean) => {
+    ws.on("message", (raw: RawData, isBinary: boolean) => {
       if (this.ws !== ws) return;
       if (isBinary) return; // preview image frames — ignore
       this.onMessage(raw.toString());

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -31,6 +31,7 @@
 import WebSocket from "ws";
 import { logger } from "../utils/logger.js";
 import { getComfyUIAuthHeaders } from "../config.js";
+import { formatComfyUIUrl } from "../transport/comfyui-url.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { sameOrigin } from "../utils/origin.js";
 
@@ -516,7 +517,7 @@ class QueueMonitorImpl {
 
   private wsUrl(): string {
     // http(s)://host:port  →  ws(s)://host:port/ws?clientId=...
-    const base = (this.url ?? "http://127.0.0.1:8188").replace(/^http/, "ws").replace(/\/+$/, "");
+    const base = formatComfyUIUrl(this.url ?? "http://127.0.0.1:8188").replace(/^http/, "ws").replace(/\/+$/, "");
     return `${base}/ws?clientId=comfyui-mcp-watchdog`;
   }
 

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -28,6 +28,7 @@ import { startQuickTunnel, type QuickTunnel } from "./tunnel.js";
 import { RelayClient } from "./relay-client.js";
 import { logger } from "../utils/logger.js";
 import { getComfyUIAuthHeaders } from "../config.js";
+import { formatComfyUIUrl } from "../transport/comfyui-url.js";
 import type { UiBridge } from "./ui-bridge.js";
 
 export interface SecureBridge {
@@ -71,7 +72,7 @@ export async function advertiseBridge(
 ): Promise<boolean> {
   let endpoint: string;
   try {
-    endpoint = new URL("/comfyui_mcp_panel/advertise_bridge", comfyuiUrl).toString();
+    endpoint = new URL("/comfyui_mcp_panel/advertise_bridge", formatComfyUIUrl(comfyuiUrl)).toString();
   } catch {
     return false;
   }

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -27,8 +27,7 @@ import { existsSync } from "node:fs";
 import { startQuickTunnel, type QuickTunnel } from "./tunnel.js";
 import { RelayClient } from "./relay-client.js";
 import { logger } from "../utils/logger.js";
-import { getComfyUIAuthHeaders } from "../config.js";
-import { formatComfyUIUrl } from "../transport/comfyui-url.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import type { UiBridge } from "./ui-bridge.js";
 
 export interface SecureBridge {
@@ -72,7 +71,7 @@ export async function advertiseBridge(
 ): Promise<boolean> {
   let endpoint: string;
   try {
-    endpoint = new URL("/comfyui_mcp_panel/advertise_bridge", formatComfyUIUrl(comfyuiUrl)).toString();
+    endpoint = new URL("/comfyui_mcp_panel/advertise_bridge", comfyuiUrl).toString();
   } catch {
     return false;
   }
@@ -83,9 +82,9 @@ export async function advertiseBridge(
     // — a stale pod must never receive the bridge URL (codex finding).
     if (shouldAdvertise && !shouldAdvertise(comfyuiUrl)) return false;
     try {
-      const res = await fetch(endpoint, {
+      const res = await comfyuiFetch(endpoint, {
         method: "POST",
-        headers: { "Content-Type": "application/json", ...getComfyUIAuthHeaders() },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
         // Without this the retry loop could not retry: a pod behind a proxy that
         // accepts the connection and then answers nothing (the characteristic
@@ -130,16 +129,12 @@ export async function fetchPanelBasePath(
 ): Promise<string | undefined> {
   let endpoint: string;
   try {
-    endpoint = new URL(
-      "/comfyui_mcp_panel/status",
-      formatComfyUIUrl(comfyuiUrl),
-    ).toString();
+    endpoint = new URL("/comfyui_mcp_panel/status", comfyuiUrl).toString();
   } catch {
     return undefined;
   }
   try {
-    const res = await fetch(endpoint, {
-      headers: { ...getComfyUIAuthHeaders() },
+    const res = await comfyuiFetch(endpoint, {
       signal: AbortSignal.timeout(timeoutMs),
     });
     if (!res.ok) return undefined;

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -130,7 +130,10 @@ export async function fetchPanelBasePath(
 ): Promise<string | undefined> {
   let endpoint: string;
   try {
-    endpoint = new URL("/comfyui_mcp_panel/status", comfyuiUrl).toString();
+    endpoint = new URL(
+      "/comfyui_mcp_panel/status",
+      formatComfyUIUrl(comfyuiUrl),
+    ).toString();
   } catch {
     return undefined;
   }

--- a/src/transport/comfyui-url.ts
+++ b/src/transport/comfyui-url.ts
@@ -12,6 +12,41 @@ export interface ComfyUITarget {
 }
 
 /**
+ * Format a parsed ComfyUI host for an authority in a connection URL.
+ *
+ * IPv6 literals must be bracketed when followed by a port. The configured
+ * host remains unchanged here; connection-only callers can use
+ * formatComfyUIConnectionHost when they need Node to select either loopback
+ * family for a legacy 127.0.0.1 target.
+ */
+export function formatComfyUIHost(host: string): string {
+  const bare = host.replace(/^\[|\]$/g, "");
+  return bare.includes(":") ? `[${bare}]` : bare;
+}
+
+/** Format a host for a network connection without changing remote identity. */
+export function formatComfyUIConnectionHost(host: string): string {
+  const bare = host.replace(/^\[|\]$/g, "");
+  return bare === "127.0.0.1" ? "localhost" : formatComfyUIHost(bare);
+}
+
+/** Apply the connection-only host formatting to a complete ComfyUI URL. */
+export function formatComfyUIUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  if (parsed.hostname.replace(/^\[|\]$/g, "") !== "127.0.0.1") return url;
+
+  const hadBareRoot = parsed.pathname === "/" && !parsed.search && !parsed.hash && !/\/$/.test(url.trim());
+  parsed.hostname = "localhost";
+  const formatted = parsed.href;
+  return hadBareRoot ? formatted.slice(0, -1) : formatted;
+}
+
+/**
  * Trim a URL pathname into a base prefix: no trailing slash, and "" for the
  * root ("" or "/"). "/comfyapi/" → "/comfyapi".
  */

--- a/src/transport/loopback-websocket.ts
+++ b/src/transport/loopback-websocket.ts
@@ -1,0 +1,153 @@
+import { EventEmitter } from "node:events";
+import WebSocket, { type ClientOptions, type RawData } from "ws";
+import { describeFetchFailure } from "../utils/errors.js";
+import { formatComfyUIUrl } from "./comfyui-url.js";
+
+type SocketEvent = "open" | "error" | "close" | "message";
+type SocketListener = (...args: any[]) => void;
+
+function isConnectionRefused(error: unknown): boolean {
+  return describeFetchFailure(error).code === "ECONNREFUSED";
+}
+
+/**
+ * A Node ws-compatible socket that preserves a literal loopback target for
+ * the first dial and retries only a refused 127.0.0.1 connection at localhost.
+ * The retry is safe because ECONNREFUSED proves the first handshake reached no
+ * server; resets and timeouts are deliberately surfaced without re-issuing.
+ *
+ * The stable-canvas client consumes the DOM-style addEventListener surface,
+ * while the MCP's direct monitors consume ws's EventEmitter surface. This
+ * adapter exposes both and keeps the underlying socket private so a failed
+ * first attempt cannot leak an error or close event before the fallback.
+ */
+export class LoopbackWebSocket extends EventEmitter {
+  static readonly CONNECTING = WebSocket.CONNECTING;
+  static readonly OPEN = WebSocket.OPEN;
+  static readonly CLOSING = WebSocket.CLOSING;
+  static readonly CLOSED = WebSocket.CLOSED;
+
+  private socket: WebSocket;
+  private readonly literalUrl: string;
+  private fallbackTried = false;
+  private callerClosed = false;
+  private readonly options?: string | string[] | ClientOptions;
+  private readonly domListeners = new Map<
+    SocketEvent,
+    Map<Function, SocketListener>
+  >();
+
+  constructor(url: string | URL, options?: string | string[] | ClientOptions) {
+    super();
+    const literalUrl = String(url);
+    this.literalUrl = literalUrl;
+    this.options = options;
+    this.socket = this.open(literalUrl);
+  }
+
+  private open(url: string): WebSocket {
+    const socket =
+      this.options && typeof this.options === "object" && !Array.isArray(this.options)
+        ? new WebSocket(url, this.options)
+        : new WebSocket(url, this.options);
+    socket.on("open", () => {
+      if (socket !== this.socket) return;
+      this.emit("open");
+    });
+    socket.on("message", (data: RawData, isBinary: boolean) => {
+      if (socket !== this.socket) return;
+      this.emit("message", data, isBinary);
+    });
+    socket.on("error", (error: Error) => {
+      if (socket !== this.socket) return;
+      if (
+        !this.callerClosed &&
+        !this.fallbackTried &&
+        formatComfyUIUrl(this.literalUrl) !== url &&
+        isConnectionRefused(error)
+      ) {
+        this.fallbackTried = true;
+        const fallback = this.open(formatComfyUIUrl(this.literalUrl));
+        this.socket = fallback;
+        socket.terminate();
+        return;
+      }
+      this.emit("error", error);
+    });
+    socket.on("close", (code: number, reason: Buffer) => {
+      if (socket !== this.socket) return;
+      this.emit("close", code, reason);
+    });
+    return socket;
+  }
+
+  get binaryType(): "nodebuffer" | "arraybuffer" | "fragments" {
+    return this.socket.binaryType;
+  }
+
+  set binaryType(value: "nodebuffer" | "arraybuffer" | "fragments") {
+    this.socket.binaryType = value;
+  }
+
+  get bufferedAmount(): number {
+    return this.socket.bufferedAmount;
+  }
+
+  get extensions(): string {
+    return this.socket.extensions;
+  }
+
+  get protocol(): string {
+    return this.socket.protocol;
+  }
+
+  get readyState(): number {
+    return this.socket.readyState;
+  }
+
+  get url(): string {
+    return this.socket.url;
+  }
+
+  addEventListener(type: SocketEvent, listener: SocketListener): void {
+    let listeners = this.domListeners.get(type);
+    if (!listeners) {
+      listeners = new Map();
+      this.domListeners.set(type, listeners);
+    }
+    if (listeners.has(listener)) return;
+    const adapted: SocketListener = (...args) => {
+      const event =
+        type === "message"
+          ? { data: args[0] }
+          : type === "close"
+            ? { code: args[0], reason: args[1] }
+            : args[0];
+      listener.call(this, event);
+    };
+    listeners.set(listener, adapted);
+    this.on(type, adapted);
+  }
+
+  removeEventListener(type: SocketEvent, listener: SocketListener): void {
+    const listeners = this.domListeners.get(type);
+    const adapted = listeners?.get(listener);
+    if (!adapted) return;
+    this.removeListener(type, adapted);
+    listeners?.delete(listener);
+  }
+
+  send(data: Parameters<WebSocket["send"]>[0], ...args: any[]): void {
+    this.socket.send(data, ...args);
+  }
+
+  close(code?: number, reason?: string | Buffer): void {
+    this.callerClosed = true;
+    this.socket.close(code, reason);
+  }
+
+  terminate(): void {
+    this.callerClosed = true;
+    this.socket.terminate();
+  }
+}

--- a/src/transport/loopback-websocket.ts
+++ b/src/transport/loopback-websocket.ts
@@ -85,6 +85,22 @@ export class LoopbackWebSocket extends EventEmitter {
     return this.socket.binaryType;
   }
 
+  get CONNECTING(): number {
+    return WebSocket.CONNECTING;
+  }
+
+  get OPEN(): number {
+    return WebSocket.OPEN;
+  }
+
+  get CLOSING(): number {
+    return WebSocket.CLOSING;
+  }
+
+  get CLOSED(): number {
+    return WebSocket.CLOSED;
+  }
+
   set binaryType(value: "nodebuffer" | "arraybuffer" | "fragments") {
     this.socket.binaryType = value;
   }


### PR DESCRIPTION
## Summary\n- fix #2719 by formatting IPv6 authorities and retrying only genuine ECONNREFUSED from exact 127.0.0.1 targets through localhost\n- preserve configured URL identity for diagnostics/restart authorization; no bind changes or remote-host aliasing\n- apply the connection formatting to SDK/direct WebSocket and health/bridge callers; keep /view panel fallback identity checks unchanged\n- add IPv6-only HTTP and WebSocket regression coverage and Unreleased changelog entry\n\n## Validation\n- focused IPv6/identity suite: 143/143 passed\n- full Vitest: 760 files, 13,991 passed, 6 skipped\n- TypeScript build and lint/anti-slop passed\n- i18n, docs links/locale/MDX, changelog checks passed\n- forbidden-file check: no init.py or apps_routes.py changes/network operations\n- dependency audit reports six pre-existing production advisories; no dependency files changed\n\nBase: 6e013339e9fffb9c860b01d12f43e4df34bcfe8d\nHead: 483cea570599ec26e91ab2fb2a17f8a4f4ab863c