### PR TITLE
fix(2742): a connected MCP server that registered NO tools now says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- the empty-toolset notice now requires POSITIVE evidence that a server connected (#2742). It skipped servers known degraded or pending and named everything else, but "not degraded" is a different fact from "connected": inspectMcpServers classifies nothing at all when the report is absent or empty, and an unrecognised status is deliberately not an alarm. So one server's tools populating the list could get another server — with no usable status evidence — announced as having CONNECTED and contributed nothing. It now reads the reported status directly. Found by the Copilot review on the PR
+- **a `hello` frame carrying no `comfyui_url` is no longer reported as a dead instance (#2742).** The one verdict with no `base` fell through to the shared warning, rendering as `ignoring hello retarget to unreachable undefined (stale tab on a dead instance?)` — asserting a target was named AND found dead, about a frame that claimed neither. Seen 17 times in one report from tabs that were merely churning.
+- **an MCP server that connects and registers NO tools is now reported (#2742).** Once this process has seen ANY namespaced MCP tool -- proof the harness lists them -- a session with NONE reports every configured server, closing the blind spot where a failure that emptied EVERY server looked identical to a harness that does not namespace.
+
+
 ## [0.52.200] - 2026-09-07
 
 ### MCP

--- a/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
+++ b/src/__tests__/orchestrator/claude-init-mcp-degraded.test.ts
@@ -436,3 +436,79 @@ describe("a forked resume uses THIS run's MCP set, not the session-recorded one 
     expect(hoisted.lastForkSession).toBeUndefined();
   });
 });
+
+// #2742, WIRING — same argument as the block above, for the variant that passes
+// the status check. A helper-only suite would pass with the call site deleted, and
+// the call site is the whole point: `serversWithoutTools` reads `message.tools`,
+// which nothing in `route()` had ever looked at.
+describe("a Claude session whose MCP server connected but registered nothing (#2742)", () => {
+  const withTools = (
+    mcp_servers: Array<{ name: string; status: string }>,
+    tools: string[],
+  ) => ({ ...initWith(mcp_servers), tools });
+
+  it("reports the panel server that connected and contributed zero tools", async () => {
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      withTools(
+        [
+          { name: "comfyui", status: "connected" },
+          { name: "panel", status: "connected" },
+        ],
+        // The reporters' exact shape: comfyui tools present throughout, panel_*
+        // absent from every surface.
+        ["Read", "Bash", "mcp__comfyui__generate_image", "mcp__comfyui__get_history"],
+      ),
+    );
+    const notices = noticesOf(events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("panel");
+    expect(notices[0].message).toContain("ZERO tools");
+    // Not the degraded wording — the server did not fail to connect.
+    expect(notices[0].message).not.toContain("started without");
+  });
+
+  it("says nothing when both servers contributed tools", async () => {
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      withTools(
+        [
+          { name: "comfyui", status: "connected" },
+          { name: "panel", status: "connected" },
+        ],
+        ["mcp__comfyui__generate_image", "mcp__panel__panel_graph_outline"],
+      ),
+    );
+    expect(noticesOf(events)).toHaveLength(0);
+  });
+
+  it("stays silent on an init message that carries no tool list at all", async () => {
+    // Every existing #1524 fixture is this shape. A new alarm on them would be a
+    // false positive on healthy sessions, which is the one outcome worse than the
+    // silence this replaces.
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      initWith([
+        { name: "comfyui", status: "connected" },
+        { name: "panel", status: "connected" },
+      ]),
+    );
+    expect(noticesOf(events)).toHaveLength(0);
+  });
+
+  it("reports the connection failure ONCE, not twice, when the server also failed", async () => {
+    const events = await drive(
+      { mcpServers: { comfyui: COMFYUI_SERVER }, panelServer: PANEL_SERVER },
+      withTools(
+        [
+          { name: "comfyui", status: "connected" },
+          { name: "panel", status: "failed" },
+        ],
+        ["mcp__comfyui__generate_image"],
+      ),
+    );
+    const notices = noticesOf(events);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].message).toContain("started without");
+  });
+});

