### PR TITLE
fix(2748): a pack workflow miss must not advertise the pack it just refused

### DIFF
--- a/src/__tests__/tools/skills-access.test.ts
+++ b/src/__tests__/tools/skills-access.test.ts
@@ -65,6 +65,7 @@ import {
   enumeratePacks,
   resolvePackWorkflowFile,
   resolveWorkflowFileName,
+  describeMissingWorkflow,
 } from "../../tools/skills-access.js";
 
 type Handler = (args: Record<string, any>) => Promise<{
@@ -739,5 +740,78 @@ describe("pack workflow filename — one derivation (#2748)", () => {
       }))
       .filter((r) => r.listed !== r.resolved);
     expect(disagreements).toEqual([]);
+  });
+});
+
+/**
+ * #2748 (gate round 2) — the workflow-miss message must not explain a state it
+ * never checked.
+ *
+ * "Installer-only" is a deliberate, working-as-intended state. The first draft
+ * of this fix returned that sentence for EVERY non-string `workflow` value, so a
+ * malformed pack.yaml, a missing pack.yaml, or `workflow: 42` — all broken
+ * bundles — were reported as intentional, hiding the breakage behind a
+ * reassuring explanation. That is the same defect (a message asserting an
+ * unverified cause) the rest of this change removes.
+ *
+ * The classifier is pure so every branch is reachable without planting fixture
+ * directories in the real packs/ tree.
+ */
+describe("describeMissingWorkflow — states are not collapsed (#2748)", () => {
+  const INSTALLER_ONLY = /installer-only/;
+
+  it("calls a pack.yaml-less directory what it is, and does not claim list reports it", () => {
+    const msg = describeMissingWorkflow("stray-dir", { hasPackYaml: false, meta: null });
+    expect(msg).toMatch(/no pack\.yaml/);
+    expect(msg).not.toMatch(INSTALLER_ONLY);
+    // action:"list" requires a pack.yaml to treat a directory as a pack, so a
+    // has_workflow footnote here would describe a row that does not exist.
+    expect(msg).not.toMatch(/has_workflow/);
+  });
+
+  it("reports unparseable pack.yaml as unparseable, not as installer-only", () => {
+    const msg = describeMissingWorkflow("broken", { hasPackYaml: true, meta: null });
+    expect(msg).toMatch(/did not parse to a YAML mapping/);
+    expect(msg).not.toMatch(INSTALLER_ONLY);
+  });
+
+  it("reports a non-string `workflow` as a bad declaration, not as installer-only", () => {
+    for (const declared of [42, true, [], {}]) {
+      const msg = describeMissingWorkflow("odd", {
+        hasPackYaml: true,
+        meta: { workflow: declared },
+      });
+      expect(msg).toMatch(/rather than a filename/);
+      expect(msg).not.toMatch(INSTALLER_ONLY);
+    }
+  });
+
+  it("reports a declared-but-absent workflow file as a broken bundle, naming the file", () => {
+    const msg = describeMissingWorkflow("broken-bundle", {
+      hasPackYaml: true,
+      meta: { workflow: "graph.json" },
+    });
+    expect(msg).toMatch(/declared workflow file \(graph\.json\) is missing/);
+    expect(msg).not.toMatch(INSTALLER_ONLY);
+  });
+
+  it("names the SANITIZED filename it actually looked for, not the raw declaration", () => {
+    // An unsafe declaration falls back to workflow.json in the resolver, so the
+    // message must name workflow.json — quoting "sub/graph.json" would send the
+    // reader hunting for a file the code never opened.
+    const msg = describeMissingWorkflow("unsafe", {
+      hasPackYaml: true,
+      meta: { workflow: "sub/graph.json" },
+    });
+    expect(msg).toMatch(/\(workflow\.json\) is missing/);
+    expect(msg).not.toContain("sub/graph.json");
+  });
+
+  it("ONLY a parsed pack.yaml with workflow null/absent is called installer-only", () => {
+    for (const meta of [{ workflow: null }, {}, { workflow: undefined }]) {
+      const msg = describeMissingWorkflow("qwen-image", { hasPackYaml: true, meta });
+      expect(msg).toMatch(INSTALLER_ONLY);
+      expect(msg).toMatch(/has_workflow: false/);
+    }
   });
 });

--- a/src/__tests__/tools/skills-access.test.ts
+++ b/src/__tests__/tools/skills-access.test.ts
@@ -808,12 +808,23 @@ describe("describeMissingWorkflow — states are not collapsed (#2748)", () => {
     expect(msg).not.toContain("sub/graph.json");
   });
 
