### PR TITLE
fix(2754): a 404 on both queue routes is not evidence that ComfyUI-Manager is missing

### DIFF
--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -115,6 +115,8 @@ const http = vi.hoisted(() => ({
     // API. The queue routes 404 exactly as in "manager-absent"; only the version
     // route tells the two apart.
     | "manager-queueless"
+    // #2754 — queue routes 404 and the version routes 5xx: presence UNKNOWN.
+    | "manager-version-unreadable"
     | "manager-unavailable",
   calls: [] as string[],
 }));
@@ -141,6 +143,11 @@ vi.mock("../../comfyui/fetch.js", async (importOriginal) => {
       }
       if (http.mode === "manager-absent") {
         return new Response("missing", { status: 404, statusText: "Not Found" });
+      }
+      if (http.mode === "manager-version-unreadable") {
+        return new URL(url).pathname.endsWith("/manager/version")
+          ? new Response("upstream down", { status: 503 })
+          : new Response("missing", { status: 404, statusText: "Not Found" });
       }
       if (http.mode === "manager-queueless") {
         // A legacy Manager that is up and answering its version route while its
@@ -369,6 +376,37 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(
       (ok as { details?: { managerStatus?: Record<string, unknown> } }).details?.managerStatus,
     ).not.toHaveProperty("manager_absent");
+  });
+
+  it("#2754 does not label the clone manager_absent when the version probe was UNREADABLE", async () => {
+    // Queue routes 404, version routes 503. The diagnostic says presence is
+    // unknown; the label must not say absent in the same breath (gate round 7).
+    http.mode = "manager-version-unreadable";
+    resetManagerApiCache("#2754 unreadable-version label");
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(ok).toMatchObject({
+      details: { managerStatus: { manager_unavailable: true } },
+    });
+    expect(
+      (ok as { details?: { managerStatus?: Record<string, unknown> } }).details?.managerStatus,
+    ).not.toHaveProperty("manager_absent");
+  });
+
+  it("#2754 STILL labels a fully-404 host manager_absent", async () => {
+    // The control: when every probe 404s, `absent` is exactly right and the round-5
+    // and round-7 predicates must not have quietly retired the label.
+    http.mode = "manager-absent";
+    resetManagerApiCache("#2754 absent control");
+
+    const { ok } = await install({ id: REPO, source: "git" });
+
+    expect(ok).toMatchObject({
+      details: { managerStatus: { manager_absent: true } },
+    });
   });
 
   it("#1129 serializes concurrent unavailable-Manager git installs", async () => {

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -114,13 +114,19 @@ const http = vi.hoisted(() => ({
     | "manager-unavailable",
   calls: [] as string[],
 }));
-vi.mock("../../comfyui/fetch.js", () => {
+// Only `comfyuiFetch` is being stood in for. Everything else in the module —
+// raceAbort, defaultComfyTimeoutSignal, the failure describers — is real, because
+// a mock that silently omits them turns "node-management started using another
+// helper from this module" into a confusing failure in a suite about install
+// TARGETS (#2754).
+vi.mock("../../comfyui/fetch.js", async (importOriginal) => {
   const json = (body: unknown) =>
     new Response(JSON.stringify(body), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
   return {
+    ...(await importOriginal<typeof import("../../comfyui/fetch.js")>()),
     comfyuiFetch: async (url: string) => {
       http.calls.push(url);
       if (http.mode === "refuse-enqueue") {

--- a/src/__tests__/services/install-node-target-1765.test.ts
+++ b/src/__tests__/services/install-node-target-1765.test.ts
@@ -111,6 +111,10 @@ const http = vi.hoisted(() => ({
     | "refuse-enqueue"
     | "accept-enqueue"
     | "manager-absent"
+    // #2754 — Manager is SERVING (its version route answers) but has no queue
+    // API. The queue routes 404 exactly as in "manager-absent"; only the version
+    // route tells the two apart.
+    | "manager-queueless"
     | "manager-unavailable",
   calls: [] as string[],
 }));
@@ -137,6 +141,13 @@ vi.mock("../../comfyui/fetch.js", async (importOriginal) => {
       }
       if (http.mode === "manager-absent") {
         return new Response("missing", { status: 404, statusText: "Not Found" });
+      }
+      if (http.mode === "manager-queueless") {
+        // A legacy Manager that is up and answering its version route while its
+        // queue routes 404 — the #2754 shape.
+        return new URL(url).pathname === "/manager/version"
+          ? new Response("V3.41", { status: 200 })
+          : new Response("missing", { status: 404, statusText: "Not Found" });
       }
       const { pathname } = new URL(url);
       if (
@@ -336,6 +347,28 @@ describe("#1765 — install_custom_node must not write into an install this sess
     expect(ok).toMatchObject({
       details: { managerStatus: { manager_unavailable: true } },
     });
+  });
+
+  it("#2754 does not label the clone manager_absent when Manager answered its version route", async () => {
+    // Both queue routes 404, so the clone is still allowed and still happens —
+    // nothing was queued. But the SAME detection saw /manager/version answer
+    // "V3.41", so calling the result manager_absent is a claim contradicted by the
+    // error object the label was read from.
+    http.mode = "manager-queueless";
+    resetManagerApiCache("#2754 queueless-Manager label");
+
+    const { ok, error } = await install({ id: REPO, source: "git" });
+
+    expect(error).toBeUndefined();
+    expect(ok).toMatchObject({ mechanism: "git-clone" });
+    expect(clonedInto()).toBe(join(CONNECTED, PACK_DIR));
+    // Routing is unchanged by #2754 — only the name the outcome is given.
+    expect(ok).toMatchObject({
+      details: { managerStatus: { manager_unavailable: true } },
+    });
+    expect(
+      (ok as { details?: { managerStatus?: Record<string, unknown> } }).details?.managerStatus,
+    ).not.toHaveProperty("manager_absent");
   });
 
   it("#1129 serializes concurrent unavailable-Manager git installs", async () => {

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -349,12 +349,15 @@ describe("#646 Manager API dialect cache invalidation", () => {
     // An unregistered GET that a frontend/proxy answers with a page of HTML must
     // never become "Manager is answering" — that is the whole point of the strict
     // parse in parseManagerMajor, and this branch is a new consumer of it.
-    stubQueuelessManager({
+    const calls = stubQueuelessManager({
       path: "/manager/version",
       body: "<!DOCTYPE html><html><body>ComfyUI</body></html>",
     });
 
     const error = await detectionError();
+    // The catchall WAS consulted (this is the new branch, not the old code path
+    // reaching the same words by never asking) and was correctly not believed.
+    expect(calls.map((c) => c.path)).toContain("/manager/version");
     expect(error.message).not.toMatch(/ComfyUI-Manager IS answering/i);
     expect(error.message).toMatch(/queue API is not reachable/i);
     expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBeUndefined();
@@ -363,9 +366,12 @@ describe("#646 Manager API dialect cache invalidation", () => {
   it("keeps the queue-detection error when the version probe hard-fails (#2754)", async () => {
     // managerFetch throws on 401/403 even in soft mode (#2085). A secondary probe
     // that throws must not replace the reader's actual failure with its own.
-    stubQueuelessManager({ path: "/manager/version", body: "", status: 401 });
+    const calls = stubQueuelessManager({ path: "/manager/version", body: "", status: 401 });
 
     const error = await detectionError();
+    // The probe that throws is the one this branch added, so it must have run —
+    // otherwise this asserts nothing about swallowing anything.
+    expect(calls.map((c) => c.path)).toContain("/manager/version");
     expect(error.message).toMatch(/queue API is not reachable/i);
     expect(error.message).not.toMatch(/HTTP 401/);
     expect((error.details as { kind?: string }).kind).toBe("manager-queue-detection");

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -339,11 +339,13 @@ describe("#646 Manager API dialect cache invalidation", () => {
     // …but it now states the second observation that makes it more than a guess.
     expect(error.message).toMatch(/neither \/v2\/manager\/version nor \/manager\/version/i);
     expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBeUndefined();
-    // Silence, NOT refusal — the two carry different messages and this is the
-    // only one entitled to the strong "nothing is serving Manager routes" claim.
+    // A clean 404 on every probe, NOT a refusal and NOT an unreadable response —
+    // this is the only state entitled to the strong "nothing is serving Manager
+    // routes at all" claim, and the message says every probe 404'd.
     expect((error.details as { managerVersionEvidence?: string }).managerVersionEvidence).toBe(
-      "none",
+      "absent",
     );
+    expect(error.message).toMatch(/every probe 404'd/);
     // The version routes were actually consulted — the claim is not asserted for free.
     expect(calls.map((c) => c.path)).toEqual(
       expect.arrayContaining(["/v2/manager/version", "/manager/version"]),
@@ -366,6 +368,31 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(error.message).not.toMatch(/ComfyUI-Manager IS answering/i);
     expect(error.message).toMatch(/queue API is not reachable/i);
     expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBeUndefined();
+    // A 200 page of HTML is a route we could not READ, not a server saying the
+    // route is absent — so it lands in `unreadable`, and the strong absence
+    // wording (with its migrate/--enable-manager advice) is withheld.
+    expect((error.details as { managerVersionEvidence?: string }).managerVersionEvidence).toBe(
+      "unreadable",
+    );
+    expect(error.message).toMatch(/NOT evidence that ComfyUI-Manager is absent/i);
+    expect(error.message).not.toMatch(/every probe 404'd/);
+    expect(error.message).not.toMatch(/only activates when ComfyUI is started with/i);
+  });
+
+  it("will not call a 5xx on the version route absence (#2754, gate round 2)", async () => {
+    // Both queue routes 404 and the version routes 503. The old single-arm message
+    // recommended --enable-manager here — a Manager migration prescribed to a
+    // ComfyUI that was merely sick for a moment.
+    stubQueuelessManager({ path: "/manager/version", body: "upstream down", status: 503 });
+
+    const error = await detectionError();
+    expect((error.details as { managerVersionEvidence?: string }).managerVersionEvidence).toBe(
+      "unreadable",
+    );
+    expect(error.message).toMatch(/could not be established/i);
+    expect(error.message).toMatch(/server-error/);
+    expect(error.message).toMatch(/do not reinstall or migrate Manager/i);
+    expect(error.message).not.toMatch(/only activates when ComfyUI is started with/i);
   });
 
   it("does not spend a REFUSED version route as absence evidence (#2754)", async () => {

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -379,6 +379,37 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(error.message).not.toMatch(/only activates when ComfyUI is started with/i);
   });
 
+  it("does not call a BODY-read failure an authentication refusal (#2754, gate round 3)", async () => {
+    // managerFetch's `await res.text()` is unguarded, so a 2xx whose body rejects
+    // throws from the same place a 401 does. Classifying every throw as "refused"
+    // would answer a broken pipe with "configure your gateway credentials".
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string): Promise<Response> => {
+        const path = new URL(url).pathname;
+        if (path === "/manager/version") {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.error(new Error("aborted"));
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("404: Not Found", { status: 404 });
+      }),
+    );
+
+    const error = await detectionError();
+    expect((error.details as { managerVersionEvidence?: string }).managerVersionEvidence).toBe(
+      "unreadable",
+    );
+    expect(error.message).not.toMatch(/authentication failure/i);
+    expect(error.message).not.toMatch(/credentials/i);
+    expect(error.message).toMatch(/could not be established/i);
+  });
+
   it("will not call a 5xx on the version route absence (#2754, gate round 2)", async () => {
     // Both queue routes 404 and the version routes 503. The old single-arm message
     // recommended --enable-manager here — a Manager migration prescribed to a

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -321,6 +321,33 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBe(3);
   });
 
+  it("does not tell a busy Manager its queue module failed to register (#2754, gate round 6)", async () => {
+    // Manager is up (V4.2.2) and its queue routes 503. The queue side gets the
+    // same treatment as the version side: 503 is a route we could not read, not a
+    // queue API that is absent, so the "queue module failed to register" reading
+    // is withheld.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string): Promise<Response> => {
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/version") return new Response("V4.2.2", { status: 200 });
+        if (path.endsWith("/manager/queue/status")) {
+          return new Response("upstream down", { status: 503 });
+        }
+        return new Response("404: Not Found", { status: 404 });
+      }),
+    );
+
+    const error = await detectionError();
+    expect(error.message).toMatch(/ComfyUI-Manager IS answering/i);
+    expect(error.message).toMatch(/generation 4\.x/);
+    // The claim withheld: nothing here establishes the queue API is absent.
+    expect(error.message).not.toMatch(/serves NO queue API/i);
+    expect(error.message).not.toMatch(/failed to register/i);
+    expect(error.message).toMatch(/server-error/);
+    expect(error.message).toMatch(/could not READ/i);
+  });
+
   it("reports the v4 generation when /v2/manager/version is the one answering (#2754)", async () => {
     stubQueuelessManager({ path: "/v2/manager/version", body: "V4.2.2" });
 

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -379,6 +379,49 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(error.message).not.toMatch(/only activates when ComfyUI is started with/i);
   });
 
+  it("settles instead of hanging on a version body that never ends (#2754, gate round 4)", async () => {
+    // comfyuiFetch's ceiling cancels the exchange but not the body read (#1672,
+    // fetch.ts:575-584), so a 200 whose body never closes leaves managerFetch's
+    // `await res.text()` pending forever. Without raceAbort around these two
+    // probes this test does not fail — it HANGS, which is the point.
+    const previousTimeout = process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
+    process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = "0.3";
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string): Promise<Response> => {
+          const path = new URL(url).pathname;
+          if (path === "/v2/manager/version") {
+            // Headers arrive; the body never does and is never closed.
+            return new Response(
+              new ReadableStream({
+                start() {
+                  /* deliberately never enqueues and never closes */
+                },
+              }),
+              { status: 200 },
+            );
+          }
+          return new Response("404: Not Found", { status: 404 });
+        }),
+      );
+
+      const started = Date.now();
+      const error = await detectionError();
+      // Bounded by ONE budget for the whole probe, not one per route.
+      expect(Date.now() - started).toBeLessThan(5_000);
+      expect((error.details as { kind?: string }).kind).toBe("manager-queue-detection");
+      // A stall is unreadable — it establishes nothing about whether Manager is there.
+      expect((error.details as { managerVersionEvidence?: string }).managerVersionEvidence).toBe(
+        "unreadable",
+      );
+      expect(error.message).not.toMatch(/every probe 404'd/);
+    } finally {
+      if (previousTimeout === undefined) delete process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
+      else process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = previousTimeout;
+    }
+  }, 20_000);
+
   it("does not call a BODY-read failure an authentication refusal (#2754, gate round 3)", async () => {
     // managerFetch's `await res.text()` is unguarded, so a 2xx whose body rejects
     // throws from the same place a 401 does. Classifying every throw as "refused"

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -339,6 +339,11 @@ describe("#646 Manager API dialect cache invalidation", () => {
     // …but it now states the second observation that makes it more than a guess.
     expect(error.message).toMatch(/neither \/v2\/manager\/version nor \/manager\/version/i);
     expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBeUndefined();
+    // Silence, NOT refusal — the two carry different messages and this is the
+    // only one entitled to the strong "nothing is serving Manager routes" claim.
+    expect((error.details as { managerVersionEvidence?: string }).managerVersionEvidence).toBe(
+      "none",
+    );
     // The version routes were actually consulted — the claim is not asserted for free.
     expect(calls.map((c) => c.path)).toEqual(
       expect.arrayContaining(["/v2/manager/version", "/manager/version"]),
@@ -363,18 +368,30 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBeUndefined();
   });
 
-  it("keeps the queue-detection error when the version probe hard-fails (#2754)", async () => {
-    // managerFetch throws on 401/403 even in soft mode (#2085). A secondary probe
-    // that throws must not replace the reader's actual failure with its own.
+  it("does not spend a REFUSED version route as absence evidence (#2754)", async () => {
+    // managerFetch throws on 401/407 even in soft mode — deliberately, because
+    // #2085 is exactly the lesson that a credential rejection is not absence. A
+    // bare catch → "no version evidence" here would launder that 401 straight back
+    // into "nothing is serving Manager routes at all" (caught by the codex gate).
     const calls = stubQueuelessManager({ path: "/manager/version", body: "", status: 401 });
 
     const error = await detectionError();
     // The probe that throws is the one this branch added, so it must have run —
-    // otherwise this asserts nothing about swallowing anything.
+    // otherwise this asserts nothing about how its failure is handled.
     expect(calls.map((c) => c.path)).toContain("/manager/version");
+    // The reader's real failure survives: this is still queue detection, not the
+    // secondary probe's error wearing its name.
     expect(error.message).toMatch(/queue API is not reachable/i);
-    expect(error.message).not.toMatch(/HTTP 401/);
     expect((error.details as { kind?: string }).kind).toBe("manager-queue-detection");
+    // …and the 401 is reported as the unknown it is, never as absence.
+    expect(error.message).toMatch(/REJECTED/);
+    expect(error.message).toMatch(/not evidence that ComfyUI-Manager is missing/i);
+    expect(error.message).toMatch(/UNKNOWN from here/);
+    expect(error.message).not.toMatch(/is serving ComfyUI-Manager routes at all/i);
+    expect(error.message).not.toMatch(/installed and enabled/i);
+    expect((error.details as { managerVersionEvidence?: string }).managerVersionEvidence).toBe(
+      "refused",
+    );
   });
 
   it("re-detects after a restart at the SAME url (explicit invalidation)", async () => {

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -268,6 +268,109 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(error.message).not.toMatch(/queue API is not reachable.*installed and enabled/i);
   });
 
+  // -------------------------------------------------------------------------
+  // #2754 — both queue/status routes 404. That is evidence about the QUEUE API;
+  // it is NOT evidence that ComfyUI-Manager is absent or disabled. The reporter's
+  // Manager was installed and had imported cleanly, so "is it installed and
+  // enabled? / start ComfyUI with --enable-manager" was the one instruction that
+  // could not help. The version routes are disjoint from the queue surface
+  // (/v2/manager/version is v4-only, /manager/version is 3.x-only), so they are
+  // the witness that decides which of the two claims the evidence supports.
+  // -------------------------------------------------------------------------
+
+  /** ComfyUI serving a Manager whose version route answers and whose queue
+   *  routes do not. `versionBody` is what BOTH version routes reply with. */
+  const stubQueuelessManager = (
+    version: { path: string; body: string; status?: number } | undefined,
+  ): Call[] => {
+    const calls: Call[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const path = new URL(url).pathname;
+        calls.push({ url, path, method: init?.method ?? "GET", body: undefined });
+        if (version && path === version.path) {
+          return new Response(version.body, { status: version.status ?? 200 });
+        }
+        return new Response("404: Not Found", { status: 404 });
+      }),
+    );
+    return calls;
+  };
+
+  const detectionError = async (): Promise<Error & { details?: unknown }> =>
+    (await detectManagerApi(BASE).catch((e: unknown) => e)) as Error & { details?: unknown };
+
+  it("does not claim Manager is missing when its VERSION route answers (#2754)", async () => {
+    stubQueuelessManager({ path: "/manager/version", body: "V3.41" });
+
+    const error = await detectionError();
+    expect(error).toBeInstanceOf(Error);
+    // The claim it is now allowed to make: Manager is up, its queue API is not.
+    expect(error.message).toMatch(/ComfyUI-Manager IS answering/i);
+    expect(error.message).toMatch(/generation 3\.x/);
+    expect(error.message).toMatch(/serves NO queue API/i);
+    // The claims the evidence does NOT support, and which cost the reporter the
+    // whole investigation.
+    expect(error.message).not.toMatch(/installed and enabled/i);
+    expect(error.message).not.toMatch(/only activates when ComfyUI is started with/i);
+    // --enable-manager may only appear as the thing being RULED OUT, never as an
+    // instruction: prescribing it here is the exact wrong turn #2754 reported.
+    expect(error.message).toMatch(/neither installing[^.]*nor adding --enable-manager will fix it/i);
+    // The evidence the message was earned on travels with the error.
+    expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBe(3);
+  });
+
+  it("reports the v4 generation when /v2/manager/version is the one answering (#2754)", async () => {
+    stubQueuelessManager({ path: "/v2/manager/version", body: "V4.2.2" });
+
+    const error = await detectionError();
+    expect(error.message).toMatch(/generation 4\.x/);
+    expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBe(4);
+  });
+
+  it("still says 'not reachable' when the version routes answer nothing either (#2754)", async () => {
+    const calls = stubQueuelessManager(undefined);
+
+    const error = await detectionError();
+    // The original diagnosis survives — it is the correct one for THIS evidence.
+    expect(error.message).toMatch(/queue API is not reachable/i);
+    expect(error.message).toMatch(/installed and enabled/i);
+    // …but it now states the second observation that makes it more than a guess.
+    expect(error.message).toMatch(/neither \/v2\/manager\/version nor \/manager\/version/i);
+    expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBeUndefined();
+    // The version routes were actually consulted — the claim is not asserted for free.
+    expect(calls.map((c) => c.path)).toEqual(
+      expect.arrayContaining(["/v2/manager/version", "/manager/version"]),
+    );
+  });
+
+  it("does not read ComfyUI's SPA catchall 200 as a Manager version (#2754)", async () => {
+    // An unregistered GET that a frontend/proxy answers with a page of HTML must
+    // never become "Manager is answering" — that is the whole point of the strict
+    // parse in parseManagerMajor, and this branch is a new consumer of it.
+    stubQueuelessManager({
+      path: "/manager/version",
+      body: "<!DOCTYPE html><html><body>ComfyUI</body></html>",
+    });
+
+    const error = await detectionError();
+    expect(error.message).not.toMatch(/ComfyUI-Manager IS answering/i);
+    expect(error.message).toMatch(/queue API is not reachable/i);
+    expect((error.details as { managerVersionMajor?: number }).managerVersionMajor).toBeUndefined();
+  });
+
+  it("keeps the queue-detection error when the version probe hard-fails (#2754)", async () => {
+    // managerFetch throws on 401/403 even in soft mode (#2085). A secondary probe
+    // that throws must not replace the reader's actual failure with its own.
+    stubQueuelessManager({ path: "/manager/version", body: "", status: 401 });
+
+    const error = await detectionError();
+    expect(error.message).toMatch(/queue API is not reachable/i);
+    expect(error.message).not.toMatch(/HTTP 401/);
+    expect((error.details as { kind?: string }).kind).toBe("manager-queue-detection");
+  });
+
   it("re-detects after a restart at the SAME url (explicit invalidation)", async () => {
     let persona: Persona = "v2-batch";
     const calls = stubServer({ persona: () => persona });

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -321,6 +321,19 @@ function stubFetch(opts: {
       if (path.startsWith("/v2/customnode/installed")) {
         return jsonResponse(opts.installedBody ?? {});
       }
+      // #2754 — "absent" means a host with NO ComfyUI-Manager, and such a host
+      // 404s the version routes exactly as it 404s the queue routes. Without this
+      // they fell through to the empty-200 catchall below, which models a server
+      // that answers every unknown path — the one shape that is neither a 404 nor
+      // a Manager. Detection reads the version routes now, so the fixture has to
+      // be honest about them or "confirmed absent" is asserted against a host that
+      // never confirmed anything.
+      if (
+        opts.managerQueueStatus === "absent" &&
+        (path === "/v2/manager/version" || path === "/manager/version")
+      ) {
+        return new Response("missing", { status: 404 });
+      }
       if (path === "/v2/manager/queue/status" || path === "/manager/queue/status") {
         if (opts.queueStatusNull) {
           // This is intentionally a status response, not an enqueue response:

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -711,6 +711,21 @@ async function probeManagerMajor(base: string): Promise<number | undefined> {
 }
 
 /**
+ * `probeManagerMajor` for the FAILURE branch, where the answer only sharpens a
+ * diagnosis we are already committed to. `managerFetch` still throws on hard
+ * failures even in soft mode (an authenticating proxy, most of all), and letting
+ * that replace the queue-detection error would swap the reader's real problem for
+ * a secondary probe's. Absence of a version is simply "no version evidence".
+ */
+async function probeManagerMajorForDiagnosis(base: string): Promise<number | undefined> {
+  try {
+    return await probeManagerMajor(base);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Given that the /v2 queue surface answered, decide between the two pip-Manager
  * (v4) dialects. Both normal-v4 and legacy-UI mode register
  * GET /v2/manager/is_legacy_manager_ui and answer truthfully; a missing route
@@ -863,16 +878,52 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
     cacheManagerApi(base, "legacy", stamp);
     return "legacy";
   }
+  // #2754 — the queue routes answered nothing. That is evidence about the QUEUE
+  // API, and the sentence below used to spend it on a much bigger claim: "is
+  // ComfyUI-Manager installed and enabled?", plus a --enable-manager pointer. The
+  // reporter's Manager was installed AND had imported cleanly (ComfyUI appends
+  // " (IMPORT FAILED)" to its `N seconds: <path>` line, and theirs had no suffix),
+  // so the one instruction we gave was the one thing that could not help.
+  //
+  // Same defect class as #2085, where an authenticating proxy's 401 was translated
+  // into "Manager is missing". The fix is the same shape: consult the AUTHORITATIVE
+  // version routes before absence may be claimed. They are the right witness here
+  // because they are disjoint from the queue surface — /v2/manager/version is
+  // registered only by v4 and /manager/version only by 3.x — so an answer on either
+  // proves Manager is serving HTTP on this base even when its queue routes 404.
+  const managerVersionMajor = await probeManagerMajorForDiagnosis(base);
   throw new NodeManagementError(
-    "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
-      "nor /manager/queue/status answered with a queue status). Is ComfyUI-Manager " +
-      "installed and enabled on the connected ComfyUI? The pip comfyui_manager " +
-      "package only activates when ComfyUI is started with --enable-manager.",
+    managerVersionMajor !== undefined
+      ? `ComfyUI-Manager IS answering on ${base} — its version route reports generation ` +
+          `${managerVersionMajor}.x — but it serves NO queue API: neither ` +
+          "/v2/manager/queue/status nor /manager/queue/status answered with a queue " +
+          "status. So this is NOT a missing or disabled Manager, and neither installing " +
+          "the pip comfyui_manager package nor adding --enable-manager will fix it. What " +
+          "fits the evidence is a Manager whose queue routes specifically are absent: a " +
+          "partial or older Manager server build, a Manager whose queue module failed to " +
+          "register, or a proxy in front of ComfyUI that forwards only some /manager " +
+          "routes. Check the ComfyUI log around Manager's startup, and retry once it " +
+          "serves a queue surface."
+      : "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
+          "nor /manager/queue/status answered with a queue status), and neither " +
+          "/v2/manager/version nor /manager/version answered with a version either — so " +
+          `nothing at ${base} is serving ComfyUI-Manager routes at all. Is ComfyUI-Manager ` +
+          "installed and enabled on the connected ComfyUI? The pip comfyui_manager " +
+          "package only activates when ComfyUI is started with --enable-manager. NOTE: a " +
+          "custom_nodes/ComfyUI-Manager clone can import cleanly and still register no " +
+          "routes — ComfyUI logs `Blocked by policy: <path>` and skips the clone entirely " +
+          "when --enable-manager is set and the pip package shadows it (with " +
+          "--disable-manager-ui on top, that leaves no Manager routes at all), and the " +
+          "clone starts in CLI-only mode, serving nothing, when its .enable-cli-only-mode " +
+          "marker file is present.",
     {
       kind: MANAGER_QUEUE_DETECTION_FAILURE,
       base,
       queueStatusCodes,
       queueStatusKinds,
+      // Undefined when the version routes answered nothing either. Kept in the
+      // details so a report carries the evidence the message was earned on.
+      managerVersionMajor,
     },
   );
 }

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -8,7 +8,7 @@ import {
   getComfyuiTargetGeneration,
   isRemoteMode,
 } from "../config.js";
-import { comfyuiFetch } from "../comfyui/fetch.js";
+import { comfyuiFetch, defaultComfyTimeoutSignal, raceAbort } from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
 import { parsePyproject } from "./node-authoring.js";
@@ -742,6 +742,20 @@ async function probeManagerVersionEvidence(base: string): Promise<ManagerVersion
   // same question about the same host, and a second private taxonomy is how the
   // two drift into disagreeing about what "absent" means.
   const kinds: ManagerQueueStatusKind[] = [];
+  // ONE budget for the whole diagnosis, not one per route.
+  //
+  // comfyuiFetch's default ceiling cancels the HTTP exchange but NOT the body
+  // read: once headers arrive, `await res.text()` inside managerFetch can stay
+  // pending for as long as the body takes, and the abort event fires without the
+  // read observing it. That is fetch.ts:575-584 (#1672), and raceAbort exists for
+  // exactly this. A ComfyUI mid-decode really does accept a request and then stall
+  // — and hanging HERE would be the worst place for it, because this is the
+  // diagnosis a caller reached after everything else had already failed.
+  //
+  // Scoped to the two probes this branch adds. managerFetch's unraced body read is
+  // pre-existing on every other call site in this file and is filed separately;
+  // fixing it there changes behaviour for every Manager operation.
+  const budget = defaultComfyTimeoutSignal();
   for (const path of MANAGER_VERSION_ROUTES) {
     let kind: ManagerQueueStatusKind = "hard-error";
     // This route's own status. Recorded per-iteration, and promoted to
@@ -750,22 +764,24 @@ async function probeManagerVersionEvidence(base: string): Promise<ManagerVersion
     let statusSeen: number | undefined;
     try {
       const major = parseManagerMajor(
-        await managerFetch<string>(path, {
-          base,
-          soft: true,
-          onSoftFailure: (status) => {
-            statusSeen = status;
-            kind = status === undefined ? "transport" : managerQueueStatusKind(status);
-          },
-          onSoftTransportFailure: () => {
-            kind = "transport";
-          },
-          // A 2xx that is not a version string — ComfyUI's SPA catchall, most of
-          // all — is malformed, never absence.
-          onSoftResponse: (body) => {
-            kind = body === undefined || body === null ? "empty" : "malformed";
-          },
-        }),
+        await raceAbort(budget, () =>
+          managerFetch<string>(path, {
+            base,
+            soft: true,
+            onSoftFailure: (status) => {
+              statusSeen = status;
+              kind = status === undefined ? "transport" : managerQueueStatusKind(status);
+            },
+            onSoftTransportFailure: () => {
+              kind = "transport";
+            },
+            // A 2xx that is not a version string — ComfyUI's SPA catchall, most of
+            // all — is malformed, never absence.
+            onSoftResponse: (body) => {
+              kind = body === undefined || body === null ? "empty" : "malformed";
+            },
+          }),
+        ),
       );
       if (major !== undefined) return { kind: "version", major };
     } catch {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -720,25 +720,50 @@ async function probeManagerMajor(base: string): Promise<number | undefined> {
  *     point: a credential rejection tells us nothing about whether Manager is
  *     installed, so it must not be spent as absence evidence — which is exactly
  *     what a bare `catch → undefined` here would do (codex gate, #2754).
- *   • `none` — every route answered, and none of them was Manager.
+ *   • `absent` — BOTH routes answered HTTP 404. Deliberately narrow, and narrow for
+ *     the same reason `probeManagerQueueAvailability` is: only a 404 is a server
+ *     saying "no such route".
+ *   • `unreadable` — anything else. A 5xx, a 403, a proxy error page, a timeout or
+ *     an HTML catchall is a route we could not READ, and reading nothing is not the
+ *     same as being told nothing is there (codex gate round 2, #2754). Collapsing
+ *     these into absence is how a momentarily sick ComfyUI gets a Manager migration
+ *     recommended to it.
  */
 type ManagerVersionEvidence =
   | { kind: "version"; major: number }
   | { kind: "refused"; status: number | undefined }
-  | { kind: "none" };
+  | { kind: "absent" }
+  | { kind: "unreadable"; kinds: ManagerQueueStatusKind[] };
 
 async function probeManagerVersionEvidence(base: string): Promise<ManagerVersionEvidence> {
   let refusedStatus: number | undefined;
   let refused = false;
+  // Same response vocabulary the queue probes use — these two surfaces answer the
+  // same question about the same host, and a second private taxonomy is how the
+  // two drift into disagreeing about what "absent" means.
+  const kinds: ManagerQueueStatusKind[] = [];
   for (const path of MANAGER_VERSION_ROUTES) {
-    let status: number | undefined;
+    let kind: ManagerQueueStatusKind = "hard-error";
+    // This route's own status. Recorded per-iteration, and promoted to
+    // `refusedStatus` ONLY from the catch below: a 404 on the first route must not
+    // be mistaken for the status that refused us on the second.
+    let statusSeen: number | undefined;
     try {
       const major = parseManagerMajor(
         await managerFetch<string>(path, {
           base,
           soft: true,
-          onSoftFailure: (s) => {
-            status = s;
+          onSoftFailure: (status) => {
+            statusSeen = status;
+            kind = status === undefined ? "transport" : managerQueueStatusKind(status);
+          },
+          onSoftTransportFailure: () => {
+            kind = "transport";
+          },
+          // A 2xx that is not a version string — ComfyUI's SPA catchall, most of
+          // all — is malformed, never absence.
+          onSoftResponse: (body) => {
+            kind = body === undefined || body === null ? "empty" : "malformed";
           },
         }),
       );
@@ -749,10 +774,89 @@ async function probeManagerVersionEvidence(base: string): Promise<ManagerVersion
       // queue-detection error with a secondary probe's — but REMEMBER that this
       // route was refused rather than silent.
       refused = true;
-      refusedStatus ??= status;
+      refusedStatus ??= statusSeen;
     }
+    kinds.push(kind);
   }
-  return refused ? { kind: "refused", status: refusedStatus } : { kind: "none" };
+  if (refused) return { kind: "refused", status: refusedStatus };
+  return kinds.every((k) => k === "not-found") ? { kind: "absent" } : { kind: "unreadable", kinds };
+}
+
+/** The one sentence in this failure that is allowed to speak with certainty. */
+const MANAGER_QUEUE_UNREACHABLE_LEDE =
+  "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status nor " +
+  "/manager/queue/status answered with a queue status)";
+
+/**
+ * Choose the diagnosis the observations actually support (#2754).
+ *
+ * The old message had one arm and made the strongest available claim from the
+ * weakest available evidence. There are four states here because the host really
+ * can be in four of them, and three of them have fixes that the fourth's advice
+ * would send the reader away from.
+ */
+function managerQueueDetectionMessage(
+  base: string,
+  queueStatusKinds: ManagerQueueStatusKind[],
+  version: ManagerVersionEvidence,
+): string {
+  if (version.kind === "version") {
+    return (
+      `ComfyUI-Manager IS answering on ${base} — its version route reports generation ` +
+      `${version.major}.x — but it serves NO queue API: neither /v2/manager/queue/status ` +
+      "nor /manager/queue/status answered with a queue status. So this is NOT a missing or " +
+      "disabled Manager, and neither installing the pip comfyui_manager package nor adding " +
+      "--enable-manager will fix it. What fits the evidence is a Manager whose queue routes " +
+      "specifically are absent: a partial or older Manager server build, a Manager whose " +
+      "queue module failed to register, or a proxy in front of ComfyUI that forwards only " +
+      "some /manager routes. Check the ComfyUI log around Manager's startup, and retry once " +
+      "it serves a queue surface."
+    );
+  }
+  if (version.kind === "refused") {
+    return (
+      `${MANAGER_QUEUE_UNREACHABLE_LEDE}, and the version routes that would establish ` +
+      "whether Manager is present at all were REJECTED" +
+      (version.status !== undefined
+        ? explainManagerAuthenticationRequired(version.status)
+        : " — an authentication failure, not evidence that ComfyUI-Manager is missing.") +
+      ` Whether ComfyUI-Manager is installed on ${base} is therefore UNKNOWN from here; ` +
+      "clear the credential/proxy rejection and retry before concluding anything about " +
+      "Manager itself."
+    );
+  }
+  // Absence is claimable only when all four probes were TOLD there is no such
+  // route. A 404 is a server answering; a 503, a proxy error page, a timeout or an
+  // HTML catchall is a route we could not read, and this branch used to spend
+  // those as absence too (codex gate round 2).
+  const provenAbsent =
+    version.kind === "absent" && queueStatusKinds.every((kind) => kind === "not-found");
+  if (!provenAbsent) {
+    const seen =
+      version.kind === "unreadable"
+        ? version.kinds.join(", ")
+        : queueStatusKinds.join(", ");
+    return (
+      `${MANAGER_QUEUE_UNREACHABLE_LEDE}, and whether ComfyUI-Manager is present could not ` +
+      `be established either: the probes came back "${seen}" rather than a clean 404. An ` +
+      "unreadable response — a 5xx, a proxy or gateway error page, a timeout, an HTML " +
+      "catchall — is NOT evidence that ComfyUI-Manager is absent, so do not reinstall or " +
+      "migrate Manager on the strength of this message. Check that the ComfyUI at " +
+      `${base} is healthy and reachable, then retry.`
+    );
+  }
+  return (
+    `${MANAGER_QUEUE_UNREACHABLE_LEDE}, and neither /v2/manager/version nor /manager/version ` +
+    `answered with a version either — every probe 404'd, so nothing at ${base} is serving ` +
+    "ComfyUI-Manager routes at all. Is ComfyUI-Manager installed and enabled on the " +
+    "connected ComfyUI? The pip comfyui_manager package only activates when ComfyUI is " +
+    "started with --enable-manager. NOTE: a custom_nodes/ComfyUI-Manager clone can import " +
+    "cleanly and still register no routes — ComfyUI logs `Blocked by policy: <path>` and " +
+    "skips the clone entirely when --enable-manager is set and the pip package shadows it " +
+    "(with --disable-manager-ui on top, that leaves no Manager routes at all), and the " +
+    "clone starts in CLI-only mode, serving nothing, when its .enable-cli-only-mode marker " +
+    "file is present."
+  );
 }
 
 /**
@@ -925,39 +1029,7 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
   const managerVersionMajor =
     versionEvidence.kind === "version" ? versionEvidence.major : undefined;
   throw new NodeManagementError(
-    versionEvidence.kind === "version"
-      ? `ComfyUI-Manager IS answering on ${base} — its version route reports generation ` +
-          `${versionEvidence.major}.x — but it serves NO queue API: neither ` +
-          "/v2/manager/queue/status nor /manager/queue/status answered with a queue " +
-          "status. So this is NOT a missing or disabled Manager, and neither installing " +
-          "the pip comfyui_manager package nor adding --enable-manager will fix it. What " +
-          "fits the evidence is a Manager whose queue routes specifically are absent: a " +
-          "partial or older Manager server build, a Manager whose queue module failed to " +
-          "register, or a proxy in front of ComfyUI that forwards only some /manager " +
-          "routes. Check the ComfyUI log around Manager's startup, and retry once it " +
-          "serves a queue surface."
-      : versionEvidence.kind === "refused"
-        ? "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
-          "nor /manager/queue/status answered with a queue status), and the version routes " +
-          "that would establish whether Manager is present at all were REJECTED" +
-          (versionEvidence.status !== undefined
-            ? explainManagerAuthenticationRequired(versionEvidence.status)
-            : " — an authentication failure, not evidence that ComfyUI-Manager is missing.") +
-          ` Whether ComfyUI-Manager is installed on ${base} is therefore UNKNOWN from here; ` +
-          "clear the credential/proxy rejection and retry before concluding anything about " +
-          "Manager itself."
-        : "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
-          "nor /manager/queue/status answered with a queue status), and neither " +
-          "/v2/manager/version nor /manager/version answered with a version either — so " +
-          `nothing at ${base} is serving ComfyUI-Manager routes at all. Is ComfyUI-Manager ` +
-          "installed and enabled on the connected ComfyUI? The pip comfyui_manager " +
-          "package only activates when ComfyUI is started with --enable-manager. NOTE: a " +
-          "custom_nodes/ComfyUI-Manager clone can import cleanly and still register no " +
-          "routes — ComfyUI logs `Blocked by policy: <path>` and skips the clone entirely " +
-          "when --enable-manager is set and the pip package shadows it (with " +
-          "--disable-manager-ui on top, that leaves no Manager routes at all), and the " +
-          "clone starts in CLI-only mode, serving nothing, when its .enable-cli-only-mode " +
-          "marker file is present.",
+    managerQueueDetectionMessage(base, queueStatusKinds, versionEvidence),
     {
       kind: MANAGER_QUEUE_DETECTION_FAILURE,
       base,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -827,17 +827,29 @@ function managerQueueDetectionMessage(
   version: ManagerVersionEvidence,
 ): string {
   if (version.kind === "version") {
-    return (
+    const lede =
       `ComfyUI-Manager IS answering on ${base} — its version route reports generation ` +
-      `${version.major}.x — but it serves NO queue API: neither /v2/manager/queue/status ` +
-      "nor /manager/queue/status answered with a queue status. So this is NOT a missing or " +
-      "disabled Manager, and neither installing the pip comfyui_manager package nor adding " +
-      "--enable-manager will fix it. What fits the evidence is a Manager whose queue routes " +
-      "specifically are absent: a partial or older Manager server build, a Manager whose " +
-      "queue module failed to register, or a proxy in front of ComfyUI that forwards only " +
-      "some /manager routes. Check the ComfyUI log around Manager's startup, and retry once " +
-      "it serves a queue surface."
-    );
+      `${version.major}.x — so this is NOT a missing or disabled Manager, and neither ` +
+      "installing the pip comfyui_manager package nor adding --enable-manager will fix it. ";
+    // The queue side deserves the same care as the version side (codex gate round
+    // 6). Two 404s mean the queue routes are genuinely not registered; a 503, a
+    // 405 or a timeout means we could not READ them, and a Manager that is merely
+    // busy or briefly sick must not be told its queue module failed to register.
+    return queueStatusKinds.every((kind) => kind === "not-found")
+      ? lede +
+          "It serves NO queue API: both /v2/manager/queue/status and /manager/queue/status " +
+          "answered 404. What fits that is a Manager whose queue routes specifically are " +
+          "absent — a partial or older Manager server build, a queue module that failed to " +
+          "register, or a proxy in front of ComfyUI forwarding only some /manager routes. " +
+          "Check the ComfyUI log around Manager's startup, and retry once it serves a queue " +
+          "surface."
+      : lede +
+          "Its queue routes did not answer with a queue status either, but they did not say " +
+          `they are absent: /v2/manager/queue/status and /manager/queue/status came back ` +
+          `"${queueStatusKinds.join(", ")}". That is a queue surface we could not READ — a ` +
+          "5xx, a wrong-method reply, a timeout — not a Manager that lacks one, so this may " +
+          "well clear on its own. Check that ComfyUI is healthy and retry before concluding " +
+          "anything about Manager's queue API.";
   }
   if (version.kind === "refused") {
     return (

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3733,10 +3733,11 @@ function initialManagerQueueAbsenceWasProven(err: unknown): boolean {
 /**
  * #2754 — did the SAME detection failure also observe ComfyUI-Manager serving?
  *
- * The queue-detection error now carries what the version routes said, and two of
- * those readings contradict the word "absent": `version` means a Manager answered
- * with its generation, and `refused` means an authentication layer stopped us
- * before anything could be established. Reporting `manager_absent: true` off the
+ * The queue-detection error now carries what the version routes said, and only
+ * ONE of those readings leaves the word "absent" standing. `version` means a
+ * Manager answered with its generation; `refused` means an authentication layer
+ * stopped us before anything could be established; `unreadable` means the message
+ * in the same object already says presence is UNKNOWN. Reporting `manager_absent: true` off the
  * back of an error object that says either one is a claim refuted by its own
  * details (codex gate round 5).
  *
@@ -3745,12 +3746,17 @@ function initialManagerQueueAbsenceWasProven(err: unknown): boolean {
  * did 404 twice, so nothing was queued and the clone is still safe. This corrects
  * what we CALL that clone, not whether it happens.
  */
-function managerWasSeenServingDuringDetection(err: unknown): boolean {
+function managerAbsenceUnprovenDuringDetection(err: unknown): boolean {
   if (!(err instanceof NodeManagementError) || !err.details || typeof err.details !== "object") {
     return false;
   }
   const evidence = (err.details as { managerVersionEvidence?: unknown }).managerVersionEvidence;
-  return evidence === "version" || evidence === "refused";
+  // `absent` is the ONLY reading that leaves "Manager is absent" standing, and an
+  // error that predates this field (undefined) keeps the old behaviour. Everything
+  // else contradicts it: `version` and `refused` positively, and `unreadable`
+  // because the diagnostic in the very same object says presence is UNKNOWN
+  // (codex gate round 7).
+  return evidence !== undefined && evidence !== "absent";
 }
 
 /**
@@ -4595,7 +4601,7 @@ async function installCustomNodeImpl(
         // Manager answer its version route (or get auth-refused), "absent" is a
         // claim its own error object refutes (#2754).
         (!initialManagerQueueAbsenceWasProven(err) ||
-          managerWasSeenServingDuringDetection(err));
+          managerAbsenceUnprovenDuringDetection(err));
       logger.info("Manager refused, was unavailable, or was proven absent — cloning directly", {
         status: refusedBy,
         gitId,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -58,7 +58,7 @@ import {
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { managerBodyClause } from "./manager-error-body.js";
-import { parseManagerMajor } from "./manager-version.js";
+import { MANAGER_VERSION_ROUTES, parseManagerMajor } from "./manager-version.js";
 
 // ---------------------------------------------------------------------------
 // Custom-node management — ports `comfy-cli node install|update|reinstall|fix|
@@ -711,18 +711,48 @@ async function probeManagerMajor(base: string): Promise<number | undefined> {
 }
 
 /**
- * `probeManagerMajor` for the FAILURE branch, where the answer only sharpens a
- * diagnosis we are already committed to. `managerFetch` still throws on hard
- * failures even in soft mode (an authenticating proxy, most of all), and letting
- * that replace the queue-detection error would swap the reader's real problem for
- * a secondary probe's. Absence of a version is simply "no version evidence".
+ * What the version routes established, for the queue-detection FAILURE branch.
+ *
+ *   • `version` — a route answered a parseable version string, so ComfyUI-Manager
+ *     is demonstrably serving HTTP on this base.
+ *   • `refused` — a route answered an AUTHENTICATION status. `managerFetch` throws
+ *     on 401/407 even in soft mode, deliberately (#2085), and that is the whole
+ *     point: a credential rejection tells us nothing about whether Manager is
+ *     installed, so it must not be spent as absence evidence — which is exactly
+ *     what a bare `catch → undefined` here would do (codex gate, #2754).
+ *   • `none` — every route answered, and none of them was Manager.
  */
-async function probeManagerMajorForDiagnosis(base: string): Promise<number | undefined> {
-  try {
-    return await probeManagerMajor(base);
-  } catch {
-    return undefined;
+type ManagerVersionEvidence =
+  | { kind: "version"; major: number }
+  | { kind: "refused"; status: number | undefined }
+  | { kind: "none" };
+
+async function probeManagerVersionEvidence(base: string): Promise<ManagerVersionEvidence> {
+  let refusedStatus: number | undefined;
+  let refused = false;
+  for (const path of MANAGER_VERSION_ROUTES) {
+    let status: number | undefined;
+    try {
+      const major = parseManagerMajor(
+        await managerFetch<string>(path, {
+          base,
+          soft: true,
+          onSoftFailure: (s) => {
+            status = s;
+          },
+        }),
+      );
+      if (major !== undefined) return { kind: "version", major };
+    } catch {
+      // managerFetch ran onSoftFailure BEFORE throwing, so the status is already
+      // captured. Swallow the throw itself — it must not replace the reader's
+      // queue-detection error with a secondary probe's — but REMEMBER that this
+      // route was refused rather than silent.
+      refused = true;
+      refusedStatus ??= status;
+    }
   }
+  return refused ? { kind: "refused", status: refusedStatus } : { kind: "none" };
 }
 
 /**
@@ -891,11 +921,13 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
   // because they are disjoint from the queue surface — /v2/manager/version is
   // registered only by v4 and /manager/version only by 3.x — so an answer on either
   // proves Manager is serving HTTP on this base even when its queue routes 404.
-  const managerVersionMajor = await probeManagerMajorForDiagnosis(base);
+  const versionEvidence = await probeManagerVersionEvidence(base);
+  const managerVersionMajor =
+    versionEvidence.kind === "version" ? versionEvidence.major : undefined;
   throw new NodeManagementError(
-    managerVersionMajor !== undefined
+    versionEvidence.kind === "version"
       ? `ComfyUI-Manager IS answering on ${base} — its version route reports generation ` +
-          `${managerVersionMajor}.x — but it serves NO queue API: neither ` +
+          `${versionEvidence.major}.x — but it serves NO queue API: neither ` +
           "/v2/manager/queue/status nor /manager/queue/status answered with a queue " +
           "status. So this is NOT a missing or disabled Manager, and neither installing " +
           "the pip comfyui_manager package nor adding --enable-manager will fix it. What " +
@@ -904,7 +936,17 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
           "register, or a proxy in front of ComfyUI that forwards only some /manager " +
           "routes. Check the ComfyUI log around Manager's startup, and retry once it " +
           "serves a queue surface."
-      : "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
+      : versionEvidence.kind === "refused"
+        ? "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
+          "nor /manager/queue/status answered with a queue status), and the version routes " +
+          "that would establish whether Manager is present at all were REJECTED" +
+          (versionEvidence.status !== undefined
+            ? explainManagerAuthenticationRequired(versionEvidence.status)
+            : " — an authentication failure, not evidence that ComfyUI-Manager is missing.") +
+          ` Whether ComfyUI-Manager is installed on ${base} is therefore UNKNOWN from here; ` +
+          "clear the credential/proxy rejection and retry before concluding anything about " +
+          "Manager itself."
+        : "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
           "nor /manager/queue/status answered with a queue status), and neither " +
           "/v2/manager/version nor /manager/version answered with a version either — so " +
           `nothing at ${base} is serving ComfyUI-Manager routes at all. Is ComfyUI-Manager ` +
@@ -921,9 +963,12 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
       base,
       queueStatusCodes,
       queueStatusKinds,
-      // Undefined when the version routes answered nothing either. Kept in the
-      // details so a report carries the evidence the message was earned on.
+      // The evidence the message was earned on, so a report carries it too.
+      // `managerVersionMajor` is undefined unless a version actually parsed;
+      // `managerVersionEvidence` is what distinguishes "the version routes said
+      // nothing" from "the version routes refused to answer".
       managerVersionMajor,
+      managerVersionEvidence: versionEvidence.kind,
     },
   );
 }

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -769,12 +769,22 @@ async function probeManagerVersionEvidence(base: string): Promise<ManagerVersion
       );
       if (major !== undefined) return { kind: "version", major };
     } catch {
-      // managerFetch ran onSoftFailure BEFORE throwing, so the status is already
-      // captured. Swallow the throw itself — it must not replace the reader's
-      // queue-detection error with a secondary probe's — but REMEMBER that this
-      // route was refused rather than silent.
-      refused = true;
-      refusedStatus ??= statusSeen;
+      // Swallow the throw — it must not replace the reader's queue-detection
+      // error with a secondary probe's — but classify it before moving on.
+      //
+      // NOT every throw here is an authentication refusal (codex gate round 3).
+      // Soft mode throws for 401/407, and it also lets a body-read rejection
+      // escape: `await res.text()` on a 2xx that stalls or resets is unguarded, so
+      // a `refused = true` in every catch would answer a broken pipe with
+      // "configure your gateway credentials". managerFetch runs onSoftFailure
+      // BEFORE the auth throw, and never runs it on a 2xx — so a status is here
+      // exactly when the response was a real, non-ok answer we can classify.
+      if (statusSeen !== undefined && explainManagerAuthenticationRequired(statusSeen) !== "") {
+        refused = true;
+        refusedStatus ??= statusSeen;
+      }
+      // Anything else keeps `kind` at its "hard-error" seed and lands in
+      // `unreadable`, which claims nothing about whether Manager is there.
     }
     kinds.push(kind);
   }

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3719,6 +3719,29 @@ function initialManagerQueueAbsenceWasProven(err: unknown): boolean {
 }
 
 /**
+ * #2754 — did the SAME detection failure also observe ComfyUI-Manager serving?
+ *
+ * The queue-detection error now carries what the version routes said, and two of
+ * those readings contradict the word "absent": `version` means a Manager answered
+ * with its generation, and `refused` means an authentication layer stopped us
+ * before anything could be established. Reporting `manager_absent: true` off the
+ * back of an error object that says either one is a claim refuted by its own
+ * details (codex gate round 5).
+ *
+ * Read for LABELLING only. Whether the git fallback is allowed to run stays with
+ * managerAbsenceAllowsGitFallback and its fresh re-probe — the queue routes really
+ * did 404 twice, so nothing was queued and the clone is still safe. This corrects
+ * what we CALL that clone, not whether it happens.
+ */
+function managerWasSeenServingDuringDetection(err: unknown): boolean {
+  if (!(err instanceof NodeManagementError) || !err.details || typeof err.details !== "object") {
+    return false;
+  }
+  const evidence = (err.details as { managerVersionEvidence?: unknown }).managerVersionEvidence;
+  return evidence === "version" || evidence === "refused";
+}
+
+/**
  * A direct clone is safe after either a Manager-native policy refusal whose body
  * explicitly proves no task was queued, a direct enqueue route-level 404, a
  * detection failure followed by a fresh probe proving BOTH queue dialects are
@@ -4556,7 +4579,11 @@ async function installCustomNodeImpl(
       const managerUnavailable =
         refusedBy === undefined &&
         isManagerQueueDetectionFailure(err) &&
-        !initialManagerQueueAbsenceWasProven(err);
+        // Two 404s no longer settle this on their own: if the same detection saw
+        // Manager answer its version route (or get auth-refused), "absent" is a
+        // claim its own error object refutes (#2754).
+        (!initialManagerQueueAbsenceWasProven(err) ||
+          managerWasSeenServingDuringDetection(err));
       logger.info("Manager refused, was unavailable, or was proven absent — cloning directly", {
         status: refusedBy,
         gitId,


### PR DESCRIPTION
Fixes #2754.

## What the reporter actually hit

`install_custom_node` detects the Manager wire dialect by probing
`/v2/manager/queue/status` then `/manager/queue/status`. After a `restart_comfyui`,
both answered **HTTP 404**, and `probeManagerApi` threw one fixed sentence:

> Is ComfyUI-Manager **installed and enabled** on the connected ComfyUI? The pip
> comfyui_manager package only activates when ComfyUI is started with `--enable-manager`.

Every clause of that was wrong for them. Their Manager *was* installed; it was a legacy
**git clone**, so `--enable-manager` (which only gates the pip package) is irrelevant to
it; and it had imported cleanly. That last point is firmer than the reporter claimed for
it — ComfyUI appends `" (IMPORT FAILED)"` to its `N seconds: <path>` lines
(`nodes.py`, `init_extra_nodes`), and theirs had no suffix. So the single instruction we
gave was the one thing that could not help.

## The defect

Two 404s are evidence about the **queue API**. They are not evidence about whether
ComfyUI-Manager is present. We spent the smaller observation on the bigger claim.

Same defect class as **#2085**, where an authenticating proxy's 401 became "Manager is
missing", and the same fix shape: consult the **authoritative version routes** before
absence may be claimed. They are the right witness precisely because they are *disjoint
from the queue surface* — `/v2/manager/version` is registered only by v4,
`/manager/version` only by 3.x — so an answer on either proves Manager is serving HTTP on
this base even while its queue routes 404.

The message now has four arms, because the host really can be in four states and three of
them have fixes the fourth's advice sends the reader away from:

| version routes | queue routes | what we say |
|---|---|---|
| a version parses | any | Manager IS answering, generation `N.x`; `--enable-manager` explicitly ruled **out** |
| 401 / 407 | 404, 404 | rejected — presence **UNKNOWN**; fix credentials first |
| 404, 404 | 404, 404 | every probe 404'd — the strong absence claim, with the `--enable-manager` / shadowed-clone guidance |
| anything else (5xx, HTML catchall, stall) | any | could not be established; **not** evidence of absence, do not migrate |

`details.managerVersionEvidence` and `details.managerVersionMajor` carry the evidence the
message was earned on, so a report cannot lose the distinction.

## Where the load-bearing claims are

1. **`parseManagerMajor` is the only thing between ComfyUI's SPA catchall and a false
   "Manager is answering".** This branch is a new consumer of that strictness.
2. **Absence is deliberately narrow** — all four probes must have been *told* there is no
   such route. That mirrors `probeManagerQueueAvailability`'s already-shipped contract in
   the same file, in the same `ManagerQueueStatusKind` vocabulary, so the two surfaces
   cannot drift into disagreeing about what "absent" means.
3. **The `--enable-manager` shadowing sentence is not speculation.** Verified in ComfyUI
   source on this machine (`main.py:205-207`, `nodes.py:2370-2373`:
   `comfyui_manager.should_be_disabled(module_path)` → `logging.info("Blocked by policy: …")`
   → `continue`) and observed in a real local ComfyUI log. With `--disable-manager-ui` on
   top, that combination leaves no Manager routes at all.
4. **The git-fallback ROUTING is unchanged.** `managerAbsenceAllowsGitFallback` and its
   fresh re-probe still decide whether the clone runs. Only the *label* now reads the
   version evidence, so a clone is no longer called `manager_absent` by an error object
   whose own details say otherwise. A control test asserts a fully-404 host is **still**
   labelled `manager_absent` — widening that predicate twice is exactly how a label gets
   quietly retired.
5. **Two extra GETs on the failure path**, bounded by one shared budget, on a branch that
   was already about to throw.

## What this does NOT do

**It does not stop the 404s.** They are host-side. I could not determine the reporter's
upstream cause without their host, and deliberately did not invent a code cause for it —
the dialect cache and probe order are both sound (analysis in the issue thread). This
changes what we are *entitled to say* about those 404s, which is what cost the reporter
the investigation.

## Codex gate: 8 rounds, 6 real findings fixed

The first cut reintroduced #2085's own bug one layer down, and the gate caught it. Each
round below produced a mutation-verified fix:

| round | finding | outcome |
|---|---|---|
| 1 | a bare `catch → undefined` laundered a 401 back into "Manager is absent" | fixed — `refused` is its own state |
| 2 | `none` swallowed 5xx / 403 / transport / HTML as absence | fixed — `absent` vs `unreadable` |
| 3 | every throw classified as auth refusal, incl. a body-read failure | fixed — gated on an actual 401/407 status |
| 4 | the version probe could hang on a body that never ends | fixed — `raceAbort`, one budget for the whole probe |
| 5 | git fallback labelled the clone `manager_absent` while the same error said Manager answered | fixed — label only |
| 6 | the version-success arm claimed "serves NO queue API" even when the queue routes 5xx'd | fixed — same care on the queue side |
| 7 | `unreadable` still fell through to `manager_absent` | fixed — `absent` is the only reading that leaves it standing |

Two findings were **declined, with reasons**, rather than widened into this PR:

- **`managerFetch`'s body read is not raced against the abort** (round 3 finding 1, round
  4). Real, and confirmed by runtime probe — but pre-existing on `origin/main` at *every*
  call site in the file, including the two queue probes that run before this code.
  `fetch.ts:575-584` documents the mechanism (#1672) and ships `raceAbort` for it. Filed as
  **#2764**. The two probes this branch adds are bounded here regardless.
- **A `/manager/version` that redirects cross-host would be attributed to the connected
  base** (round 6 finding 2). `probeManagerMajor` on `origin/main` has the identical
  exposure; closing it means changing redirect policy on the shared `comfyuiFetch`, i.e.
  on every ComfyUI request in the process.

Final gate verdict: **SHIP** on `20fedc52`, the SHA in this PR.

## Verification

- 8 new tests across `manager-dialect-cache.test.ts` and `install-node-target-1765.test.ts`.
- **Every one was mutation-verified**: the production hunk deleted, the named test watched
  to fail. Two initially passed with the fix removed (the old code reached the same words
  by never consulting a version route) and were strengthened until they didn't. The
  round-4 test does not *fail* without its fix — it **hangs**, confirmed at the 20s timeout.
- `npm test` — **all 14 checks green**, 761/761 files, 14 049 tests.
- Two test fixtures were corrected, with **no assertion loosened**: a `comfyui/fetch.js`
  mock that replaced a whole module to stand in for one function, and an `"absent"` fixture
  that answered unknown paths with an empty 200 instead of the 404 a Manager-less ComfyUI
  actually returns.
- **No panel code is touched and the panel Playwright suite was not run.** This is an
  MCP-side error string; no panel behaviour changed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)