### PR TITLE
fix(2757): the tunnel/pairing listener reads the handshake Origin it was throwing away

### DIFF
--- a/src/__tests__/services/relay-identity-origin.test.ts
+++ b/src/__tests__/services/relay-identity-origin.test.ts
@@ -141,3 +141,32 @@ describe("setupRelayBridge actually passes the origin (#1077)", () => {
     );
   });
 });
+
+// #2757 asked whether the RELAY path loses its derived origin when the live tab
+// re-registers under a new workflow uuid — the report's own stated mechanism.
+// It does not, and this pins that: `serverOrigin` is a parameter of
+// `handleConnection`, so the hello handler closes over it and every later hello on
+// that socket — including one that retires the tab id for a new `wf:` one — writes
+// the same value onto the new conn. The transport that actually dropped it was the
+// token-gated listener (see tunnel-listener-handshake-origin.test.ts).
+describe("a relay tab keeps its derived origin across a re-registration (#2757)", () => {
+  const ORIGIN = "https://abc-8188.proxy.runpod.net";
+
+  it("still reports the origin under the NEW workflow tab id", () => {
+    const bridge = new UiBridge(0);
+    const sock = fakeSocket();
+    bridge.attachRelayConnection(sock as never, ORIGIN);
+    sock.emit(
+      "message",
+      JSON.stringify({ type: "hello", tab_id: "wf:route-1:old", title: "wf" }),
+    );
+    expect(bridge.tabServerOrigin("wf:route-1:old")).toBe(ORIGIN);
+
+    // Save-as / open / switch: the SAME socket re-hellos under a new workflow id.
+    sock.emit(
+      "message",
+      JSON.stringify({ type: "hello", tab_id: "wf:route-1:new", title: "wf (2)" }),
+    );
+    expect(bridge.tabServerOrigin("wf:route-1:new")).toBe(ORIGIN);
+  });
+});