-  it("ONLY a parsed pack.yaml with workflow null/absent is called installer-only", () => {
-    for (const meta of [{ workflow: null }, {}, { workflow: undefined }]) {
-      const msg = describeMissingWorkflow("qwen-image", { hasPackYaml: true, meta });
-      expect(msg).toMatch(INSTALLER_ONLY);
-      expect(msg).toMatch(/has_workflow: false/);
-    }
+  it("ONLY an EXPLICIT `workflow: null` is called installer-only", () => {
+    const msg = describeMissingWorkflow("qwen-image", {
+      hasPackYaml: true,
+      meta: { workflow: null },
+    });
+    expect(msg).toMatch(INSTALLER_ONLY);
+    expect(msg).toMatch(/has_workflow: false/);
+  });
+
+  it("an OMITTED workflow key is not treated as a declaration of installer-only", () => {
+    // All 56 bundled packs write `workflow:` explicitly, so an absent key
+    // expresses no intent — the author may equally have meant workflow.json to
+    // be present. Blessing it as installer-only would hide a broken pack.
+    const msg = describeMissingWorkflow("no-key", { hasPackYaml: true, meta: {} });
+    expect(msg).not.toMatch(INSTALLER_ONLY);
+    expect(msg).toMatch(/no `workflow` key/);
+    expect(msg).toMatch(/default workflow\.json is not in the pack/);
   });
 });
 

--- a/src/__tests__/tools/skills-access.test.ts
+++ b/src/__tests__/tools/skills-access.test.ts
@@ -66,6 +66,7 @@ import {
   resolvePackWorkflowFile,
   resolveWorkflowFileName,
   describeMissingWorkflow,
+  coercePackMeta,
 } from "../../tools/skills-access.js";
 
 type Handler = (args: Record<string, any>) => Promise<{
@@ -813,5 +814,47 @@ describe("describeMissingWorkflow — states are not collapsed (#2748)", () => {
       expect(msg).toMatch(INSTALLER_ONLY);
       expect(msg).toMatch(/has_workflow: false/);
     }
+  });
+});
+
+/**
+ * #2748 (gate round 3) — a top-level YAML SEQUENCE is not metadata.
+ *
+ * `parseYaml("[]")` is truthy and `typeof === "object"`, so the obvious
+ * `parsed && typeof parsed === "object"` check accepts it as a record. Every
+ * field then reads `undefined`, and `workflow: undefined` is indistinguishable
+ * from a deliberate `workflow: null` — so `pack.yaml` containing `[]` had its
+ * malformed bundle reported as an intentional "installer-only" pack.
+ */
+describe("coercePackMeta — only a YAML mapping is metadata (#2748)", () => {
+  it("rejects a top-level sequence, which is truthy AND typeof object", () => {
+    expect([] as unknown).toBeTruthy();
+    expect(typeof []).toBe("object");
+    // …and is therefore exactly what a naive object check lets through.
+    expect(coercePackMeta([])).toBeNull();
+    expect(coercePackMeta([{ workflow: "graph.json" }])).toBeNull();
+  });
+
+  it("rejects scalars, null and undefined", () => {
+    for (const v of [null, undefined, "", "text", 0, 42, false, true]) {
+      expect(coercePackMeta(v)).toBeNull();
+    }
+  });
+
+  it("accepts a mapping unchanged", () => {
+    const meta = { workflow: "graph.json", family: "qwen" };
+    expect(coercePackMeta(meta)).toEqual(meta);
+    expect(coercePackMeta({})).toEqual({});
+  });
+
+  it("a sequence pack.yaml is described as unparseable, NOT as installer-only", () => {
+    // The end-to-end consequence: readPackMeta returns null for `[]`, and the
+    // classifier's null branch says so rather than inventing an intent.
+    const msg = describeMissingWorkflow("seq-pack", {
+      hasPackYaml: true,
+      meta: coercePackMeta([]),
+    });
+    expect(msg).toMatch(/did not parse to a YAML mapping/);
+    expect(msg).not.toMatch(/installer-only/);
   });
 });

--- a/src/__tests__/tools/skills-access.test.ts
+++ b/src/__tests__/tools/skills-access.test.ts
@@ -60,7 +60,12 @@ vi.mock("../../services/panel-template-relay.js", () => ({
   requestPanelTemplateIndex: (...args: unknown[]) => mocks.requestPanelTemplateIndex(...args),
 }));
 
