### PR TITLE
fix(2394): treat flattened Power Lora types as the same ordinary node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`panel_set_widget` creates a documented `lora_N` row on an ordinary Power Lora Loader inside a live subgraph (#2394).** Current panels flatten parentheses in the `graph_get_subgraph` "is not a subgraph" line, so a live `Power Lora Loader (rgthree)` was reported as `Power Lora Loader rgthree` and the identity-fenced ordinary write refused it as a type change. The two types are compared after that flatten; the write still fences the real unflattened type.
+
 ## [0.52.180] - 2026-09-03
 
 ### MCP

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -5131,6 +5131,108 @@ describe("definitive non-promoted read tolerates a parenthesised node type (#239
     ]);
   });
 
+  // Recurrence 2026-09-03: a current panel publishes node_identity on the
+  // ordinary pinpoint AND flattens parentheses in the graph_get_subgraph
+  // refusal (panel#1941). Strict string compare then refuses a live
+  // `Power Lora Loader (rgthree)` as if the type had changed.
+  it("writes an inside-subgraph rgthree lora_N row when the subgraph refusal flattened parentheses (#2394)", async () => {
+    const nodeIdentity = "node-incarnation:92:fresh";
+    const { isError, text, mutations, calls } = await setWidget(
+      { node_id: 92, widget: "lora_1", value: RGTHREE_VALUE },
+      {
+        ownerNodeId: 78,
+        startInSubgraph: true,
+        firstWrite: "ok",
+        nestedSubgraph: new Error("Node 92 (Power Lora Loader rgthree) is not a subgraph"),
+        promotedDetail: {
+          nodes: [
+            {
+              id: 92,
+              type: "Power Lora Loader (rgthree)",
+              is_subgraph: false,
+              node_identity: nodeIdentity,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(text).not.toMatch(/ordinary node type changed between the scope and subgraph reads/);
+    expect(text).not.toMatch(/could not determine whether the addressed node is a promoted container/);
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({
+        node_id: 92,
+        widget: "lora_1",
+        value: RGTHREE_VALUE,
+        expected_node_type: "Power Lora Loader (rgthree)",
+        expected_node_identity: nodeIdentity,
+      }),
+    ]);
+  });
+
+  it("writes an inside-subgraph rgthree lora_N row when identity is present and nested parens are kept (#2394)", async () => {
+    const nodeIdentity = "node-incarnation:92:fresh";
+    const { isError, mutations, calls } = await setWidget(
+      { node_id: 92, widget: "lora_1", value: RGTHREE_VALUE },
+      {
+        ownerNodeId: 78,
+        startInSubgraph: true,
+        firstWrite: "ok",
+        nestedSubgraph: new Error("Node 92 (Power Lora Loader (rgthree)) is not a subgraph"),
+        promotedDetail: {
+          nodes: [
+            {
+              id: 92,
+              type: "Power Lora Loader (rgthree)",
+              is_subgraph: false,
+              node_identity: nodeIdentity,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({
+        node_id: 92,
+        widget: "lora_1",
+        expected_node_type: "Power Lora Loader (rgthree)",
+        expected_node_identity: nodeIdentity,
+      }),
+    ]);
+  });
+
+  it("still refuses an inside-subgraph ordinary write when the node type actually changed (#2394)", async () => {
+    const { isError, text, mutations, calls } = await setWidget(
+      { node_id: 92, widget: "lora_1", value: RGTHREE_VALUE },
+      {
+        ownerNodeId: 78,
+        startInSubgraph: true,
+        firstWrite: "ok",
+        nestedSubgraph: new Error("Node 92 (KSampler) is not a subgraph"),
+        promotedDetail: {
+          nodes: [
+            {
+              id: 92,
+              type: "Power Lora Loader (rgthree)",
+              is_subgraph: false,
+              node_identity: "node-incarnation:92:fresh",
+            },
+          ],
+        },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/ordinary node type changed between the scope and subgraph reads/);
+    expect(mutations).toBe(0);
+    expect(calls.filter((c) => c.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
   // CONTROLS — these must hold BEFORE and AFTER the classifier change, or the two
   // pins above would be satisfied by simply authorizing every failed read.
   it("still refuses a genuinely indeterminate read", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7949,6 +7949,26 @@ function definitiveNonPromotedNodeType(res: ToolResult): string | null {
   return unwrapped || null;
 }
 
+/** Panel `graph_get_subgraph` flattens parentheses in the node type before
+ * embedding it in the definitive ordinary-node refusal (panel#1941), so a live
+ * `Power Lora Loader (rgthree)` is reported as `Power Lora Loader rgthree`.
+ * The scope probe still publishes the real type. Compare after that flatten;
+ * the write fence must keep the unflattened scope type (#2394). */
+function flattenDefinitiveOrdinaryNodeType(type: string): string {
+  return type.replace(/[()]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function sameDefinitiveOrdinaryNodeType(
+  fromSubgraphRead: string | null,
+  fromScopeProbe: string,
+): boolean {
+  if (!fromSubgraphRead) return false;
+  if (fromSubgraphRead === fromScopeProbe) return true;
+  const left = flattenDefinitiveOrdinaryNodeType(fromSubgraphRead);
+  const right = flattenDefinitiveOrdinaryNodeType(fromScopeProbe);
+  return left.length > 0 && left === right;
+}
+
 type PromotedSubgraphReadErrorKind = "definitive-ordinary" | "transient" | "permanent";
 
 /** The promoted-write refresh is deliberately narrower than the broad panel
@@ -8895,7 +8915,7 @@ async function preparePromotedWidgetWrite(
         // available.
         if (!targetScope.nodeIdentity) return null;
         const expectedNodeType = definitiveNonPromotedNodeType(sub);
-        if (expectedNodeType !== targetScope.nodeType) {
+        if (!sameDefinitiveOrdinaryNodeType(expectedNodeType, targetScope.nodeType)) {
           return promotedWriteRefusal(
             widget,
             "the ordinary node type changed between the scope and subgraph reads",


### PR DESCRIPTION
Fixes #2394

## What was still broken

PRs #2399/#2402 already allow documented `lora_N` JSON-object creation on a **root** Power Lora Loader. The 2026-09-03 recurrence is the **inside-subgraph ordinary-node** path:

`panel_set_widget` on a freshly added `Power Lora Loader (rgthree)` inside a live subgraph refused before dispatch:

> the ordinary node type changed between the scope and subgraph reads

That is not a real replacement. Current panels flatten parentheses in the `graph_get_subgraph` "is not a subgraph" line (panel#1941), so the scope probe's `Power Lora Loader (rgthree)` is reported as `Power Lora Loader rgthree`. The #2489 identity fence compared those strings strictly and over-classified the ordinary write.

#2393 (promoted vs root under-resolution) is a different failure. This patch does not loosen promoted-container mapping.

## Fix

Compare the subgraph-read type and the scope-probe type after the same parenthesis flatten. The write still fences the **unflattened** scope type (`expected_node_type: "Power Lora Loader (rgthree)"`).

A genuine type change (`Power Lora Loader (rgthree)` vs `KSampler`) still refuses.

## Tests

`src/__tests__/orchestrator/promoted-widget.test.ts`

- creates `lora_1` inside a subgraph when the refusal flattened parens
- still creates `lora_1` when nested parens are kept
- still refuses a real type change
- existing root + inside-subgraph #2394 pins remain

Targeted: **12 passed / 210 skipped**
Full file: **222 passed**