--- a/src/__tests__/services/tunnel-listener-handshake-origin.test.ts
+++ b/src/__tests__/services/tunnel-listener-handshake-origin.test.ts
@@ -1,0 +1,191 @@
+// #2757 / #2752 — the token-gated listener threw the WebSocket upgrade away, so
+// every tunnel-fronted panel tab was PERMANENTLY unable to adopt a workflow fence.
+//
+// `UiBridge` has two listeners. The primary one has always read the handshake:
+//
+//     wss.on("connection", (sock, req) => {
+//       const handshakeOrigin = normalizeHandshakeOrigin(req?.headers?.origin);
+//       this.handleConnection(sock, …, handshakeOrigin);
+//     });
+//
+// The second one, opened by `addListener`, took `(sock)` alone and called
+// `this.handleConnection(sock)` — no third argument, so `serverOrigin` defaulted
+// to `undefined`.
+//
+// That listener is not a corner of the product. `ensureSecureBridge` puts the
+// cloudflared quick-tunnel in front of exactly it
+// (`bridge.addListener("0.0.0.0", tunnelPort, tunnelToken)`), which makes it the
+// transport for EVERY remote-pod panel tab; the phone-pairing LAN listener is the
+// same call. cloudflared forwards the browser's `Origin` header on the upgrade
+// untouched — nothing was stripping it, the orchestrator just never looked.
+//
+// `workflowIdentityParts()` gates on an origin being PRESENT (it never compares
+// it against anything), so the whole chain failed closed: no identity, no fence
+// adoption, and `panel_set_workflow_target({mode:"current"})` reporting that it
+// applied the mode while refusing the rebind — for the life of the session, no
+// matter how many times the tab was refreshed.
+//
+// These tests drive the REAL listener over a REAL WebSocket carrying a REAL
+// `Origin` header, because the defect lived entirely in the argument list of the
+// connection callback: a test that called `handleConnection` directly, or that
+// asserted on a fake socket, would have passed with the bug in place.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import WebSocket from "ws";
+import { UiBridge } from "../../services/ui-bridge.js";
+import { workflowIdentityParts } from "../../orchestrator/session-store.js";
+
+/** An ephemeral port the OS has just released — same helper the sibling suite uses. */
+async function freePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const srv = createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+const TOKEN = "tunnel-token";
+/** What a RunPod pod's ComfyUI tab actually sends: the https proxy origin. */
+const POD_ORIGIN = "https://abcd1234-3000.proxy.runpod.net";
+/** How the primary listener normalises that: explicit port, lowercased host. */
+const POD_ORIGIN_NORMALIZED = "https://abcd1234-3000.proxy.runpod.net:443";
+const WF_UUID_OLD = "0ed9e3f1-1111-4222-8333-444455556666";
+const WF_UUID_NEW = "c7596084-9999-4888-8777-666655554444";
+
+const bridges: UiBridge[] = [];
+const sockets: WebSocket[] = [];
+
+afterEach(async () => {
+  for (const s of sockets.splice(0)) {
+    try {
+      s.close();
+    } catch {
+      // already gone
+    }
+  }
+  for (const b of bridges.splice(0)) await b.stop();
+});
+
+/** Stand up a bridge whose ONLY listener is the token-gated one — the tunnel shape. */
+async function tunnelBridge(): Promise<{ bridge: UiBridge; port: number }> {
+  const bridge = new UiBridge(await freePort());
+  bridges.push(bridge);
+  const port = await freePort();
+  await bridge.addListener("127.0.0.1", port, TOKEN);
+  return { bridge, port };
+}
+
+/** Open a tab through the token-gated listener with the given `Origin` header. */
+async function connectTab(
+  port: number,
+  origin: string | undefined,
+  tabId: string,
+): Promise<WebSocket> {
+  const sock = await new Promise<WebSocket>((resolve, reject) => {
+    const s = new WebSocket(
+      `ws://127.0.0.1:${port}/?token=${TOKEN}`,
+      origin === undefined ? {} : { headers: { Origin: origin } },
+    );
+    s.on("open", () => resolve(s));
+    s.on("error", reject);
+  });
+  sockets.push(sock);
+  sock.send(JSON.stringify({ type: "hello", tab_id: tabId, title: "wf" }));
+  return sock;
+}
+
+/** The hello is delivered asynchronously — wait for the bridge to register it. */
+async function waitForTab(bridge: UiBridge, tabId: string): Promise<void> {
+  for (let i = 0; i < 300; i++) {
+    if (bridge.tabs().some((t) => t.tab_id === tabId)) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error(`tab ${tabId} never registered`);
+}
+
+describe("the token-gated (tunnel/pairing) listener carries the handshake Origin (#2757)", () => {
+  it("reports the browser's Origin for a tunnel-fronted tab", async () => {
+    const { bridge, port } = await tunnelBridge();
+    await connectTab(port, POD_ORIGIN, "tab-pod-1");
+    await waitForTab(bridge, "tab-pod-1");
+
+    expect(bridge.tabServerOrigin("tab-pod-1")).toBe(POD_ORIGIN_NORMALIZED);
+  });
+
+  it("lets that tab's workflow identity VALIDATE — the gate the report died on", async () => {
+    // The origin is not the goal; adopting a fence is. `workflowIdentityParts` is
+    // the exact function the fence-adoption validator calls, and its origin check
+    // is a PRESENCE check — so before the fix it returned undefined for every
+    // tunnel tab no matter how well-formed the uuid was.
+    const { bridge, port } = await tunnelBridge();
+    await connectTab(port, POD_ORIGIN, "tab-pod-2");
+    await waitForTab(bridge, "tab-pod-2");
+
+    const identity = workflowIdentityParts({
+      workflowUuid: WF_UUID_NEW,
+      origin: bridge.tabServerOrigin("tab-pod-2"),
+    });
+    expect(identity).toBeDefined();
+    expect(identity?.uuid).toBe(WF_UUID_NEW);
+  });
+
+  it("KEEPS the origin when the tab re-registers under a new workflow uuid", async () => {
+    // The reported sequence, in full: a live pod tab re-hellos under a new
+    // workflow tab id (save-as / open / switch), `panel_graph_outline` refuses on
+    // the stale fence, and `mode:"current"` then has to adopt the live identity.
+    // The re-hello arrives on the SAME socket with a DIFFERENT tab id, which is
+    // the branch that decides whether `serverOrigin` survives the re-registration.
+    const { bridge, port } = await tunnelBridge();
+    const oldTab = `wf:route-1:${WF_UUID_OLD}`;
+    const newTab = `wf:route-1:${WF_UUID_NEW}`;
+    const sock = await connectTab(port, POD_ORIGIN, oldTab);
+    await waitForTab(bridge, oldTab);
+    expect(bridge.tabServerOrigin(oldTab)).toBe(POD_ORIGIN_NORMALIZED);
+
+    sock.send(JSON.stringify({ type: "hello", tab_id: newTab, title: "wf (2)" }));
+    await waitForTab(bridge, newTab);
+
+    const origin = bridge.tabServerOrigin(newTab);
+    expect(origin).toBe(POD_ORIGIN_NORMALIZED);
+    // …and the NEW identity validates, so `mode:"current"` can adopt it.
+    expect(workflowIdentityParts({ workflowUuid: WF_UUID_NEW, origin })?.uuid).toBe(WF_UUID_NEW);
+  });
+
+  it("does NOT make a tunnel/pairing tab trusted-local", async () => {
+    // Reading the origin must not smuggle in transport trust: this listener is
+    // token-gated and reachable off the machine, so `local` stays false and
+    // nothing keyed on loopback placement changes.
+    const { bridge, port } = await tunnelBridge();
+    await connectTab(port, POD_ORIGIN, "tab-pod-3");
+    await waitForTab(bridge, "tab-pod-3");
+
+    expect(bridge.tabIsLocal("tab-pod-3")).toBe(false);
+  });
+
+  it("still reports NO origin for a client that sends no Origin header", async () => {
+    // A non-browser client (a script, a CLI) presents no Origin, and the fix must
+    // not invent one — the refusal it earns is accurate, and a fabricated origin
+    // would scope a fence to an identity no other transport reproduces.
+    const { bridge, port } = await tunnelBridge();
+    await connectTab(port, undefined, "tab-cli-1");
+    await waitForTab(bridge, "tab-cli-1");
+
+    expect(bridge.tabServerOrigin("tab-cli-1")).toBeUndefined();
+  });
+
+  it("rejects an Origin that is not a bare, well-formed origin", async () => {
+    // The value goes through the same `normalizeHandshakeOrigin` screen the
+    // primary listener uses: a path-bearing or otherwise non-canonical spelling is
+    // dropped rather than trimmed into something that looks trustworthy.
+    const { bridge, port } = await tunnelBridge();
+    await connectTab(port, "https://evil.example/path", "tab-bad-1");
+    await waitForTab(bridge, "tab-bad-1");
+
+    expect(bridge.tabServerOrigin("tab-bad-1")).toBeUndefined();
+  });
+});

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -3018,10 +3018,29 @@ export class UiBridge {
           cb(false, 401, "Unauthorized");
         },
       });