-import { registerSkillsAccessTools, enumeratePacks } from "../../tools/skills-access.js";
+import {
+  registerSkillsAccessTools,
+  enumeratePacks,
+  resolvePackWorkflowFile,
+  resolveWorkflowFileName,
+} from "../../tools/skills-access.js";
 
 type Handler = (args: Record<string, any>) => Promise<{
   isError?: boolean;
@@ -586,5 +591,153 @@ describe("the eight knowledge names are retired", () => {
   it("no action is spelled the same as any retired name", () => {
     const dead = new Set(DEAD_NAMES.map((d) => d.name));
     for (const action of ACTIONS) expect(dead.has(action)).toBe(false);
+  });
+});
+
+/**
+ * #2748 — a workflow miss must not advertise the pack it just refused.
+ *
+ * Not every bundled pack ships a graph: an installer-only pack declares
+ * `workflow: null` in pack.yaml (qwen-image, ltx-2.3 at time of writing), and
+ * action:"list" correctly reports has_workflow: false for it. But both workflow
+ * exits built their suggestion list as `enumeratePacks().map(p => p.name)` with
+ * NO has_workflow filter, under a sentence promising "with a ready workflow" —
+ * so check_runtime refused qwen-image and then listed qwen-image as an
+ * available pack. Copying a name out of that list reproduced the same refusal,
+ * which reads as the catalog disagreeing with the filesystem.
+ *
+ * These drive the REAL handler over the REAL bundled packs/ dir, so they fail
+ * if the filter is removed or if a future pack breaks the invariant.
+ */
+describe("list_packs — workflow-miss suggestions (#2748)", () => {
+  /** Parse the suggestion sentence into EXACT names.
+   *
+   *  Two parsing traps, both of which silently pass a broken assertion:
+   *  - Substring matching is wrong — "qwen-image" is a prefix of
+   *    "qwen-image-edit", so `toContain("qwen-image")` matches the wrong pack.
+   *  - Pack names CONTAIN dots (ltx-2.3, ltx-2.3-flf, ...), so stopping the
+   *    capture at the first "." truncates the list to a name that does not
+   *    exist ("ltx-2"). The suggestion is the last sentence, so take the rest
+   *    of the message and strip only the trailing period. */
+  function suggestedNames(message: string): string[] {
+    const m = /Packs with a ready workflow: (.*)$/.exec(message);
+    if (!m) return [];
+    return m[1]
+      .replace(/\.\s*$/, "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  /** A really-bundled pack that ships NO workflow — the #2748 shape. */
+  function installerOnlyPack(): string {
+    const pack = enumeratePacks().find((p) => p.has_workflow === false);
+    // Premise check: if every bundled pack ever gains a workflow this whole
+    // describe block is vacuous, so fail loudly rather than pass silently.
+    expect(pack, "expected at least one bundled installer-only pack").toBeDefined();
+    return String(pack!.name);
+  }
+
+  it('action:"check_runtime" on an installer-only pack does not deny the pack exists', async () => {
+    const name = installerOnlyPack();
+    const res = await handler()({ action: "check_runtime", pack: name });
+    expect(res.isError).toBe(true);
+    // It DOES exist and action:"list" lists it — claiming otherwise is the bug.
+    expect(text(res)).not.toContain(`No pack named "${name}"`);
+    expect(text(res)).toContain("ships no workflow");
+  });
+
+  it('action:"check_runtime" never suggests a pack that has no ready workflow', async () => {
+    const name = installerOnlyPack();
+    const res = await handler()({ action: "check_runtime", pack: name });
+    const suggested = suggestedNames(text(res));
+    expect(suggested.length).toBeGreaterThan(0);
+    expect(suggested).not.toContain(name);
+    // Every suggestion must survive the resolver the action itself uses.
+    const ready = new Set(
+      enumeratePacks()
+        .filter((p) => p.has_workflow)
+        .map((p) => String(p.name)),
+    );
+    for (const s of suggested) expect(ready.has(s)).toBe(true);
+  });
+
+  it('action:"read_workflow" on an installer-only pack explains it and suggests only ready packs', async () => {
+    const name = installerOnlyPack();
+    const res = await handler()({ action: "read_workflow", name });
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain("ships no workflow");
+    expect(suggestedNames(text(res))).not.toContain(name);
+  });
+
+  it('action:"read_workflow" on an unknown pack suggests only packs with a ready workflow', async () => {
+    const res = await handler()({ action: "read_workflow", name: "definitely-not-a-pack" });
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain('No pack named "definitely-not-a-pack"');
+    expect(suggestedNames(text(res))).not.toContain(installerOnlyPack());
+  });
+
+  it('action:"read_manifest" still suggests ALL packs — an installer-only pack HAS a manifest', async () => {
+    // Deliberately NOT filtered by has_workflow: read_manifest answers a
+    // different question, and hiding installer-only packs here would break the
+    // one action they exist for.
+    const name = installerOnlyPack();
+    const res = await handler()({ action: "read_manifest", name });
+    expect(res.isError).toBeUndefined();
+    expect(text(res)).toMatch(/custom_nodes|models/);
+  });
+});
+
+/**
+ * #2748 — action:"list" must derive has_workflow from the SAME filename the
+ * resolver opens.
+ *
+ * The reported symptom (has_workflow: true alongside "workflow.json not found")
+ * was reachable through a real divergence: enumeratePacks() took `meta.workflow`
+ * verbatim, while resolvePackWorkflowFile() rejected any value that is not a
+ * single safe path segment and silently fell back to workflow.json. A pack
+ * declaring `workflow: "sub/graph.json"` would therefore advertise a graph the
+ * resolver would never open. Today's bundled packs happen not to declare such a
+ * value, so a corpus test alone cannot see it — the shared derivation is pinned
+ * directly instead.
+ */
+describe("pack workflow filename — one derivation (#2748)", () => {
+  it("falls back to workflow.json for every value the resolver would reject", () => {
+    for (const declared of [
+      "sub/graph.json", // separator — resolver falls back, list must too
+      "../escape.json", // traversal
+      "..",
+      "sub\\graph.json", // Windows separator
+      "", // empty
+      ".hidden.json", // SAFE_NAME requires an alphanumeric first char
+    ]) {
+      expect(resolveWorkflowFileName({ workflow: declared })).toBe("workflow.json");
+    }
+  });
+
+  it("keeps a safe declared filename, and defaults when none is declared", () => {
+    expect(resolveWorkflowFileName({ workflow: "graph.json" })).toBe("graph.json");
+    expect(resolveWorkflowFileName({ workflow: "workflow.json" })).toBe("workflow.json");
+    // `workflow: null` (installer-only), absent, and non-string all default.
+    expect(resolveWorkflowFileName({ workflow: null })).toBe("workflow.json");
+    expect(resolveWorkflowFileName({})).toBe("workflow.json");
+    expect(resolveWorkflowFileName({ workflow: 42 })).toBe("workflow.json");
+    expect(resolveWorkflowFileName(null)).toBe("workflow.json");
+    expect(resolveWorkflowFileName(undefined)).toBe("workflow.json");
+  });
+
+  /** The invariant the issue actually reports, over the REAL bundled corpus:
+   *  action:"list" and the resolver must agree for every pack, always. */
+  it("has_workflow agrees with resolvePackWorkflowFile for every bundled pack", () => {
+    const packs = enumeratePacks();
+    expect(packs.length).toBeGreaterThan(0);
+    const disagreements = packs
+      .map((p) => ({
+        name: String(p.name),
+        listed: p.has_workflow === true,
+        resolved: resolvePackWorkflowFile(String(p.name)) !== null,
+      }))
+      .filter((r) => r.listed !== r.resolved);
+    expect(disagreements).toEqual([]);
   });
 });

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -175,13 +175,27 @@ function enumerateSkills(): Array<{ name: string; description: string }> {
  *  found" — the catalog disagreeing with the filesystem (#2748). Deriving it once
  *  makes that divergence unrepresentable rather than merely absent from today's
  *  bundled packs. */
-/** Parse `packs/<name>/pack.yaml`, or null when absent/unreadable/malformed. */
+/** A pack.yaml must parse to a YAML MAPPING — pure so the trap below is
+ *  directly testable.
+ *
+ *  A top-level SEQUENCE is the trap: `parseYaml("[]")` is truthy AND
+ *  `typeof === "object"`, so a `parsed && typeof parsed === "object"` check
+ *  accepts it as a metadata record. Every field then reads `undefined`, and
+ *  `workflow: undefined` is indistinguishable from a deliberate `workflow: null`
+ *  — so a malformed bundle gets reported as an intentional installer-only pack.
+ *  Array.isArray is the only thing separating metadata from "something else that
+ *  happens to parse". */
+export function coercePackMeta(parsed: unknown): Record<string, unknown> | null {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  return parsed as Record<string, unknown>;
+}
+
+/** Parse `packs/<name>/pack.yaml`, or null when absent/unreadable/not a mapping. */
 function readPackMeta(packDir: string): Record<string, unknown> | null {
   const metaFile = join(packDir, "pack.yaml");
   if (!existsSync(metaFile)) return null;
   try {
-    const parsed = parseYaml(readFileSync(metaFile, "utf8"));
-    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+    return coercePackMeta(parseYaml(readFileSync(metaFile, "utf8")));
   } catch {
     return null;
   }
@@ -215,13 +229,9 @@ export function enumeratePacks(): Array<Record<string, unknown>> {
     if (!isDir) continue;
     const metaFile = join(packDir, "pack.yaml");
     if (!existsSync(metaFile)) continue; // not a pack
-    let meta: Record<string, unknown> = {};
-    try {
-      const parsed = parseYaml(readFileSync(metaFile, "utf8"));
-      if (parsed && typeof parsed === "object") meta = parsed as Record<string, unknown>;
-    } catch {
-      // malformed pack.yaml — still report the pack with just its dir name
-    }
+    // Same parse contract read_workflow/check_runtime use — a malformed or
+    // non-mapping pack.yaml still reports the pack with just its dir name.
+    const meta = readPackMeta(packDir) ?? {};
     const workflowName = resolveWorkflowFileName(meta);
     out.push({
       name: entry,

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -331,9 +331,16 @@ export function describeMissingWorkflow(
   if (declared != null) {
     return `Pack "${name}" ships no workflow — its pack.yaml sets \`workflow\` to a ${typeof declared} rather than a filename.${footnote}`;
   }
-  // `workflow: null` or absent, in a pack.yaml that parsed — the intended
-  // installer-only shape (qwen-image, ltx-2.3).
-  return `Pack "${name}" ships no workflow — pack.yaml declares no workflow, so it is installer-only.${footnote}`;
+  // An OMITTED key is not a declaration. All 56 bundled packs write `workflow:`
+  // explicitly, so an absent key expresses no intent — the author may equally
+  // have meant workflow.json to be there. Report only what was checked and let
+  // the reader judge, rather than blessing a possibly-broken pack.
+  if (!("workflow" in state.meta)) {
+    return `Pack "${name}" ships no workflow — its pack.yaml has no \`workflow\` key, and the default workflow.json is not in the pack.${footnote}`;
+  }
+  // An EXPLICIT `workflow: null` — the declared installer-only shape
+  // (qwen-image, ltx-2.3).
+  return `Pack "${name}" ships no workflow — pack.yaml declares \`workflow: null\`, so it is installer-only.${footnote}`;
 }
 
 /** I/O half: read the pack's metadata state, then describe it. read_workflow and

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -162,6 +162,41 @@ function enumerateSkills(): Array<{ name: string; description: string }> {
   return out;
 }
 
+/** The workflow filename a pack.yaml resolves to — the SINGLE derivation shared
+ *  by action:"list" (has_workflow), resolvePackWorkflowFile() (which backs
+ *  read_workflow, check_runtime and run_template), and read_workflow's own
+ *  message.
+ *
+ *  This existed three times and one copy was different: action:"list" took
+ *  `meta.workflow` verbatim while the resolver rejected any value that is not a
+ *  single safe path segment and fell back to workflow.json. A pack declaring
+ *  `workflow: "sub/graph.json"` therefore reported has_workflow: true from a file
+ *  the resolver would never open, and read_workflow answered "workflow.json not
+ *  found" — the catalog disagreeing with the filesystem (#2748). Deriving it once
+ *  makes that divergence unrepresentable rather than merely absent from today's
+ *  bundled packs. */
+/** Parse `packs/<name>/pack.yaml`, or null when absent/unreadable/malformed. */
+function readPackMeta(packDir: string): Record<string, unknown> | null {
+  const metaFile = join(packDir, "pack.yaml");
+  if (!existsSync(metaFile)) return null;
+  try {
+    const parsed = parseYaml(readFileSync(metaFile, "utf8"));
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveWorkflowFileName(meta: unknown): string {
+  const fallback = "workflow.json";
+  if (!meta || typeof meta !== "object") return fallback;
+  const declared = (meta as Record<string, unknown>).workflow;
+  if (typeof declared !== "string") return fallback;
+  // A traversal, a separator or an empty value is not a usable filename.
+  if (!SAFE_NAME.test(declared)) return fallback;
+  return declared;
+}
+
 /** Enumerate installer packs as { name, family, kind, description, workflow,
  *  has_workflow, has_manifest }. Reads each packs/<name>/pack.yaml. */
 export function enumeratePacks(): Array<Record<string, unknown>> {
@@ -187,7 +222,7 @@ export function enumeratePacks(): Array<Record<string, unknown>> {
     } catch {
       // malformed pack.yaml — still report the pack with just its dir name
     }
-    const workflowName = typeof meta.workflow === "string" ? meta.workflow : "workflow.json";
+    const workflowName = resolveWorkflowFileName(meta);
     out.push({
       name: entry,
       family: meta.family ?? null,
@@ -211,6 +246,62 @@ export function enumeratePacks(): Array<Record<string, unknown>> {
   return out;
 }
 
+/** Pack names that actually HAVE a ready workflow — the only names worth
+ *  suggesting after a workflow lookup fails.
+ *
+ *  Not every bundled pack ships a graph: a pack may be installer-only, declaring
+ *  `workflow: null` in pack.yaml because the upstream installer never shipped one
+ *  (qwen-image, ltx-2.3). Suggesting those after a workflow miss advertises the
+ *  very pack that was just refused, and re-calling with a name copied out of the
+ *  list fails identically — which reads as the catalog disagreeing with the
+ *  filesystem (#2748). `has_workflow` is the same existsSync the resolver uses,
+ *  so this list and resolvePackWorkflowFile() cannot disagree.
+ *
+ *  enqueue_workflow (action:"run_template") already filters its suggestions this
+ *  way; this is the shared version of that filter. */
+function packsWithReadyWorkflow(): string[] {
+  return enumeratePacks()
+    .filter((p) => p.has_workflow)
+    .map((p) => String(p.name));
+}
+
+/** True when `packs/<name>/` exists as a directory, regardless of whether it
+ *  ships a workflow. Lets a workflow miss say "this pack ships no workflow"
+ *  instead of the false "no pack named <name>". */
+function packDirExists(name: string): boolean {
+  if (!SAFE_NAME.test(name)) return false;
+  const packDir = join(packsDir(), name);
+  if (!packDir.startsWith(packsDir())) return false;
+  try {
+    return statSync(packDir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Render a suggestion list, or a clear note when nothing qualifies. */
+function suggest(names: string[]): string {
+  return names.length
+    ? `Packs with a ready workflow: ${names.join(", ")}.`
+    : "No bundled pack ships a ready workflow.";
+}
+
+/** The whole "this pack exists but has no graph" sentence, for a pack that IS
+ *  bundled. Distinguishes an installer-only pack (pack.yaml `workflow: null`,
+ *  working as intended) from a pack that DECLARES a filename which is then
+ *  absent (a broken bundle) — so the message never asserts a cause it did not
+ *  check. read_workflow and check_runtime share this one builder; deriving it
+ *  twice is the defect class this whole change is about. Error path only. */
+function noWorkflowSentence(name: string): string {
+  const packDir = join(packsDir(), name);
+  const meta = readPackMeta(packDir);
+  const why =
+    typeof meta?.workflow === "string"
+      ? `its declared workflow file (${resolveWorkflowFileName(meta)}) is missing from the pack`
+      : "pack.yaml declares no workflow, so it is installer-only";
+  return `Pack "${name}" ships no workflow — ${why}. action:"list" reports has_workflow: false for it.`;
+}
+
 /** Locate a pack's workflow.json file path (name-guarded, must exist). Returns
  *  null when the pack or its workflow is missing. Shared by action:"read_workflow"
  *  and action:"check_runtime" so they resolve the file identically. Also
@@ -223,19 +314,7 @@ export function resolvePackWorkflowFile(packName: string): string | null {
   if (!packDir.startsWith(packsDir()) || !existsSync(packDir) || !statSync(packDir).isDirectory()) {
     return null;
   }
-  let workflowName = "workflow.json";
-  const metaFile = join(packDir, "pack.yaml");
-  if (existsSync(metaFile)) {
-    try {
-      const meta = parseYaml(readFileSync(metaFile, "utf8")) as Record<string, unknown>;
-      if (meta && typeof meta.workflow === "string") workflowName = meta.workflow;
-    } catch {
-      // keep default
-    }
-  }
-  if (!SAFE_NAME.test(workflowName) && workflowName !== "workflow.json") {
-    workflowName = "workflow.json";
-  }
+  const workflowName = resolveWorkflowFileName(readPackMeta(packDir));
   const wfFile = join(packDir, workflowName);
   if (!wfFile.startsWith(packDir) || !existsSync(wfFile)) return null;
   return wfFile;
@@ -486,32 +565,20 @@ function readPackWorkflowAction(rawName: string): ToolText {
   }
   const packDir = join(packsDir(), name);
   if (!packDir.startsWith(packsDir()) || !existsSync(packDir) || !statSync(packDir).isDirectory()) {
-    const known = enumeratePacks().map((p) => p.name);
     return {
       isError: true,
       content: [
         {
           type: "text" as const,
-          text: `No pack named "${name}". Available packs: ${known.join(", ") || "(none bundled)"}.`,
+          text: `No pack named "${name}". ${suggest(packsWithReadyWorkflow())}`,
         },
       ],
     };
   }
-  // Resolve the workflow filename from pack.yaml (default workflow.json).
-  let workflowName = "workflow.json";
-  const metaFile = join(packDir, "pack.yaml");
-  if (existsSync(metaFile)) {
-    try {
-      const meta = parseYaml(readFileSync(metaFile, "utf8")) as Record<string, unknown>;
-      if (meta && typeof meta.workflow === "string") workflowName = meta.workflow;
-    } catch {
-      // keep default
-    }
-  }
-  if (!SAFE_NAME.test(workflowName) && workflowName !== "workflow.json") {
-    // pack.yaml controls this, but stay defensive against odd values.
-    workflowName = "workflow.json";
-  }
+  // Same single derivation action:"list" and resolvePackWorkflowFile() use, so
+  // the filename this message names is the filename that was actually looked for.
+  const meta = readPackMeta(packDir);
+  const workflowName = resolveWorkflowFileName(meta);
   const wfFile = join(packDir, workflowName);
   if (!wfFile.startsWith(packDir) || !existsSync(wfFile)) {
     return {
@@ -519,7 +586,7 @@ function readPackWorkflowAction(rawName: string): ToolText {
       content: [
         {
           type: "text" as const,
-          text: `Pack "${name}" has no ready workflow (${workflowName} not found).`,
+          text: `${noWorkflowSentence(name)} ${suggest(packsWithReadyWorkflow())}`,
         },
       ],
     };
@@ -690,13 +757,20 @@ async function checkRuntimeAction(args: {
   if (args.pack) {
     const wfFile = resolvePackWorkflowFile(args.pack);
     if (!wfFile) {
-      const known = enumeratePacks().map((p) => p.name);
+      // TWO different failures shared one message: a pack that does not exist,
+      // and a pack that exists but is installer-only. Saying `No pack named
+      // "qwen-image"` for a pack action:"list" plainly lists reads as the
+      // catalog contradicting itself (#2748) — name which one it actually is.
+      const packName = args.pack.trim();
+      const head = packDirExists(packName)
+        ? `${noWorkflowSentence(packName)} There is no graph to runtime-check.`
+        : `No pack named "${args.pack}".`;
       return {
         isError: true,
         content: [
           {
             type: "text" as const,
-            text: `No pack named "${args.pack}" with a ready workflow. Available packs: ${known.join(", ") || "(none bundled)"}.`,
+            text: `${head} ${suggest(packsWithReadyWorkflow())}`,
           },
         ],
       };

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -286,20 +286,54 @@ function suggest(names: string[]): string {
     : "No bundled pack ships a ready workflow.";
 }
 
-/** The whole "this pack exists but has no graph" sentence, for a pack that IS
- *  bundled. Distinguishes an installer-only pack (pack.yaml `workflow: null`,
- *  working as intended) from a pack that DECLARES a filename which is then
- *  absent (a broken bundle) — so the message never asserts a cause it did not
- *  check. read_workflow and check_runtime share this one builder; deriving it
- *  twice is the defect class this whole change is about. Error path only. */
+/** The "this directory exists but has no graph" sentence — the PURE half, so
+ *  every branch is testable without planting fixture directories in packs/.
+ *
+ *  FIVE distinct states share this exit, and collapsing them is the same defect
+ *  this PR is fixing one level up: a message that asserts a cause nobody checked.
+ *  "Installer-only" is a deliberate, working-as-intended state (pack.yaml
+ *  `workflow: null`) — reporting a malformed pack.yaml, an absent pack.yaml, or
+ *  `workflow: 42` as "installer-only" hides a broken bundle behind a reassuring
+ *  explanation, and the has_workflow footnote is itself false when action:"list"
+ *  does not list the directory at all (it requires a pack.yaml to consider one a
+ *  pack). */
+export function describeMissingWorkflow(
+  name: string,
+  state: { hasPackYaml: boolean; meta: Record<string, unknown> | null },
+): string {
+  // No pack.yaml → action:"list" does not consider this a pack at all, so the
+  // "has_workflow: false" footnote below would be a claim about a row that
+  // does not exist.
+  if (!state.hasPackYaml) {
+    return `"${name}" is a directory under packs/ with no pack.yaml, so it is not a bundled pack and action:"list" does not report it.`;
+  }
+  // Covers unreadable, malformed, empty, and "parsed to something that is not a
+  // mapping" alike — in none of them did anyone verify an installer-only intent.
+  if (state.meta === null) {
+    return `Pack "${name}" has a pack.yaml that did not parse to a YAML mapping, so no workflow filename could be resolved.`;
+  }
+  const declared = state.meta.workflow;
+  const footnote = ` action:"list" reports has_workflow: false for it.`;
+  if (typeof declared === "string") {
+    // Declared a name; the file is absent — a broken bundle, NOT installer-only.
+    return `Pack "${name}" ships no workflow — its declared workflow file (${resolveWorkflowFileName(state.meta)}) is missing from the pack.${footnote}`;
+  }
+  if (declared != null) {
+    return `Pack "${name}" ships no workflow — its pack.yaml sets \`workflow\` to a ${typeof declared} rather than a filename.${footnote}`;
+  }
+  // `workflow: null` or absent, in a pack.yaml that parsed — the intended
+  // installer-only shape (qwen-image, ltx-2.3).
+  return `Pack "${name}" ships no workflow — pack.yaml declares no workflow, so it is installer-only.${footnote}`;
+}
+
+/** I/O half: read the pack's metadata state, then describe it. read_workflow and
+ *  check_runtime share this one builder. Error path only. */
 function noWorkflowSentence(name: string): string {
   const packDir = join(packsDir(), name);
-  const meta = readPackMeta(packDir);
-  const why =
-    typeof meta?.workflow === "string"
-      ? `its declared workflow file (${resolveWorkflowFileName(meta)}) is missing from the pack`
-      : "pack.yaml declares no workflow, so it is installer-only";
-  return `Pack "${name}" ships no workflow — ${why}. action:"list" reports has_workflow: false for it.`;
+  return describeMissingWorkflow(name, {
+    hasPackYaml: existsSync(join(packDir, "pack.yaml")),
+    meta: readPackMeta(packDir),
+  });
 }
 
 /** Locate a pack's workflow.json file path (name-guarded, must exist). Returns

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -163,9 +163,9 @@ function enumerateSkills(): Array<{ name: string; description: string }> {
 }
 
 /** The workflow filename a pack.yaml resolves to — the SINGLE derivation shared
- *  by action:"list" (has_workflow), resolvePackWorkflowFile() (which backs
- *  read_workflow, check_runtime and run_template), and read_workflow's own
- *  message.
+ *  by action:"list" (has_workflow), resolvePackWorkflowFile() — which backs
+ *  action:"read_workflow", action:"check_runtime" and also
+ *  enqueue_workflow (action:"run_template") — and read_workflow's own message.
  *
  *  This existed three times and one copy was different: action:"list" took
  *  `meta.workflow` verbatim while the resolver rejected any value that is not a


### PR DESCRIPTION
Closes #2748

## What the reporter hit

`list_packs action:"check_runtime" pack:"qwen-image"` answered:

> `No pack named "qwen-image" with a ready workflow. Available packs: <all 56, including qwen-image>`

…for a pack that `action:"list"` plainly lists. The list offered as the remedy **contained the pack it had just refused**, so copying a name out of it reproduced the identical failure. That is what made the catalog look like it disagreed with the filesystem.

## Two independent defects

**1. The suggestion list was never filtered.** Both workflow exits built it as `enumeratePacks().map(p => p.name)` — no `has_workflow` filter — under a sentence promising *"with a ready workflow"*. Two of the 56 bundled packs (`qwen-image`, `ltx-2.3`) are installer-only and ship no graph.

The sibling call site already does this correctly: `runTemplateAction` (`src/tools/run-template.ts:141-143`) filters `.filter((p) => p.has_workflow)` before suggesting. **One exit was fixed and two were left behind** — this restores the family.

**2. The workflow filename was derived three times and one copy differed.** `enumeratePacks` took `meta.workflow` verbatim; `resolvePackWorkflowFile` rejected anything that is not a single safe path segment and fell back to `workflow.json`. A pack declaring `workflow: "sub/graph.json"` would report `has_workflow: true` for a file the resolver never opens while `read_workflow` said `workflow.json not found` — **exactly the reported symptom**. Reachable, but not triggered by today's pack data, so a corpus test alone cannot see it.

## The change

- `resolveWorkflowFileName()` — one exported derivation now shared by `action:"list"`, `resolvePackWorkflowFile()` and `read_workflow`'s own message. The divergence becomes unrepresentable rather than merely absent.
- `noWorkflowSentence()` — distinguishes *"no such pack"* from *"this pack exists and is installer-only"*, and does **not** assert a cause it did not check (a declared-but-absent filename reads differently from `workflow: null`).
- Both workflow exits suggest only packs that actually have a ready workflow.

Observed output on this branch:

```
Pack "qwen-image" ships no workflow — pack.yaml declares no workflow, so it is
installer-only. action:"list" reports has_workflow: false for it. There is no
graph to runtime-check. Packs with a ready workflow: <54 names, qwen-image absent>
```

## What does NOT reproduce — and I did not manufacture a fix for it

The `has_workflow: true` half of the report. I unpacked the **published `comfyui-mcp@0.52.176` tarball** the reporter names and enumerated its own bundled `packs/`: `qwen-image → has_workflow: false` there and on `main`, with zero divergence across all 56 packs. `packs/qwen-image/` ships no `workflow.json` in either tree. There is no catalog/filesystem inconsistency to fix; the misleading *message* is the whole defect.

## Where the load-bearing claims are (please poke here)

- **`packDirExists()` is a new filesystem read on an error path.** It is `statSync` in a try/catch returning `false`, name-guarded by `SAFE_NAME` and prefix-checked against `packsDir()` before use — but it is a new failure surface inside a branch that previously only formatted a string.
- **`resolveWorkflowFileName` is now the single gate for a path segment that gets `join`ed.** It is strictly *tighter* than the old `enumeratePacks` copy (which had no guard) and equivalent to the resolver's, so this narrows rather than widens what can be opened — worth a second read anyway.
- **`read_manifest`'s list is deliberately left unfiltered.** All 56 packs have a manifest; filtering it by `has_workflow` would hide the two packs that exist *precisely* for manifest installs. Pinned with a test asserting `read_manifest` still succeeds for an installer-only pack.
- The corpus test (`has_workflow` agrees with the resolver for every bundled pack) **passes before and after** — it is a forward-looking invariant, not the behavioural pin. The behavioural pins are the mutation-verified ones below.

## Verification — fix deleted, tests watched to fail

| Mutation | Result |
|---|---|
| Remove `.filter(p => p.has_workflow)` | **3 tests fail**, one per exit |
| Replace `packDirExists(...)` with `false` | **1 test fails** — "does not deny the pack exists" |
| Remove the `SAFE_NAME` guard in the shared derivation | **1 test fails** — the filename test |

- Full suite: **760 files, 13994 passed, 6 skipped, 0 failed**.
- `npm run lint` (tsc + anti-slop): clean, *none added*.
- `npm run check:vocabulary`: OK.
- One test-authoring bug the tests themselves caught: my first list parser used `[^.]*`, which truncates at the dot in `ltx-2.3`. Names are parsed exactly now — `qwen-image` is a prefix of `qwen-image-edit`, so substring matching would silently pass on the wrong pack.

**No panel code was touched** (`src/orchestrator/panel-tools.ts` is deliberately unchanged — its messages do not advertise a false list). This changes MCP tool result text only, so the Playwright browser suite was not run and this PR claims no browser coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
