### PR TITLE
fix(2446): normalize saved workflow filenames

### DIFF
--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -232,7 +232,7 @@ WRITE to the ComfyUI user library: persist a workflow, or capture/verify its pro
   Options: `action:"save"`, `action:"lock"`, `action:"verify_lock"`.
 </ParamField>
 <ParamField path="filename" type="string">
-  Workflow filename in the ComfyUI user library (e.g. 'my_workflow.json'). REQUIRED for every action. For action:"save" this OVERWRITES an existing file of the same name; for "lock"/"verify_lock" the lock is read/written as '&lt;filename&gt;.lock.json' alongside it.
+  Workflow filename in the ComfyUI user library (e.g. 'my_workflow.json'). REQUIRED for every action. A missing `.json` suffix is appended before use; extension case and forward-slash subfolders are preserved. The name must be a safe relative path. For action:"save" this OVERWRITES an existing file of the same canonical name; for "lock"/"verify_lock" the lock is read/written as '&lt;filename&gt;.lock.json' alongside it.
 </ParamField>
 <ParamField path="workflow" type="object">
   action:"save" (REQUIRED) — Workflow JSON to save. Web UI format (&#123; nodes: [], links: [] &#125;) is stored verbatim; API format (&#123; '1': &#123; class_type, inputs &#125; &#125;) is auto-converted to Web UI format (generated layout) so it stays openable in ComfyUI's canvas. Not validated against the server before saving.

--- a/src/__tests__/tools/workflow-library.test.ts
+++ b/src/__tests__/tools/workflow-library.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { DEAD_NAMES, TOOL_NAMES } from "../../tools/vocabulary.js";
+import { normalizeWorkflowFilename } from "../../services/workflow-filename.js";
 
 /**
  * The consolidated `get_workflow` (8 read actions) and `save_workflow` (3
@@ -360,6 +361,67 @@ describe("save_workflow actions call the same services with the same arguments",
     expect(text(res)).toContain("auto-converted to Web UI format");
   });
 
+  it('action:"save" appends `.json` and returns the canonical nested filename', async () => {
+    mocks.isUiFormat.mockReturnValue(true);
+    mocks.fetchApi.mockResolvedValueOnce({ ok: true, status: 200, statusText: "OK" });
+    const res = await save()({
+      action: "save",
+      filename: "VIDEO/My Clip",
+      workflow: UI_GRAPH,
+    });
+    expect(mocks.fetchApi).toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/VIDEO/My Clip.json")}`,
+      { method: "POST", body: JSON.stringify(UI_GRAPH) },
+    );
+    expect(text(res)).toContain('Workflow saved as "VIDEO/My Clip.json"');
+  });
+
+  it('preserves an existing `.JSON` suffix and its path spelling', async () => {
+    expect(normalizeWorkflowFilename("video/Clip.JSON")).toBe("video/Clip.JSON");
+    expect(normalizeWorkflowFilename("日本語/Clip.JSON")).toBe("日本語/Clip.JSON");
+    expect(normalizeWorkflowFilename("日本語/Clip")).toBe("日本語/Clip.json");
+    mocks.isUiFormat.mockReturnValue(true);
+    mocks.fetchApi.mockResolvedValueOnce({ ok: true, status: 200, statusText: "OK" });
+    await save()({ action: "save", filename: "video/Clip.JSON", workflow: UI_GRAPH });
+    expect(mocks.fetchApi).toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/video/Clip.JSON")}`,
+      { method: "POST", body: JSON.stringify(UI_GRAPH) },
+    );
+  });
+
+  it("normalizes lock and verify-lock filenames to the same workflow", async () => {
+    mocks.lockWorkflowAction.mockResolvedValueOnce({ content: [{ type: "text", text: "locked" }] });
+    await save()({ action: "lock", filename: "video/Clip" });
+    expect(mocks.lockWorkflowAction).toHaveBeenCalledWith("video/Clip.json");
+
+    mocks.verifyWorkflowLockAction.mockResolvedValueOnce({
+      content: [{ type: "text", text: "no drift" }],
+    });
+    await save()({ action: "verify_lock", filename: "video/Clip" });
+    expect(mocks.verifyWorkflowLockAction).toHaveBeenCalledWith("video/Clip.json");
+  });
+
+  it("rejects empty, absolute, traversal, and backslash paths before any write", async () => {
+    for (const filename of [
+      "",
+      "../escape",
+      "nested/../../escape",
+      "%2e%2e/escape",
+      "nested/%2E%2e/escape",
+      "%252e%252e/escape",
+      "nested%2fescape",
+      "nested%5Cescape",
+      "/absolute",
+      "C:/escape",
+      "nested\\escape",
+    ]) {
+      const res = await save()({ action: "save", filename, workflow: UI_GRAPH });
+      expect(res.isError, `filename ${JSON.stringify(filename)}`).toBe(true);
+      expect(text(res)).toMatch(/workflow filename/i);
+    }
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
+  });
+
   it('action:"lock" and action:"verify_lock" delegate to the lock bodies', async () => {
     mocks.lockWorkflowAction.mockResolvedValueOnce({ content: [{ type: "text", text: "locked" }] });
     await save()({ action: "lock", filename: "a.json" });
@@ -489,15 +551,11 @@ describe("per-action requiredness NAMES the missing field", () => {
     expect(text(res)).toContain("Workflow not found:  (404)");
   });
 
-  it("an explicitly empty `filename` still reaches the SAVE POST", async () => {
-    mocks.isUiFormat.mockReturnValue(true);
-    mocks.fetchApi.mockResolvedValueOnce({ ok: false, status: 400, statusText: "Bad Request", text: async () => "" });
+  it("rejects an explicitly empty save `filename` before reaching the userdata API", async () => {
     const res = await save()({ action: "save", filename: "", workflow: UI_GRAPH });
-    expect(mocks.fetchApi).toHaveBeenCalledWith(
-      `/api/userdata/${encodeURIComponent("workflows/")}`,
-      { method: "POST", body: JSON.stringify(UI_GRAPH) },
-    );
-    expect(text(res)).toContain("Failed to save workflow: 400");
+    expect(res.isError).toBe(true);
+    expect(text(res)).toMatch(/non-empty library-relative path/i);
+    expect(mocks.fetchApi).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/workflow-filename.ts
+++ b/src/services/workflow-filename.ts
@@ -1,0 +1,73 @@
+import { ValidationError } from "../utils/errors.js";
+
+const CONTROL_CHARS_RE = /[\x00-\x1f\x7f]/;
+const PERCENT_ESCAPE_RE = /%[0-9a-f]{2}/i;
+const ENCODED_SEPARATOR_RE = /%(?:2f|5c)/i;
+const MAX_PERCENT_DECODE_PASSES = 8;
+
+function decodeWorkflowFilenameForValidation(filename: string): string {
+  let decoded = filename;
+
+  for (let pass = 0; pass <= MAX_PERCENT_DECODE_PASSES; pass++) {
+    // ComfyUI's userdata route can decode the path after the request URL has
+    // already been decoded once by the HTTP framework. Inspect every layer so
+    // a caller cannot smuggle a separator through as `%252f`/`%255c`.
+    if (ENCODED_SEPARATOR_RE.test(decoded)) {
+      throw new ValidationError(
+        `Invalid workflow filename "${filename}": percent-encoded path separators are not allowed.`,
+      );
+    }
+    if (!PERCENT_ESCAPE_RE.test(decoded)) return decoded;
+
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      throw new ValidationError(
+        `Invalid workflow filename "${filename}": malformed percent-encoding is not allowed.`,
+      );
+    }
+    if (next === decoded) return decoded;
+    decoded = next;
+  }
+
+  throw new ValidationError(
+    `Invalid workflow filename "${filename}": too many layers of percent-encoding.`,
+  );
+}
+
+/**
+ * Return the canonical filename used by the ComfyUI workflow library.
+ *
+ * The library only exposes JSON workflows in its browser, recursive listing,
+ * and autoload paths. A caller may omit the extension, but the name sent to
+ * ComfyUI must still end in `.json`. The original spelling and case are kept
+ * so existing names such as `VIDEO/Clip.JSON` remain addressable.
+ */
+export function normalizeWorkflowFilename(filename: string): string {
+  if (typeof filename !== "string" || filename.trim().length === 0) {
+    throw new ValidationError("Workflow filename must be a non-empty library-relative path.");
+  }
+  const decoded = decodeWorkflowFilenameForValidation(filename);
+  if (CONTROL_CHARS_RE.test(decoded)) {
+    throw new ValidationError("Workflow filename must not contain control characters or NUL bytes.");
+  }
+  if (decoded.includes("\\")) {
+    throw new ValidationError(
+      `Invalid workflow filename "${filename}": use forward slashes, not backslashes.`,
+    );
+  }
+  if (decoded.startsWith("/") || /^[A-Za-z]:/.test(decoded) || decoded.includes(":")) {
+    throw new ValidationError(
+      `Invalid workflow filename "${filename}": it must be relative to ComfyUI's workflows directory.`,
+    );
+  }
+  const segments = decoded.split("/");
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    throw new ValidationError(
+      `Invalid workflow filename "${filename}": empty, ".", and ".." path segments are not allowed.`,
+    );
+  }
+
+  return filename.toLowerCase().endsWith(".json") ? filename : `${filename}.json`;
+}

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -36,6 +36,7 @@ import {
 import { convertToMermaid } from "../services/mermaid-converter.js";
 import { analyzeGraphHealth } from "../services/workflow-health.js";
 import { extractWorkflowFromImage } from "../services/image-management.js";
+import { normalizeWorkflowFilename } from "../services/workflow-filename.js";
 import { promptDirectorInspectAction } from "./prompt-director.js";
 import { lockWorkflowAction, verifyWorkflowLockAction } from "./workflow-lock.js";
 
@@ -500,7 +501,8 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         .optional()
         .describe(
           "Workflow filename in the ComfyUI user library (e.g. 'my_workflow.json'). REQUIRED for every action. " +
-            'For action:"save" this OVERWRITES an existing file of the same name; for "lock"/"verify_lock" the lock ' +
+            'A missing `.json` suffix is appended before use; extension case and forward-slash subfolders are preserved. ' +
+            'The name must be a safe relative path. For action:"save" this OVERWRITES an existing file of the same canonical name; for "lock"/"verify_lock" the lock ' +
             "is read/written as '<filename>.lock.json' alongside it.",
         ),
       workflow: z
@@ -513,8 +515,8 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
     async (args) => {
       try {
         // `filename` is required by all three actions but cannot be schema-required
-        // in a flat shape. ABSENCE only: `filename: ""` passed z.string() before and
-        // reached the userdata POST/GET, which answers for itself.
+        // in a flat shape. Check ABSENCE before the shared normalizer so the error
+        // can name the missing field; explicit values are then validated uniformly.
         if (args.filename === undefined) {
           throw new Error(
             `save_workflow action:"${args.action}" requires \`filename\` — the workflow library name to write.`,
@@ -527,12 +529,12 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
                 'save_workflow action:"save" requires `workflow` — the workflow JSON to write.',
               );
             }
-            return await saveWorkflowAction(args.filename, args.workflow);
+            return await saveWorkflowAction(normalizeWorkflowFilename(args.filename), args.workflow);
           }
           case "lock":
-            return await lockWorkflowAction(args.filename);
+            return await lockWorkflowAction(normalizeWorkflowFilename(args.filename));
           case "verify_lock":
-            return await verifyWorkflowLockAction(args.filename);
+            return await verifyWorkflowLockAction(normalizeWorkflowFilename(args.filename));
           default: {
             const exhaustive: never = args.action;
             throw new Error(


### PR DESCRIPTION
Fixes #2446

Root cause: save_workflow sent the caller filename verbatim, while the recursive workflow library and autoload paths only expose .json files. Bare workflow names are normalized to a canonical .json target before save, lock, and verify_lock; existing .json/.JSON case, nested forward-slash paths, and valid Unicode are preserved. The shared validator now inspects repeated percent-decoding layers and rejects encoded traversal, encoded separators, malformed encoding, absolute/drive/colon/control/dot paths before URL encoding. No init.py or apps_routes.py changes or network operations were introduced.

Validation: focused workflow-library, conversion, recursive-list, autoload, and lock suites passed (96/96), including encoded traversal/separator regressions. Build, TypeScript/lint, anti-slop, full npm test (763 files; 14,079 passed, 6 skipped), i18n, docs, vocabulary, unknown-collapse, asset, changelog, and related checks passed. npm audit still reports six pre-existing transitive vulnerabilities.