### PR TITLE
fix(panel#2191): a screenshot is a READ — stop calling its timeout a mutation, and give it the bounded read budget

### DIFF
--- a/src/__tests__/orchestrator/screenshot-read-budget.test.ts
+++ b/src/__tests__/orchestrator/screenshot-read-budget.test.ts
@@ -60,7 +60,7 @@ async function driveTool(name: string, args: Record<string, unknown> = {}): Prom
     return typeof c === "string" ? c : undefined;
   };
 
-  const ctx = {
+  const stub = {
     call: async (cmd: Record<string, unknown>, timeoutMs?: number) => {
       const c = nameOf(cmd);
       if (c) observed.callTimeouts.set(c, timeoutMs);
@@ -87,10 +87,12 @@ async function driveTool(name: string, args: Record<string, unknown> = {}): Prom
     },
     tabId: "tab-1",
     ensureReachable: () => {},
-  } as unknown as HandlerCtx;
+  };
 
   try {
-    await def!.handler(args, ctx);
+    /* PanelToolCtx is a large orchestrator interface and this probe implements only the five members the two driven tools touch (call, bridge.send, tabId, ensureReachable, confirm) — a structurally complete ctx would be a fake of the thing under observation, and the sibling probe in graph-command-effect.test.ts narrows the same way. */
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- test probe implements only the ctx members the driven tools touch; see the note above
+    await def!.handler(args, stub as unknown as HandlerCtx);
   } catch {
     /* dispatch already recorded; a synthetic ctx cannot satisfy every reply path */
   }

--- a/src/__tests__/orchestrator/screenshot-read-budget.test.ts
+++ b/src/__tests__/orchestrator/screenshot-read-budget.test.ts
@@ -38,6 +38,8 @@ type HandlerCtx = Parameters<Handler>[1];
 type Observed = {
   /** `ctx.bridge.send(cmd, { timeoutMs })` — panel_screenshot's door. */
   sendTimeouts: Map<string, number | undefined>;
+  /** The full send options, so a claim about retries is read from the same call. */
+  sendOpts: Map<string, { timeoutMs?: number; maxReconnectRetries?: number } | undefined>;
   /** `ctx.call(cmd, timeoutMs)` — panel_get_errors' door (positional). */
   callTimeouts: Map<string, number | undefined>;
 };
@@ -54,7 +56,7 @@ async function driveTool(name: string, args: Record<string, unknown> = {}): Prom
   // Guard the guard: a typo'd tool name would make every assertion below vacuous.
   expect(def, `${name} must be a registered tool`).toBeTruthy();
 