-      wss.on("connection", (sock) => {
+      wss.on("connection", (sock, req) => {
         this.missedPongs.set(sock, 0);
         sock.on("pong", () => this.missedPongs.set(sock, 0));
-        this.handleConnection(sock);
+        // #2757/#2752 — READ THE HANDSHAKE `Origin`, exactly as the primary
+        // listener does. This callback used to take `(sock)` alone and throw the
+        // upgrade request away, so every connection arriving here had
+        // `serverOrigin === undefined`.
+        //
+        // That is not an edge case: this is the listener the cloudflared
+        // quick-tunnel is put in front of (`ensureSecureBridge` calls
+        // `addListener("0.0.0.0", tunnelPort, tunnelToken)`), so it carries EVERY
+        // remote-pod panel tab. cloudflared forwards the browser's `Origin`
+        // header on the upgrade untouched — the orchestrator simply never looked.
+        // The consequence is the reported wedge: `workflowIdentityParts()` gates
+        // on an origin being PRESENT, so no tunnel-fronted tab could ever adopt a
+        // workflow fence, and `panel_set_workflow_target({mode:"current"})`
+        // applied the mode while refusing the rebind — permanently, for the whole
+        // session.
+        //
+        // `local` stays false. This listener is token-gated and reachable off the
+        // machine; the origin is identity/diagnostic metadata, never a
+        // trusted-local or authorization signal (see handleConnection's doc).
+        this.handleConnection(sock, false, normalizeHandshakeOrigin(req?.headers?.origin));
       });
       wss.on("listening", () => {
         settled = true;
@@ -7092,10 +7111,13 @@ export class UiBridge {
    * rather than only to stderr.
    *
    * It matters here more than a diagnostic usually would, because one of those
-   * gates can be structurally unsatisfiable: a relay-backend connection carries
-   * no server Origin (attachRelayConnection has none to pass), so
+   * gates can be structurally unsatisfiable: without a server Origin,
    * workflowIdentityParts can NEVER validate and the fence can never be adopted,
-   * no matter how many times the user refreshes the tab.
+   * no matter how many times the user refreshes the tab. The two transports that
+   * used to land there have both been given one — the relay derives it from
+   * COMFYUI_URL (#1077/#1240) and the token-gated tunnel/pairing listener now
+   * reads it off the upgrade (#2757) — so what is left here is a genuinely
+   * origin-less client: a non-browser one, or a proxy that strips the header.
    */
   lastFenceRefusal(tabId: string): string | undefined {
     return this.fenceRefusals.get(tabId);


### PR DESCRIPTION
Closes #2757. Closes #2752 (same defect, reported twice).

## The defect

`UiBridge` opens two WebSocket listeners. The primary one has always captured the
upgrade's `Origin`:

```ts
wss.on("connection", (sock, req) => {
  const handshakeOrigin = normalizeHandshakeOrigin(req?.headers?.origin);
  this.handleConnection(sock, !this.token && isLoopbackBindHost(this.host), handshakeOrigin);
});
```

The second — `addListener` — took `(sock)` alone and threw `req` away:

```ts
wss.on("connection", (sock) => {
  this.missedPongs.set(sock, 0);
  sock.on("pong", () => this.missedPongs.set(sock, 0));
  this.handleConnection(sock);        // <- no serverOrigin
});
```

So every connection arriving there had `serverOrigin === undefined`.

**That listener carries every remote-pod tab.** `ensureSecureBridge` mints a tunnel
token and calls `bridge.addListener("0.0.0.0", tunnelPort, tunnelToken)`, then puts
the cloudflared quick-tunnel in front of *that* port (`src/orchestrator/index.ts:7031`).
The phone-pairing LAN bind (`:1189`) is the same call. cloudflared forwards the
browser's `Origin` header on the upgrade untouched — nothing was stripping it; the
orchestrator never read it.

`workflowIdentityParts()` gates on an origin being **present** (it never compares it
against anything), so the whole chain failed closed at the adoption validator:

```ts
// src/orchestrator/index.ts:3445
const origin = bridge.tabServerOrigin(tabId);
const identity = workflowIdentityParts({ workflowUuid, origin });
if (!identity)
  return { ok: false, reason: identityReason(tabId, origin, workflowUuid, …) };
```

`identityReason(…, origin === undefined, …)` renders the exact sentence both reports
quote. And because it is structural, it never cleared: the tab re-registered under a
new workflow uuid, `panel_graph_outline` refused on the stale fence, `mode:"current"`
applied the mode and refused the rebind, and every graph read/edit stayed blocked for
the rest of the session.

## The fix

Read the handshake `Origin` on the token-gated listener, through the same
`normalizeHandshakeOrigin` screen the primary listener uses.

`local` stays `false` — this listener is token-gated and reachable off the machine, so
nothing keyed on loopback placement changes. The origin is identity/diagnostic
metadata here exactly as it is on the primary listener, never an authorization signal.

## The report's own stated mechanism is NOT the bug

Both reports guessed at the relay transport losing a *derived* origin across a
re-registration. It does not, and the appended test in `relay-identity-origin.test.ts`
pins that: `serverOrigin` is a **parameter of `handleConnection`**, so the hello
handler closes over it, and a re-hello under a new `wf:` tab id writes the same value
onto the new conn. The reporter's setup was almost certainly the default cloudflared
tunnel, not `COMFYUI_MCP_TUNNEL_BACKEND=relay`.

## Where to look hardest (the load-bearing claims)

1. **Is filling this in a widening?** Yes, deliberately, and it is the part worth
   reviewing. Several gates currently deny tunnel tabs *because* the origin is absent:
   `resolvePanelTarget` (`index.ts:1894`) needs `claimedOrigin === observedOrigin`, and
   `judgeHelloRetarget` classifies an origin-less hello as UNTRUSTED. After this change
   a pod tab is TRUSTED there. I believe that is the intended design rather than a new
   hole — `hello-retarget.ts`'s trust model rests on "the browser sets it and forbids
   page scripts from overriding it", which is true through cloudflared — and it makes
   the RunPod-proxy probe skip (#303) reachable for pods for the first time. But it IS a
   behaviour change beyond the fence, and it is the thing to argue with.
2. **Forgeability.** A non-browser client with the tunnel token could write any
   `Origin`. It already holds the bridge token at that point, so it has full bridge
   access regardless; the primary listener accepts a forgeable header on the same terms
   and documents it. `local` staying false is what keeps this from escalating.
3. **The re-registration test** fails pre-fix only because the origin was never there
   at all — it does not independently exercise the inheritance branch. The relay test
   is what covers that branch.

## Verification

- **Deleted the fix and watched it fail.** With `ui-bridge.ts` reverted and the tests
  kept, 3 of the 6 new tests fail (`expected undefined to be
  'https://abcd1234-3000.proxy.runpod.net:443'`, `expected undefined to be defined`).
  The other 3 are polarity guards (no Origin → still undefined; a path-bearing Origin →
  rejected; the tab is still not trusted-local) and correctly pass both ways.
- The tests drive the **real** listener over a **real** WebSocket carrying a **real**
  `Origin` header. The defect lived in the argument list of the connection callback, so
  anything calling `handleConnection` directly, or asserting on a fake socket, would
  have passed with the bug in place.
- Production reach confirmed by grep, not assumed: `bridge.tabServerOrigin()` is what
  `index.ts:3445` (the adoption validator) and `index.ts:4271` (the per-hello stamp)
  read.
- Both `wss.on("connection")` sites in `src/` are now covered — no sibling exit.
- `npm test`: **all 14 checks green**, 762 files / 14055 tests. `npm run lint` green
  with oxlint actually installed (785 known findings, none added).

Playwright was **not** run: this change is entirely orchestrator-side in the mcp repo
and the panel repo is untouched, so the browser suite has nothing to say about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)