### PR TITLE
fix: track Manager v4 apply_manifest enqueues (#2725)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - support IPv6-only ComfyUI loopback targets when `COMFYUI_URL` uses `127.0.0.1`, for issue #2719 (#2747)
 
+### MCP
+
+#### Fixed
+- **`apply_manifest` now tracks Manager v4 custom-node enqueues that return an empty success body (#2725).** Already-enabled packs are satisfied without a duplicate enqueue, and an unverified empty-ack outcome remains pending instead of authorizing a speculative fallback.
 
 ## [0.52.177] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`apply_manifest` now tracks Manager v4 custom-node enqueues that return an empty success body (#2725, #2749).** Already-enabled packs are satisfied without a duplicate enqueue, and an unverified empty-ack outcome remains pending instead of authorizing a speculative fallback.
+
 ## [0.52.178] - 2026-09-02
 
 ### MCP
 
 #### Fixed
 - support IPv6-only ComfyUI loopback targets when `COMFYUI_URL` uses `127.0.0.1`, for issue #2719 (#2747)
-
-### MCP
-
-#### Fixed
-- **`apply_manifest` now tracks Manager v4 custom-node enqueues that return an empty success body (#2725).** Already-enabled packs are satisfied without a duplicate enqueue, and an unverified empty-ack outcome remains pending instead of authorizing a speculative fallback.
 
 ## [0.52.177] - 2026-09-02
 

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -823,6 +823,60 @@ describe("node-management service", () => {
         .toBeUndefined();
     });
 
+    it("#2725 does not clone when an empty-ack Manager record is absent on disk", async () => {
+      let installedListReads = 0;
+      fsCtl.readdirSync = () => [];
+      const { calls } = stubFetch({
+        queueOpEmpty: true,
+        installedBody: () =>
+          installedListReads++ === 0
+            ? {}
+            : { "rgthree-comfy": { cnr_id: "rgthree-comfy", enabled: true } },
+      });
+
+      const result = await applyManifest({
+        manifest: {
+          custom_nodes: ["https://github.com/rgthree/rgthree-comfy"],
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 1 });
+      expect(result.results[0]).toMatchObject({ status: "pending" });
+      expect(result.results[0].message).toMatch(/UNKNOWN/i);
+      expect(result.results[0].message).toMatch(/no local fallback is authorized/i);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeUndefined();
+    });
+
+    it("#2725 keeps an empty-ack install UNKNOWN when its installed list is unreadable", async () => {
+      let installedListReads = 0;
+      const { calls } = stubFetch({
+        queueOpEmpty: true,
+        installedBody: () =>
+          installedListReads++ === 0 ? {} : { error: {} },
+      });
+
+      const result = await applyManifest({
+        manifest: {
+          custom_nodes: ["https://github.com/rgthree/rgthree-comfy"],
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 1 });
+      expect(result.results[0]).toMatchObject({ status: "pending" });
+      expect(result.results[0].message).toMatch(/installed-pack list could not be read/i);
+      expect(result.results[0].message).toMatch(/UNKNOWN/i);
+      expect(result.results[0].message).toMatch(/no local fallback is authorized/i);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeUndefined();
+    });
+
     it("throws when a registry id is queued but never lands (silent no-op)", async () => {
       // The Manager drains "done" without installing an unknown CNR id; a non-URL
       // id can't be cloned, so this must be a hard error — not a false success.

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -264,8 +264,10 @@ type QueueStatusFixture = {
   pending_count?: number;
 };
 
+type InstalledBodyFixture = Record<string, object> | object[];
+
 function stubFetch(opts: {
-  installedBody?: unknown;
+  installedBody?: InstalledBodyFixture | (() => InstalledBodyFixture);
   statusSequence?: QueueStatusFixture[] | (() => QueueStatusFixture);
   /** Fires when a queue op is submitted — lets a test make the install REAL. */
   onQueue?: () => void;
@@ -319,12 +321,20 @@ function stubFetch(opts: {
         return jsonResponse(opts.registryDetails ?? {});
       }
       if (path.startsWith("/v2/customnode/installed")) {
-        return jsonResponse(opts.installedBody ?? {});
+        const installedBody = typeof opts.installedBody === "function"
+          ? opts.installedBody()
+          : opts.installedBody ?? {};
+        return jsonResponse(installedBody);
       }
       if (path === "/v2/manager/queue/status" || path === "/manager/queue/status") {
         if (opts.queueStatusNull) {
           // This is intentionally a status response, not an enqueue response:
           // the accepted task has already crossed the Manager boundary.
+          return jsonResponse(null);
+        }
+        if (opts.managerQueueStatus === "manager-unavailable-null") {
+          // This is a status response, not an enqueue response: the accepted
+          // task has already crossed the Manager boundary.
           return jsonResponse(null);
         }
         if (opts.managerQueueStatus === "absent") {
@@ -391,11 +401,6 @@ function stubFetch(opts: {
         if (opts.queueOpEmpty && isInstallOp) {
           opts.onQueue?.();
           return new Response("", { status: 200 });
-        }
-        if (opts.managerQueueStatus === "manager-unavailable-null") {
-          // A JSON null is a successful response with no queue evidence. It
-          // must take the same fail-closed path as the empty 200 body.
-          return jsonResponse(null);
         }
         // A 405 on the unified task route is retried through v2-batch; model
         // that downgrade as an acknowledged enqueue for the existing race
@@ -726,6 +731,96 @@ describe("node-management service", () => {
       expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(
         true,
       );
+    });
+
+    it("#2725 skips already-enabled manifest packs without re-enqueueing them", async () => {
+      const { calls } = stubFetch({
+        installedBody: {
+          "rgthree-comfy": { cnr_id: "rgthree-comfy", enabled: true },
+          "ComfyUI-KJNodes": { cnr_id: "comfyui-kjnodes", enabled: true },
+          "ComfyUI-Krea2T-Enhancer": {
+            cnr_id: "comfyui-krea2t-enhancer",
+            enabled: true,
+          },
+          "ComfyUI-RBG-SmartSeedVariance": {
+            cnr_id: "comfyui-rbg-smartseedvariance",
+            enabled: true,
+          },
+        },
+      });
+
+      const result = await applyManifest({
+        manifest: {
+          custom_nodes: [
+            "https://github.com/rgthree/rgthree-comfy",
+            "https://github.com/kijai/ComfyUI-KJNodes",
+            "https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer",
+            "https://github.com/RamonGuthrie/ComfyUI-RBG-SmartSeedVariance",
+          ],
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toMatchObject({ applied: 0, skipped: 4, failed: 0, pending: 0 });
+      expect(result.results.every((entry) => entry.status === "skipped")).toBe(true);
+      expect(calls.some((c) => c.url.includes("/v2/manager/queue/task"))).toBe(false);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(false);
+    });
+
+    it("#2725 starts and tracks a Manager-v4 empty-ack manifest install", async () => {
+      let installedListReads = 0;
+      const { calls } = stubFetch({
+        queueOpEmpty: true,
+        installedBody: () =>
+          installedListReads++ === 0
+            ? {}
+            : { "rgthree-comfy": { cnr_id: "rgthree-comfy", enabled: true } },
+      });
+
+      const result = await applyManifest({
+        manifest: {
+          custom_nodes: ["https://github.com/rgthree/rgthree-comfy"],
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.results).toEqual([
+        expect.objectContaining({
+          item: "https://github.com/rgthree/rgthree-comfy",
+          action: "custom_node",
+          status: "applied",
+        }),
+      ]);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/status"))).toBe(true);
+      expect(installedListReads).toBeGreaterThanOrEqual(2);
+    });
+
+    it("#2725 keeps an empty-ack install UNKNOWN when no post-state is visible", async () => {
+      const { calls } = stubFetch({
+        queueOpEmpty: true,
+        installedBody: {},
+      });
+
+      const result = await applyManifest({
+        manifest: {
+          custom_nodes: ["https://github.com/rgthree/rgthree-comfy"],
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.summary).toMatchObject({ applied: 0, skipped: 0, failed: 0, pending: 1 });
+      expect(result.results[0]).toMatchObject({ status: "pending" });
+      expect(result.results[0].message).toMatch(/UNKNOWN/i);
+      expect(result.partial).toMatchObject({
+        still_installing: ["https://github.com/rgthree/rgthree-comfy"],
+        outcome_unknown: ["https://github.com/rgthree/rgthree-comfy"],
+      });
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/task"))).toBe(true);
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
+      expect(mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"))
+        .toBeUndefined();
     });
 
     it("throws when a registry id is queued but never lands (silent no-op)", async () => {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -1048,7 +1048,7 @@ async function resolveLocalManifestCustomNodesBase(): Promise<string | undefined
 
 /**
  * Manager can report a successful-but-empty enqueue or an empty queue/status
- * response after a warm dialect cache. For apply_manifest, both are
+ * response after a warm dialect cache. For apply_manifest, these are
  * deliberately tagged UNKNOWN by node-management: the request may already
  * have reached the host, so no caller may reissue it or authorize a local
  * clone. Keep that meaning intact when apply_manifest assembles its
@@ -1059,7 +1059,11 @@ function isUnknownManagerInstallOutcome(err: unknown): boolean {
   const details = (err as { details?: unknown }).details;
   if (!details || typeof details !== "object") return false;
   const kind = (details as { kind?: unknown }).kind;
-  return kind === "manager-enqueue-empty-success" || kind === "manager-queue-empty-status";
+  return (
+    kind === "manager-enqueue-empty-success" ||
+    kind === "manager-enqueue-empty-unverified" ||
+    kind === "manager-queue-empty-status"
+  );
 }
 
 async function applyManifestSections(
@@ -1263,10 +1267,16 @@ async function applyManifestSections(
       ...(isGitManifestSource
         ? { localCloneFallback: "verified-only" as const }
         : {}),
-      // A budget timeout may return apply_manifest while the Manager enqueue
-      // is still unresolved. Keep an empty enqueue UNKNOWN/fail-closed here
-      // so a late completion cannot authorize a background local clone.
-      ...(isGitManifestSource ? { allowEmptyV2Enqueue: false } : {}),
+      // Manager v4 can accept a git install with an empty 2xx body. Let the
+      // install path explicitly start and track that queue, but keep the
+      // apply_manifest budget boundary fail-closed: an empty-ack task with no
+      // matching post-state may not authorize a late background clone.
+      ...(isGitManifestSource
+        ? {
+            allowEmptyV2Enqueue: true,
+            allowLocalFallbackAfterEmptyV2Enqueue: false,
+          }
+        : {}),
       managerBase,
       targetGeneration,
       localFallbackBinding: fallbackBinding,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1531,6 +1531,8 @@ interface ManagerEnqueueOptions {
   rejectEmptyEnqueue?: boolean;
   /** Allow an empty v4 unified enqueue to proceed to drain/verification. */
   allowEmptyV2Enqueue?: boolean;
+  /** Observe the normal v4 empty-ack path without changing its outcome. */
+  onEmptyV2Enqueue?: () => void;
 }
 
 type ManagerEnqueueResponse = Record<string, unknown> | string | null | undefined;
@@ -1543,10 +1545,14 @@ function assertManagerEnqueueResponse(
   path: string,
   base: string,
 ): void {
+  const empty = response === undefined || response === null;
+  if (empty && api === "v2" && options.allowEmptyV2Enqueue) {
+    options.onEmptyV2Enqueue?.();
+    return;
+  }
   if (
     !options.rejectEmptyEnqueue ||
-    (response !== undefined && response !== null) ||
-    (api === "v2" && options.allowEmptyV2Enqueue)
+    !empty
   ) return;
   throw new NodeManagementError(
     `ComfyUI-Manager returned a successful but empty response for the ${kind} enqueue ` +
@@ -3947,10 +3953,16 @@ export interface InstallOptions {
   localCloneFallback?: "verified-only";
   /**
    * Internal caller policy for an empty Manager v4 Git enqueue. Direct installs
-   * can drain and verify before cloning; budgeted apply_manifest keeps the
-   * UNKNOWN/no-background-write behavior.
+   * can drain and verify before cloning; apply_manifest enables the queue path
+   * but separately disables a late local fallback after an empty acknowledgement.
    */
   allowEmptyV2Enqueue?: boolean;
+  /**
+   * Internal apply_manifest policy: an empty v4 acknowledgement may be the
+   * normal response, but an unresolved/absent post-state must not trigger a
+   * speculative local clone after the manifest call has returned.
+   */
+  allowLocalFallbackAfterEmptyV2Enqueue?: boolean;
   /** Call-scoped Manager base captured with the target generation at operation entry. */
   managerBase?: string;
   /** Monotonic ComfyUI target generation captured with managerBase. */
@@ -4292,6 +4304,7 @@ async function installCustomNodeImpl(
     // Start and drain the queue first, then the exact installed-pack/disk
     // verification below decides whether a local clone is still needed.
     let refusedBy: number | undefined;
+    let emptyV2Enqueue = false;
     const enqueue = async (): Promise<unknown> =>
       await queueManagerTask(
       "install",
@@ -4333,6 +4346,9 @@ async function installCustomNodeImpl(
       {
         rejectEmptyEnqueue: true,
         allowEmptyV2Enqueue: opts.allowEmptyV2Enqueue !== false,
+        onEmptyV2Enqueue: () => {
+          emptyV2Enqueue = true;
+        },
       },
     );
 
@@ -4423,7 +4439,12 @@ async function installCustomNodeImpl(
     // unreadable custom_nodes) keeps the Manager result and says the disk was not
     // checked. "Could not look" is never folded into "not there".
     const installed = await listInstalledNodesAt(managerBase).catch(
-      () => [] as InstalledNode[],
+      (err) => {
+        if (emptyV2Enqueue) {
+          throw err;
+        }
+        return [] as InstalledNode[];
+      },
     );
     assertInstallTargetStable(targetGeneration, managerBase);
     const listedNode = findInstalledNode(gitId, installed);
@@ -4434,6 +4455,24 @@ async function installCustomNodeImpl(
       listedNode !== undefined &&
       !listedNode.cnrId &&
       !gitOriginMatchesRequested(gitId, listedNode.auxId);
+    if (
+      emptyV2Enqueue &&
+      opts.allowLocalFallbackAfterEmptyV2Enqueue === false &&
+      (listedNode === undefined || originMismatch)
+    ) {
+      throw new NodeManagementError(
+        `ComfyUI-Manager accepted the git install with an empty v4 response and the queue ` +
+          `drained, but it did not provide a matching installed-pack record for "${repoName}". ` +
+          `The result is UNKNOWN; no local fallback is authorized because that could duplicate ` +
+          `a Manager task that completed without a visible record. Verify the pack state before ` +
+          `reissuing the install.`,
+        {
+          kind: "manager-enqueue-empty-unverified",
+          base: managerBase,
+          repoName,
+        },
+      );
+    }
     /** #2714 — why the Manager's own "installed" verdict was not taken. */
     let uncorroboratedNote: string | undefined;
     if (listedNode && !originMismatch) {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -4433,15 +4433,30 @@ async function installCustomNodeImpl(
     // VERIFY: the Manager's installed-pack list is the FIRST witness — but it is
     // Manager's own bookkeeping, not the filesystem, so #2714 crosses it with a
     // disk scan before any success wording (see diskCorroboratesManagerInstall).
-    // Three outcomes, and only one of them writes: a scan that finds the pack
-    // ABSENT falls through to the same direct clone an unregistered pack takes; a
-    // HUSK throws; a scan that could not answer (remote, no proven scan root, an
+    // Three outcomes, and only one of them writes: for ordinary direct installs,
+    // a scan that finds the pack ABSENT falls through to the same direct clone an
+    // unregistered pack takes; apply_manifest disables that fallback after an
+    // empty v4 acknowledgement because the Manager task may still have landed.
+    // A HUSK throws; a scan that could not answer (remote, no proven scan root, an
     // unreadable custom_nodes) keeps the Manager result and says the disk was not
     // checked. "Could not look" is never folded into "not there".
     const installed = await listInstalledNodesAt(managerBase).catch(
       (err) => {
         if (emptyV2Enqueue) {
-          throw err;
+          const listError = err instanceof Error ? err.message : String(err);
+          throw new NodeManagementError(
+            `ComfyUI-Manager accepted the git install with an empty v4 response and the queue ` +
+              `drained, but its installed-pack list could not be read (${listError}). ` +
+              `The result is UNKNOWN; no local fallback is authorized because that could ` +
+              `duplicate a Manager task whose post-state cannot be verified. Verify the pack ` +
+              `state before reissuing the install.`,
+            {
+              kind: "manager-enqueue-empty-unverified",
+              base: managerBase,
+              repoName,
+              listError,
+            },
+          );
         }
         return [] as InstalledNode[];
       },
@@ -4455,22 +4470,32 @@ async function installCustomNodeImpl(
       listedNode !== undefined &&
       !listedNode.cnrId &&
       !gitOriginMatchesRequested(gitId, listedNode.auxId);
+    const rejectEmptyV2Fallback = (
+      verification: string,
+      extra: Record<string, unknown> = {},
+    ): never => {
+      throw new NodeManagementError(
+        `ComfyUI-Manager accepted the git install with an empty v4 response and the queue ` +
+          `drained, but ${verification}. The result is UNKNOWN; no local fallback is ` +
+          `authorized because that could duplicate a Manager task that completed without a ` +
+          `visible matching post-state. Verify the pack state before reissuing the install.`,
+        {
+          kind: "manager-enqueue-empty-unverified",
+          base: managerBase,
+          repoName,
+          ...extra,
+        },
+      );
+    };
     if (
       emptyV2Enqueue &&
       opts.allowLocalFallbackAfterEmptyV2Enqueue === false &&
       (listedNode === undefined || originMismatch)
     ) {
-      throw new NodeManagementError(
-        `ComfyUI-Manager accepted the git install with an empty v4 response and the queue ` +
-          `drained, but it did not provide a matching installed-pack record for "${repoName}". ` +
-          `The result is UNKNOWN; no local fallback is authorized because that could duplicate ` +
-          `a Manager task that completed without a visible record. Verify the pack state before ` +
-          `reissuing the install.`,
-        {
-          kind: "manager-enqueue-empty-unverified",
-          base: managerBase,
-          repoName,
-        },
+      rejectEmptyV2Fallback(
+        originMismatch
+          ? `it listed a different source origin for "${repoName}"`
+          : `it did not provide a matching installed-pack record for "${repoName}"`,
       );
     }
     /** #2714 — why the Manager's own "installed" verdict was not taken. */
@@ -4485,6 +4510,15 @@ async function installCustomNodeImpl(
           ? undefined
           : diskCorroboratesManagerInstall(gitId, listedNode, presenceCtx.diskRoot);
       if (corroboration?.state === "absent") {
+        if (
+          emptyV2Enqueue &&
+          opts.allowLocalFallbackAfterEmptyV2Enqueue === false
+        ) {
+          rejectEmptyV2Fallback(
+            `it still lists "${repoName}", but no matching pack exists under ${corroboration.scanned}`,
+            { scanned: corroboration.scanned },
+          );
+        }
         uncorroboratedNote =
           `ComfyUI-Manager drained the install task and still lists "${repoName}" in its ` +
           `installed-pack list, but NO matching pack exists under ${corroboration.scanned} ` +


### PR DESCRIPTION
## Summary\n- accept Manager v4 empty-success custom-node enqueue responses for apply_manifest git sources and use the existing explicit queue start/status drain path\n- satisfy already-installed packs without enqueueing duplicates\n- keep empty-ack installs UNKNOWN/pending when no matching post-state is visible; no speculative local clone or retry\n\n## Verification\n- npm run lint\n- npm run build\n- focused node-management Vitest: 241 passed\n- apply-manifest/manager-dialect/dispatch Vitest suites: 58 passed\n- full Vitest: 13,986 passed, 6 skipped; three unrelated timing/packaging failures were reproduced as 53/53 passing after build in a direct rerun\n- docs links/locale/MDX, changelog, vocabulary, unknown-collapse, anti-slop, i18n, manifest validation, and asset-count checks pass\n- no init.py or apps_routes.py files exist in the target tree or diff