-  const observed: Observed = { sendTimeouts: new Map(), callTimeouts: new Map() };
+  const observed: Observed = { sendTimeouts: new Map(), sendOpts: new Map(), callTimeouts: new Map() };
   const nameOf = (cmd: unknown): string | undefined => {
     const c = (cmd as { cmd?: unknown } | undefined)?.cmd;
     return typeof c === "string" ? c : undefined;
@@ -68,9 +70,12 @@ async function driveTool(name: string, args: Record<string, unknown> = {}): Prom
     },
     confirm: async () => "yes" as const,
     bridge: {
-      send: async (cmd: unknown, opts?: { timeoutMs?: number }) => {
+      send: async (cmd: unknown, opts?: { timeoutMs?: number; maxReconnectRetries?: number }) => {
         const c = nameOf(cmd);
-        if (c) observed.sendTimeouts.set(c, opts?.timeoutMs);
+        if (c) {
+          observed.sendTimeouts.set(c, opts?.timeoutMs);
+          observed.sendOpts.set(c, opts);
+        }
         // A 1x1 transparent PNG, so panel_screenshot gets past `if (!res?.image)`
         // and the rest of its body runs the way production's would.
         return {
@@ -134,5 +139,28 @@ describe("panel#2191 — panel_screenshot dispatches with the bounded read budge
 
     expect(errs, "panel_get_errors must have dispatched graph_get_errors").toBeTypeOf("number");
     expect(shot).toBe(errs);
+  });
+
+  // The half of the read classification this call site deliberately DECLINES.
+  //
+  // Admitting graph_screenshot to BRIDGE_READONLY_CMDS also makes it eligible
+  // for the bridge park-and-resume, which re-dispatches on `tabId` alone. A
+  // `wf:` route key recurs — the hello handler fires onTabTakenOver on exactly
+  // that (#486, "same key is not the same tab") — so a parked capture could be
+  // resumed onto a different browser tab and answer this caller with a picture
+  // of a canvas they never asked about. maxReconnectRetries:0 keeps it out of
+  // that branch (handleMidCommandDisconnect gates the park on
+  // `reconnectRetriesRemaining > 0`).
+  //
+  // Pinned because it is a SILENT property: drop the option and every other
+  // test in this file still passes, the tool still works, and the exposure
+  // comes back with nothing to show for it.
+  it("stays one-shot across reconnects, so a parked capture cannot resume onto another tab", async () => {
+    const { sendOpts } = await driveTool("panel_screenshot", { padding: 50 });
+
+    const opts = sendOpts.get("graph_screenshot");
+    // Guard the guard: no dispatch would make the assertion below vacuous.
+    expect(opts, "panel_screenshot must have dispatched graph_screenshot").toBeTruthy();
+    expect(opts?.maxReconnectRetries).toBe(0);
   });
 });

--- a/src/__tests__/orchestrator/screenshot-read-budget.test.ts
+++ b/src/__tests__/orchestrator/screenshot-read-budget.test.ts
@@ -1,0 +1,136 @@
+// panel#2191 — `panel_screenshot` timed out at 20 000 ms on a live, answering tab.
+//
+// The reporter laid out a 264-node / 63-group workflow and called
+// panel_screenshot({padding:50}). It was declared "backgrounded or frozen" while,
+// in the same session on the same graph, panel_query_graph, panel_get_errors
+// (all 264 nodes) and panel_save_workflow all completed. That is not a frozen
+// tab; it is a busy-but-alive main thread — the exact condition
+// graph_get_errors' own budget comment in panel-tools.ts describes.
+//
+// graph_get_errors survives that graph because it dispatches with the bounded
+// 90 s read budget. panel_screenshot dispatched with NO timeoutMs at all and took
+// the bare default, even though its cost scales with the graph the same way: it
+// forces one synchronous LiteGraph repaint of every node and group at the fitted
+// transform, PNG-encodes it, and repaints again on restore.
+//
+// WHY THIS FILE ASSERTS THE CALL SITE, NOT A HELPER. The fix is one option key on
+// one `ctx.bridge.send`. `defaultBridgeTimeoutMs("graph_screenshot")` cannot see
+// it — that helper answers what an UNSPECIFIED dispatch gets, and both defaults
+// are currently 20 000 anyway, so a helper-level assertion is green with or
+// without the fix. The only observation that distinguishes them is what the real
+// registered handler actually passes, so that is what is watched here: the tool
+// surface from buildPanelToolDefs(), driven, with the send options recorded.
+//
+// And the budget is pinned RELATIVELY, to the value panel_get_errors uses, not to
+// the literal 90 000. The number's provenance is "the bounded budget this repo
+// already gives an idempotent read on a busy panel main thread"; writing 90_000
+// here would let the two drift apart silently and would promote a borrowed
+// constant into an independent claim about how long a screenshot takes. It is
+// not that — see the PR: no browser run was possible to measure a real capture.
+import { describe, it, expect } from "vitest";
+import { buildPanelToolDefs } from "../../orchestrator/panel-tools.js";
+import { BRIDGE_DEFAULT_TIMEOUT_MS, BRIDGE_READ_DEFAULT_TIMEOUT_MS } from "../../services/ui-bridge.js";
+
+type Handler = ReturnType<typeof buildPanelToolDefs>[number]["handler"];
+type HandlerCtx = Parameters<Handler>[1];
+
+/** What a driven handler asked the panel to wait for, per door. */
+type Observed = {
+  /** `ctx.bridge.send(cmd, { timeoutMs })` — panel_screenshot's door. */
+  sendTimeouts: Map<string, number | undefined>;
+  /** `ctx.call(cmd, timeoutMs)` — panel_get_errors' door (positional). */
+  callTimeouts: Map<string, number | undefined>;
+};
+
+/**
+ * Drive one registered tool and record the ack budget it asked for.
+ *
+ * The handler is allowed to throw once it has dispatched — several of these do
+ * more work on the reply than a synthetic ctx can satisfy, and the dispatch has
+ * already been observed by then.
+ */
+async function driveTool(name: string, args: Record<string, unknown> = {}): Promise<Observed> {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  // Guard the guard: a typo'd tool name would make every assertion below vacuous.
+  expect(def, `${name} must be a registered tool`).toBeTruthy();
+
+  const observed: Observed = { sendTimeouts: new Map(), callTimeouts: new Map() };
+  const nameOf = (cmd: unknown): string | undefined => {
+    const c = (cmd as { cmd?: unknown } | undefined)?.cmd;
+    return typeof c === "string" ? c : undefined;
+  };
+
+  const ctx = {
+    call: async (cmd: Record<string, unknown>, timeoutMs?: number) => {
+      const c = nameOf(cmd);
+      if (c) observed.callTimeouts.set(c, timeoutMs);
+      return { content: [{ type: "text", text: "{}" }] };
+    },
+    confirm: async () => "yes" as const,
+    bridge: {
+      send: async (cmd: unknown, opts?: { timeoutMs?: number }) => {
+        const c = nameOf(cmd);
+        if (c) observed.sendTimeouts.set(c, opts?.timeoutMs);
+        // A 1x1 transparent PNG, so panel_screenshot gets past `if (!res?.image)`
+        // and the rest of its body runs the way production's would.
+        return {
+          image:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+          mimeType: "image/png",
+        };
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "tab-1", title: "t", connected_at: 0 }],
+      resolveActiveTabId: () => "tab-1",
+    },
+    tabId: "tab-1",
+    ensureReachable: () => {},
+  } as unknown as HandlerCtx;
+
+  try {
+    await def!.handler(args, ctx);
+  } catch {
+    /* dispatch already recorded; a synthetic ctx cannot satisfy every reply path */
+  }
+  return observed;
+}
+
+describe("panel#2191 — panel_screenshot dispatches with the bounded read budget", () => {
+  it("passes an explicit timeoutMs on the send, instead of falling through to the default", async () => {
+    const { sendTimeouts } = await driveTool("panel_screenshot", { padding: 50 });
+
+    // Guard the guard: if the handler never reached its dispatch, "not the
+    // default" would be true because nothing was observed at all.
+    expect(
+      sendTimeouts.has("graph_screenshot"),
+      "panel_screenshot must have dispatched graph_screenshot",
+    ).toBe(true);
+
+    const budget = sendTimeouts.get("graph_screenshot");
+    expect(budget, "the screenshot must not be dispatched with no budget").toBeTypeOf("number");
+    // The regression, stated as the reporter would: the window it was cut off at.
+    expect(budget).toBeGreaterThan(BRIDGE_DEFAULT_TIMEOUT_MS);
+    expect(budget).toBeGreaterThan(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
+    // Still BOUNDED. A read may wait longer than a write; it may not wait forever,
+    // or a genuinely frozen tab never surfaces as frozen at all.
+    expect(Number.isFinite(budget as number)).toBe(true);
+  });
+
+  it("takes the SAME budget as panel_get_errors, the read it was measured against", async () => {
+    // Relative, not a literal. panel_get_errors earned this number for the
+    // identical failure — "declared 'backgrounded or frozen' at 20 000 ms by a
+    // tab that had just answered four commands and did reply, late" — and it is
+    // the reason that tool succeeded on the very graph this one timed out on. If
+    // someone retunes that budget, the screenshot must move with it rather than
+    // silently keeping a stale copy.
+    const shot = (await driveTool("panel_screenshot", { padding: 50 })).sendTimeouts.get(
+      "graph_screenshot",
+    );
+    const errs = (await driveTool("panel_get_errors")).callTimeouts.get("graph_get_errors");
+
+    expect(errs, "panel_get_errors must have dispatched graph_get_errors").toBeTypeOf("number");
+    expect(shot).toBe(errs);
+  });
+});

--- a/src/__tests__/services/mutating-reply-timeout-disclosure.test.ts
+++ b/src/__tests__/services/mutating-reply-timeout-disclosure.test.ts
@@ -134,6 +134,32 @@ describe("a reply-timeout on a mutating command discloses that it may have appli
     expect(msg).not.toMatch(/apply it twice/i);
   });
 
