### PR TITLE
chore: release v0.52.179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.179] - 2026-09-02
+
 ### MCP
 
 #### Fixed
-- **the UI→API converter no longer shifts widgets past a `forceInput`-only input (#2753).**
+- **the UI→API converter no longer shifts widgets past a `forceInput`-only input (#2753, #2755).**
   A `["STRING", {forceInput: true}]` input is a socket on canvas, so ComfyUI writes no
   `widgets_values` slot for it; the converter classified it as a widget, consumed the first
   saved value, and reported every real widget with its neighbour's value — `get_workflow`
@@ -20,6 +22,14 @@ All notable changes to this project are documented here. This project adheres to
   The deprecated `defaultInput` spelling is honoured the way the frontend migrates it:
   socket-only on an OPTIONAL input, widget kept on a REQUIRED one.
 - **`apply_manifest` now tracks Manager v4 custom-node enqueues that return an empty success body (#2725, #2749).** Already-enabled packs are satisfied without a duplicate enqueue, and an unverified empty-ack outcome remains pending instead of authorizing a speculative fallback.
+
+- a parked read resumes only for a tab that PROVES it is the one that issued it (#2769)
+- qwen-txt2img examples start 16-channel, matching the official Qwen Image template (#2767)
+- the tunnel/pairing listener reads the handshake Origin it was throwing away (#2766)
+- a 404 on both queue routes is not evidence that ComfyUI-Manager is missing (#2762)
+- a screenshot is a READ — stop calling its timeout a mutation, and give it the bounded read budget (#2760)
+- a pack workflow miss must not advertise the pack it just refused (#2750)
+
 
 ## [0.52.178] - 2026-09-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.178",
+  "version": "0.52.179",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.178",
+      "version": "0.52.179",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.178",
+  "version": "0.52.179",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.52.179 from merge 37b8e37fcf4718ccfcbb587a2dfd73c54fcb3135. Version witnesses and changelog are updated; check-changelog passes. This release includes the merged Manager v4 apply_manifest fix and subsequent validated fixes. No init.py/apps_routes.py changes.