### PR TITLE
fix(2753): a forceInput-only input is a socket, not a widget slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@ All notable changes to this project are documented here. This project adheres to
 - **the UI→API converter no longer shifts widgets past a `forceInput`-only input (#2753).**
   A `["STRING", {forceInput: true}]` input is a socket on canvas, so ComfyUI writes no
   `widgets_values` slot for it; the converter classified it as a widget, consumed the first
-  saved value, and reported every real widget with its neighbour's value. Legacy rows that
-  DO carry the placeholder are still read correctly, matching the frontend's own
-  length-based migration.
+  saved value, and reported every real widget with its neighbour's value — `get_workflow`
+  returned `unet_name` holding `clip_name`'s model, and so on down the row.
 
 ## [0.52.178] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project are documented here. This project adheres to
   `widgets_values` slot for it; the converter classified it as a widget, consumed the first
   saved value, and reported every real widget with its neighbour's value — `get_workflow`
   returned `unet_name` holding `clip_name`'s model, and so on down the row.
+  A workflow saved before ComfyUI's widget/input unification kept a placeholder slot for
+  such an input; that row is indistinguishable from one carrying an extra serialized
+  value, so it is no longer guessed at — it is reported, naming the unmapped values.
 
 ## [0.52.178] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **the UI→API converter no longer shifts widgets past a `forceInput`-only input (#2753).**
+  A `["STRING", {forceInput: true}]` input is a socket on canvas, so ComfyUI writes no
+  `widgets_values` slot for it; the converter classified it as a widget, consumed the first
+  saved value, and reported every real widget with its neighbour's value. Legacy rows that
+  DO carry the placeholder are still read correctly, matching the frontend's own
+  length-based migration.
+
 ## [0.52.178] - 2026-09-02
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project are documented here. This project adheres to
   A workflow saved before ComfyUI's widget/input unification kept a placeholder slot for
   such an input; that row is indistinguishable from one carrying an extra serialized
   value, so it is no longer guessed at — it is reported, naming the unmapped values.
+  The deprecated `defaultInput` spelling is honoured the way the frontend migrates it:
+  socket-only on an OPTIONAL input, widget kept on a REQUIRED one.
 
 ## [0.52.178] - 2026-09-02
 

--- a/src/__tests__/services/workflow-converter-api-to-ui.test.ts
+++ b/src/__tests__/services/workflow-converter-api-to-ui.test.ts
@@ -402,6 +402,40 @@ describe("convertApiToUi — forceInput-only scalar input (issue #2753)", () => 
     expect(slot?.widget).toBeUndefined();
   });
 
+  // An API graph MAY carry a literal on a forceInput input — ComfyUI's backend
+  // ignores forceInput, it is a frontend hint. UI format has nowhere to put it: the
+  // canvas renders a socket, so there is no widget and no widgets_values slot. This
+  // is therefore the converter's ordinary treatment of a literal on a socket input,
+  // the same warning every other link input gets, and it is DELIBERATE.
+  //
+  // The alternative is what this PR removed: writing a placeholder into
+  // widgets_values. That is not a carrier either — ComfyUI's own loader
+  // (migrateWidgetsValues) drops exactly that slot on load — it just loses the value
+  // silently, one step later, and misaligns every widget after it in the meantime.
+  it("a literal on the socket-only input is dropped, and SAID so", () => {
+    const withLiteral = {
+      "7": {
+        class_type: "AnimaTrainerLoader",
+        inputs: {
+          trainer_status: "a literal the canvas cannot hold",
+          unet_name: "anima-base-v1.0.safetensors",
+          clip_name: "qwen_3_06b_base.safetensors",
+          weight_dtype: "default",
+        },
+      },
+    } as never;
+    const { workflow, warnings } = convertApiToUi(withLiteral, INFO);
+    const node = workflow.nodes[0];
+    // the literal does NOT become a widget slot — that is what shifted the row
+    expect(node.widgets_values).toEqual([
+      "anima-base-v1.0.safetensors",
+      "qwen_3_06b_base.safetensors",
+      "default",
+    ]);
+    expect(warnings.join(" ")).toContain('"trainer_status"');
+    expect(warnings.join(" ")).toContain("dropped");
+  });
+
   it("round-trips back to the same widget values", () => {
     const { workflow: ui } = convertApiToUi(API, INFO);
     const { workflow: api } = convertUiToApi(ui as never, INFO);

--- a/src/__tests__/services/workflow-converter-api-to-ui.test.ts
+++ b/src/__tests__/services/workflow-converter-api-to-ui.test.ts
@@ -351,3 +351,65 @@ describe("isApiFormat / isUiFormat detection", () => {
     expect(isApiFormat({ a: { inputs: {} } })).toBe(false); // no class_type
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #2753 — the reverse direction has to agree, or a round-trip re-introduces the
+// shift. A forceInput-only input is a plain SOCKET on canvas: it gets an inputs[]
+// slot with no `widget` marker, and NO widgets_values placeholder.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("convertApiToUi — forceInput-only scalar input (issue #2753)", () => {
+  const INFO = {
+    AnimaTrainerLoader: {
+      input: {
+        required: {
+          trainer_status: ["STRING", { forceInput: true }],
+          unet_name: [["anima-base-v1.0.safetensors", "other.safetensors"]],
+          clip_name: [["qwen_3_06b_base.safetensors", "other.safetensors"]],
+          weight_dtype: [["default", "fp8_e4m3fn"]],
+        },
+      },
+      input_order: {
+        required: ["trainer_status", "unet_name", "clip_name", "weight_dtype"],
+      },
+      output: ["MODEL"],
+      output_name: ["MODEL"],
+    },
+  } as never;
+
+  const API = {
+    "7": {
+      class_type: "AnimaTrainerLoader",
+      inputs: {
+        unet_name: "anima-base-v1.0.safetensors",
+        clip_name: "qwen_3_06b_base.safetensors",
+        weight_dtype: "default",
+      },
+    },
+  } as never;
+
+  it("emits a socket slot and NO widgets_values placeholder for it", () => {
+    const { workflow } = convertApiToUi(API, INFO);
+    const node = workflow.nodes[0];
+    expect(node.widgets_values).toEqual([
+      "anima-base-v1.0.safetensors",
+      "qwen_3_06b_base.safetensors",
+      "default",
+    ]);
+    const slot = (node.inputs ?? []).find((i) => i.name === "trainer_status");
+    expect(slot).toBeDefined();
+    // a real socket, not a converted widget — an unwired `widget:{…}` slot is
+    // stripped by the frontend on load, which would lose the socket entirely.
+    expect(slot?.widget).toBeUndefined();
+  });
+
+  it("round-trips back to the same widget values", () => {
+    const { workflow: ui } = convertApiToUi(API, INFO);
+    const { workflow: api } = convertUiToApi(ui as never, INFO);
+    expect((api["7"] as { inputs: Record<string, unknown> }).inputs).toMatchObject({
+      unet_name: "anima-base-v1.0.safetensors",
+      clip_name: "qwen_3_06b_base.safetensors",
+      weight_dtype: "default",
+    });
+  });
+});
+

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3864,120 +3864,13 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
     expect(inputs.clip_device).toBe("default");
   });
 
