### PR TITLE
fix(2758): qwen-txt2img examples start 16-channel, matching the official Qwen Image template

### DIFF
--- a/plugin/skills/qwen-txt2img/SKILL.md
+++ b/plugin/skills/qwen-txt2img/SKILL.md
@@ -189,10 +189,19 @@ VAELoader → VAE
 CLIPTextEncode (positive) → CONDITIONING
 ConditioningZeroOut → negative CONDITIONING
 
-EmptyLatentImage (1024x1344) → LATENT
+EmptySD3LatentImage (1024x1344) → LATENT
 
 KSampler → VAEDecode → SaveImage
 ```
+
+**Latent node:** use `EmptySD3LatentImage`, matching the official Comfy-Org
+`image_qwen_image` template. Qwen Image’s latent format is `Wan21`, so its latent is
+16-channel; `EmptyLatentImage` emits 4. A bare `EmptyLatentImage → KSampler` still renders,
+because ComfyUI’s `fix_empty_latent_channels` (`comfy/sample.py`, called by every sampler
+node) repeats an **all-zero** latent up to the model’s channel count. But that rescue is
+gated on `torch.count_nonzero(latent) == 0`, so it stops applying the moment a node inserted
+here writes into the latent — which is exactly what this approach is for. Start 16-channel
+and the question never arises.
 
 ### Complete Workflow: Separate Loading (Lightning 4-Step)
 
@@ -204,7 +213,7 @@ KSampler → VAEDecode → SaveImage
   "4": { "class_type": "VAELoader", "inputs": { "vae_name": "qwen_image_vae.safetensors" }},
   "5": { "class_type": "CLIPTextEncode", "inputs": { "clip": ["3", 0], "text": "<detailed natural language prompt>" }},
   "6": { "class_type": "ConditioningZeroOut", "inputs": { "conditioning": ["5", 0] }},
-  "7": { "class_type": "EmptyLatentImage", "inputs": { "width": 1024, "height": 1344, "batch_size": 1 }},
+  "7": { "class_type": "EmptySD3LatentImage", "inputs": { "width": 1024, "height": 1344, "batch_size": 1 }},
   "8": { "class_type": "KSampler", "inputs": {
     "model": ["2", 0],
     "positive": ["5", 0],
@@ -227,7 +236,7 @@ KSampler → VAEDecode → SaveImage
   "4": { "class_type": "VAELoader", "inputs": { "vae_name": "qwen_image_vae.safetensors" }},
   "5": { "class_type": "CLIPTextEncode", "inputs": { "clip": ["3", 0], "text": "<detailed natural language prompt>" }},
   "6": { "class_type": "ConditioningZeroOut", "inputs": { "conditioning": ["5", 0] }},
-  "7": { "class_type": "EmptyLatentImage", "inputs": { "width": 1328, "height": 1328, "batch_size": 1 }},
+  "7": { "class_type": "EmptySD3LatentImage", "inputs": { "width": 1328, "height": 1328, "batch_size": 1 }},
   "8": { "class_type": "KSampler", "inputs": {
     "model": ["2", 0],
     "positive": ["5", 0],
@@ -333,5 +342,5 @@ Tips:
 
 ## Sources
 
-- **Official:** none found.
+- **Official:** Comfy-Org workflow template `image_qwen_image.json` — https://github.com/Comfy-Org/workflow_templates/blob/main/templates/image_qwen_image.json
 - **Empirical:** sampler values, wiring, and prompt notes from working graphs in `packs/` and observed renders; not a vendor prompting guide.

--- a/src/__tests__/orchestrator/qwen-txt2img-latent.test.ts
+++ b/src/__tests__/orchestrator/qwen-txt2img-latent.test.ts
@@ -1,0 +1,85 @@
+// #2758 — the bundled qwen-txt2img skill wired Qwen Image to `EmptyLatentImage`
+// while the official Comfy-Org `image_qwen_image` template uses `EmptySD3LatentImage`.
+//
+// The report's stated impact was WRONG and this test deliberately does not encode it:
+// ComfyUI's `fix_empty_latent_channels` (comfy/sample.py, called by common_ksampler)
+// repeats an all-zero latent up to the model's channel count, so both nodes hand the
+// Qwen sampler a byte-identical (1, 16, 1, H/8, W/8) tensor. Measured against the
+// installed ComfyUI, and that fixup is present verbatim at upstream tag v0.33.0.
+//
+// What IS load-bearing: the rescue is gated on `torch.count_nonzero(latent) == 0`.
+// Approach 2 exists to invite inserting nodes between stages, and the first inserted
+// node that writes into the latent takes the rescue away. So the examples must start
+// 16-channel, and must agree with the template a preflight will compare them against.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const SKILL_URL = new URL("../../../plugin/skills/qwen-txt2img/SKILL.md", import.meta.url);
+const SKILL = readFileSync(SKILL_URL, "utf-8").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+type Node = { class_type?: unknown; inputs?: Record<string, unknown> };
+
+/** Every ```json block in the skill that parses, as a parsed value. */
+function jsonBlocks(markdown: string): unknown[] {
+  const out: unknown[] = [];
+  for (const m of markdown.matchAll(/```json\n([\s\S]*?)\n```/g)) {
+    // A block that does not parse is a separate defect; surface it rather than skip it.
+    out.push(JSON.parse(m[1]));
+  }
+  return out;
+}
+
+/** A prompt-format graph: an object whose values are all nodes carrying a class_type. */
+function asGraph(value: unknown): Record<string, Node> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return undefined;
+  const isNode = (v: unknown) =>
+    typeof v === "object" && v !== null && typeof (v as Node).class_type === "string";
+  return entries.every(([, v]) => isNode(v)) ? (value as Record<string, Node>) : undefined;
+}
+
+describe("#2758 qwen-txt2img latent examples match the official Qwen Image template", () => {
+  it("parses every JSON example the skill ships", () => {
+    expect(jsonBlocks(SKILL).length).toBeGreaterThan(0);
+  });
+
+  it("feeds every KSampler's latent_image from EmptySD3LatentImage, not EmptyLatentImage", () => {
+    let checked = 0;
+    for (const block of jsonBlocks(SKILL)) {
+      const graph = asGraph(block);
+      if (!graph) continue;
+      for (const [id, node] of Object.entries(graph)) {
+        if (node.class_type !== "KSampler") continue;
+        const link = node.inputs?.latent_image;
+        expect(Array.isArray(link), `KSampler "${id}" has no linked latent_image`).toBe(true);
+        const producer = graph[(link as [string, number])[0]];
+        expect(producer, `KSampler "${id}" latent_image points at a missing node`).toBeDefined();
+        expect(producer.class_type).toBe("EmptySD3LatentImage");
+        checked += 1;
+      }
+    }
+    // Guards the guard: if the examples stop containing a KSampler, the loop above
+    // passes vacuously and this test would stop defending anything.
+    expect(checked, "no KSampler example left to check").toBeGreaterThanOrEqual(2);
+  });
+
+  it("names no EmptyLatentImage node in any shipped example or the pipeline diagram", () => {
+    expect(SKILL).not.toMatch(/"class_type":\s*"EmptyLatentImage"/);
+    expect(SKILL).not.toMatch(/^EmptyLatentImage \(/m);
+  });
+
+  it("keeps the reason on the page so this is not re-filed, or 'fixed' elsewhere on a false premise", () => {
+    // Six other bundled skills use EmptyLatentImage with 16-channel models and are
+    // correct for the same reason. Naming the mechanism is what stops that edit.
+    expect(SKILL).toContain("fix_empty_latent_channels");
+    expect(SKILL).toContain("count_nonzero");
+  });
+
+  it("cites the official template it now agrees with", () => {
+    expect(SKILL).toContain(
+      "https://github.com/Comfy-Org/workflow_templates/blob/main/templates/image_qwen_image.json",
+    );
+    expect(SKILL).not.toMatch(/\*\*Official:\*\*\s*none found/i);
+  });
+});


### PR DESCRIPTION
Closes #2758.

## The report's observation is right; its stated impact is not

`plugin/skills/qwen-txt2img/SKILL.md` used `EmptyLatentImage` in the Approach 2 pipeline
diagram and both separate-component examples, while the official Comfy-Org
`image_qwen_image` template uses `EmptySD3LatentImage`. That part is true.

The claimed consequence — "can create a latent with the wrong channel/layout contract for
Qwen Image" — does not happen. ComfyUI's `common_ksampler` (`nodes.py`) calls
`comfy.sample.fix_empty_latent_channels`, which repeats an **all-zero** latent up to the
model's `latent_channels`. Qwen Image's latent format is `Wan21` (16 channels,
`latent_dimensions=3`), and both empty-latent nodes emit `downscale_ratio_spacial: 8`, so
the two paths converge exactly.

Measured against the installed ComfyUI (0.34.2), by executing ComfyUI's own function — not
read off the source:

```
Wan21 latent_channels= 16 latent_dimensions= 3 spacial_downscale_ratio= 8
EmptyLatentImage   -> after fixup: (1, 16, 1, 168, 128) torch.float32
EmptySD3LatentImage-> after fixup: (1, 16, 1, 168, 128) torch.float32
SHAPES EQUAL: True
TENSORS EQUAL: True
```

That fixup is present verbatim at upstream tag **v0.33.0** — the exact ComfyUI version in
the report's environment — carrying the upstream comment
`#Resize the empty latent image so it has the right number of channels`. So no wrong-shaped
latent ever reached a Qwen sampler and nothing was actually blocked.

## Why it is still worth changing

`fix_empty_latent_channels` gates the rescue on `torch.count_nonzero(latent_image) == 0`.
Approach 2 exists specifically to invite inserting nodes between stages ("More flexible,
since it allows inserting additional processing nodes between stages"). The first inserted
node that writes into that latent makes it non-zero, the rescue stops applying, and a
4-channel latent *does* reach Qwen. Starting 16-channel closes that edge, and makes the
skill agree with the template a preflight will diff it against — which is what stopped an
agent and produced this report in the first place.

## What changed

- the 3 `EmptyLatentImage` sites → `EmptySD3LatentImage` (diagram + both JSON examples)
- a short note naming the mechanism, so this is neither re-filed nor "fixed" elsewhere
- `## Sources` **Official:** was `none found`; it is now the template this skill agrees with
- `src/__tests__/orchestrator/qwen-txt2img-latent.test.ts`, following the
  `minimax-h3-skill.test.ts` precedent

## Where to look hardest

**The load-bearing claim is the equivalence above.** If `fix_empty_latent_channels` did NOT
run on some sampler path, the report would be right and this PR would be understating it.
I checked the three call sites in ComfyUI (`nodes.py:1573`, `nodes_custom_sampler.py:761`
and `:1044` — `SamplerCustom` and `SamplerCustomAdvanced`); all sampler entry points call it.
`Wan21` does not override `fix_empty_latent`, so the base no-op applies.

**The test is over a doc, so it could easily be tautological.** It is not a substring check:
it parses every ```json block, finds each `KSampler`, follows its `latent_image` link to the
producing node and asserts that node's `class_type`. It also asserts at least 2 KSamplers
were reached, so it cannot pass vacuously if the examples change shape.

## Verification

Each of the four elements was mutated **independently** and the suite re-run:

| mutation | result |
|---|---|
| revert node swap (JSON + diagram) | 2 failed / 3 passed |
| revert the JSON examples only | 2 failed / 3 passed |
| delete the rationale note only | 1 failed / 4 passed |
| revert the `Sources` citation only | 1 failed / 4 passed |
| restored | **5 passed** |

Reachability: `plugin` is in `package.json` `files`, and `src/tools/skills-access.ts:97`
resolves `plugin/skills` for `list_packs action:"skill_read"` — so the edited file is the
one served.

## Deliberately NOT done

- **The report's second request — "a node-contract test for Qwen Image latent shape" — is
  not implemented.** It would pin a false invariant; the shapes are provably identical.
- `flux-txt2img`, `z-image-txt2img`, `anima-base`, `ideogram-ultra`, `comfyui-core` and
  `director` also use `EmptyLatentImage` with 16-channel models. They are correct for the
  same reason and are untouched. The note exists to stop someone editing them on the false
  premise.
- No Playwright run: this changes a bundled skill document served over the MCP tool surface,
  not anything the panel renders.

Severity re-labelled P2 → P3 on the issue: no image was produced, nothing was broken, and
this is a docs divergence from upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