+  // panel#2191 — the same claim, for the read that was NOT getting it.
+  //
+  // A screenshot takes a picture and puts the viewport back. It was nonetheless
+  // outside BRIDGE_READONLY_CMDS, so `ctx.mutating` was true and a reporter whose
+  // 264-node graph outran the reply window was told their SCREENSHOT "MUTATES and
+  // was already delivered to the tab … a blind retry can apply it twice" — advice
+  // to go verify state before daring to take another picture.
+  //
+  // This case is not redundant with graph_serialize above. That one asserts the
+  // branch exists; this one asserts graph_screenshot is ON it, which is the whole
+  // of the defect and the only thing that regresses if the ledger entry is
+  // dropped again.
+  it("panel#2191: a screenshot is a READ, and its timeout does not call it a mutation", async () => {
+    const msg = await timeoutMessage("graph_screenshot");
+
+    // Guard the guard: a pre-dispatch refusal would make every absence below
+    // true for the wrong reason. This must be a genuine reply-timeout.
+    expect(msg).toMatch(/did not reply to "graph_screenshot"/);
+    expect(msg).toMatch(/backgrounded or frozen/);
+
+    expect(msg).not.toMatch(/MUTATES/);
+    expect(msg).not.toMatch(/already delivered/i);
+    expect(msg).not.toMatch(/may have been applied/i);
+    expect(msg).not.toMatch(/apply it twice/i);
+  });
+
   // The disclosure is tied to DELIVERY, not merely to "this command mutates".
   // A pre-dispatch refusal never reached the socket, so claiming it "was already
   // delivered … may have been applied" would be the very inversion this file

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -6160,25 +6160,34 @@ describe("UiBridge (late MUTATION outcome — #694)", () => {
 
   it("asks the FILTER, not the mutating flag — the #778 commands stay out", async () => {
     // ctx.mutating is !BRIDGE_READONLY_CMDS.has(cmd), which this file documents
-    // as misclassifying graph_screenshot &c. The first cut of #694 gated on it
-    // and retained seven reads under a comment claiming reads were excluded.
-    // graph_screenshot is mutating:true AND not retainable — the exact pair that
-    // tells the two discriminators apart.
+    // as misclassifying graph_canvas &c. The first cut of #694 gated on it and
+    // retained seven reads under a comment claiming reads were excluded.
+    //
+    // The fixture must be a command that is mutating:true AND not retainable —
+    // that pair is the only thing that tells the two discriminators apart. This
+    // test used `graph_screenshot` until panel#2191 admitted it to
+    // BRIDGE_READONLY_CMDS; it would still have PASSED afterwards, on
+    // mutating:false, proving nothing. `graph_canvas` is the durable choice and
+    // is deliberately, permanently out of that set: `pan` is a dx/dy DELTA, so
+    // replaying it after a reconnect pans twice (graph-command-effect.test.ts
+    // pins exactly that). It is not retainable either — it is absent from
+    // RETRY_TOKEN_CMD_BY_TOOL, which is what the filter is built from.
+    expect(BRIDGE_READONLY_CMDS.has("graph_canvas"), "fixture must be mutating:true").toBe(false);
     const sock = await connectPanel("tab-778", "wf");
     await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-778")).toBe(true));
     let rid = "";
     sock.on("message", (buf) => {
       const msg = JSON.parse(buf.toString());
-      if (msg.rid && msg.cmd === "graph_screenshot") {
+      if (msg.rid && msg.cmd === "graph_canvas") {
         rid = msg.rid;
         setTimeout(() => sock.send(JSON.stringify({ rid: msg.rid, ok: true })), 80);
       }
     });
     await expect(
-      bridge.send({ cmd: "graph_screenshot" }, { tabId: "tab-778", timeoutMs: 30 }),
+      bridge.send({ cmd: "graph_canvas" }, { tabId: "tab-778", timeoutMs: 30 }),
     ).rejects.toThrow(/did not reply/i);
     await new Promise((r) => setTimeout(r, 140));
-    expect(rid, "graph_screenshot should have been dispatched").toBeTruthy();
+    expect(rid, "graph_canvas should have been dispatched").toBeTruthy();
     expect(bridge.takeLateMutation(rid)).toBeUndefined();
     sock.close();
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1864,7 +1864,7 @@ function isWorkerTransportRetrySafeCmd(cmd: Record<string, unknown>): boolean {
 // This is an EXPLICIT ALLOWLIST, deliberately NOT "everything not read-only":
 // several genuine reads/probes/views that flow through ctx.call are absent from
 // BRIDGE_READONLY_CMDS (e.g. graph_list_subgraphs, training_get_state,
-// graph_canvas, graph_screenshot), so an exclusion rule would wrongly make THOSE
+// graph_canvas), so an exclusion rule would wrongly make THOSE
 // wait out the reconnect budget. Under-inclusion here is at worst an unfixed edge
 // (a command keeps today's behavior); over-inclusion would regress a read — so we
 // list only commands that unambiguously mutate the graph. Keep in sync when new
@@ -26186,8 +26186,28 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             { cmd: "graph_screenshot", padding: args.padding },
             target ?? { mode: "current" },
           );
+          // panel#2191 — the SAME bounded budget the sibling idempotent reads
+          // already take, for the same reason and against the same evidence.
+          //
+          // A screenshot's cost scales with the graph: the frontend handler forces
+          // one synchronous LiteGraph repaint of every node and group at the fitted
+          // transform, PNG-encodes the result, and repaints again on restore — all
+          // on the panel's single main thread. Dispatched with no `timeoutMs` it
+          // took the bare 20 000 ms default, and a reporter's 264-node / 63-group
+          // graph was declared "backgrounded or frozen" on a tab that, in the same
+          // session, answered panel_query_graph, panel_get_errors over all 264
+          // nodes, and panel_save_workflow. That is a busy-but-alive main thread,
+          // which is precisely what graph_get_errors' own budget comment describes
+          // — and graph_get_errors survived that graph because it already passes
+          // this constant while the screenshot alone was left on the default.
+          //
+          // Safe to widen because the read is idempotent (see the panel#2191 entry
+          // in BRIDGE_READONLY_CMDS): waiting longer costs a slow reply, never a
+          // double-applied write. Still BOUNDED, never Infinity, so a genuinely
+          // frozen tab fails — at 90 s instead of 20 s.
           const res = (await ctx.bridge.send(cmd as { cmd: string }, {
             tabId: ctx.tabId,
+            timeoutMs: OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
           })) as {
             image?: string;
             mimeType?: string;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -26205,9 +26205,21 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // in BRIDGE_READONLY_CMDS): waiting longer costs a slow reply, never a
           // double-applied write. Still BOUNDED, never Infinity, so a genuinely
           // frozen tab fails — at 90 s instead of 20 s.
+          //
+          // ONE-SHOT ACROSS RECONNECTS, deliberately. Being a read now also makes
+          // this command eligible for the bridge's park-and-resume, and that
+          // resume re-dispatches on `tabId` alone — but a `wf:` route key recurs,
+          // and the hello handler's own #486 rule is that "same key is not the
+          // same tab". A parked capture could be resumed onto a DIFFERENT browser
+          // tab that took the key over, and answer this caller with a picture of a
+          // canvas they never asked about. `maxReconnectRetries: 0` keeps it out
+          // of that branch: a mid-capture drop fails honestly, and re-asking for a
+          // screenshot costs nothing. The general resume-vs-incarnation gap is
+          // real and older than this call site; it is tracked on its own.
           const res = (await ctx.bridge.send(cmd as { cmd: string }, {
             tabId: ctx.tabId,
             timeoutMs: OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+            maxReconnectRetries: 0,
           })) as {
             image?: string;
             mimeType?: string;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -26215,7 +26215,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // canvas they never asked about. `maxReconnectRetries: 0` keeps it out
           // of that branch: a mid-capture drop fails honestly, and re-asking for a
           // screenshot costs nothing. The general resume-vs-incarnation gap is
-          // real and older than this call site; it is tracked on its own.
+          // real and older than this call site; it is tracked in #2761.
           const res = (await ctx.bridge.send(cmd as { cmd: string }, {
             tabId: ctx.tabId,
             timeoutMs: OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1226,25 +1226,35 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   // and the panel's own READ_ONLY_GRAPH_COMMANDS already classifies as a read.
   // Two ledgers said read; the one that writes the message said mutation.
   //
-  // THE CONSEQUENCE A REVIEWER WILL ASK ABOUT, written down so the next one does
-  // not have to reconstruct it: membership here is what lets
-  // handleMidCommandDisconnect park an un-acked frame and resume it when the tab
-  // re-hellos, keyed on ctx.tabId. "Could a DIFFERENT tab claim that id and be
-  // handed the parked capture?" is answered upstream, twice over:
+  // THE CONSEQUENCE, written down because it is NOT free and a reviewer should
+  // not have to reconstruct it. Membership here also makes a command eligible
+  // for handleMidCommandDisconnect's park-and-resume, and that resume keys on
+  // `ctx.tabId` ALONE: `resumeAwaitingReconnect` looks up `conns.get(tabId)` and
+  // re-dispatches, without consulting the connection's incarnation.
   //
-  //  - The panel's bridge ROUTE identity is minted per page load, persisted
-  //    nowhere, and taken under an origin-wide exclusive Web Lock, precisely so
-  //    a duplicated tab cannot inherit one (panel #640/#709 — a duplicated
-  //    sessionStorage candidate ROTATES before its hello, and a tab that cannot
-  //    establish uniqueness omits the identity rather than guessing). Two tabs
-  //    sharing a route id is the collision that fix exists to make unreachable.
-  //  - And the exposure is the SET'S, not this entry's: the resume branch is
-  //    gated on `!ctx.mutating`, so graph_serialize, graph_outline, graph_query,
-  //    graph_get_errors and graph_view_selected have all parked and resumed on
-  //    ctx.tabId for as long as they have been listed. A wrong-tab SERIALIZE is
-  //    strictly worse than a wrong-tab picture — it drives edits. Adding a read
-  //    to the set does not author the set's identity model, and this change does
-  //    not touch it.
+  // A route key RECURS. The hello handler says so itself (#486): "a `wf:` route
+  // key recurs, so a DIFFERENT tab opening the same saved workflow takes it
+  // over … Same key is not the same tab; only the same incarnation coming back
+  // is a proven return." It fires `onTabTakenOver` on exactly that, so the
+  // bridge already knows how to tell an occupant change from a reconnect — the
+  // resume path just does not ask. A parked read can therefore be handed to the
+  // stranger and its reply resolve the departed caller's promise.
+  //
+  // That hole is the SET'S and predates this entry: the park branch is gated on
+  // `!ctx.mutating`, so graph_serialize, graph_outline, graph_query,
+  // graph_get_errors and graph_view_selected have all resumed this way for as
+  // long as they have been listed — and a wrong-tab SERIALIZE is worse than a
+  // wrong-tab picture, because it drives edits. Fixing it means teaching the
+  // resume the incarnation rule without breaking panels that legitimately have
+  // no proven identity (#2104: a refused or unreadable lock manager omits
+  // `tab_session_id`, so every reconnect looks like a new occupant). That is its
+  // own change, with its own blast radius, and is tracked separately.
+  //
+  // So this entry takes the half it needs and declines the half it does not: the
+  // panel_screenshot call site passes `maxReconnectRetries: 0`, which keeps the
+  // command out of the park branch entirely. A screenshot that drops mid-capture
+  // fails honestly and is free to re-ask; it is never answered with a picture of
+  // someone else's canvas.
   "graph_screenshot",
   "graph_prompt_director_audit",
   "graph_query",

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1248,7 +1248,7 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   // resume the incarnation rule without breaking panels that legitimately have
   // no proven identity (#2104: a refused or unreadable lock manager omits
   // `tab_session_id`, so every reconnect looks like a new occupant). That is its
-  // own change, with its own blast radius, and is tracked separately.
+  // own change, with its own blast radius, and is tracked in #2761.
   //
   // So this entry takes the half it needs and declines the half it does not: the
   // panel_screenshot call site passes `maxReconnectRetries: 0`, which keeps the

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1211,6 +1211,21 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "graph_get_subgraph",
   "graph_view_selected",
   "graph_view_nodes_in_viewport",
+  // panel#2191 — a capture, and nothing else. The frontend handler saves
+  // ds.scale / ds.offset, LiteGraph.vueNodesMode and the active (sub)graph, fits
+  // the whole graph, draws, encodes a PNG, and restores all four in a `finally`.
+  // Re-dispatching it after a reconnect re-takes the same picture; it is strictly
+  // SAFER to replay than the two entries above it, which move the user's viewport
+  // and do not put it back.
+  //
+  // Its absence here was not a judgement, it was an omission — and it was the
+  // whole of panel#2191. `ctx.mutating` is `!READONLY_CMDS.has(cmd)`, so a
+  // reply-timeout on a screenshot told the reporter their screenshot "MUTATES and
+  // was already delivered to the tab … a blind retry can apply it twice", about a
+  // command GRAPH_CMD_EFFECT (thirty lines below) already classifies as `inert`
+  // and the panel's own READ_ONLY_GRAPH_COMMANDS already classifies as a read.
+  // Two ledgers said read; the one that writes the message said mutation.
+  "graph_screenshot",
   "graph_prompt_director_audit",
   "graph_query",
   "civitai_results",
@@ -1247,7 +1262,10 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
  * workflow content at all. `graph_find_nodes` (#778) was the reported instance;
  * `graph_list_subgraphs`, `graph_screenshot`, `graph_canvas`,
  * `graph_select_nodes`, `graph_enter_subgraph`, `graph_exit_subgraph` and
- * `graph_copy_nodes` were the same defect, unreported. The orchestrator already
+ * `graph_copy_nodes` were the same defect, unreported. (`graph_screenshot` was
+ * later reported on its own — panel#2191, where the mutation reading reached the
+ * user as "this command MUTATES … a blind retry can apply it twice" — and is now
+ * in BRIDGE_READONLY_CMDS as well as here.) The orchestrator already
  * knew they were reads — RETRY_TOKEN_CMD_BY_TOOL's doc names them one by one as
  * "view/read-only" and "reads in spirit" — but that knowledge lived in a third
  * list, so the gate could not see it.
@@ -5037,9 +5055,10 @@ export class UiBridge {
    * The bridge cannot answer this itself, and the first attempt at this proved
    * why. It gated on `ctx.mutating`, i.e. `!BRIDGE_READONLY_CMDS.has(cmd)` --
    * the discriminator this very file documents (see BRIDGE_READONLY_CMDS) as
-   * misclassifying graph_find_nodes, graph_list_subgraphs, graph_screenshot,
-   * graph_canvas, graph_select_nodes, graph_enter/exit_subgraph and
-   * graph_copy_nodes. That is #778, and re-asking it retained seven reads under
+   * misclassifying graph_find_nodes, graph_list_subgraphs, graph_canvas,
+   * graph_select_nodes, graph_enter/exit_subgraph and graph_copy_nodes
+   * (graph_screenshot was in that list too until panel#2191 admitted it to the
+   * set). That is #778, and re-asking it retained seven reads under
    * a comment claiming reads were excluded. The real question is not "does this
    * mutate" but "can this rid ever come back to us as a retry token", which only
    * the retry-token layer knows. So it tells us.

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1225,6 +1225,26 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   // command GRAPH_CMD_EFFECT (thirty lines below) already classifies as `inert`
   // and the panel's own READ_ONLY_GRAPH_COMMANDS already classifies as a read.
   // Two ledgers said read; the one that writes the message said mutation.
+  //
+  // THE CONSEQUENCE A REVIEWER WILL ASK ABOUT, written down so the next one does
+  // not have to reconstruct it: membership here is what lets
+  // handleMidCommandDisconnect park an un-acked frame and resume it when the tab
+  // re-hellos, keyed on ctx.tabId. "Could a DIFFERENT tab claim that id and be
+  // handed the parked capture?" is answered upstream, twice over:
+  //
+  //  - The panel's bridge ROUTE identity is minted per page load, persisted
+  //    nowhere, and taken under an origin-wide exclusive Web Lock, precisely so
+  //    a duplicated tab cannot inherit one (panel #640/#709 — a duplicated
+  //    sessionStorage candidate ROTATES before its hello, and a tab that cannot
+  //    establish uniqueness omits the identity rather than guessing). Two tabs
+  //    sharing a route id is the collision that fix exists to make unreachable.
+  //  - And the exposure is the SET'S, not this entry's: the resume branch is
+  //    gated on `!ctx.mutating`, so graph_serialize, graph_outline, graph_query,
+  //    graph_get_errors and graph_view_selected have all parked and resumed on
+  //    ctx.tabId for as long as they have been listed. A wrong-tab SERIALIZE is
+  //    strictly worse than a wrong-tab picture — it drives edits. Adding a read
+  //    to the set does not author the set's identity model, and this change does
+  //    not touch it.
   "graph_screenshot",
   "graph_prompt_director_audit",
   "graph_query",


### PR DESCRIPTION
Fixes the panel report **artokun/comfyui-mcp-panel#2191** — `panel_screenshot` timed out at 20 000 ms on a 264-node / 63-group workflow and told the reporter their *screenshot* "MUTATES and was already delivered to the tab … a blind retry can apply it twice".

The tab was demonstrably alive: in the same session, on the same graph, `panel_query_graph`, `panel_get_errors` (all 264 nodes, zero errors) and `panel_save_workflow` all completed.

## One omission, both halves

`graph_screenshot` was missing from `BRIDGE_READONLY_CMDS`.

**The message.** `SendCtx.mutating` is `!READONLY_CMDS.has(cmd.cmd)` and `mutatedButUnacked()` gates on it, so the false disclosure was appended to a pure capture. The same file already classifies `graph_screenshot: "inert"` in `GRAPH_CMD_EFFECT`, and the panel's own `READ_ONLY_GRAPH_COMMANDS` already classifies it a read. Two ledgers said read; the one that writes the message said mutation. This is #778 / panel#1478 again, at a command those fixes named but did not admit to this set.

**The 20 000 ms.** `panel_screenshot` dispatches through `ctx.bridge.send` with **no `timeoutMs`**, so it took the bare default. `graph_get_errors` carries `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` (90 s), added for a comment-for-comment identical failure — *"declared 'backgrounded or frozen' at 20 000 ms by a tab that had just answered four commands and did reply, late"* — and that is why `panel_get_errors` survived the very graph this tool timed out on. A screenshot's cost scales with the graph the same way: one synchronous LiteGraph repaint of every node and group at the fitted transform, a PNG encode, and another repaint on restore, all on the panel's single main thread.

Both defaults are currently 20 000, so admitting the command to the read set does **not** by itself widen its budget — the call site is the only thing that does. Hence both changes.

## What the review gate changed, because it was right

Round 1 raised: does park-and-resume now let a different tab be handed the parked capture? I answered "unreachable — the panel's route identity is lock-guarded per page load (#640/#709)". **That was wrong**, and the correction is the more interesting half of this PR.

It is true of `tab_session_id`. It is *not* true of the route key. The hello handler says so itself and acts on it (#486):

> a `wf:` route key recurs, so a DIFFERENT tab opening the same saved workflow takes it over […] **Same key is not the same tab; only the same incarnation coming back is a proven return.**

It fires `onTabTakenOver` on exactly that condition — but `resumeAwaitingReconnect` never asks: it does `conns.get(tabId)` and re-dispatches. So a parked read **can** resume onto a stranger and settle the departed caller's promise.

That hole is the **set's**, and older than this PR: the park branch is gated on `!ctx.mutating`, so every listed read has resumed this way for as long as it has been listed, and a wrong-tab `graph_serialize` is worse than a wrong-tab picture because it drives edits. It is now filed as **#2761**, with the trap spelled out — a naive "require a matching incarnation" rule breaks every panel that legitimately has no proven identity (#2104: a refused lock manager omits `tab_session_id`, so each reconnect looks like a new occupant).

**This PR does not fix that, and does not pretend to.** It takes the half it needs and declines the half it does not: the call site passes `maxReconnectRetries: 0`, which keeps the screenshot out of the park branch entirely (`handleMidCommandDisconnect` gates it on `reconnectRetriesRemaining > 0`). A mid-capture drop fails honestly; re-asking for a screenshot costs nothing. No other read's behaviour changes.

## Why the read classification is still right

Read off the frontend handler, not asserted: `graph_screenshot` saves `ds.scale`, `ds.offset`, `LiteGraph.vueNodesMode` and the active (sub)graph and restores all four in a `finally`. What the classification buys here is the honest timeout message and the tolerant-read semantics; the resume half is explicitly opted out of above.

## Please look hardest at these

1. **The 90 s number.** This repo's existing bounded budget for an idempotent read on a busy panel main thread, reused. **Not a measured screenshot cost** — see the coverage gap. The test pins it *relatively* (`panel_screenshot`'s budget === `panel_get_errors`'), never as a literal, so the two cannot drift and a borrowed constant is not promoted into an independent claim about capture time.
2. **Lane hold.** `graph_screenshot` is `inert`, so `graphLaneWaitsForReply` is true and it holds the per-tab graph lane until its reply. A frozen tab now holds it 90 s instead of 20 s. Judged already-accepted rather than new: `graph_get_errors` is also inert, also lane-waiting, already on 90 s.
3. **`maxReconnectRetries: 0` as the mitigation** rather than fixing #2761 here. That is a scope call and I would rather it be argued with than assumed.

## Verified by mutation, not by a green suite

Each half was deleted and the named test watched go red:

| mutation | result |
|---|---|
| remove `"graph_screenshot"` from `BRIDGE_READONLY_CMDS` | `mutating-reply-timeout-disclosure › panel#2191 …` **FAILS** |
| remove `timeoutMs:` from the screenshot `send` | both budget tests **FAIL** |
| replace the budget with an unrelated `30_000` | *only* the relative pin fails — so that assertion is load-bearing, not decorative |
| remove `maxReconnectRetries: 0` | the one-shot pin **FAILS** (and nothing else does, which is why it is pinned) |

The call-site tests drive the **real** `buildPanelToolDefs()` handler and record what it passes to `bridge.send`. A helper-level assertion could not see this fix at all: `defaultBridgeTimeoutMs("graph_screenshot")` is green with or without it, because both defaults are 20 000.

## A stale fixture this change would have silently hollowed out

`ui-bridge.test.ts › "asks the FILTER, not the mutating flag"` used `graph_screenshot` *precisely because* it was `mutating:true` **and** not retainable — the pair that tells the two discriminators apart. After this change it would still have **passed**, on `mutating:false`, proving nothing. Moved to `graph_canvas`, permanently out of the set (`pan` is a delta) and pinned there by `graph-command-effect.test.ts`. Three now-inaccurate comments naming `graph_screenshot` as misclassified are corrected too.

## Coverage I do **not** have

- **No browser run.** No ComfyUI is listening on this machine, so the Playwright suite cannot start and I could not time a real 264-node capture. The 90 s is a reasoned reuse, not a measurement. If the reporter's graph still exceeds it, the panel's own capture path needs work — a different fix, in the other repo.
- **Full vitest: 14 035 passed, 1 failed** (before the last three commits; affected files re-run green since). The failure is `panel-image-relay.test.ts › carries one deadline through the bridge` (`expected 0 to be greater than 0`) — a wall-clock test whose `deadlineAt = createdAt + 50` expires under full-suite load. It stubs its own `bridge` and never touches `BRIDGE_READONLY_CMDS`, the screenshot handler, or `graph_screenshot`. **45/45 pass** when the file runs alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