-  // A row saved BEFORE ComfyUI's widget/input unification kept a placeholder slot
-  // for the forceInput input. ComfyUI's own loader (migrateWidgetsValues) drops it
-  // by matching the row length against that legacy layout; so do we, otherwise the
-  // fix above would shift a legacy row the other way.
-  it("legacy row with a forceInput placeholder is still read correctly", () => {
-    const { workflow } = convertUiToApi(
-      animaGraph([null, ...SAVED_ROW]),
-      ANIMA_INFO,
-    );
-    const inputs = (workflow["7"] as { inputs: Record<string, unknown> }).inputs;
-    expect(inputs).toMatchObject({
-      unet_name: "anima-base-v1.0.safetensors",
-      clip_name: "qwen_3_06b_base.safetensors",
-      vae_name: "qwen_image_vae.safetensors",
-      weight_dtype: "default",
-      clip_device: "default",
-    });
-  });
-
-  // The length gate must not fire on a row that is neither layout — a modern row
-  // with an extra serialized value must keep falling through to the existing
-  // #1869 extras handling rather than silently losing its FIRST value.
-  it("does not strip anything when the row matches neither layout", () => {
-    const row = [...SAVED_ROW, "trailing_extra", "one_more"];
-    const { workflow } = convertUiToApi(animaGraph(row), ANIMA_INFO);
-    const inputs = (workflow["7"] as { inputs: Record<string, unknown> }).inputs;
-    expect(inputs.unet_name).toBe("anima-base-v1.0.safetensors");
-  });
-
-  // A SHIPPED node with the same shape, so the pin is not only on the reporter's
-  // custom node: rgthree's SDXLPowerPromptPositive declares opt_clip_width and
-  // opt_clip_height as ["INT", {forceInput: true, default: 1024}] ahead of three
-  // combo widgets, so before the fix BOTH stole a slot and the three combos read
-  // two positions late.
-  it("rgthree SDXLPowerPromptPositive: two forceInput INTs steal no slots", () => {
-    const RGTHREE_INFO = {
-      "SDXL Power Prompt - Positive (rgthree)": {
-        input: {
-          required: {
-            prompt_g: ["STRING", { multiline: true }],
-            prompt_l: ["STRING", { multiline: true }],
-          },
-          optional: {
-            opt_model: ["MODEL"],
-            opt_clip: ["CLIP"],
-            opt_clip_width: ["INT", { forceInput: true, default: 1024 }],
-            opt_clip_height: ["INT", { forceInput: true, default: 1024 }],
-            insert_lora: [["CHOOSE", "DISABLE LORAS", "detail.safetensors"]],
-            insert_embedding: [["CHOOSE", "badhands"]],
-            insert_saved: [["CHOOSE", "my_prompt"]],
-          },
-        },
-        input_order: {
-          required: ["prompt_g", "prompt_l"],
-          optional: [
-            "opt_model",
-            "opt_clip",
-            "opt_clip_width",
-            "opt_clip_height",
-            "insert_lora",
-            "insert_embedding",
-            "insert_saved",
-          ],
-        },
-        output: ["CONDITIONING"],
-        output_name: ["CONDITIONING"],
-      },
-    } as never;
-    const { workflow } = convertUiToApi(
-      {
-        nodes: [
-          {
-            id: 4,
-            type: "SDXL Power Prompt - Positive (rgthree)",
-            mode: 0,
-            inputs: [
-              { name: "opt_model", type: "MODEL", link: null },
-              { name: "opt_clip", type: "CLIP", link: null },
-              { name: "opt_clip_width", type: "INT", link: null },
-              { name: "opt_clip_height", type: "INT", link: null },
-            ],
-            outputs: [{ name: "CONDITIONING", type: "CONDITIONING", links: [] }],
-            widgets_values: [
-              "a photo of a cat",
-              "cat",
-              "detail.safetensors",
-              "badhands",
-              "my_prompt",
-            ],
-          },
-        ],
-        links: [],
-      } as never,
-      RGTHREE_INFO,
-    );
-    const inputs = (workflow["4"] as { inputs: Record<string, unknown> }).inputs;
-    expect(inputs).toMatchObject({
-      prompt_g: "a photo of a cat",
-      prompt_l: "cat",
-      insert_lora: "detail.safetensors",
-      insert_embedding: "badhands",
-      insert_saved: "my_prompt",
-    });
-    // pre-fix: the two forceInput INTs consumed prompt_g/prompt_l's slots and the
-    // three combos each read two positions late (falling back to "CHOOSE").
-    expect(inputs.insert_lora).not.toBe("CHOOSE");
-    expect(inputs.insert_embedding).not.toBe("CHOOSE");
-  });
-
-  // A row ONE longer than the modern layout is equally well explained by a modern
-  // row carrying a frontend-only serialized extra (#1869), and THAT reading is the
-  // right one — the extras pass recovers the real value and reports the skip, while
-  // a legacy strip would put the extra on a real widget. So the length coincidence
-  // must not be enough on its own.
+  // Excluding the socket-only input hands a row that is one longer than the widget
+  // layout back to the #1869 extras pass, which is what reads it correctly. Pin
+  // that, because the tempting "normalize the row by length first" shortcut breaks
+  // exactly here: it would claim the extra as a legacy placeholder and put
+  // "detect_range" on `path`, silently. (The reverse — a genuinely legacy row with a
+  // placeholder — is the accepted limitation noted at the mapping site: the two are
+  // indistinguishable by length, so neither is guessed.)
   const AMVIDEO_INFO = {
     AMVideoRead: {
       input: {
@@ -4008,7 +3901,7 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
     } as never;
   }
 
-  it("a serialized action button beats the legacy-placeholder reading of the same length", () => {
+  it("hands a one-long row to the #1869 extras pass, which recovers the real value", () => {
     const { workflow, warnings } = convertUiToApi(
       amVideoGraph(["D:/input.mov", "detect_range", 12]),
       AMVIDEO_INFO,
@@ -4020,7 +3913,7 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
     expect(warnings.join(" ")).toContain("detect_range");
   });
 
-  it("a type-refuted extra beats it too (the other #1869 signal)", () => {
+  it("…via the other #1869 signal too (a value the declared type refutes)", () => {
     const { workflow } = convertUiToApi(
       amVideoGraph(["D:/input.mov", "not_a_number", 12]),
       AMVIDEO_INFO,

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3796,24 +3796,23 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
     "default",
   ];
 
-  function animaGraph(row: unknown[], trainerLink: number | null = null) {
+  function animaNode(row: unknown[], trainerLink: number | null = null) {
     return {
-      nodes: [
-        {
-          id: 7,
-          type: "AnimaTrainerLoader",
-          mode: 0,
-          inputs: [{ name: "trainer_status", type: "STRING", link: trainerLink }],
-          outputs: [
-            { name: "MODEL", type: "MODEL", links: [] },
-            { name: "CLIP", type: "CLIP", links: [] },
-            { name: "VAE", type: "VAE", links: [] },
-          ],
-          widgets_values: row,
-        },
+      id: 7,
+      type: "AnimaTrainerLoader",
+      mode: 0,
+      inputs: [{ name: "trainer_status", type: "STRING", link: trainerLink }],
+      outputs: [
+        { name: "MODEL", type: "MODEL", links: [] },
+        { name: "CLIP", type: "CLIP", links: [] },
+        { name: "VAE", type: "VAE", links: [] },
       ],
-      links: [],
-    } as never;
+      widgets_values: row,
+    };
+  }
+
+  function animaGraph(row: unknown[]) {
+    return { nodes: [animaNode(row)], links: [] } as never;
   }
 
   it("exact reported symptom: every widget keeps its own saved value", () => {
@@ -3845,7 +3844,7 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
           outputs: [{ name: "MODEL", type: "MODEL", links: [1] }],
           widgets_values: ["x.safetensors"],
         },
-        (animaGraph(SAVED_ROW, 1) as unknown as { nodes: unknown[] }).nodes[0],
+        animaNode(SAVED_ROW, 1),
       ],
       links: [[1, 6, 0, 7, 0, "STRING"]],
     } as never;

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -4031,6 +4031,59 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
     expect(inputs.label).toBe("my label");
   });
 
+  // The socket-only rule is TOP-LEVEL ONLY, and that is not an omission.
+  // `_migrateDefaultInput` walks the node's own input.required/input.optional in
+  // two flat loops and does NOT recurse into a dynamic combo option's inputs, and
+  // the widget factory that honours forceInput runs on the node's own inputs. A
+  // nested leaf therefore keeps its widget and its slot whatever it declares —
+  // dropping it here would remove a slot the frontend does write, which is the same
+  // shift in the other direction.
+  it("a NESTED combo leaf keeps its slot whatever it declares", () => {
+    const INFO = {
+      N: {
+        input: {
+          required: {
+            combo: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "a",
+                    inputs: {
+                      optional: { hook: ["STRING", { defaultInput: true }] },
+                    },
+                  },
+                ],
+              },
+            ],
+            tail: ["INT", { default: 0 }],
+          },
+        },
+        input_order: { required: ["combo", "tail"] },
+        output: [],
+      },
+    } as never;
+    const { workflow } = convertUiToApi(
+      {
+        nodes: [
+          {
+            id: 1,
+            type: "N",
+            mode: 0,
+            inputs: [],
+            outputs: [],
+            widgets_values: ["a", "hooked", 7],
+          },
+        ],
+        links: [],
+      } as never,
+      INFO,
+    );
+    const inputs = (workflow["1"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs["combo.hook"]).toBe("hooked");
+    expect(inputs.tail).toBe(7); // NOT stolen by the nested leaf
+  });
+
   it("an INT forceInput input is socket-only too (not just STRING)", () => {
     const INFO = {
       N: {

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3749,3 +3749,263 @@ describe("convertUiToApi — extras-skipping must never eat a legitimate value (
     expect(workflow["1"].inputs.count).toBe(7);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #2753 — a forceInput-only scalar input is a SOCKET, not a widget, so it has no
+// widgets_values slot. Classifying it as one consumed the first saved value and
+// shifted every real widget down the row.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => {
+  // The reporter's node: trainer_status is declared ["STRING", {forceInput:true}]
+  // and rendered as an input socket only; the five widgets after it are the ones
+  // the frontend actually serializes.
+  const ANIMA_INFO = {
+    AnimaTrainerLoader: {
+      input: {
+        required: {
+          trainer_status: ["STRING", { forceInput: true }],
+          unet_name: [["anima-base-v1.0.safetensors", "qwen_3_06b_base.safetensors"]],
+          clip_name: [["qwen_3_06b_base.safetensors", "qwen_image_vae.safetensors"]],
+          vae_name: [["qwen_image_vae.safetensors", "other_vae.safetensors"]],
+          weight_dtype: [["default", "fp8_e4m3fn"]],
+          clip_device: [["default", "cpu"]],
+        },
+      },
+      input_order: {
+        required: [
+          "trainer_status",
+          "unet_name",
+          "clip_name",
+          "vae_name",
+          "weight_dtype",
+          "clip_device",
+        ],
+      },
+      output: ["MODEL", "CLIP", "VAE"],
+      output_name: ["MODEL", "CLIP", "VAE"],
+    },
+  } as never;
+
+  // Exactly the widgets_values the reporter's saved workflow carries: FIVE values
+  // for five widgets, with NO slot for the socket-only trainer_status.
+  const SAVED_ROW = [
+    "anima-base-v1.0.safetensors",
+    "qwen_3_06b_base.safetensors",
+    "qwen_image_vae.safetensors",
+    "default",
+    "default",
+  ];
+
+  function animaGraph(row: unknown[], trainerLink: number | null = null) {
+    return {
+      nodes: [
+        {
+          id: 7,
+          type: "AnimaTrainerLoader",
+          mode: 0,
+          inputs: [{ name: "trainer_status", type: "STRING", link: trainerLink }],
+          outputs: [
+            { name: "MODEL", type: "MODEL", links: [] },
+            { name: "CLIP", type: "CLIP", links: [] },
+            { name: "VAE", type: "VAE", links: [] },
+          ],
+          widgets_values: row,
+        },
+      ],
+      links: [],
+    } as never;
+  }
+
+  it("exact reported symptom: every widget keeps its own saved value", () => {
+    const { workflow, warnings } = convertUiToApi(animaGraph(SAVED_ROW), ANIMA_INFO);
+    const inputs = (workflow["7"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs).toMatchObject({
+      unet_name: "anima-base-v1.0.safetensors",
+      clip_name: "qwen_3_06b_base.safetensors",
+      vae_name: "qwen_image_vae.safetensors",
+      weight_dtype: "default",
+      clip_device: "default",
+    });
+    // the pre-fix (shifted) reading must not reappear
+    expect(inputs.unet_name).not.toBe("qwen_3_06b_base.safetensors");
+    expect(inputs.clip_name).not.toBe("qwen_image_vae.safetensors");
+    expect(inputs.vae_name).not.toBe("default");
+    expect(warnings).toEqual([]);
+  });
+
+  it("the socket-only input never steals a widget slot, wired or not", () => {
+    // Wired: the value arrives over the link, and the widgets stay put.
+    const wired = {
+      nodes: [
+        {
+          id: 6,
+          type: "CheckpointLoaderSimple",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "MODEL", type: "MODEL", links: [1] }],
+          widgets_values: ["x.safetensors"],
+        },
+        (animaGraph(SAVED_ROW, 1) as unknown as { nodes: unknown[] }).nodes[0],
+      ],
+      links: [[1, 6, 0, 7, 0, "STRING"]],
+    } as never;
+    const { workflow } = convertUiToApi(wired, {
+      ...(ANIMA_INFO as object),
+      CheckpointLoaderSimple: {
+        input: { required: { ckpt_name: [["x.safetensors"]] } },
+        input_order: { required: ["ckpt_name"] },
+        output: ["MODEL"],
+        output_name: ["MODEL"],
+      },
+    } as never);
+    const inputs = (workflow["7"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.trainer_status).toEqual(["6", 0]);
+    expect(inputs.unet_name).toBe("anima-base-v1.0.safetensors");
+    expect(inputs.clip_device).toBe("default");
+  });
+
+  // A row saved BEFORE ComfyUI's widget/input unification kept a placeholder slot
+  // for the forceInput input. ComfyUI's own loader (migrateWidgetsValues) drops it
+  // by matching the row length against that legacy layout; so do we, otherwise the
+  // fix above would shift a legacy row the other way.
+  it("legacy row with a forceInput placeholder is still read correctly", () => {
+    const { workflow } = convertUiToApi(
+      animaGraph([null, ...SAVED_ROW]),
+      ANIMA_INFO,
+    );
+    const inputs = (workflow["7"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs).toMatchObject({
+      unet_name: "anima-base-v1.0.safetensors",
+      clip_name: "qwen_3_06b_base.safetensors",
+      vae_name: "qwen_image_vae.safetensors",
+      weight_dtype: "default",
+      clip_device: "default",
+    });
+  });
+
+  // The length gate must not fire on a row that is neither layout — a modern row
+  // with an extra serialized value must keep falling through to the existing
+  // #1869 extras handling rather than silently losing its FIRST value.
+  it("does not strip anything when the row matches neither layout", () => {
+    const row = [...SAVED_ROW, "trailing_extra", "one_more"];
+    const { workflow } = convertUiToApi(animaGraph(row), ANIMA_INFO);
+    const inputs = (workflow["7"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.unet_name).toBe("anima-base-v1.0.safetensors");
+  });
+
+  // A SHIPPED node with the same shape, so the pin is not only on the reporter's
+  // custom node: rgthree's SDXLPowerPromptPositive declares opt_clip_width and
+  // opt_clip_height as ["INT", {forceInput: true, default: 1024}] ahead of three
+  // combo widgets, so before the fix BOTH stole a slot and the three combos read
+  // two positions late.
+  it("rgthree SDXLPowerPromptPositive: two forceInput INTs steal no slots", () => {
+    const RGTHREE_INFO = {
+      "SDXL Power Prompt - Positive (rgthree)": {
+        input: {
+          required: {
+            prompt_g: ["STRING", { multiline: true }],
+            prompt_l: ["STRING", { multiline: true }],
+          },
+          optional: {
+            opt_model: ["MODEL"],
+            opt_clip: ["CLIP"],
+            opt_clip_width: ["INT", { forceInput: true, default: 1024 }],
+            opt_clip_height: ["INT", { forceInput: true, default: 1024 }],
+            insert_lora: [["CHOOSE", "DISABLE LORAS", "detail.safetensors"]],
+            insert_embedding: [["CHOOSE", "badhands"]],
+            insert_saved: [["CHOOSE", "my_prompt"]],
+          },
+        },
+        input_order: {
+          required: ["prompt_g", "prompt_l"],
+          optional: [
+            "opt_model",
+            "opt_clip",
+            "opt_clip_width",
+            "opt_clip_height",
+            "insert_lora",
+            "insert_embedding",
+            "insert_saved",
+          ],
+        },
+        output: ["CONDITIONING"],
+        output_name: ["CONDITIONING"],
+      },
+    } as never;
+    const { workflow } = convertUiToApi(
+      {
+        nodes: [
+          {
+            id: 4,
+            type: "SDXL Power Prompt - Positive (rgthree)",
+            mode: 0,
+            inputs: [
+              { name: "opt_model", type: "MODEL", link: null },
+              { name: "opt_clip", type: "CLIP", link: null },
+              { name: "opt_clip_width", type: "INT", link: null },
+              { name: "opt_clip_height", type: "INT", link: null },
+            ],
+            outputs: [{ name: "CONDITIONING", type: "CONDITIONING", links: [] }],
+            widgets_values: [
+              "a photo of a cat",
+              "cat",
+              "detail.safetensors",
+              "badhands",
+              "my_prompt",
+            ],
+          },
+        ],
+        links: [],
+      } as never,
+      RGTHREE_INFO,
+    );
+    const inputs = (workflow["4"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs).toMatchObject({
+      prompt_g: "a photo of a cat",
+      prompt_l: "cat",
+      insert_lora: "detail.safetensors",
+      insert_embedding: "badhands",
+      insert_saved: "my_prompt",
+    });
+    // pre-fix: the two forceInput INTs consumed prompt_g/prompt_l's slots and the
+    // three combos each read two positions late (falling back to "CHOOSE").
+    expect(inputs.insert_lora).not.toBe("CHOOSE");
+    expect(inputs.insert_embedding).not.toBe("CHOOSE");
+  });
+
+  it("an INT forceInput input is socket-only too (not just STRING)", () => {
+    const INFO = {
+      N: {
+        input: {
+          required: {
+            steps: ["INT", { forceInput: true, default: 20 }],
+            cfg: ["FLOAT", { default: 8 }],
+            sampler: [["euler", "dpmpp_2m"]],
+          },
+        },
+        input_order: { required: ["steps", "cfg", "sampler"] },
+        output: [],
+      },
+    } as never;
+    const { workflow } = convertUiToApi(
+      {
+        nodes: [
+          {
+            id: 1,
+            type: "N",
+            mode: 0,
+            inputs: [{ name: "steps", type: "INT", link: null }],
+            outputs: [],
+            widgets_values: [7.5, "dpmpp_2m"],
+          },
+        ],
+        links: [],
+      } as never,
+      INFO,
+    );
+    const inputs = (workflow["1"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.cfg).toBe(7.5);
+    expect(inputs.sampler).toBe("dpmpp_2m");
+  });
+});
+

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3922,6 +3922,38 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
     expect(inputs.first_frame).toBe(12);
   });
 
+  // The accepted limitation must be AUDIBLE. A pre-unification row keeps a
+  // placeholder slot for the socket-only input, so it is one longer than the widget
+  // layout and every widget reads one position early. Which reading is right cannot
+  // be decided from the row, so nothing is changed — but it must not pass silently.
+  it("a leftover value on a forceInput node is reported, not swallowed", () => {
+    const { workflow, warnings } = convertUiToApi(
+      animaGraph([null, ...SAVED_ROW]),
+      ANIMA_INFO,
+    );
+    // values are NOT guessed at — the row is mapped exactly as saved
+    const inputs = (workflow["7"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.unet_name).toBe(null);
+    // …but the leftover, and why it matters, are named
+    const w = warnings.join(" ");
+    expect(w).toContain("remain unmapped");
+    expect(w).toContain("forceInput");
+    expect(w).toContain('"default"'); // the value left over
+  });
+
+  it("stays quiet when the row maps exactly (no false leftover warning)", () => {
+    const { warnings } = convertUiToApi(animaGraph(SAVED_ROW), ANIMA_INFO);
+    expect(warnings.join(" ")).not.toContain("remain unmapped");
+  });
+
+  it("stays quiet when the extras pass already accounted for the row", () => {
+    const { warnings } = convertUiToApi(
+      amVideoGraph(["D:/input.mov", "detect_range", 12]),
+      AMVIDEO_INFO,
+    );
+    expect(warnings.join(" ")).not.toContain("remain unmapped");
+  });
+
   it("an INT forceInput input is socket-only too (not just STRING)", () => {
     const INFO = {
       N: {

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3954,6 +3954,83 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
     expect(warnings.join(" ")).not.toContain("remain unmapped");
   });
 
+  // `defaultInput` is the deprecated spelling, and the frontend migrates it
+  // ASYMMETRICALLY (ComfyNodeDefImpl._migrateDefaultInput): on an OPTIONAL input it
+  // becomes forceInput — socket-only, no slot — while on a REQUIRED input it only
+  // logs "please drop the defaultInput option" and the widget is KEPT. Both halves
+  // are pinned, because getting the required half wrong shifts the row in the
+  // opposite direction to the bug being fixed.
+  it("an OPTIONAL defaultInput input is socket-only, like forceInput", () => {
+    const INFO = {
+      N: {
+        input: {
+          required: { mode: [["a", "b"]] },
+          optional: {
+            hook: ["STRING", { defaultInput: true }],
+            label: ["STRING", {}],
+          },
+        },
+        input_order: { required: ["mode"], optional: ["hook", "label"] },
+        output: [],
+      },
+    } as never;
+    const { workflow } = convertUiToApi(
+      {
+        nodes: [
+          {
+            id: 1,
+            type: "N",
+            mode: 0,
+            inputs: [{ name: "hook", type: "STRING", link: null }],
+            outputs: [],
+            widgets_values: ["b", "my label"],
+          },
+        ],
+        links: [],
+      } as never,
+      INFO,
+    );
+    const inputs = (workflow["1"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.mode).toBe("b");
+    expect(inputs.label).toBe("my label");
+  });
+
+  it("a REQUIRED defaultInput input keeps its widget slot", () => {
+    const INFO = {
+      N: {
+        input: {
+          required: {
+            hook: ["STRING", { defaultInput: true }],
+            label: ["STRING", {}],
+          },
+        },
+        input_order: { required: ["hook", "label"] },
+        output: [],
+      },
+    } as never;
+    const { workflow } = convertUiToApi(
+      {
+        nodes: [
+          {
+            id: 1,
+            type: "N",
+            mode: 0,
+            inputs: [],
+            outputs: [],
+            widgets_values: ["hooked", "my label"],
+          },
+        ],
+        links: [],
+      } as never,
+      INFO,
+    );
+    const inputs = (workflow["1"] as { inputs: Record<string, unknown> }).inputs;
+    // the frontend keeps this widget, so its slot is real — dropping it would
+    // shift `label` onto `hook`
+    expect(inputs.hook).toBe("hooked");
+    expect(inputs.label).toBe("my label");
+  });
+
   it("an INT forceInput input is socket-only too (not just STRING)", () => {
     const INFO = {
       N: {

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -3973,6 +3973,63 @@ describe("convertUiToApi — forceInput-only scalar input (issue #2753)", () => 
     expect(inputs.insert_embedding).not.toBe("CHOOSE");
   });
 
+  // A row ONE longer than the modern layout is equally well explained by a modern
+  // row carrying a frontend-only serialized extra (#1869), and THAT reading is the
+  // right one — the extras pass recovers the real value and reports the skip, while
+  // a legacy strip would put the extra on a real widget. So the length coincidence
+  // must not be enough on its own.
+  const AMVIDEO_INFO = {
+    AMVideoRead: {
+      input: {
+        required: {
+          trigger: ["STRING", { forceInput: true }],
+          path: ["STRING", {}],
+          first_frame: ["INT", { default: 0 }],
+        },
+      },
+      input_order: { required: ["trigger", "path", "first_frame"] },
+      output: [],
+    },
+  } as never;
+
+  function amVideoGraph(row: unknown[]) {
+    return {
+      nodes: [
+        {
+          id: 1,
+          type: "AMVideoRead",
+          mode: 0,
+          inputs: [{ name: "trigger", type: "STRING", link: null }],
+          outputs: [],
+          widgets_values: row,
+        },
+      ],
+      links: [],
+    } as never;
+  }
+
+  it("a serialized action button beats the legacy-placeholder reading of the same length", () => {
+    const { workflow, warnings } = convertUiToApi(
+      amVideoGraph(["D:/input.mov", "detect_range", 12]),
+      AMVIDEO_INFO,
+    );
+    const inputs = (workflow["1"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.path).toBe("D:/input.mov");
+    expect(inputs.first_frame).toBe(12);
+    // and the discarded value is REPORTED, never dropped silently
+    expect(warnings.join(" ")).toContain("detect_range");
+  });
+
+  it("a type-refuted extra beats it too (the other #1869 signal)", () => {
+    const { workflow } = convertUiToApi(
+      amVideoGraph(["D:/input.mov", "not_a_number", 12]),
+      AMVIDEO_INFO,
+    );
+    const inputs = (workflow["1"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.path).toBe("D:/input.mov");
+    expect(inputs.first_frame).toBe(12);
+  });
+
   it("an INT forceInput input is socket-only too (not just STRING)", () => {
     const INFO = {
       N: {

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -113,6 +113,27 @@ function isForceInputSpec(spec: unknown): boolean {
 }
 
 /**
+ * `defaultInput` is the deprecated spelling of the same idea, and the frontend
+ * migrates it ASYMMETRICALLY (`ComfyNodeDefImpl._migrateDefaultInput`):
+ *
+ *   - on an OPTIONAL input it sets `forceInput = true` — socket-only, so no
+ *     widget and no `widgets_values` slot;
+ *   - on a REQUIRED input it only warns ("please drop the defaultInput option")
+ *     and the widget is KEPT.
+ *
+ * So the two spellings cannot share one rule. Promoting a required
+ * `defaultInput` to socket-only would drop a slot the frontend does write,
+ * shifting the row in the opposite direction to the bug this fixes.
+ */
+function isSocketOnlyInput(inputName: string, def: ComfyUINodeDef): boolean {
+  const required = def.input.required?.[inputName];
+  const optional = def.input.optional?.[inputName];
+  if (isForceInputSpec(required ?? optional)) return true;
+  if (required !== undefined || !Array.isArray(optional)) return false;
+  return (optional[1] as { defaultInput?: unknown } | undefined)?.defaultInput === true;
+}
+
+/**
  * Check if an input spec represents a widget (value input) vs a link (connection input).
  * Widget inputs have an array type spec like ["INT", {...}] or ["STRING", {...}].
  * Link inputs have a plain string type like "MODEL" or "CLIP".
@@ -126,7 +147,7 @@ function isWidgetInput(
   if (!spec) return false;
   // Socket-only by declaration — checked BEFORE any type classification, because
   // the frontend checks it first too (it applies to inline combos as well).
-  if (isForceInputSpec(spec)) return false;
+  if (isSocketOnlyInput(inputName, def)) return false;
 
   const typeSpec = spec[0];
   // If the type is an array of choices like ["option1", "option2"], it's a widget
@@ -3321,7 +3342,7 @@ export function convertUiToApi(
         const sp =
           (def.input?.required as Record<string, unknown> | undefined)?.[n] ??
           (def.input?.optional as Record<string, unknown> | undefined)?.[n];
-        return isForceInputSpec(sp) && isPositionalWidgetType(sp);
+        return isSocketOnlyInput(n, def) && isPositionalWidgetType(sp);
       })
     ) {
       warnings.push(

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -95,6 +95,24 @@ function isScalarWidgetType(type: unknown, cfg?: unknown): boolean {
 }
 
 /**
+ * `forceInput: true` on a widget-typed input means "render this as a SOCKET, never
+ * a widget" (#2753). ComfyUI's frontend honours it for EVERY type — its widget
+ * factory returns early on `forceInput` before it looks at the type at all — so a
+ * `["STRING", {forceInput: true}]` input has no widget, and therefore no
+ * `widgets_values` slot, even though its spec is otherwise indistinguishable from
+ * a real STRING widget.
+ *
+ * Classifying one as a widget consumes a positional slot that was never written,
+ * which shifts every REAL widget after it by one (the reported symptom: a node
+ * whose first input is a forceInput-only STRING reported `unet_name` with the
+ * value of `clip_name`, `clip_name` with `vae_name`'s, and so on down the row).
+ */
+function isForceInputSpec(spec: unknown): boolean {
+  if (!Array.isArray(spec)) return false;
+  return (spec[1] as { forceInput?: unknown } | undefined)?.forceInput === true;
+}
+
+/**
  * Check if an input spec represents a widget (value input) vs a link (connection input).
  * Widget inputs have an array type spec like ["INT", {...}] or ["STRING", {...}].
  * Link inputs have a plain string type like "MODEL" or "CLIP".
@@ -106,6 +124,9 @@ function isWidgetInput(
   const spec =
     def.input.required?.[inputName] ?? def.input.optional?.[inputName];
   if (!spec) return false;
+  // Socket-only by declaration — checked BEFORE any type classification, because
+  // the frontend checks it first too (it applies to inline combos as well).
+  if (isForceInputSpec(spec)) return false;
 
   const typeSpec = spec[0];
   // If the type is an array of choices like ["option1", "option2"], it's a widget
@@ -188,13 +209,18 @@ function resolveLinkedNestedArity(opts: {
   return fitsRetained ? retained : omitted;
 }
 
-function isPositionalWidgetSpec(spec: unknown): boolean {
+function isPositionalWidgetType(spec: unknown): boolean {
   if (!Array.isArray(spec)) return false;
   const type = spec[0];
   if (Array.isArray(type)) return true; // inline combo options
   const cfg = spec[1] as { options?: unknown } | undefined;
   if (Array.isArray(cfg?.options)) return true; // dynamic combo (options-carrying)
   return isScalarWidgetType(type, cfg);
+}
+
+function isPositionalWidgetSpec(spec: unknown): boolean {
+  // forceInput is socket-only, so it is never serialized positionally (#2753).
+  return !isForceInputSpec(spec) && isPositionalWidgetType(spec);
 }
 
 /**
@@ -674,6 +700,53 @@ function remainingPositionalSlots(
     if (hasControlAfterGenerate(widgetNames[i], def)) n += 1;
   }
   return n;
+}
+
+/**
+ * #2753 — a saved row from BEFORE ComfyUI's widget/input unification DID carry a
+ * placeholder slot for every `forceInput` input; a row saved after it does not.
+ * The two layouts are positionally indistinguishable from a single node, so
+ * excluding forceInput from the widget list (which is correct for every current
+ * frontend) would shift a legacy row the other way.
+ *
+ * ComfyUI's own loader settles it by LENGTH — `migrateWidgetsValues` builds the
+ * legacy slot layout from the node def, and only when the saved row's length
+ * matches it exactly does it drop the forceInput positions. Mirror that here so
+ * the converter reads both eras the way the canvas would.
+ *
+ * Deliberately narrow: it is a no-op unless the node actually declares a
+ * forceInput widget-typed input AND the row length matches the legacy layout
+ * exactly. A row already in the modern layout is shorter, so it can never match.
+ * A dynamic combo contributes an unknowable number of nested slots, so its
+ * presence makes the length argument meaningless and the row is left alone.
+ */
+function stripLegacyForceInputSlots<
+  T extends unknown[] | Record<string, unknown>,
+>(
+  widgetValues: T,
+  def: ComfyUINodeDef,
+  orderedNames: string[],
+  widgetNames: string[],
+): T | unknown[] {
+  if (!Array.isArray(widgetValues)) return widgetValues;
+  const isWidget = new Set(widgetNames);
+  const placeholderAt: boolean[] = [];
+  let sawForceInput = false;
+  for (const name of orderedNames) {
+    const spec =
+      (def.input?.required as Record<string, unknown> | undefined)?.[name] ??
+      (def.input?.optional as Record<string, unknown> | undefined)?.[name];
+    const forced = isForceInputSpec(spec) && isPositionalWidgetType(spec);
+    if (!forced && !isWidget.has(name)) continue;
+    if (Array.isArray(spec) && spec[0] === "COMFY_DYNAMICCOMBO_V3") return widgetValues;
+    if (forced) sawForceInput = true;
+    placeholderAt.push(forced);
+    // Mirrors the frontend: a control_after_generate input occupies a second
+    // slot, and that slot is never the forceInput placeholder.
+    if (hasControlAfterGenerate(name, def)) placeholderAt.push(false);
+  }
+  if (!sawForceInput || placeholderAt.length !== widgetValues.length) return widgetValues;
+  return widgetValues.filter((_v, i) => !placeholderAt[i]);
 }
 
 /**
@@ -2746,7 +2819,14 @@ export function convertUiToApi(
     // string landing on `seed`, a LoRA name landing on a VAE). A name-keyed map has
     // no order to disagree about, so it routes into the object branch below, which
     // already fails CLOSED when a name is ambiguous.
-    const widgetValues = node.capturedWidgetValues ?? node.widgets_values ?? [];
+    // …and normalize a legacy forceInput layout first (#2753), so the positional
+    // mapping below sees the same row the current frontend would.
+    const widgetValues = stripLegacyForceInputSlots(
+      node.capturedWidgetValues ?? node.widgets_values ?? [],
+      def,
+      orderedNames,
+      widgetNames,
+    );
 
     // Some nodes (e.g. VHS_VideoCombine) store widgets_values as a name->value
     // object instead of a positional array — as does the #384 live-canvas

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -3303,6 +3303,36 @@ export function convertUiToApi(
         } are left to their defaults rather than risk a silently shifted value on a later widget (such as a seed) or nested leaf.`,
       );
     }
+
+    // #2753 — the accepted limitation, made AUDIBLE. A row saved before ComfyUI's
+    // widget/input unification carries a placeholder slot for each `forceInput`
+    // input, so it is longer than the layout mapped here and every widget reads one
+    // position early. Which reading is right cannot be decided from the row (see
+    // the note at the mapping site), so nothing is changed — but a leftover on a
+    // node that HAS such an input is the signature, and it must not pass in
+    // silence. Scoped to those nodes so it cannot become noise elsewhere, and
+    // suppressed after a refusal or a dynamic combo, whose leftovers are already
+    // explained above.
+    if (
+      !sawDynamicCombo &&
+      !refusalOccurred &&
+      widgetIdx < widgetValues.length &&
+      orderedNames.some((n) => {
+        const sp =
+          (def.input?.required as Record<string, unknown> | undefined)?.[n] ??
+          (def.input?.optional as Record<string, unknown> | undefined)?.[n];
+        return isForceInputSpec(sp) && isPositionalWidgetType(sp);
+      })
+    ) {
+      warnings.push(
+        `Node ${nodeId} (${classType}): ${
+          widgetValues.length - widgetIdx
+        } saved widget value(s) remain unmapped (${widgetValues
+          .slice(widgetIdx)
+          .map((v) => JSON.stringify(v))
+          .join(", ")}), and this node has a forceInput-only input. That is the signature of a workflow saved before ComfyUI's widget/input unification, whose widgets_values kept a placeholder slot for such an input — in which case EVERY widget on this node is reading one position early. A saved row cannot distinguish that from a node that simply serializes an extra value, so the values above are reported rather than guessed at. Open and re-save this workflow in ComfyUI to normalize it, then check this node's values.`,
+      );
+    }
     }
 
     // Nodes with a CUSTOM serialized-widget layout (properties.has_serialized_properties

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -773,86 +773,6 @@ function skipSerializedActionWidgets(opts: {
   return widgetIdx;
 }
 
-/**
- * #2753 — a saved row from BEFORE ComfyUI's widget/input unification DID carry a
- * placeholder slot for every `forceInput` input; a row saved after it does not.
- * The two layouts are positionally indistinguishable from a single node, so
- * excluding forceInput from the widget list (which is correct for every current
- * frontend) would shift a legacy row the other way.
- *
- * ComfyUI's own loader settles it by LENGTH — `migrateWidgetsValues` builds the
- * legacy slot layout from the node def, and only when the saved row's length
- * matches it exactly does it drop the forceInput positions. Mirror that here so
- * the converter reads both eras the way the canvas would.
- *
- * Deliberately narrow. It is a no-op unless the node declares a forceInput
- * widget-typed input AND the row length matches the legacy layout exactly (a
- * modern row is strictly shorter, so it can never match), and it bails out on a
- * dynamic combo, whose nested arity makes any length argument meaningless.
- *
- * It also YIELDS to #1869. A row one longer than the modern layout is equally
- * well explained by a MODERN row carrying a frontend-only serialized extra, and
- * the extras pass reads that case CORRECTLY while a legacy strip here would
- * pre-empt it and put the extra on a real widget — `["D:/input.mov",
- * "detect_range", 12]` against {forceInput, path, first_frame} became
- * `path: "detect_range"`, silently, where the extras pass recovers
- * `path: "D:/input.mov"` and reports the skip. So the same skip decision is run
- * as a dry pass first: if it fires anywhere in this row, the length coincidence
- * settles nothing and the row is left exactly as saved.
- */
-function stripLegacyForceInputSlots<
-  T extends unknown[] | Record<string, unknown>,
->(
-  widgetValues: T,
-  def: ComfyUINodeDef,
-  orderedNames: string[],
-  widgetNames: string[],
-): T | unknown[] {
-  if (!Array.isArray(widgetValues)) return widgetValues;
-  const specFor = (name: string) =>
-    (def.input?.required as Record<string, unknown> | undefined)?.[name] ??
-    (def.input?.optional as Record<string, unknown> | undefined)?.[name];
-
-  const isWidget = new Set(widgetNames);
-  const placeholderAt: boolean[] = [];
-  let sawForceInput = false;
-  for (const name of orderedNames) {
-    const spec = specFor(name);
-    const forced = isForceInputSpec(spec) && isPositionalWidgetType(spec);
-    if (!forced && !isWidget.has(name)) continue;
-    if (Array.isArray(spec) && spec[0] === "COMFY_DYNAMICCOMBO_V3") return widgetValues;
-    if (forced) sawForceInput = true;
-    placeholderAt.push(forced);
-    // Mirrors the frontend: a control_after_generate input occupies a second
-    // slot, and that slot is never the forceInput placeholder.
-    if (hasControlAfterGenerate(name, def)) placeholderAt.push(false);
-  }
-  if (!sawForceInput || placeholderAt.length !== widgetValues.length) return widgetValues;
-
-  // Dry run of the #1869 extras pass over the row AS SAVED, against the MODERN
-  // widget layout. Any skip means that reading accounts for the extra value, so
-  // this one must not claim it.
-  let idx = 0;
-  for (let nameIdx = 0; nameIdx < widgetNames.length && idx < widgetValues.length; nameIdx++) {
-    const name = widgetNames[nameIdx];
-    const skipped: unknown[] = [];
-    idx = skipSerializedActionWidgets({
-      values: widgetValues,
-      widgetIdx: idx,
-      spec: specFor(name),
-      def,
-      widgetNames,
-      nameIdx,
-      skipped,
-    });
-    if (skipped.length > 0) return widgetValues;
-    idx++;
-    if (hasControlAfterGenerate(name, def) && nextValueIsControlMode(widgetValues, idx)) idx++;
-  }
-
-  return widgetValues.filter((_v, i) => !placeholderAt[i]);
-}
-
 // ── De-virtualization (Get/Set/Reroute) pre-pass ────────────────────────────
 
 /**
@@ -2852,14 +2772,18 @@ export function convertUiToApi(
     // string landing on `seed`, a LoRA name landing on a VAE). A name-keyed map has
     // no order to disagree about, so it routes into the object branch below, which
     // already fails CLOSED when a name is ambiguous.
-    // …and normalize a legacy forceInput layout first (#2753), so the positional
-    // mapping below sees the same row the current frontend would.
-    const widgetValues = stripLegacyForceInputSlots(
-      node.capturedWidgetValues ?? node.widgets_values ?? [],
-      def,
-      orderedNames,
-      widgetNames,
-    );
+    //
+    // ACCEPTED LIMITATION (#2753): a row saved BEFORE ComfyUI's widget/input
+    // unification carried a placeholder slot for each `forceInput` input, so it is
+    // one longer than the layout mapped here and reads shifted. That length is not
+    // enough to identify it — a MODERN row carrying a frontend-only serialized
+    // extra (#1869) has exactly the same length, and the two readings disagree
+    // about which value is real ([null, "D:/in.mov", 12] is either
+    // placeholder+path+frame or path+button+frame). Normalizing on length alone
+    // therefore breaks one case to fix the other, so neither is guessed: the
+    // extras pass handles the modern reading and reports what it discards, and a
+    // legacy row surfaces through that same warning or through combo validation.
+    const widgetValues = node.capturedWidgetValues ?? node.widgets_values ?? [];
 
     // Some nodes (e.g. VHS_VideoCombine) store widgets_values as a name->value
     // object instead of a positional array — as does the #384 live-canvas

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -230,18 +230,22 @@ function resolveLinkedNestedArity(opts: {
   return fitsRetained ? retained : omitted;
 }
 
-function isPositionalWidgetType(spec: unknown): boolean {
+/**
+ * NOTE (#2753): deliberately does NOT exclude `forceInput`/`defaultInput`. This
+ * predicate is used for a dynamic combo option's NESTED leaves, and the frontend's
+ * socket-only handling is TOP-LEVEL only — `_migrateDefaultInput` walks the node's
+ * own `input.required`/`input.optional` and does not recurse into an option's
+ * inputs. Excluding them here would drop a slot the frontend does write. The
+ * top-level rule lives in `isSocketOnlyInput`, which has the required/optional
+ * context this spec-only predicate cannot see.
+ */
+function isPositionalWidgetSpec(spec: unknown): boolean {
   if (!Array.isArray(spec)) return false;
   const type = spec[0];
   if (Array.isArray(type)) return true; // inline combo options
   const cfg = spec[1] as { options?: unknown } | undefined;
   if (Array.isArray(cfg?.options)) return true; // dynamic combo (options-carrying)
   return isScalarWidgetType(type, cfg);
-}
-
-function isPositionalWidgetSpec(spec: unknown): boolean {
-  // forceInput is socket-only, so it is never serialized positionally (#2753).
-  return !isForceInputSpec(spec) && isPositionalWidgetType(spec);
 }
 
 /**
@@ -3342,7 +3346,7 @@ export function convertUiToApi(
         const sp =
           (def.input?.required as Record<string, unknown> | undefined)?.[n] ??
           (def.input?.optional as Record<string, unknown> | undefined)?.[n];
-        return isSocketOnlyInput(n, def) && isPositionalWidgetType(sp);
+        return isSocketOnlyInput(n, def) && isPositionalWidgetSpec(sp);
       })
     ) {
       warnings.push(

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -703,53 +703,6 @@ function remainingPositionalSlots(
 }
 
 /**
- * #2753 — a saved row from BEFORE ComfyUI's widget/input unification DID carry a
- * placeholder slot for every `forceInput` input; a row saved after it does not.
- * The two layouts are positionally indistinguishable from a single node, so
- * excluding forceInput from the widget list (which is correct for every current
- * frontend) would shift a legacy row the other way.
- *
- * ComfyUI's own loader settles it by LENGTH — `migrateWidgetsValues` builds the
- * legacy slot layout from the node def, and only when the saved row's length
- * matches it exactly does it drop the forceInput positions. Mirror that here so
- * the converter reads both eras the way the canvas would.
- *
- * Deliberately narrow: it is a no-op unless the node actually declares a
- * forceInput widget-typed input AND the row length matches the legacy layout
- * exactly. A row already in the modern layout is shorter, so it can never match.
- * A dynamic combo contributes an unknowable number of nested slots, so its
- * presence makes the length argument meaningless and the row is left alone.
- */
-function stripLegacyForceInputSlots<
-  T extends unknown[] | Record<string, unknown>,
->(
-  widgetValues: T,
-  def: ComfyUINodeDef,
-  orderedNames: string[],
-  widgetNames: string[],
-): T | unknown[] {
-  if (!Array.isArray(widgetValues)) return widgetValues;
-  const isWidget = new Set(widgetNames);
-  const placeholderAt: boolean[] = [];
-  let sawForceInput = false;
-  for (const name of orderedNames) {
-    const spec =
-      (def.input?.required as Record<string, unknown> | undefined)?.[name] ??
-      (def.input?.optional as Record<string, unknown> | undefined)?.[name];
-    const forced = isForceInputSpec(spec) && isPositionalWidgetType(spec);
-    if (!forced && !isWidget.has(name)) continue;
-    if (Array.isArray(spec) && spec[0] === "COMFY_DYNAMICCOMBO_V3") return widgetValues;
-    if (forced) sawForceInput = true;
-    placeholderAt.push(forced);
-    // Mirrors the frontend: a control_after_generate input occupies a second
-    // slot, and that slot is never the forceInput placeholder.
-    if (hasControlAfterGenerate(name, def)) placeholderAt.push(false);
-  }
-  if (!sawForceInput || placeholderAt.length !== widgetValues.length) return widgetValues;
-  return widgetValues.filter((_v, i) => !placeholderAt[i]);
-}
-
-/**
  * Button tokens observed serialized into a real `widgets_values` row (#1869,
  * comfyui-am-vfx-tools AMVideoRead/AMVideoWrite).
  *
@@ -818,6 +771,86 @@ function skipSerializedActionWidgets(opts: {
     widgetIdx++;
   }
   return widgetIdx;
+}
+
+/**
+ * #2753 — a saved row from BEFORE ComfyUI's widget/input unification DID carry a
+ * placeholder slot for every `forceInput` input; a row saved after it does not.
+ * The two layouts are positionally indistinguishable from a single node, so
+ * excluding forceInput from the widget list (which is correct for every current
+ * frontend) would shift a legacy row the other way.
+ *
+ * ComfyUI's own loader settles it by LENGTH — `migrateWidgetsValues` builds the
+ * legacy slot layout from the node def, and only when the saved row's length
+ * matches it exactly does it drop the forceInput positions. Mirror that here so
+ * the converter reads both eras the way the canvas would.
+ *
+ * Deliberately narrow. It is a no-op unless the node declares a forceInput
+ * widget-typed input AND the row length matches the legacy layout exactly (a
+ * modern row is strictly shorter, so it can never match), and it bails out on a
+ * dynamic combo, whose nested arity makes any length argument meaningless.
+ *
+ * It also YIELDS to #1869. A row one longer than the modern layout is equally
+ * well explained by a MODERN row carrying a frontend-only serialized extra, and
+ * the extras pass reads that case CORRECTLY while a legacy strip here would
+ * pre-empt it and put the extra on a real widget — `["D:/input.mov",
+ * "detect_range", 12]` against {forceInput, path, first_frame} became
+ * `path: "detect_range"`, silently, where the extras pass recovers
+ * `path: "D:/input.mov"` and reports the skip. So the same skip decision is run
+ * as a dry pass first: if it fires anywhere in this row, the length coincidence
+ * settles nothing and the row is left exactly as saved.
+ */
+function stripLegacyForceInputSlots<
+  T extends unknown[] | Record<string, unknown>,
+>(
+  widgetValues: T,
+  def: ComfyUINodeDef,
+  orderedNames: string[],
+  widgetNames: string[],
+): T | unknown[] {
+  if (!Array.isArray(widgetValues)) return widgetValues;
+  const specFor = (name: string) =>
+    (def.input?.required as Record<string, unknown> | undefined)?.[name] ??
+    (def.input?.optional as Record<string, unknown> | undefined)?.[name];
+
+  const isWidget = new Set(widgetNames);
+  const placeholderAt: boolean[] = [];
+  let sawForceInput = false;
+  for (const name of orderedNames) {
+    const spec = specFor(name);
+    const forced = isForceInputSpec(spec) && isPositionalWidgetType(spec);
+    if (!forced && !isWidget.has(name)) continue;
+    if (Array.isArray(spec) && spec[0] === "COMFY_DYNAMICCOMBO_V3") return widgetValues;
+    if (forced) sawForceInput = true;
+    placeholderAt.push(forced);
+    // Mirrors the frontend: a control_after_generate input occupies a second
+    // slot, and that slot is never the forceInput placeholder.
+    if (hasControlAfterGenerate(name, def)) placeholderAt.push(false);
+  }
+  if (!sawForceInput || placeholderAt.length !== widgetValues.length) return widgetValues;
+
+  // Dry run of the #1869 extras pass over the row AS SAVED, against the MODERN
+  // widget layout. Any skip means that reading accounts for the extra value, so
+  // this one must not claim it.
+  let idx = 0;
+  for (let nameIdx = 0; nameIdx < widgetNames.length && idx < widgetValues.length; nameIdx++) {
+    const name = widgetNames[nameIdx];
+    const skipped: unknown[] = [];
+    idx = skipSerializedActionWidgets({
+      values: widgetValues,
+      widgetIdx: idx,
+      spec: specFor(name),
+      def,
+      widgetNames,
+      nameIdx,
+      skipped,
+    });
+    if (skipped.length > 0) return widgetValues;
+    idx++;
+    if (hasControlAfterGenerate(name, def) && nextValueIsControlMode(widgetValues, idx)) idx++;
+  }
+
+  return widgetValues.filter((_v, i) => !placeholderAt[i]);
 }
 
 // ── De-virtualization (Get/Set/Reroute) pre-pass ────────────────────────────


### PR DESCRIPTION
Fixes #2753.

## The defect

`isWidgetInput()` in `src/services/workflow-converter.ts` classified an input by its
TYPE only. `["STRING", {forceInput: true}]` looks exactly like a real STRING widget,
so it was given a positional `widgets_values` slot — but ComfyUI's frontend checks
`forceInput` **first** and renders a socket instead of a widget, so no slot is ever
written for it. Consuming one shifts every real widget after it by one.

The reporter's node returned `unet_name=qwen_3_06b_base`, `clip_name=qwen_image_vae`,
`vae_name=default` from a row whose true values sat one position earlier. Reached
through `get_workflow` (`query`/`strip`/`slice`) → `convertUiWorkflow` →
`convertUiToApi` (`src/tools/workflow-library.ts:188`).

Not confined to one custom node: rgthree's `SDXLPowerPromptPositive` declares
`opt_clip_width` and `opt_clip_height` as `["INT", {forceInput: True, ...}]` ahead of
three combo widgets, so it read two positions late on every install. `forceInput`
appears 536 times across 26 of the packs installed on this machine.

## The fix

Purely additive — two predicates, one guard line, one warning. The whole production
diff is 92 lines, most of them comment.

- `isSocketOnlyInput(name, def)` gates `isWidgetInput()` **before** any type
  classification, matching the frontend, whose widget factory returns early on
  `forceInput` regardless of type (`comfyui_frontend_package` 1.49.6:
  `let s = widgets.get(type); if (!s || spec.forceInput) return`, with the sibling
  `addInputSocket` creating the socket instead).
- It also handles the deprecated `defaultInput` spelling **asymmetrically**, exactly
  as `ComfyNodeDefImpl._migrateDefaultInput` does: on an **optional** input it becomes
  `forceInput` (socket-only); on a **required** input the frontend only warns
  "please drop the defaultInput option" and KEEPS the widget. Promoting a required one
  would drop a slot the frontend does write — the same shift, pointed the other way.
- Both conversion directions change together: `convertApiToUi` now emits a plain
  socket rather than a `widget:{name}` slot plus a placeholder.
- The rule stays **top-level**, where the evidence is: `_migrateDefaultInput` walks the
  node's own `input.required`/`input.optional` in two flat loops and does not recurse
  into a dynamic combo option's inputs, so a nested leaf keeps its widget and its slot.
  `isPositionalWidgetSpec` is therefore byte-identical to `main`; only its comment is new.

## Two behaviours that are deliberate, and tested as such

**A pre-unification row is reported, not normalized.** Such a row carried a
placeholder slot for each socket-only input, so it is one longer than the layout
mapped here. It cannot be normalized — review established that from both sides, each
reproduced by execution:

- normalizing on length (mirroring the frontend's `migrateWidgetsValues`) claims a
  *modern* row's frontend-only serialized extra (#1869) as a placeholder:
  `["D:/input.mov", "detect_range", 12]` → `path: "detect_range"`;
- yielding to the #1869 extras pass then blocks a *genuine* legacy strip:
  `[null, "D:/in.mov", 12]` → `path: null`.

Same length, opposite readings, nothing in the row to separate them. Per #1037's rule
in this same file, ambiguity stays a refusal. So no value is guessed — but the case is
no longer **silent**: a leftover on a node that has a socket-only input now names the
unmapped values, what they imply, and how to normalize the file. (It was silent for
an all-STRING/combo node, where the extras pass has nothing to refute.)

**A literal on a socket-only input is dropped in API→UI, with a warning.** UI format
has nowhere to put it — the canvas renders a socket. This is the converter's ordinary
treatment of a literal on a socket input, the same warning every other link input
gets. The alternative is what `main` does: write a placeholder into `widgets_values`,
which ComfyUI's own loader then strips — losing the value silently one step later, and
misaligning every widget in the meantime.

## Verification

- 11 new tests in `workflow-converter.test.ts` + 3 in `workflow-converter-api-to-ui.test.ts`.
- **Deleted the fix and watched them fail**, per mechanism: removing the
  `isWidgetInput` gate fails every forceInput test; removing the `defaultInput` clause
  fails the optional case; making that clause **symmetric** fails the required case, so
  the asymmetry is load-bearing and not incidental; disabling the leftover warning
  fails only the leftover test.
- Pinned: the reporter's exact node, the shipped rgthree node (two forceInput INTs,
  two-slot shift), a wired forceInput input, an INT forceInput, both `defaultInput`
  buckets, a nested combo leaf, both #1869 signals on a one-long row, and the two
  deliberate behaviours above.
- Exact reported symptom pinned as a negative assertion (the shifted values must not
  reappear), following the #193 precedent in the same file.
- Every review finding reproduced by **execution** against `dist/` before acting, and
  the two that were retractions were checked against the frontend bundle rather than
  against the claim.
- `npm test`: all 14 checks green (760 files, 14026 tests). `npm run lint`: clean,
  no new anti-slop findings.
- **No browser verification, and none applies**: server-side TypeScript in the MCP
  repo. Nothing the panel renders in the browser changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
