### PR TITLE
fix(2761): a parked read resumes only for a tab that PROVES it is the one that issued it

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1192,8 +1192,15 @@ describe("UiBridge (multi-tab)", () => {
     await expect(promise).rejects.toThrow(/graph_run/);
   });
 
+  // #2761 — these park/resume fixtures carry a `tab_session_id` because every
+  // panel that routes at all sends one: `createTabRouteIdentity` yields either a
+  // Web Locks lease or, where the API is absent, a per-page-load id, and the third
+  // outcome (a lease another tab holds) makes the panel refuse to route rather
+  // than hello anonymously. A resume now requires that proof, so an identity-less
+  // fixture would be testing a client that no current build produces — the
+  // anonymous case has its own test below, asserting the refusal.
   it("an IDEMPOTENT read dropped mid-command RESUMES when the tab reconnects (#450)", async () => {
-    const a1 = await connectPanel("tab-aaaa-1111");
+    const a1 = await connectPanel("tab-aaaa-1111", "workflow-a", { tabSessionId: "browser-tab-450" });
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
     // No autoReply on a1 → the read stays in-flight (un-acked) when we drop it.
     const promise = bridge.send({ cmd: "graph_get_errors" }, { timeoutMs: 5000 });
@@ -1201,7 +1208,7 @@ describe("UiBridge (multi-tab)", () => {
     await new Promise((r) => setTimeout(r, 50));
     a1.close();
     // Same tab reconnects within the grace window and answers the resumed read.
-    const a2 = await connectPanel("tab-aaaa-1111");
+    const a2 = await connectPanel("tab-aaaa-1111", "workflow-a", { tabSessionId: "browser-tab-450" });
     autoReply(a2, "A2");
     await expect(promise).resolves.toMatchObject({ from: "A2", cmd: "graph_get_errors" });
     a2.close();
@@ -1238,9 +1245,10 @@ describe("UiBridge (multi-tab)", () => {
   // wrong-tab `graph_serialize` is the worst of the set: an agent edits against it.
   //
   // These tests pin BOTH refusal sites (resumeAwaitingReconnect and
-  // handleMidCommandDisconnect's already-reconnected fast path) AND the three
-  // shapes that must keep resuming — the #2104 half is the reason this is a
-  // proof-of-takeover rule and not an incarnation-match rule.
+  // handleMidCommandDisconnect's already-reconnected fast path), the shape that
+  // must keep resuming (a proven return), and the PRICE of the rule — a client
+  // that advertises no identity can never prove a return, so it stops resuming at
+  // all and fails immediately instead of stalling for the grace.
   describe("a parked read is never answered by a tab that merely took the route key over (#2761)", () => {
     const KEY = "wf:recurring-2761.json";
 
@@ -1298,7 +1306,7 @@ describe("UiBridge (multi-tab)", () => {
       // The load-bearing assertion: B is never even ASKED. Asserting only on the
       // rejection would pass against a "fix" that dispatched to B and discarded
       // the answer — B's canvas would still have been read.
-      await expect(promise).rejects.toThrow(/DIFFERENT browser tab/);
+      await expect(promise).rejects.toThrow(/could not prove it is the same browser tab/);
       expect(seenByB.some((m) => m.cmd === "graph_serialize")).toBe(false);
       b.close();
     });
@@ -1315,7 +1323,7 @@ describe("UiBridge (multi-tab)", () => {
       const b = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-B" });
       const seenByB = recordAndAnswer(b, "B");
 
-      await expect(promise).rejects.toThrow(/DIFFERENT browser tab/);
+      await expect(promise).rejects.toThrow(/could not prove it is the same browser tab/);
       expect(seenByB.some((m) => m.cmd === "graph_outline")).toBe(false);
       b.close();
     });
@@ -1334,35 +1342,44 @@ describe("UiBridge (multi-tab)", () => {
       a2.close();
     });
 
-    it("still resumes when NEITHER side proved an identity — the #2104 panel keeps working", async () => {
-      // A panel whose Web Locks lease is refused or unreadable omits `tab_session_id`
-      // entirely, and the bridge mints it a fresh per-CONNECTION `anon:<n>`. So every
-      // genuine reconnect of such a panel presents a new incarnation: an
-      // incarnation-match rule would refuse this resume forever, converting a working
-      // feature into an unconditional failure for those installs. The rule refuses
-      // only on PROOF, and there is none here in either direction.
+    it("REFUSES to resume when neither side proved an identity, and does not park at all", async () => {
+      // The rule is positive proof, so an anonymous client can never earn a resume:
+      // no future hello could match it. #2761 proposed sparing this case, on the
+      // premise that a panel unable to prove uniqueness omits `tab_session_id` —
+      // the panel source says otherwise (see `isProvenSameTab`), so the anonymous
+      // population is old builds, which `tabConnectionIdentity` already fails
+      // closed on. Parking would burn the caller's whole budget on a wait with no
+      // reachable success, so it fails NOW and names the reason.
       const a1 = await connectPanel(KEY, "wf");
       await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
-      const firstAnon = bridge.tabIncarnation(KEY);
-      expect(firstAnon).toMatch(/^anon:/);
-      const { promise } = await readInFlightOn(a1, "graph_serialize", 3000);
-      a1.close();
-      await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
-
-      const a2 = await connectPanel(KEY, "wf");
-      autoReply(a2, "A2");
-      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
-      // The reconnect really does look like a stranger to an incarnation test…
       expect(bridge.tabIncarnation(KEY)).toMatch(/^anon:/);
-      expect(bridge.tabIncarnation(KEY)).not.toBe(firstAnon);
-      // …and is resumed anyway, because nothing proved that it was one.
-      await expect(promise).resolves.toMatchObject({ from: "A2", cmd: "graph_serialize" });
+      const { promise } = await readInFlightOn(a1, "graph_serialize", 30_000);
+
+      const started = Date.now();
+      a1.close();
+      const err = await promise.then(
+        () => null,
+        (e: Error) => e,
+      );
+      expect(err?.message).toMatch(/advertised no browser-tab identity/);
+      expect(err?.message).toMatch(/cannot be proven to be the same tab/);
+      // Immediate, not after the 4 s grace — and far inside the 30 s budget it was
+      // given, which is what proves it was never parked rather than merely expiring.
+      expect(Date.now() - started).toBeLessThan(2000);
+
+      // And the replacement is never asked, however it identifies itself.
+      const a2 = await connectPanel(KEY, "wf");
+      const seen = recordAndAnswer(a2, "A2");
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      await new Promise((r) => setTimeout(r, 60));
+      expect(seen.some((m) => m.cmd === "graph_serialize")).toBe(false);
       a2.close();
     });
 
-    it("still resumes when only ONE side proved an identity (no evidence either way)", async () => {
-      // The same browser tab can fail to take its lock on one connection and take it
-      // on the next, so proven-after-anonymous is not proof of a different tab.
+    it("REFUSES to resume when only the RETURNING side proves an identity", async () => {
+      // Proof has to be a MATCH, not merely present on the connection that showed
+      // up: a stranger that can prove who IT is has still not proved it is the tab
+      // that issued the read.
       const a1 = await connectPanel(KEY, "wf");
       await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
       const { promise } = await readInFlightOn(a1, "graph_serialize", 3000);
@@ -1370,8 +1387,9 @@ describe("UiBridge (multi-tab)", () => {
       await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
 
       const a2 = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-late-proof" });
-      autoReply(a2, "A2");
-      await expect(promise).resolves.toMatchObject({ from: "A2", cmd: "graph_serialize" });
+      const seen = recordAndAnswer(a2, "A2");
+      await expect(promise).rejects.toThrow(/no browser-tab identity|could not prove/);
+      expect(seen.some((m) => m.cmd === "graph_serialize")).toBe(false);
       a2.close();
     });
 
@@ -1399,7 +1417,7 @@ describe("UiBridge (multi-tab)", () => {
       a2.close();
     });
 
-    it("says a takeover happened rather than calling a visibly-live panel 'genuinely gone'", async () => {
+    it("names the unproven occupant rather than calling a visibly-live panel 'genuinely gone'", async () => {
       const a = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
       await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
       const { promise } = await readInFlightOn(a, "graph_serialize", 900);
@@ -1412,7 +1430,7 @@ describe("UiBridge (multi-tab)", () => {
         () => null,
         (e: Error) => e,
       );
-      expect(err?.message).toMatch(/DIFFERENT browser tab has since taken its route key over/);
+      expect(err?.message).toMatch(/could not prove it is the same browser tab/);
       expect(err?.message).toMatch(/Re-issue it against the tab you meant/);
       // The old wording would send an operator staring at a live panel off to wait
       // for a tab that is sitting right there in front of them.
@@ -1422,7 +1440,7 @@ describe("UiBridge (multi-tab)", () => {
   });
 
   it("dropQueuedDeliveries CANCELS a parked read so it is NOT re-dispatched onto a replacement (#570 P0)", async () => {
-    const a1 = await connectPanel("wf:foo.json");
+    const a1 = await connectPanel("wf:foo.json", "workflow-a", { tabSessionId: "browser-tab-570" });
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
     // Workflow A has an idempotent read in flight (no autoReply → un-acked).
     const promise = bridge.send({ cmd: "graph_get_errors" }, { tabId: "wf:foo.json", timeoutMs: 5000 });
@@ -1459,20 +1477,20 @@ describe("UiBridge (multi-tab)", () => {
   });
 
   it("resumes a read addressed by tab-id PREFIX after reconnect (canonical key) (#450)", async () => {
-    const a1 = await connectPanel("tab-aaaa-1111");
+    const a1 = await connectPanel("tab-aaaa-1111", "workflow-a", { tabSessionId: "browser-tab-450p" });
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
     // Address by prefix — parking must key on the canonical resolved id, not "tab-aaaa".
     const promise = bridge.send({ cmd: "graph_get_errors" }, { tabId: "tab-aaaa", timeoutMs: 5000 });
     await new Promise((r) => setTimeout(r, 50));
     a1.close();
-    const a2 = await connectPanel("tab-aaaa-1111");
+    const a2 = await connectPanel("tab-aaaa-1111", "workflow-a", { tabSessionId: "browser-tab-450p" });
     autoReply(a2, "A2");
     await expect(promise).resolves.toMatchObject({ from: "A2" });
     a2.close();
   });
 
   it("resumes nodes_search as a read with a fresh dispatch RID (#2145)", async () => {
-    const a1 = await connectPanel("tab-2145");
+    const a1 = await connectPanel("tab-2145", "workflow-a", { tabSessionId: "browser-tab-2145" });
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
     const frames: Array<Record<string, unknown>> = [];
     a1.on("message", (buf) => {
@@ -1487,7 +1505,7 @@ describe("UiBridge (multi-tab)", () => {
     await waitFor(() => expect(frames).toHaveLength(1));
     a1.close();
 
-    const a2 = await connectPanel("tab-2145");
+    const a2 = await connectPanel("tab-2145", "workflow-a", { tabSessionId: "browser-tab-2145" });
     a2.on("message", (buf) => {
       const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
       if (msg.cmd === "nodes_search") {
@@ -1507,7 +1525,7 @@ describe("UiBridge (multi-tab)", () => {
     expect(BRIDGE_READONLY_CMDS.has("nodes_queue_status")).toBe(true);
     expect(defaultBridgeTimeoutMs("nodes_queue_status")).toBe(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
 
-    const a1 = await connectPanel("tab-2181");
+    const a1 = await connectPanel("tab-2181", "workflow-a", { tabSessionId: "browser-tab-2181" });
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
     const frames: Array<Record<string, unknown>> = [];
     a1.on("message", (buf) => {
@@ -1522,7 +1540,7 @@ describe("UiBridge (multi-tab)", () => {
     await waitFor(() => expect(frames).toHaveLength(1));
     a1.close();
 
-    const a2 = await connectPanel("tab-2181");
+    const a2 = await connectPanel("tab-2181", "workflow-a", { tabSessionId: "browser-tab-2181" });
     a2.on("message", (buf) => {
       const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
       if (msg.cmd === "nodes_queue_status") {
@@ -1538,7 +1556,7 @@ describe("UiBridge (multi-tab)", () => {
   });
 
   it("does NOT extend the caller's deadline when a read resumes (#450)", async () => {
-    const a1 = await connectPanel("tab-aaaa-1111");
+    const a1 = await connectPanel("tab-aaaa-1111", "workflow-a", { tabSessionId: "browser-tab-450d" });
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
     // Short deadline. Drop, reconnect with a tab that NEVER replies → must reject
     // near the original 300ms deadline, not restart a fresh full timeout.
@@ -1546,14 +1564,14 @@ describe("UiBridge (multi-tab)", () => {
     const promise = bridge.send({ cmd: "graph_get_errors" }, { timeoutMs: 300 });
     await new Promise((r) => setTimeout(r, 30));
     a1.close();
-    const a2 = await connectPanel("tab-aaaa-1111"); // reconnects but never autoReplies
+    const a2 = await connectPanel("tab-aaaa-1111", "workflow-a", { tabSessionId: "browser-tab-450d" }); // reconnects but never autoReplies
     await expect(promise).rejects.toThrow(/did not reply|genuinely gone/);
     expect(Date.now() - started).toBeLessThan(2000);
     a2.close();
   });
 
   it("an idempotent read whose tab never returns fails as genuinely gone (#450)", async () => {
-    const a = await connectPanel("tab-aaaa-1111");
+    const a = await connectPanel("tab-aaaa-1111", "workflow-a", { tabSessionId: "browser-tab-450g" });
     // BOUNDED UNDER THIS TEST'S OWN BUDGET (#1325). The helper's 15s default is larger
     // than the 10s below, so a stuck connect would be killed by the runner and reported as
     // vitest's generic "test timed out" instead of naming the wait. This connect is local

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1231,6 +1231,196 @@ describe("UiBridge (multi-tab)", () => {
     a2.close();
   });
 
+  // #2761 — park-and-resume used to key on `tabId` ALONE. A `wf:` route key
+  // RECURS (#486), so the connection holding it at resume time may be a different
+  // browser tab that opened the same saved workflow — and it would be handed the
+  // departed caller's parked read, its answer resolving that caller's promise. A
+  // wrong-tab `graph_serialize` is the worst of the set: an agent edits against it.
+  //
+  // These tests pin BOTH refusal sites (resumeAwaitingReconnect and
+  // handleMidCommandDisconnect's already-reconnected fast path) AND the three
+  // shapes that must keep resuming — the #2104 half is the reason this is a
+  // proof-of-takeover rule and not an incarnation-match rule.
+  describe("a parked read is never answered by a tab that merely took the route key over (#2761)", () => {
+    const KEY = "wf:recurring-2761.json";
+
+    /** Dispatch an idempotent read that is never answered, and confirm it reached
+     *  the socket — so the drop that follows is a genuine mid-command disconnect
+     *  (un-acked, in `pending`) rather than a command that never went out.
+     *
+     *  Returns the pending send WRAPPED in an object, deliberately: an async
+     *  function that returns a promise ADOPTS it, so a bare return would make
+     *  `await readInFlightOn(...)` wait for the very send the caller means to
+     *  hold and assert on later. */
+    async function readInFlightOn(
+      sock: WebSocket,
+      cmd: string,
+      timeoutMs: number,
+    ): Promise<{ promise: Promise<unknown> }> {
+      const frames: Array<Record<string, unknown>> = [];
+      sock.on("message", (buf) => frames.push(JSON.parse(buf.toString())));
+      const promise = bridge.send({ cmd }, { tabId: KEY, timeoutMs });
+      // Swallow the eventual rejection here; every caller asserts on it itself.
+      promise.catch(() => {});
+      await waitFor(() => expect(frames.some((f) => f.cmd === cmd)).toBe(true));
+      return { promise };
+    }
+
+    /** Record every frame the panel receives, and answer any command with `tag` —
+     *  so a wrongly-resumed read would visibly RESOLVE, not merely be observed. */
+    function recordAndAnswer(sock: WebSocket, tag: string): Array<Record<string, unknown>> {
+      const seen: Array<Record<string, unknown>> = [];
+      sock.on("message", (buf) => {
+        const msg = JSON.parse(buf.toString()) as Record<string, unknown>;
+        seen.push(msg);
+        if (msg.rid && msg.cmd) {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { from: tag } }));
+        }
+      });
+      return seen;
+    }
+
+    it("withholds a PARKED read from a different proven browser tab on the recurring key", async () => {
+      const a = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const { promise } = await readInFlightOn(a, "graph_serialize", 1200);
+
+      // Drop A and let its close handler PARK the read BEFORE the stranger arrives.
+      // That ordering is what routes this through resumeAwaitingReconnect rather
+      // than through the already-reconnected fast path (pinned separately below).
+      a.close();
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+
+      const b = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-B" });
+      const seenByB = recordAndAnswer(b, "B");
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+
+      // The load-bearing assertion: B is never even ASKED. Asserting only on the
+      // rejection would pass against a "fix" that dispatched to B and discarded
+      // the answer — B's canvas would still have been read.
+      await expect(promise).rejects.toThrow(/DIFFERENT browser tab/);
+      expect(seenByB.some((m) => m.cmd === "graph_serialize")).toBe(false);
+      b.close();
+    });
+
+    it("withholds it on the already-reconnected FAST PATH too, where the stranger's hello beat the close", async () => {
+      const a = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const { promise } = await readInFlightOn(a, "graph_outline", 1200);
+
+      // B hellos while A is STILL open. The hello supersedes A's socket, so A's
+      // close handler runs with B ALREADY live in `conns` — handleMidCommandDisconnect
+      // takes its "already reconnected, re-dispatch straight onto it" branch and never
+      // parks at all. Fixing only the resume would leave this path open.
+      const b = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-B" });
+      const seenByB = recordAndAnswer(b, "B");
+
+      await expect(promise).rejects.toThrow(/DIFFERENT browser tab/);
+      expect(seenByB.some((m) => m.cmd === "graph_outline")).toBe(false);
+      b.close();
+    });
+
+    it("still resumes when the SAME proven tab comes back (a reload is not a takeover)", async () => {
+      const a1 = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const { promise } = await readInFlightOn(a1, "graph_serialize", 3000);
+      a1.close();
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+
+      // `tab_session_id` is sessionStorage-backed, so an F5 brings the same one back.
+      const a2 = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
+      autoReply(a2, "A2");
+      await expect(promise).resolves.toMatchObject({ from: "A2", cmd: "graph_serialize" });
+      a2.close();
+    });
+
+    it("still resumes when NEITHER side proved an identity — the #2104 panel keeps working", async () => {
+      // A panel whose Web Locks lease is refused or unreadable omits `tab_session_id`
+      // entirely, and the bridge mints it a fresh per-CONNECTION `anon:<n>`. So every
+      // genuine reconnect of such a panel presents a new incarnation: an
+      // incarnation-match rule would refuse this resume forever, converting a working
+      // feature into an unconditional failure for those installs. The rule refuses
+      // only on PROOF, and there is none here in either direction.
+      const a1 = await connectPanel(KEY, "wf");
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const firstAnon = bridge.tabIncarnation(KEY);
+      expect(firstAnon).toMatch(/^anon:/);
+      const { promise } = await readInFlightOn(a1, "graph_serialize", 3000);
+      a1.close();
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+
+      const a2 = await connectPanel(KEY, "wf");
+      autoReply(a2, "A2");
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      // The reconnect really does look like a stranger to an incarnation test…
+      expect(bridge.tabIncarnation(KEY)).toMatch(/^anon:/);
+      expect(bridge.tabIncarnation(KEY)).not.toBe(firstAnon);
+      // …and is resumed anyway, because nothing proved that it was one.
+      await expect(promise).resolves.toMatchObject({ from: "A2", cmd: "graph_serialize" });
+      a2.close();
+    });
+
+    it("still resumes when only ONE side proved an identity (no evidence either way)", async () => {
+      // The same browser tab can fail to take its lock on one connection and take it
+      // on the next, so proven-after-anonymous is not proof of a different tab.
+      const a1 = await connectPanel(KEY, "wf");
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const { promise } = await readInFlightOn(a1, "graph_serialize", 3000);
+      a1.close();
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+
+      const a2 = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-late-proof" });
+      autoReply(a2, "A2");
+      await expect(promise).resolves.toMatchObject({ from: "A2", cmd: "graph_serialize" });
+      a2.close();
+    });
+
+    it("resumes for the ORIGINAL tab if it reclaims the key inside the grace, after a stranger was refused", async () => {
+      // A withheld read stays PARKED rather than being rejected on the spot, so the
+      // tab that issued it can still be served if it wins its key back. That is the
+      // difference between "never answer with a stranger's canvas" and "give up".
+      const a1 = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const { promise } = await readInFlightOn(a1, "graph_serialize", 3000);
+      a1.close();
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+
+      const b = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-B" });
+      const seenByB = recordAndAnswer(b, "B");
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      await new Promise((r) => setTimeout(r, 60));
+      expect(seenByB.some((m) => m.cmd === "graph_serialize")).toBe(false);
+
+      // A comes back and takes its own key back.
+      const a2 = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
+      autoReply(a2, "A2");
+      await expect(promise).resolves.toMatchObject({ from: "A2", cmd: "graph_serialize" });
+      b.close();
+      a2.close();
+    });
+
+    it("says a takeover happened rather than calling a visibly-live panel 'genuinely gone'", async () => {
+      const a = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const { promise } = await readInFlightOn(a, "graph_serialize", 900);
+      a.close();
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+      const b = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-B" });
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+
+      const err = await promise.then(
+        () => null,
+        (e: Error) => e,
+      );
+      expect(err?.message).toMatch(/DIFFERENT browser tab has since taken its route key over/);
+      expect(err?.message).toMatch(/Re-issue it against the tab you meant/);
+      // The old wording would send an operator staring at a live panel off to wait
+      // for a tab that is sitting right there in front of them.
+      expect(err?.message).not.toMatch(/genuinely gone/);
+      b.close();
+    });
+  });
+
   it("dropQueuedDeliveries CANCELS a parked read so it is NOT re-dispatched onto a replacement (#570 P0)", async () => {
     const a1 = await connectPanel("wf:foo.json");
     await waitFor(() => expect(bridge.tabs()).toHaveLength(1));

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1393,6 +1393,48 @@ describe("UiBridge (multi-tab)", () => {
       a2.close();
     });
 
+    it("REFUSES the fast path to an unproven stranger already live on the key", async () => {
+      // The gate's P1, and the case the other two anonymous tests CANNOT reach:
+      // there, the drop happens with nobody else on the key, so the "never park an
+      // unproven read" short circuit answers before the predicate is ever consulted.
+      // Here a second anonymous client is ALREADY live when the socket dies, so
+      // handleMidCommandDisconnect evaluates its fast path first — and the weaker
+      // "refuse only a provable takeover" rule hands the read straight to it,
+      // because two unproven identities never provably differ.
+      const a1 = await connectPanel(KEY, "wf");
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const { promise } = await readInFlightOn(a1, "graph_serialize", 3000);
+
+      // B hellos while A is still open: the supersede closes A, so A's close
+      // handler runs with B live in `conns`.
+      const b = await connectPanel(KEY, "wf");
+      const seenByB = recordAndAnswer(b, "B");
+
+      await expect(promise).rejects.toThrow(/no browser-tab identity|could not prove/);
+      expect(seenByB.some((m) => m.cmd === "graph_serialize")).toBe(false);
+      b.close();
+    });
+
+    it("REFUSES to resume a PROVEN read onto an occupant that proves nothing", async () => {
+      // The mirror of the above at the resume site. An absent `tab_session_id` on
+      // the newcomer is not a point in its favour: it has not proved it is the tab
+      // that issued the read, which is the only question. Under the weaker rule
+      // this resumes, since an undefined identity never "provably differs".
+      const a1 = await connectPanel(KEY, "wf", { tabSessionId: "browser-tab-A" });
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const { promise } = await readInFlightOn(a1, "graph_serialize", 1200);
+      a1.close();
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+
+      const b = await connectPanel(KEY, "wf"); // anonymous occupant
+      const seenByB = recordAndAnswer(b, "B");
+      await waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+
+      await expect(promise).rejects.toThrow(/could not prove it is the same browser tab/);
+      expect(seenByB.some((m) => m.cmd === "graph_serialize")).toBe(false);
+      b.close();
+    });
+
     it("resumes for the ORIGINAL tab if it reclaims the key inside the grace, after a stranger was refused", async () => {
       // A withheld read stays PARKED rather than being rejected on the spot, so the
       // tab that issued it can still be served if it wins its key back. That is the

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -26208,16 +26208,13 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           //
           // ONE-SHOT ACROSS RECONNECTS, deliberately — and still so after #2761.
           // Being a read makes this command eligible for the bridge's
-          // park-and-resume. That resume no longer hands a parked read to a tab
-          // that PROVED itself a different browser tab (#2761 taught both resume
-          // sites the takeover rule), so the wrong-canvas outcome this originally
-          // guarded against is closed at the bridge. What is NOT closed, and
-          // cannot be, is the unproven case: a panel that omits `tab_session_id`
-          // (#2104) leaves no evidence either way, and the bridge resumes it
-          // rather than break park/resume for those installs. A screenshot is
-          // exactly the read where that residual risk is not worth taking — it is
-          // free to re-ask, and a picture of someone else's canvas is a silent
-          // wrong answer, not a visible failure. So the budget stays zero.
+          // park-and-resume. That resume now requires the returning connection to
+          // PROVE it is the tab that issued the read (#2761), so the wrong-canvas
+          // outcome this originally guarded against is closed at the bridge for
+          // every command in the set, not just this one. The budget stays zero
+          // regardless: a capture is free to re-ask, so it gains nothing from
+          // resuming, and keeping it out of the branch entirely means this call
+          // site does not depend on that rule staying correct.
           const res = (await ctx.bridge.send(cmd as { cmd: string }, {
             tabId: ctx.tabId,
             timeoutMs: OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -26206,16 +26206,18 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           // double-applied write. Still BOUNDED, never Infinity, so a genuinely
           // frozen tab fails — at 90 s instead of 20 s.
           //
-          // ONE-SHOT ACROSS RECONNECTS, deliberately. Being a read now also makes
-          // this command eligible for the bridge's park-and-resume, and that
-          // resume re-dispatches on `tabId` alone — but a `wf:` route key recurs,
-          // and the hello handler's own #486 rule is that "same key is not the
-          // same tab". A parked capture could be resumed onto a DIFFERENT browser
-          // tab that took the key over, and answer this caller with a picture of a
-          // canvas they never asked about. `maxReconnectRetries: 0` keeps it out
-          // of that branch: a mid-capture drop fails honestly, and re-asking for a
-          // screenshot costs nothing. The general resume-vs-incarnation gap is
-          // real and older than this call site; it is tracked in #2761.
+          // ONE-SHOT ACROSS RECONNECTS, deliberately — and still so after #2761.
+          // Being a read makes this command eligible for the bridge's
+          // park-and-resume. That resume no longer hands a parked read to a tab
+          // that PROVED itself a different browser tab (#2761 taught both resume
+          // sites the takeover rule), so the wrong-canvas outcome this originally
+          // guarded against is closed at the bridge. What is NOT closed, and
+          // cannot be, is the unproven case: a panel that omits `tab_session_id`
+          // (#2104) leaves no evidence either way, and the bridge resumes it
+          // rather than break park/resume for those installs. A screenshot is
+          // exactly the read where that residual risk is not worth taking — it is
+          // free to re-ask, and a picture of someone else's canvas is a silent
+          // wrong answer, not a visible failure. So the budget stays zero.
           const res = (await ctx.bridge.send(cmd as { cmd: string }, {
             tabId: ctx.tabId,
             timeoutMs: OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -144,42 +144,56 @@ type AwaitingReconnectEntry = {
   ctx: SendCtx;
   graceTimer: ReturnType<typeof setTimeout>;
   /** #2761 — set when a hello for this route key was declined as a resume target
-   *  because it PROVED itself a different browser tab. Only changes the message
-   *  the grace timer eventually rejects with: "gone" is a lie when the operator
-   *  can see a live tab sitting on the key. */
-  refusedTakeover?: boolean;
+   *  because it could not prove it is the tab that issued the read. Only changes
+   *  the message the grace timer eventually rejects with: "gone" is a lie when
+   *  the operator can see a live tab sitting on the key. */
+  refusedUnprovenReturn?: boolean;
 };
 
 /**
- * #2761 — is `conn` PROVABLY a different browser tab from the one `ctx` was
- * dispatched to? A `wf:` route key recurs (#486), so holding the key is not
- * evidence of being the same tab; only two proven-and-differing identities are.
+ * #2761 — may a read parked by `ctx` be resumed onto `conn`? ONLY when `conn`
+ * PROVES it is the browser tab that issued it: both carry a `tab_session_id`
+ * and they match.
  *
- * Deliberately three-valued collapsed to "refuse only on proof":
- *   both proven, equal      → the same tab came back. Resume.
- *   both proven, different  → a takeover. NEVER hand the parked read over.
- *   either side unproven    → no evidence in EITHER direction. Resume, exactly
- *                             as before this check existed.
+ * This is a POSITIVE proof, not "refuse when they provably differ", and the
+ * difference is the whole decision. A `wf:` route key RECURS (#486) — another
+ * browser tab opening the same saved workflow takes it over — so holding the key
+ * is not evidence of anything. An UNPROVEN connection is therefore not neutral:
+ * it is a connection that cannot rule out being a stranger, and resuming onto it
+ * answers the departed caller with a canvas that may not be theirs.
  *
- * That last line is the load-bearing one, and it is why this does not simply
- * compare `incarnationId`. An incarnation falls back to a per-connection
- * `anon:<n>`, so for a panel whose lock manager refuses or is unreadable (#2104)
- * EVERY genuine reconnect presents a new one — an incarnation-strict rule would
- * turn working park/resume into an unconditional refusal for those installs.
+ * The cost is real and falls on one population: a panel that never advertises
+ * `tab_session_id` can never prove a return, so park-and-resume does nothing for
+ * it and a mid-command drop fails instead of recovering. That is deliberate, and
+ * it is the side this codebase already takes at every adjacent site:
  *
- * This is therefore a DELIBERATE disagreement with the hello handler, which
- * treats a differing anon as a takeover and retires the departed tab's asks. The
- * two sites ask the same question with opposite safety directions: there, acting
- * without proof RETIRES state that a stranger must not reach (fail-safe); here,
- * acting without proof REFUSES a read that a legitimate panel is waiting on
- * (fail-closed against the user). Each takes the conservative side of its own
- * trade, which is not the same side.
+ *   - `tabConnectionIdentity` returns undefined for exactly these panels rather
+ *     than "fabricating graph-tool readiness" for the restart gate.
+ *   - the hello handler (#486) counts a differing anonymous incarnation as a
+ *     TAKEOVER and retires the departed tab's asks.
+ *   - the panel's own `bridge-route.js`, on this same trade: "Losing a resume is
+ *     recoverable; delivering a command to the wrong canvas is not."
+ *
+ * #2761 proposed sparing the unproven case, on the premise that a panel which
+ * cannot prove uniqueness omits the field. THE PANEL SOURCE SAYS OTHERWISE, and
+ * that is why this does not follow the suggestion: `createTabRouteIdentity` has
+ * three outcomes, and two of them send an id — an exclusive Web Locks lease, or,
+ * where `navigator.locks` does not exist (plain http:// on a LAN), a
+ * never-persisted per-page-load id. The third, a lease actively refused by
+ * another tab, makes the panel REFUSE TO ROUTE AT ALL rather than hello
+ * anonymously. So a current panel that is talking to us has always proved
+ * something; the anonymous population is old builds, and old builds are exactly
+ * who `tabConnectionIdentity` already fails closed on.
+ *
+ * Note this also makes a page-instance RELOAD (new id each load) a non-return,
+ * which is correct and already true elsewhere: the hello handler fires
+ * `onTabTakenOver` for it, and the panel documents the cost as "route stability,
+ * not uniqueness".
  */
-function isProvenDifferentTab(ctx: SendCtx, conn: Conn): boolean {
+function isProvenSameTab(ctx: SendCtx, conn: Conn): boolean {
   return (
     ctx.issuedToTabSessionId !== undefined &&
-    conn.tabSessionId !== undefined &&
-    ctx.issuedToTabSessionId !== conn.tabSessionId
+    ctx.issuedToTabSessionId === conn.tabSessionId
   );
 }
 
@@ -1290,22 +1304,20 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   // handleMidCommandDisconnect's park-and-resume — and that resume used to key on
   // `ctx.tabId` ALONE, so a route key that RECURS (#486: "same key is not the same
   // tab") could hand a parked read to whichever tab happened to hold the key at
-  // resume time. #2761 closed that at both resume sites, which now refuse on PROOF
-  // of a takeover (see `isProvenDifferentTab`). A wrong-tab SERIALIZE — worse than
-  // a wrong-tab picture, because it drives edits — no longer resolves the departed
-  // caller's promise.
+  // resume time. #2761 closed that at both resume sites: a parked read now resumes
+  // only onto a connection that PROVES it is the tab that issued it (see
+  // `isProvenSameTab`). A wrong-tab SERIALIZE — worse than a wrong-tab picture,
+  // because it drives edits — can no longer resolve the departed caller's promise.
   //
-  // What remains, deliberately, is the UNPROVEN case. A panel whose lock manager
-  // refuses or is unreadable (#2104) omits `tab_session_id`, so neither side is
-  // evidence of anything; refusing there would turn working park/resume into an
-  // unconditional failure for those installs. So adding a command to this set
-  // still accepts a residual, unprovable wrong-tab risk in exchange for surviving
-  // a reconnect.
+  // The price, paid knowingly: a panel that advertises no `tab_session_id` can
+  // never prove a return, so membership here no longer buys it reconnect survival
+  // — its mid-command drop fails immediately instead. Every current panel that
+  // routes at all sends one, so this falls on old builds, and it is the same side
+  // `tabConnectionIdentity` already takes for them.
   //
-  // This entry declines even that: the panel_screenshot call site passes
-  // `maxReconnectRetries: 0`, which keeps the command out of the park branch
-  // entirely. A screenshot that drops mid-capture fails honestly and is free to
-  // re-ask, so there is nothing worth buying with the risk.
+  // This entry declines the park branch outright anyway: the panel_screenshot call
+  // site passes `maxReconnectRetries: 0`. A screenshot that drops mid-capture fails
+  // honestly and is free to re-ask, so it has nothing to gain from resuming.
   "graph_screenshot",
   "graph_prompt_director_audit",
   "graph_query",
@@ -6936,19 +6948,19 @@ export class UiBridge {
       // and expiring as "gone". Safe: idempotent read, un-acked.
       //
       // #2761 — "a replacement socket is live under this key" is NOT "this tab is
-      // back". `isProvenDifferentTab` is the same test resumeAwaitingReconnect
-      // applies; without it this fast path is the earlier of the two ways a
-      // stranger gets handed the read, and it fires FIRST (its hello beat the
-      // close handler), so fixing only the resume would leave the race that is
-      // hardest to reproduce. On proof of a takeover, fall through and park: if
-      // the original tab reclaims its key inside the grace it still resumes, and
-      // if it does not, the timer below rejects — which is the honest outcome.
+      // back". `isProvenSameTab` is the same test resumeAwaitingReconnect applies;
+      // without it this fast path is the earlier of the two ways a stranger gets
+      // handed the read, and it fires FIRST (its hello beat the close handler), so
+      // fixing only the resume would leave the race that is hardest to reproduce.
+      // Unproven, fall through and park: if the issuing tab proves a return inside
+      // the grace it still resumes, and if it does not, the timer below rejects —
+      // which is the honest outcome.
       const live = this.conns.get(ctx.tabId);
       if (
         live &&
         live.sock !== pend.sock &&
         live.sock.readyState === WebSocket.OPEN &&
-        !isProvenDifferentTab(ctx, live)
+        isProvenSameTab(ctx, live)
       ) {
         ctx.reconnectRetriesRemaining -= 1;
         logger.info(
@@ -6957,10 +6969,26 @@ export class UiBridge {
         this.dispatch(live, ctx);
         return;
       }
-      const takenOverAtDrop = live !== undefined && isProvenDifferentTab(ctx, live);
-      if (takenOverAtDrop) {
+      // #2761 — a read issued to a tab that never advertised a `tab_session_id`
+      // can NEVER be resumed: no future hello can prove it is that tab. Parking it
+      // would burn the caller's whole remaining budget on a wait with no reachable
+      // success, so fail now and say why. This is the visible cost of the proof
+      // rule, and it is deliberately loud rather than a silent stall.
+      if (ctx.issuedToTabSessionId === undefined) {
         logger.info(
-          `[ui-bridge] tab ${short} is now held by a DIFFERENT browser tab — not resuming "${cmd}" onto it; parking for the original`,
+          `[ui-bridge] tab ${short} dropped mid-command ("${cmd}") without a browser-tab identity — a reconnect on this route key could not be proven to be the same tab, so it is not parked`,
+        );
+        ctx.reject(
+          new Error(
+            `panel tab ${short} disconnected mid-command ("${cmd}") and advertised no browser-tab identity, so a reconnect on this route key cannot be proven to be the same tab — the read was not resumed rather than risk answering with a different canvas. Retry once a tab is connected; updating the panel restores automatic resume.`,
+          ),
+        );
+        return;
+      }
+      const unprovenAtDrop = live !== undefined;
+      if (unprovenAtDrop) {
+        logger.info(
+          `[ui-bridge] tab ${short} route key is held by a connection that did not prove it is the same browser tab — not resuming "${cmd}" onto it; parking for a proven return`,
         );
       }
       ctx.reconnectRetriesRemaining -= 1;
@@ -6968,7 +6996,7 @@ export class UiBridge {
       const graceMs = Math.max(0, Math.min(UiBridge.RECONNECT_GRACE_MS, ctx.deadline - Date.now()));
       const entry: AwaitingReconnectEntry = {
         ctx,
-        refusedTakeover: takenOverAtDrop,
+        refusedUnprovenReturn: unprovenAtDrop,
         graceTimer: setTimeout(() => {
           this.removeAwaiting(ctx.tabId, entry);
           ctx.reject(
@@ -6977,8 +7005,8 @@ export class UiBridge {
               // key. If a different browser tab did, say THAT: an operator looking
               // at a live panel would otherwise be told it had vanished, and the
               // remedy is different (re-issue against the tab you meant, not wait).
-              entry.refusedTakeover
-                ? `panel tab ${short} disconnected mid-command ("${cmd}") and a DIFFERENT browser tab has since taken its route key over — the read was NOT resumed onto that tab (its answer would describe someone else's canvas). Re-issue it against the tab you meant.`
+              entry.refusedUnprovenReturn
+                ? `panel tab ${short} disconnected mid-command ("${cmd}") and the connection now holding its route key could not prove it is the same browser tab — the read was NOT resumed onto it, because its answer could describe a different canvas. Re-issue it against the tab you meant.`
                 : `panel tab ${short} disconnected mid-command ("${cmd}") and did not reconnect within ${graceMs} ms — panel genuinely gone; retry once a tab is connected`,
             ),
           );
@@ -7037,9 +7065,10 @@ export class UiBridge {
    *  route key RECURS, so the connection now holding it may be a different browser
    *  tab that opened the same saved workflow; handing it a parked `graph_serialize`
    *  answers the departed caller with a stranger's canvas, and an agent then edits
-   *  against it. Entries whose issuing tab is PROVABLY not this one stay parked —
-   *  their own grace timer decides — so the original still resumes if it reclaims
-   *  the key in time. Everything else resumes exactly as before. */
+   *  against it. So an entry resumes only onto a connection that PROVES it is the
+   *  tab that issued it (`isProvenSameTab`). Everything else stays parked — its own
+   *  grace timer decides — so a proven return later in the window is still served,
+   *  and an unproven one never is. */
   private resumeAwaitingReconnect(tabId: string): void {
     const list = this.awaitingReconnect.get(tabId);
     if (!list || list.length === 0) return;
@@ -7052,11 +7081,11 @@ export class UiBridge {
     this.awaitingReconnect.delete(tabId);
     const withheld: AwaitingReconnectEntry[] = [];
     for (const entry of list) {
-      if (isProvenDifferentTab(entry.ctx, conn)) {
-        entry.refusedTakeover = true;
+      if (!isProvenSameTab(entry.ctx, conn)) {
+        entry.refusedUnprovenReturn = true;
         withheld.push(entry);
         logger.warn(
-          `[ui-bridge] tab ${tabId.slice(0, 8)} is now a DIFFERENT browser tab — withholding parked "${entry.ctx.command.cmd}" rather than answering its caller with another tab's canvas`,
+          `[ui-bridge] tab ${tabId.slice(0, 8)} did not prove it is the browser tab that issued "${entry.ctx.command.cmd}" — withholding the parked read rather than answering its caller with another tab's canvas`,
         );
         continue;
       }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -108,6 +108,20 @@ type SendCtx = {
   deadline: number;
   /** Remaining bridge-owned reconnect re-dispatches for this send. */
   reconnectRetriesRemaining: number;
+  /**
+   * #2761 — the PROVEN browser-tab identity of the connection this command was
+   * issued to, captured at dispatch. Present only when that hello carried a
+   * `tab_session_id`; absent when the panel could not prove one.
+   *
+   * Exists so a park-and-resume can tell "the same tab came back" from "a
+   * different tab took this recurring `wf:` route key over". `Conn.incarnationId`
+   * is deliberately NOT what is stored here: it is always populated, falling back
+   * to a per-CONNECTION `anon:<n>`, so a panel whose Web Locks lease is refused or
+   * unreadable (#2104) presents a fresh incarnation on every genuine reconnect.
+   * `tabSessionId` is the field whose contract is "a proof, absent when unproven"
+   * (#709), which is exactly the question the resume has to ask.
+   */
+  issuedToTabSessionId?: string;
   /** #570 — the trusted per-instance workflow uuid this command was ISSUED FOR (the
    *  caller's intended tab), stamped onto the outgoing frame so the panel can refuse to
    *  EXECUTE it against a DIFFERENT workflow it has since switched to. Undefined for a tab
@@ -123,6 +137,51 @@ type SendCtx = {
    */
   siblingReply?: string;
 };
+
+/** An idempotent read parked by handleMidCommandDisconnect, waiting a bounded
+ *  grace for its tab to come back so it can be re-dispatched. */
+type AwaitingReconnectEntry = {
+  ctx: SendCtx;
+  graceTimer: ReturnType<typeof setTimeout>;
+  /** #2761 — set when a hello for this route key was declined as a resume target
+   *  because it PROVED itself a different browser tab. Only changes the message
+   *  the grace timer eventually rejects with: "gone" is a lie when the operator
+   *  can see a live tab sitting on the key. */
+  refusedTakeover?: boolean;
+};
+
+/**
+ * #2761 — is `conn` PROVABLY a different browser tab from the one `ctx` was
+ * dispatched to? A `wf:` route key recurs (#486), so holding the key is not
+ * evidence of being the same tab; only two proven-and-differing identities are.
+ *
+ * Deliberately three-valued collapsed to "refuse only on proof":
+ *   both proven, equal      → the same tab came back. Resume.
+ *   both proven, different  → a takeover. NEVER hand the parked read over.
+ *   either side unproven    → no evidence in EITHER direction. Resume, exactly
+ *                             as before this check existed.
+ *
+ * That last line is the load-bearing one, and it is why this does not simply
+ * compare `incarnationId`. An incarnation falls back to a per-connection
+ * `anon:<n>`, so for a panel whose lock manager refuses or is unreadable (#2104)
+ * EVERY genuine reconnect presents a new one — an incarnation-strict rule would
+ * turn working park/resume into an unconditional refusal for those installs.
+ *
+ * This is therefore a DELIBERATE disagreement with the hello handler, which
+ * treats a differing anon as a takeover and retires the departed tab's asks. The
+ * two sites ask the same question with opposite safety directions: there, acting
+ * without proof RETIRES state that a stranger must not reach (fail-safe); here,
+ * acting without proof REFUSES a read that a legitimate panel is waiting on
+ * (fail-closed against the user). Each takes the conservative side of its own
+ * trade, which is not the same side.
+ */
+function isProvenDifferentTab(ctx: SendCtx, conn: Conn): boolean {
+  return (
+    ctx.issuedToTabSessionId !== undefined &&
+    conn.tabSessionId !== undefined &&
+    ctx.issuedToTabSessionId !== conn.tabSessionId
+  );
+}
 
 type Pending = {
   resolve: (v: unknown) => void;
@@ -2516,7 +2575,7 @@ export class UiBridge {
   /** In-flight IDEMPOTENT reads whose socket dropped mid-command, parked per tabId
    *  waiting a bounded grace for that tab to reconnect so we can re-dispatch them
    *  (resume) instead of hard-failing. Never holds mutating commands. */
-  private awaitingReconnect = new Map<string, Array<{ ctx: SendCtx; graceTimer: ReturnType<typeof setTimeout> }>>();
+  private awaitingReconnect = new Map<string, AwaitingReconnectEntry[]>();
   /** How long a dropped idempotent read waits for its tab to re-hello before we
    *  declare the panel genuinely gone. Bounded so a caller never hangs. */
   private static readonly RECONNECT_GRACE_MS = 4000;
@@ -6481,6 +6540,10 @@ export class UiBridge {
           // read cannot itself produce the reporter's 30 s false timeout (#2069).
           deadline: Date.now() + timeoutMs,
           reconnectRetriesRemaining,
+          // #2761 — captured HERE, on the connection that actually receives the
+          // frame, not read back later from `conns` (by resume time the key may be
+          // held by somebody else, which is the whole point of storing it).
+          issuedToTabSessionId: live.tabSessionId,
           // #570 — graph ops resolve from the CALLER'S intended tab (opts.tabId), NOT
           // the canonical conn.tabId: after a same-socket switch the two differ, and
           // we must stamp the workflow the command was ISSUED FOR (so the panel, now
@@ -6879,8 +6942,22 @@ export class UiBridge {
       // hello landed before this dead socket's close handler ran — so resume already
       // fired and won't fire again). Re-dispatch straight onto it instead of parking
       // and expiring as "gone". Safe: idempotent read, un-acked.
+      //
+      // #2761 — "a replacement socket is live under this key" is NOT "this tab is
+      // back". `isProvenDifferentTab` is the same test resumeAwaitingReconnect
+      // applies; without it this fast path is the earlier of the two ways a
+      // stranger gets handed the read, and it fires FIRST (its hello beat the
+      // close handler), so fixing only the resume would leave the race that is
+      // hardest to reproduce. On proof of a takeover, fall through and park: if
+      // the original tab reclaims its key inside the grace it still resumes, and
+      // if it does not, the timer below rejects — which is the honest outcome.
       const live = this.conns.get(ctx.tabId);
-      if (live && live.sock !== pend.sock && live.sock.readyState === WebSocket.OPEN) {
+      if (
+        live &&
+        live.sock !== pend.sock &&
+        live.sock.readyState === WebSocket.OPEN &&
+        !isProvenDifferentTab(ctx, live)
+      ) {
         ctx.reconnectRetriesRemaining -= 1;
         logger.info(
           `[ui-bridge] tab ${short} already reconnected — resuming "${cmd}" on the live socket`,
@@ -6888,16 +6965,29 @@ export class UiBridge {
         this.dispatch(live, ctx);
         return;
       }
+      const takenOverAtDrop = live !== undefined && isProvenDifferentTab(ctx, live);
+      if (takenOverAtDrop) {
+        logger.info(
+          `[ui-bridge] tab ${short} is now held by a DIFFERENT browser tab — not resuming "${cmd}" onto it; parking for the original`,
+        );
+      }
       ctx.reconnectRetriesRemaining -= 1;
       const list = this.awaitingReconnect.get(ctx.tabId) ?? [];
       const graceMs = Math.max(0, Math.min(UiBridge.RECONNECT_GRACE_MS, ctx.deadline - Date.now()));
-      const entry = {
+      const entry: AwaitingReconnectEntry = {
         ctx,
+        refusedTakeover: takenOverAtDrop,
         graceTimer: setTimeout(() => {
           this.removeAwaiting(ctx.tabId, entry);
           ctx.reject(
             new Error(
-              `panel tab ${short} disconnected mid-command ("${cmd}") and did not reconnect within ${graceMs} ms — panel genuinely gone; retry once a tab is connected`,
+              // #2761 — "genuinely gone" is only true when nobody proved up on the
+              // key. If a different browser tab did, say THAT: an operator looking
+              // at a live panel would otherwise be told it had vanished, and the
+              // remedy is different (re-issue against the tab you meant, not wait).
+              entry.refusedTakeover
+                ? `panel tab ${short} disconnected mid-command ("${cmd}") and a DIFFERENT browser tab has since taken its route key over — the read was NOT resumed onto that tab (its answer would describe someone else's canvas). Re-issue it against the tab you meant.`
+                : `panel tab ${short} disconnected mid-command ("${cmd}") and did not reconnect within ${graceMs} ms — panel genuinely gone; retry once a tab is connected`,
             ),
           );
         }, graceMs),
@@ -6940,10 +7030,7 @@ export class UiBridge {
     }
   }
 
-  private removeAwaiting(
-    tabId: string,
-    entry: { ctx: SendCtx; graceTimer: ReturnType<typeof setTimeout> },
-  ): void {
+  private removeAwaiting(tabId: string, entry: AwaitingReconnectEntry): void {
     const list = this.awaitingReconnect.get(tabId);
     if (!list) return;
     const i = list.indexOf(entry);
@@ -6952,19 +7039,49 @@ export class UiBridge {
   }
 
   /** A tab re-helloed: resume any idempotent reads parked for it on a mid-command
-   *  disconnect by re-dispatching them onto the fresh socket. */
+   *  disconnect by re-dispatching them onto the fresh socket.
+   *
+   *  #2761 — "a hello arrived for this key" is not "this tab is back". A `wf:`
+   *  route key RECURS, so the connection now holding it may be a different browser
+   *  tab that opened the same saved workflow; handing it a parked `graph_serialize`
+   *  answers the departed caller with a stranger's canvas, and an agent then edits
+   *  against it. Entries whose issuing tab is PROVABLY not this one stay parked —
+   *  their own grace timer decides — so the original still resumes if it reclaims
+   *  the key in time. Everything else resumes exactly as before. */
   private resumeAwaitingReconnect(tabId: string): void {
     const list = this.awaitingReconnect.get(tabId);
     if (!list || list.length === 0) return;
     const conn = this.conns.get(tabId);
     if (!conn) return;
+    // Clear the key BEFORE dispatching, exactly as this did before #2761: a
+    // re-dispatch that fails and re-parks must land in a fresh list, not be
+    // clobbered by a write-back of the list we are iterating. Withheld entries
+    // are merged onto whatever is there when the loop ends.
     this.awaitingReconnect.delete(tabId);
+    const withheld: AwaitingReconnectEntry[] = [];
     for (const entry of list) {
+      if (isProvenDifferentTab(entry.ctx, conn)) {
+        entry.refusedTakeover = true;
+        withheld.push(entry);
+        logger.warn(
+          `[ui-bridge] tab ${tabId.slice(0, 8)} is now a DIFFERENT browser tab — withholding parked "${entry.ctx.command.cmd}" rather than answering its caller with another tab's canvas`,
+        );
+        continue;
+      }
       clearTimeout(entry.graceTimer);
       logger.info(
         `[ui-bridge] tab ${tabId.slice(0, 8)} reconnected — resuming "${entry.ctx.command.cmd}"`,
       );
       this.dispatch(conn, entry.ctx);
+    }
+    // Withheld entries keep their LIVE grace timers, so they must stay in the
+    // map: the timer alone would still reject the caller, but dropping the entry
+    // here would put it out of reach of a later resume (the original tab
+    // reclaiming its key inside the grace) and of dropQueuedDeliveries/stop(),
+    // which cancel parked reads by walking this map.
+    if (withheld.length > 0) {
+      const reparked = this.awaitingReconnect.get(tabId);
+      this.awaitingReconnect.set(tabId, reparked ? [...reparked, ...withheld] : withheld);
     }
   }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1286,34 +1286,26 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   // Two ledgers said read; the one that writes the message said mutation.
   //
   // THE CONSEQUENCE, written down because it is NOT free and a reviewer should
-  // not have to reconstruct it. Membership here also makes a command eligible
-  // for handleMidCommandDisconnect's park-and-resume, and that resume keys on
-  // `ctx.tabId` ALONE: `resumeAwaitingReconnect` looks up `conns.get(tabId)` and
-  // re-dispatches, without consulting the connection's incarnation.
+  // not have to reconstruct it. Membership here also makes a command eligible for
+  // handleMidCommandDisconnect's park-and-resume — and that resume used to key on
+  // `ctx.tabId` ALONE, so a route key that RECURS (#486: "same key is not the same
+  // tab") could hand a parked read to whichever tab happened to hold the key at
+  // resume time. #2761 closed that at both resume sites, which now refuse on PROOF
+  // of a takeover (see `isProvenDifferentTab`). A wrong-tab SERIALIZE — worse than
+  // a wrong-tab picture, because it drives edits — no longer resolves the departed
+  // caller's promise.
   //
-  // A route key RECURS. The hello handler says so itself (#486): "a `wf:` route
-  // key recurs, so a DIFFERENT tab opening the same saved workflow takes it
-  // over … Same key is not the same tab; only the same incarnation coming back
-  // is a proven return." It fires `onTabTakenOver` on exactly that, so the
-  // bridge already knows how to tell an occupant change from a reconnect — the
-  // resume path just does not ask. A parked read can therefore be handed to the
-  // stranger and its reply resolve the departed caller's promise.
+  // What remains, deliberately, is the UNPROVEN case. A panel whose lock manager
+  // refuses or is unreadable (#2104) omits `tab_session_id`, so neither side is
+  // evidence of anything; refusing there would turn working park/resume into an
+  // unconditional failure for those installs. So adding a command to this set
+  // still accepts a residual, unprovable wrong-tab risk in exchange for surviving
+  // a reconnect.
   //
-  // That hole is the SET'S and predates this entry: the park branch is gated on
-  // `!ctx.mutating`, so graph_serialize, graph_outline, graph_query,
-  // graph_get_errors and graph_view_selected have all resumed this way for as
-  // long as they have been listed — and a wrong-tab SERIALIZE is worse than a
-  // wrong-tab picture, because it drives edits. Fixing it means teaching the
-  // resume the incarnation rule without breaking panels that legitimately have
-  // no proven identity (#2104: a refused or unreadable lock manager omits
-  // `tab_session_id`, so every reconnect looks like a new occupant). That is its
-  // own change, with its own blast radius, and is tracked in #2761.
-  //
-  // So this entry takes the half it needs and declines the half it does not: the
-  // panel_screenshot call site passes `maxReconnectRetries: 0`, which keeps the
-  // command out of the park branch entirely. A screenshot that drops mid-capture
-  // fails honestly and is free to re-ask; it is never answered with a picture of
-  // someone else's canvas.
+  // This entry declines even that: the panel_screenshot call site passes
+  // `maxReconnectRetries: 0`, which keeps the command out of the park branch
+  // entirely. A screenshot that drops mid-capture fails honestly and is free to
+  // re-ask, so there is nothing worth buying with the risk.
   "graph_screenshot",
   "graph_prompt_director_audit",
   "graph_query",


### PR DESCRIPTION
Fixes #2761.

`UiBridge` parked an idempotent read on a mid-command socket drop and resumed it keyed on `ctx.tabId` **alone**. A `wf:` route key RECURS (#486) — a different browser tab opening the same saved workflow takes it over — so the connection holding the key at resume time need not be the tab that issued the read. It was handed the parked command anyway, and its reply resolved the departed caller's promise. A wrong-tab `graph_serialize` or `graph_outline` returns another workflow's graph, and an agent then edits against it.

Surfaced by the review gate on #2760, which declined the exposure for its own call site with `maxReconnectRetries: 0` and deliberately left the general defect.

## Both sites, because they are reached by different orderings

- `resumeAwaitingReconnect` — the stranger hellos *after* the read is parked.
- `handleMidCommandDisconnect`'s already-reconnected fast path — the stranger's hello beat the dead socket's close handler, so the read is **never parked at all** and is re-dispatched straight onto the live socket.

## I did not implement the shape the issue prescribed — please check this part

#2761 proposed refusing only a **provable** takeover (both sides carry a `tab_session_id` and they differ) and preserving today's behaviour when either side is anonymous. I built that first. **The gate called it a P1 and it was right**: two unproven identities never "provably differ", so an anonymous tab could still be handed another tab's read.

The issue's reason for sparing that case is a factual premise, and **the panel source contradicts it**. `createTabRouteIdentity` (panel `web/js/lib/bridge-route.js`) has three outcomes, and *two of them send an id*:

- an exclusive Web Locks lease;
- where `navigator.locks` does not exist (plain `http://` on a LAN), a never-persisted **per-page-load** id;
- a lease another tab actively holds → the panel **refuses to route at all** rather than hello anonymously.

So a current panel that is talking to us has always proved something. The anonymous population is old builds — and old builds are exactly who `tabConnectionIdentity` already fails closed on, "rather than fabricating graph-tool readiness".

With the premise gone, the rule inverts to **positive proof**: resume only onto a connection carrying the same `tab_session_id` the read was issued to. That makes three adjacent decisions agree rather than two — this, the #486 hello handler (a differing anonymous incarnation *is* a takeover), and the panel's own statement of this exact trade: *"Losing a resume is recoverable; delivering a command to the wrong canvas is not."*

## The price, stated rather than buried

A client that advertises no identity can never prove a return, so **park-and-resume no longer does anything for it**. Rather than let it stall for the full 4 s grace on a wait with no reachable success, an unproven read is not parked at all: it fails immediately, names the reason, and says that updating the panel restores automatic resume.

This is a real behaviour change for old panels — a mid-command drop that used to recover silently now fails loudly. It is the deliberate side of the trade, and the one every adjacent site in this codebase already takes. If you'd rather keep the weaker rule, the predicate is a single function and the mutation table below tells you exactly which tests would need to change.

Seven pre-existing park/resume fixtures connected without a `tab_session_id`, so they were modelling a client no current build produces. They now carry one; the anonymous path has its own tests asserting the refusal, so coverage moved rather than shrank.

## Verification

9 new tests. **Each guard proven by deleting it and watching exactly the right tests fail:**

| mutation | result |
|---|---|
| disable the `resumeAwaitingReconnect` guard | 3 fail; fast-path test still passes |
| disable the fast-path guard | 1 fails; other 8 pass |
| let unproven reads park again | 1 fails (on the timing assertion — it stalls 4 s instead of failing) |
| revert to the weaker "refuse only a provable takeover" rule | **2 fail** |

That last row is the one worth noting. The first time I ran it, **the entire suite stayed green** — the two anonymous tests are answered by the never-park short circuit before the predicate is ever consulted, so they were not pinning the decision they were written to defend. The predicate's unproven behaviour is only observable with a *second* client present, so I added those two cases (an unproven read dropping while another anonymous client is already live; a proven read whose key is taken by an anonymous occupant). They are the gate's exact P1.

The primary assertion throughout is that the stranger is **never asked**, not merely that the caller rejects — asserting only on the rejection would pass against a "fix" that dispatched to B and discarded the answer, having already read B's canvas.

- `npx vitest run` — 762/763 files, **14069 passed**.
- The one failure, `panel-image-relay.test.ts > carries one deadline through the bridge…`, is **pre-existing and unrelated**: it injects a *stub* bridge and never constructs `UiBridge`, `panel-image-relay.ts` does not reference `ui-bridge` at all, it passes 45/45 in isolation, and it fails identically with my diff fully reverted (control run on the same tree and the same `node_modules`). It is a 50 ms-deadline-vs-75 ms-sleep wall-clock race under load.
- `npm test` — 13/14 green; its concurrent `vitest` step reports that same flake.
- Dependencies installed with `npm ci` **in this worktree**: the parent checkout is 872 commits behind `origin/main` with a different `package.json`, so borrowing its `node_modules` would have been a fake result in either direction.
- Independent gate (codex): **SHIP** on `e2a14bf`, after a NO-SHIP on the first shape.

**Reachability, not just green:** the shipping panel stamps `tab_session_id` on every hello (`session-rebind.js` on panel `origin/main`), so the guard is live rather than dormant. Production readers (`graph_serialize` etc. via `ctx.call`) use the default reconnect budget of 1 and therefore do park; only `panel_screenshot` opts out with `maxReconnectRetries: 0`.

**Not done:** no panel-side change, and no Playwright run — this is orchestrator/bridge-side only and renders nothing in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