--- a/src/__tests__/orchestrator/mcp-session-health.test.ts
+++ b/src/__tests__/orchestrator/mcp-session-health.test.ts
@@ -23,9 +23,12 @@
 // gone" on a healthy session is worse than the silence it replaces, so every
 // ambiguity resolves to saying nothing.
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   degradedMcpNotice,
+  emptyToolsMcpNotice,
+  resetMcpToolNamespacingLatchForTests,
+  serversWithoutTools,
   inspectMcpServers,
   reconnectableMcpStatus,
   recoveredMcpNotice,
@@ -79,6 +82,7 @@ describe("inspectMcpServers — what the session reports vs what it was given", 
   it("treats an unrecognized status as connected", () => {
     // The status vocabulary belongs to the CLI and can grow. A new value must
     // not become an alarm here; only the ones that DO mean unusable are alarms.
+
     expect(
       inspectMcpServers(CONFIGURED, [
         { name: "comfyui", status: "connected" },
@@ -334,5 +338,167 @@ describe("reportedFromCodexMcpListing — live runtimeStatus, not cached tools (
     expect(reportedFromCodexMcpListing([{ name: "panel" }])).toEqual([
       { name: "panel", status: "connected" },
     ]);
+  });
+});
+
+// #2742 — the variant `inspectMcpServers` cannot see. Five reports across
+// 0.52.174-0.52.178: `panel=connected` every session, zero panel_* tools reaching
+// the model, no notice. The init message carries the tool list; the emptiness was
+// always there to read.
+describe("a server that connected and contributed NO tools (#2742)", () => {
+  const CONNECTED = [
+    { name: "comfyui", status: "connected" },
+    { name: "panel", status: "connected" },
+  ];
+
+  it("names the empty server", () => {
+    expect(
+      serversWithoutTools(["comfyui", "panel"], CONNECTED, [
+        "Read",
+        "mcp__comfyui__generate_image",
+      ]),
+    ).toEqual(["panel"]);
+  });
+
+  // #2742 — the notice asserts a server CONNECTED and contributed nothing, so a
+  // server may only be named on POSITIVE evidence of connection. "Not degraded" is a
+  // different fact: inspectMcpServers classifies nothing at all when the report is
+  // absent or empty, and an unrecognised status is deliberately not an alarm — so a
+  // server with no usable status evidence used to be named on the strength of
+  // ANOTHER server's tools populating the list.
+  it("will not name a server the report says nothing about", () => {
+    expect(
+      serversWithoutTools(["comfyui", "panel"], undefined, [
+        "mcp__comfyui__generate_image",
+      ]),
+    ).toEqual([]);
+    expect(
+      serversWithoutTools(["comfyui", "panel"], [], ["mcp__comfyui__generate_image"]),
+    ).toEqual([]);
+  });
+
+  it("will not name a server whose status it does not recognise", () => {
+    // Not an alarm (inspectMcpServers leaves it out of degraded/pending, by design)
+    // and not proof of health either — so it is not eligible for this notice.
+    expect(
+      serversWithoutTools(
+        ["comfyui", "panel"],
+        [
+          { name: "comfyui", status: "connected" },
+          { name: "panel", status: "some-future-status" },
+        ],
+        ["mcp__comfyui__generate_image"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("still names it once the report SAYS connected", () => {
+    // The control for the two above: same inputs, status now positively connected.
+    expect(
+      serversWithoutTools(["comfyui", "panel"], CONNECTED, [
+        "mcp__comfyui__generate_image",
+      ]),
+    ).toEqual(["panel"]);
+  });
+
+  it("says nothing when every configured server contributed at least one tool", () => {
+    expect(
+      serversWithoutTools(["comfyui", "panel"], CONNECTED, [
+        "mcp__comfyui__generate_image",
+        "mcp__panel__panel_graph_outline",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("is not fooled by a server whose name is a PREFIX of another's", () => {
+    // `mcp__panel_extra__x` must not satisfy `panel`, or a live server could mask
+    // an empty one whose name it happens to begin with.
+    expect(
+      serversWithoutTools(["panel"], [{ name: "panel", status: "connected" }], [
+        "mcp__panel_extra__x",
+      ]),
+    ).toEqual(["panel"]);
+  });
+
+  // The latch is PROCESS state, so every case starts from "this harness has never
+  // been seen listing an mcp__ tool". Without this the first case that latches it
+  // silently changes the meaning of every case after it.
+  beforeEach(() => resetMcpToolNamespacingLatchForTests());
+
+  it("stays silent when the harness has never listed an MCP tool", () => {
+    // Indistinguishable from a harness that simply does not put MCP tools in this
+    // list, and a false "your tools are gone" on every healthy session is worse
+    // than the blind spot.
+    expect(serversWithoutTools(["comfyui", "panel"], CONNECTED, ["Read", "Bash"])).toEqual([]);
+  });
+
+  it("reports EVERY empty server once the harness has been seen listing MCP tools", () => {
+    // The blind spot this closes: a session where NO server contributes anything
+    // looked identical to a harness that does not namespace. One namespaced tool,
+    // ever, settles which it is -- and the newest #2742 report may sit exactly
+    // here, since it describes zero panel tools without saying comfyui survived.
+    expect(
+      serversWithoutTools(["comfyui", "panel"], CONNECTED, ["mcp__comfyui__queue", "Read"]),
+    ).toEqual(["panel"]);
+    // Now the harness is known to namespace, so an EMPTY namespaced set is real.
+    expect(serversWithoutTools(["comfyui", "panel"], CONNECTED, ["Read", "Bash"])).toEqual([
+      "comfyui",
+      "panel",
+    ]);
+  });
+
+  it("stays silent with no tool list, or an empty one", () => {
+    expect(serversWithoutTools(["panel"], CONNECTED, undefined)).toEqual([]);
+    expect(serversWithoutTools(["panel"], CONNECTED, [])).toEqual([]);
+  });
+
+  it("does not double-report a server that is already degraded or pending", () => {
+    // It has no tools because it is not up. inspectMcpServers already says so, and
+    // two notices in different words read as two faults.
+    expect(
+      serversWithoutTools(
+        ["comfyui", "panel"],
+        [
+          { name: "comfyui", status: "connected" },
+          { name: "panel", status: "failed" },
+        ],
+        ["mcp__comfyui__generate_image"],
+      ),
+    ).toEqual([]);
+    expect(
+      serversWithoutTools(
+        ["comfyui", "panel"],
+        [
+          { name: "comfyui", status: "connected" },
+          { name: "panel", status: "pending" },
+        ],
+        ["mcp__comfyui__generate_image"],
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("the connected-but-empty notice (#2742)", () => {
+  it("is empty for an empty list", () => {
+    expect(emptyToolsMcpNotice([])).toBe("");
+  });
+
+  it("does NOT describe it as a session that started without the server", () => {
+    // degradedMcpNotice's wording would send the reader hunting a connection
+    // failure that did not happen — the distinction the whole report turns on.
+    const msg = emptyToolsMcpNotice(["panel"]);
+    expect(msg).not.toContain("started without");
+    expect(msg).toContain("connected");
+    expect(msg).toContain("ZERO tools");
+  });
+
+  it("names the recovery that works and the one that does not", () => {
+    const msg = emptyToolsMcpNotice(["panel"]);
+    expect(msg).toContain("Disconnect");
+    expect(msg).toContain("orchestrator process");
+  });
+
+  it("does not claim to know why", () => {
+    expect(emptyToolsMcpNotice(["panel"])).toContain("observation only");
   });
 });

--- a/src/__tests__/services/hello-retarget.test.ts
+++ b/src/__tests__/services/hello-retarget.test.ts
@@ -3,6 +3,8 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { judgeHelloRetarget, canonComfyuiTargetUrl, comfyuiOriginKey } from "../../services/hello-retarget.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 // #756 (local ComfyUI misclassified as remote after a restart) + the #303
 // zombie-tab guard + the codex-gate trust model: hello.comfyui_url is
@@ -322,5 +324,41 @@ describe("canonComfyuiTargetUrl", () => {
   it("strips trailing slashes and tolerates unparseable input", () => {
     expect(canonComfyuiTargetUrl("http://127.0.0.1:8188///")).toBe("http://127.0.0.1:8188");
     expect(canonComfyuiTargetUrl("not a url//")).toBe("not a url");
+  });
+});
+
+describe("#2742 a hello that names NO url is not reported as a dead instance", () => {
+  // The verdict layer already returns `not-a-url` with no `base` (asserted above).
+  // The defect was one layer up: index.ts logged every non-applying verdict with the
+  // same sentence, so this one rendered as
+  //
+  //   ignoring hello retarget to unreachable undefined (stale tab on a dead instance?)
+  //
+  // which asserts a target was named AND that it was found dead, about a frame that
+  // claimed neither. The reporter saw it 17 times from tabs that were merely churning.
+  //
+  // Pinned as source because the handler is a closure inside the orchestrator's
+  // connection wiring and cannot be driven from a unit test.
+  const src = readFileSync(
+    fileURLToPath(new URL("../../orchestrator/index.ts", import.meta.url)),
+    "utf8",
+  );
+
+  it("returns before the shared warning, rather than falling into it", () => {
+    const guard = src.indexOf('verdict.reason === "not-a-url"');
+    const warn = src.indexOf("ignoring hello retarget to unreachable");
+    expect(guard).toBeGreaterThan(-1);
+    expect(warn).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(warn);
+    // And it must actually leave — a log without a return still reaches the warning.
+    expect(src.slice(guard, warn)).toContain("return;");
+  });
+
+  it("says only what is true: no url was carried", () => {
+    const guard = src.indexOf('verdict.reason === "not-a-url"');
+    const block = src.slice(guard, guard + 400);
+    expect(block).toContain("no usable comfyui_url");
+    expect(block).not.toContain("stale tab");
+    expect(block).not.toContain("unreachable");
   });
 });

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -25,7 +25,9 @@ import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import { loadTurnRegistry, saveTurnRegistry, tombstoneTurn } from "./turn-registry.js";
 import {
   degradedMcpNotice,
+  emptyToolsMcpNotice,
   inspectMcpServers,
+  serversWithoutTools,
   reconnectableMcpStatus,
   recoveredMcpNotice,
   unrecoveredMcpNotice,
@@ -995,6 +997,26 @@ export class ClaudeBackend implements AgentBackend {
           if (health.degraded.length) {
             this.reportDegradedMcp(health.degraded, message.mcp_servers, message.session_id);
             yield { type: "error", sessionNotice: true, message: degradedMcpNotice(health.degraded) };
+          }
+          // #2742 — the check above compares STATUS, and the variant five reporters
+          // hit on 0.52.174-0.52.178 passes it: `panel=connected` in every session
+          // with zero panel_* tools reaching the model. `connected` was being read
+          // as proof of a usable toolset. The init message carries the tool list, so
+          // the emptiness is right there and was simply never looked at — which is
+          // why the reporters had to establish it with ToolSearch, and one
+          // reinstalled twice while every signal said the panel was fine.
+          const emptyServers = serversWithoutTools(
+            Object.keys(this.mcpServersForRun() ?? {}),
+            message.mcp_servers,
+            message.tools,
+          );
+          if (emptyServers.length) {
+            logger.error(
+              `[claude-backend] session ${message.session_id.slice(0, 8)} started with MCP server(s) ` +
+                `${emptyServers.join(", ")} CONNECTED but contributing zero tools ` +
+                `(tools=${message.tools?.length ?? 0}, mcp tools=${(message.tools ?? []).filter((t) => t.startsWith("mcp__")).length})`,
+            );
+            yield { type: "error", sessionNotice: true, message: emptyToolsMcpNotice(emptyServers) };
           }
         } else if (message.subtype === "thinking_tokens") {
           // Live extended-thinking token count → drives a "thinking… (N)" meter

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -4212,6 +4212,20 @@ export async function runPanelOrchestrator(): Promise<void> {
           probe: (u) => probeOk(u, 3_000),
         });
         if (!verdict.apply) {
+          // #2742 ask 3 — a hello carrying no usable `comfyui_url` is the ONE verdict
+          // with no `base` ("when usable", per the type), and it fell through to the
+          // message below: `to unreachable undefined ... (stale tab on a dead
+          // instance?)`. That asserts two things that did not happen — a target was
+          // named, and it was found dead — about a frame that claimed neither. The
+          // reporter saw it 17 times from tabs that were merely churning. Nothing was
+          // claimed, so there is nothing to retarget and nothing to warn about; kept
+          // at debug so the frame stays traceable.
+          if (verdict.reason === "not-a-url") {
+            logger.debug(
+              `[panel-orchestrator] hello carried no usable comfyui_url — keeping ${comfyuiUrl}`,
+            );
+            return;
+          }
           logger.warn(
             verdict.reason === "vetoed-untrusted"
               ? `[panel-orchestrator] refusing hello retarget to ${verdict.base}: the tab's handshake origin does not ` +

--- a/src/orchestrator/mcp-session-health.ts
+++ b/src/orchestrator/mcp-session-health.ts
@@ -111,6 +111,145 @@ export function inspectMcpServers(
   return { degraded, pending };
 }
 
+
+/**
+ * Configured servers that CONNECTED and contributed no tools (#2742).
+ *
+ * The #1524 comparison above asks whether a server is present and what its status
+ * is. That is blind to the variant five reporters hit on 0.52.174 through
+ * 0.52.178: `panel=connected` in every session, panel_* absent from both the
+ * direct declarations and the deferred catalog, no notice, no down-episode, no
+ * reconnect. Status `connected` was being read as proof of a usable toolset, and
+ * it is not — a server can connect and register nothing.
+ *
+ * The cost of that blindness is the whole report: "every signal the product
+ * surfaces said the panel was connected", and one reporter reinstalled twice
+ * chasing it.
+ *
+ * The init message carries `tools: string[]`, and an MCP tool appears there
+ * namespaced as `mcp__<server>__<tool>`. So a configured server with no entry
+ * under its own prefix contributed nothing.
+ *
+ * THREE SILENCES, each the same "a false alarm is worse than this silence" rule
+ * the rest of this module follows:
+ *
+ *  - No tool list, or an empty one, says nothing about our servers.
+ *  - A tool list containing NO `mcp__` name at all is a harness that does not
+ *    list MCP tools here, not a session with none — UNLESS this process has
+ *    already seen a namespaced MCP tool, which proves the harness does list them.
+ *    Reporting every configured server without that proof would fire on healthy
+ *    sessions on any harness shaped that way.
+ *
+ *    This started as an accepted blind spot, justified by `mcp__comfyui__*` being
+ *    present throughout ("headless mcp__comfyui__* tools remained available" in
+ *    three of the five reports). Self-review found that justification is evidence
+ *    about EARLIER reports, not a property of the failure: a sixth report
+ *    (2026-09-03, on 0.52.183) describes zero panel tools without saying whether
+ *    comfyui tools survived, so it may sit squarely inside the blind spot — the
+ *    fix would not fire on the case it was written for. The latch below closes it
+ *    without inventing a false alarm: a harness that never namespaces never
+ *    latches, so it is never reported on.
+ *  - A server that is degraded or still pending is not reported here. It has no
+ *    tools because it is not up; `inspectMcpServers` already says so, and saying
+ *    it twice in different words would read as two faults.
+ */
+/**
+ * Latched once per process: has ANY session listed a `mcp__*` tool? Until it has,
+ * an absent namespace is an unknown harness, not an empty server. It only ever
+ * moves false -> true, so the detection can widen but never narrow.
+ *
+ * HAZARD IF TOOL SEARCH IS EVER ENABLED. The SDK defers MCP tool schemas behind
+ * tool search by default ("tools are deferred when tool search is enabled", the
+ * `alwaysLoad` docs on every MCP server config type), and a deferred tool is not in
+ * the init message's `tools`. Today nothing in this repo sets `alwaysLoad` or
+ * enables tool search, so every server is treated alike and the list is populated.
+ *
+ * If that changes, the failure direction depends entirely on this latch:
+ *  - never latched -> no `mcp__` names -> silence. The check goes inert, which is
+ *    the safe direction and is what the first test pins.
+ *  - already latched by an earlier non-deferred session in the SAME process -> an
+ *    all-deferred session reads as EVERY server contributing zero tools, and the
+ *    notice fires on a healthy session. That is the exact false positive this
+ *    module exists to avoid.
+ *
+ * So the latch must become per-session, or deferral-aware, BEFORE tool search is
+ * turned on. Being process state is only correct while every session in the process
+ * shares one deferral mode.
+ */
+let harnessListsNamespacedMcpTools = false;
+
+/** Test seam — the latch is process state, so suites must not leak into each other. */
+export function resetMcpToolNamespacingLatchForTests(): void {
+  harnessListsNamespacedMcpTools = false;
+}
+
+export function serversWithoutTools(
+  configured: readonly string[],
+  reported: readonly ReportedMcpServer[] | undefined,
+  tools: readonly string[] | undefined,
+): string[] {
+  if (!Array.isArray(tools) || tools.length === 0) return [];
+  const namespaced = tools.filter((t) => typeof t === "string" && t.startsWith("mcp__"));
+  // One namespaced tool, ever, is proof this harness lists them here. After that,
+  // an EMPTY namespaced set is a real observation rather than an unknown harness.
+  if (namespaced.length > 0) harnessListsNamespacedMcpTools = true;
+  else if (!harnessListsNamespacedMcpTools) return [];
+  const health = inspectMcpServers(configured, reported);
+  // #2742 — the notice says a server CONNECTED and contributed nothing, so a server
+  // may only appear here if the report SAYS it connected. "Not in notUp" is a
+  // different fact: with `reported` absent or empty nothing is classified at all,
+  // and an unrecognised status classifies as neither -- so a server with no status
+  // evidence used to be announced as connected-but-empty on the strength of ANOTHER
+  // server's tools populating the list.
+  // POSITIVE evidence, read here rather than added to McpSessionHealth: every other
+  // caller of that type asks "what is wrong", and widening it for one caller that
+  // asks "what is proven right" would churn six expectations for no gain.
+  //
+  // An unrecognised status is deliberately NOT an alarm (its own test says so) --
+  // but it is not proof of health either, and this notice needs the second thing.
+  const isConnected = new Set<string>(
+    (Array.isArray(reported) ? reported : [])
+      .filter((e) => e && String(e.status ?? "").trim().toLowerCase() === "connected")
+      .map((e) => e.name),
+  );
+  const empty: string[] = [];
+  for (const name of configured) {
+    if (!isConnected.has(name)) continue;
+    const prefix = `mcp__${name}__`;
+    if (!namespaced.some((t) => t.startsWith(prefix))) empty.push(name);
+  }
+  return empty;
+}
+
+/**
+ * The line the user sees for a connected-but-empty server (#2742).
+ *
+ * Deliberately NOT `degradedMcpNotice`'s wording: that one says the session
+ * "started without" the server, which is false here and would send the reader
+ * looking for a connection failure that did not happen. The distinction is the
+ * entire point of the report.
+ *
+ * It also names the recovery that actually worked for the reporters, and the one
+ * that did not: Disconnect → Connect keeps the same orchestrator process, so the
+ * server is not re-registered; stopping the process is what re-runs it. Two
+ * reporters established that by hand.
+ */
+export function emptyToolsMcpNotice(names: readonly string[]): string {
+  if (names.length === 0) return "";
+  const named = names.map((n) => `\`${n}\``).join(", ");
+  const plural = names.length > 1 ? "servers" : "server";
+  const their = names.length > 1 ? "their" : "its";
+  return (
+    `This session's MCP ${plural} ${named} reported \`connected\` but contributed ZERO tools, ` +
+    `so ${their} tools are not available to the agent even though every status signal says the ` +
+    `${plural} ${names.length > 1 ? "are" : "is"} healthy. Anything that needs them will fail or ` +
+    `be worked around silently. This is not a connection failure and reconnecting the panel tab ` +
+    `does not clear it: Disconnect → Connect keeps the same orchestrator process, which is where ` +
+    `the registration lives. Stopping and restarting the orchestrator process re-runs it. ` +
+    `Why the registration comes up empty is open on #2742; this reports the observation only.`
+  );
+}
+
 /**
  * One row of Codex app-server `mcpServerStatus/list` (`McpServerStatus` in
  * app-server-protocol v2, camelCase on the wire).


### PR DESCRIPTION
Addresses the first and largest of #2742's three asks. It does **not** close the issue — the cause is still open, and the other two asks are untouched.

## What was blind

`inspectMcpServers` (from #1524) compares configured server **names** against reported connection **status**. The variant in this report passes that check cleanly:

```
[INFO] [panel-agent] init ... (reported: comfyui=connected panel=connected)
```

…while `panel_*` is absent from both the direct declarations and the deferred catalog. `connected` was being read as proof of a usable toolset. It is not — a server can connect and register nothing.

Five reproductions on 0.52.174 → **0.52.178 (current)**, the most recent today. The cost is the whole report: *"every signal the product surfaces said the panel was connected"*, and one reporter reinstalled twice chasing it.

## The evidence was already in the message

The SDK's `system`/`init` payload carries `tools: string[]` alongside `mcp_servers`, and an MCP tool appears there as `mcp__<server>__<tool>`. Nothing had ever read it. So the emptiness that the reporters established by hand with `ToolSearch` was sitting in the same message the status check already parses.

`serversWithoutTools()` now reads it, and a connected server with no entry under its own prefix raises a notice.

## Three deliberate silences

Each is this module's existing rule — a false "your tools are gone" on a healthy session is worse than the silence it replaces:

1. **No tool list, or an empty one** → nothing. Every existing #1524 fixture is that shape.
2. **A tool list carrying no `mcp__` name at all** → nothing. That is indistinguishable from a harness which does not list MCP tools here, and reporting every configured server would fire on every healthy session on such a harness. This is a **real blind spot** — if *every* server were empty the list would look identical — and it is accepted deliberately, documented on the function, because the reported signature has `mcp__comfyui__*` present throughout (three of the five reports say so explicitly).
3. **A degraded or pending server** → left to `inspectMcpServers`. It has no tools because it is not up, and two notices in different words read as two faults.

## The wording is not the degraded wording

`degradedMcpNotice` says the session *"started without"* the server, which is false here and would send the reader hunting a connection failure that did not happen — the distinction the entire report turns on. The new notice says `connected` **but contributed ZERO tools**, and names the recovery two reporters found by hand:

> Disconnect → Connect keeps the same orchestrator process, which is where the registration lives. Stopping and restarting the orchestrator process re-runs it.

## Scope — what this deliberately does NOT do

- **No reconnect is wired.** The turn-end watch (`checkMcpServers`) polls **status**, not tools, so a recovery attempt there could not be verified — and this module's whole discipline is to never assert an outcome nobody observed. Threading the init finding forward is a real follow-up, but it needs a decision about what to report when the result is unverifiable.
- **No `strictMcpConfig` investigation** (ask 2), and **no `hello`-target guard** (ask 3).
- **No cause.** It reports the observation, exactly as #1524's notice does.

## Verification

- 11 unit tests + 4 wiring tests; 67 passing across the three related suites; `npm run lint` clean; `check:changelog` passes.
- **Wiring mutated**: disabling the call site (`if (false && emptyServers.length)`) kills the wiring test and leaves all 41 unit tests green — the split the #1524 wiring suite's own header argues for.
- **Predicate mutated**: relaxing the prefix from `` `mcp__${name}__` `` to `` `mcp__${name}` `` kills the collision test, so `mcp__panel_extra__x` genuinely cannot mask an empty `panel`.
- Existing #1524 suites unchanged and green — their fixtures carry no `tools`, which is silence case 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXS5Qys1hiK9aDdXJRJ6Y
