### PR TITLE
chore(release): 0.52.178

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.178] - 2026-09-02
+
 ### MCP
 
 #### Fixed
 - support IPv6-only loopback ComfyUI listeners when `COMFYUI_URL` uses `127.0.0.1` (#2719)
+
+### MCP
+
+#### Fixed
+- support IPv6-only ComfyUI loopback targets (#2747)
+
 
 ## [0.52.177] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
-- support IPv6-only loopback ComfyUI listeners when `COMFYUI_URL` uses `127.0.0.1` (#2719)
-
-### MCP
-
-#### Fixed
-- support IPv6-only ComfyUI loopback targets (#2747)
+- support IPv6-only ComfyUI loopback targets when `COMFYUI_URL` uses `127.0.0.1`, for issue #2719 (#2747)
 
 
 ## [0.52.177] - 2026-09-02

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.177",
+  "version": "0.52.178",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.177",
+      "version": "0.52.178",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.177",
+  "version": "0.52.178",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Release 0.52.178\n\n- Bumps package.json and package-lock.json to 0.52.178.\n- Promotes the IPv6-only loopback target fix from #2719 / #2747.\n- Generated CHANGELOG.md from the merged mainline.\n\nRelease only after exact-head review and all hosted release checks pass.