### PR TITLE
fix(1539): refuse git URL node installs before Manager v4 queueing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 #### Fixed
 - **`panel_slice_workflow` seeds outputs inside nested overlapping groups (#2780).** Membership used the first containing box only, so a SaveImage inside both an outer group and a nested inner group was missed when slicing by the inner title. Any matching containing group now seeds, and a miss lists every containing title.
+- panel_search_nodes no longer returns a raw Git URL as an install `id`, and panel_install_node refuses Git URLs before Manager v4 queueing rather than sending an unlisted URL as a registry lookup (#1539)
 
 ## [0.52.182] - 2026-09-03
 
@@ -20,14 +21,12 @@ All notable changes to this project are documented here. This project adheres to
 - **`panel_save_workflow(name)` rebinds the session onto the Save-As dest canvas (#2768, #2805).** After a named save the live instance is dest, but the source tab id can still `canReach`; staying there left `panel_list_workflows` and `panel_set_workflow_target({mode:"current"})` stamped for the replaced instance. Dest is followed when this save replaced the session canvas, and dest's command stamp is refreshed from the save reply.
 - **`list_local_models` `action:"remove"` resolves against the same launch-proven extra-path files as inventory, including ComfyUI Desktop's `extra_models_config.yaml` (#2739, #2803).** Removal previously searched only the Desktop shared models yaml from argv, so a listed LTX file under another active extra root could not be deleted. Desktop extra roots are included only when the connected snapshot already named a Desktop extra-path config — never by probing a guessed :8188 origin — and still fail closed when that file cannot be proven unchanged since launch.
 
-
 ## [0.52.181] - 2026-09-03
 
 ### MCP
 
 #### Fixed
 - **`panel_set_widget` creates a documented `lora_N` row on an ordinary Power Lora Loader inside a live subgraph (#2394, #2794).** Current panels flatten parentheses in the `graph_get_subgraph` "is not a subgraph" line, so a live `Power Lora Loader (rgthree)` was reported as `Power Lora Loader rgthree` and the identity-fenced ordinary write refused it as a type change. The two types are compared after that flatten; the write still fences the real unflattened type.
-
 
 ## [0.52.180] - 2026-09-03
 

--- a/src/__tests__/orchestrator/install-node-ambiguous-name.test.ts
+++ b/src/__tests__/orchestrator/install-node-ambiguous-name.test.ts
@@ -34,8 +34,8 @@
 // the choice themselves and gets the collision named instead — which is also the escape
 // hatch from a stale snapshot, since a refusal a caller cannot get past would be a worse
 // tool than the hazard it prevents.
-import { describe, expect, it, vi } from "vitest";
-import { nodesInstallCommandArgs } from "../../services/node-management.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { nodesInstallCommandArgs, resetManagerApiCacheForTests } from "../../services/node-management.js";
 import {
   AMBIGUOUS_BARE_NAMES,
   ambiguousBareNameRefusal,
@@ -96,9 +96,13 @@ function installNodeDef() {
  * `if (conflict) return fail(conflict)` line at the call site passes every unit assertion
  * in this file and fails only here.
  */
+afterEach(() => resetManagerApiCacheForTests());
+
 async function attemptInstall(
   args: Record<string, unknown>,
+  dialect: "legacy" | "v2" | "v2-batch" = "legacy",
 ): Promise<{ sent: Record<string, unknown> | undefined; text: string; isError: boolean }> {
+  resetManagerApiCacheForTests(dialect);
   let sent: Record<string, unknown> | undefined;
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {

--- a/src/__tests__/orchestrator/install-node-git-expectation.test.ts
+++ b/src/__tests__/orchestrator/install-node-git-expectation.test.ts
@@ -60,8 +60,12 @@
 //
 // So the reply is not corrected by a refusal here. The REQUEST is corrected instead:
 // the git-URL route stops asking a channel nobody chose.
-import { describe, expect, it, vi } from "vitest";
-import { nodesInstallCommandArgs } from "../../services/node-management.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  nodesInstallCommandArgs,
+  resetManagerApiCacheForTests,
+  v4GitUrlQueueRefusal,
+} from "../../services/node-management.js";
 
 vi.mock("../../comfyui/client.js", () => ({
   getObjectInfo: vi.fn(),
@@ -91,9 +95,13 @@ function installNodeDef() {
  * deleting the `...cmdArgs` spread at the call site, or computing a note and never
  * appending it (#1129, which shipped once and never ran), fails here and nowhere else.
  */
+afterEach(() => resetManagerApiCacheForTests());
+
 async function dispatchInstall(
   args: Record<string, unknown>,
-): Promise<{ sent: Record<string, unknown>; text: string }> {
+  dialect: "legacy" | "v2" | "v2-batch" = "legacy",
+): Promise<{ sent: Record<string, unknown> | undefined; text: string; isError: boolean }> {
+  resetManagerApiCacheForTests(dialect);
   let sent: Record<string, unknown> | undefined;
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {
@@ -119,9 +127,20 @@ async function dispatchInstall(
   } as unknown as PanelToolCtx["bridge"];
   const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
   const res: ToolResult = await installNodeDef().handler(args as never, ctx);
-  expect(res.isError).not.toBe(true);
-  if (!sent) throw new Error("nodes_install was never dispatched");
-  return { sent, text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" ") };
+  return {
+    sent,
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+  };
+}
+
+async function dispatchLegacyInstall(
+  args: Record<string, unknown>,
+): Promise<{ sent: Record<string, unknown>; text: string }> {
+  const out = await dispatchInstall(args, "legacy");
+  expect(out.isError).not.toBe(true);
+  if (!out.sent) throw new Error("nodes_install was never dispatched");
+  return { sent: out.sent, text: out.text };
 }
 
 describe("legacy direct-URL normalization remains intact (#1539)", () => {
@@ -253,7 +272,7 @@ describe("legacy direct-URL normalization covers every git spelling (#1539)", ()
   });
 
   it("REACHES THE PANEL for the shorthand too, not just the args object", async () => {
-    const { sent } = await dispatchInstall({ id: "Wenaka2004/comfyui-anima-ipadapter" });
+    const { sent } = await dispatchLegacyInstall({ id: "Wenaka2004/comfyui-anima-ipadapter" });
     expect(sent.channel).toBe("default");
     expect(sent.repository).toBe(REPORTED_URL);
   });
@@ -418,7 +437,7 @@ describe("the FIRST attempt's wrong-author risk is disclosed too (#1539 gate rou
   });
 
   it("does not append the v4-only warning to a legacy-shaped response", async () => {
-    const cmd = await dispatchInstall({ repository: COLLIDING });
+    const cmd = await dispatchLegacyInstall({ repository: COLLIDING });
     expect(cmd.sent.channel).toBe("default");
     expect(cmd.text).not.toMatch(/NOT NECESSARILY THE URL YOU PASSED/i);
     expect(cmd.text).not.toMatch(/BlenderNeko\/ComfyUI_TiledKSampler you passed/);
@@ -427,22 +446,56 @@ describe("the FIRST attempt's wrong-author risk is disclosed too (#1539 gate rou
 
 describe("panel_install_node preserves legacy direct-URL dispatch normalization (#1539)", () => {
   it("sends channel 'default' to the panel for the reporter's request", async () => {
-    const { sent } = await dispatchInstall({ repository: REPORTED_URL });
+    const { sent } = await dispatchLegacyInstall({ repository: REPORTED_URL });
     expect(sent.cmd).toBe("nodes_install");
     expect(sent.repository).toBe(REPORTED_URL);
     expect(sent.channel).toBe("default");
   });
 
   it("relays an explicit channel unchanged", async () => {
-    const { sent } = await dispatchInstall({ repository: REPORTED_URL, channel: "dev" });
+    const { sent } = await dispatchLegacyInstall({ repository: REPORTED_URL, channel: "dev" });
     expect(sent.channel).toBe("dev");
   });
 
   it("does not append the v4-only channel disclosure to a legacy-shaped response", async () => {
-    const { sent, text } = await dispatchInstall({ repository: REPORTED_URL });
+    const { sent, text } = await dispatchLegacyInstall({ repository: REPORTED_URL });
     expect(sent.channel).toBe("default");
     expect(text).not.toMatch(/asked ComfyUI-Manager's "default" channel/i);
     expect(text).not.toMatch(/rules the pack out of "default" ONLY/);
+  });
+});
+
+describe("panel_install_node refuses Git URLs before Manager v4 queueing (#1539)", () => {
+  const REPORTER_SEARCH_ID = "https://github.com/Slimy-Comfy/Slimy_ImageComparer";
+
+  it("does not queue the reporter search id as a v4 registry lookup", async () => {
+    const out = await dispatchInstall({ id: REPORTER_SEARCH_ID }, "v2");
+    expect(out.isError).toBe(true);
+    expect(out.sent).toBeUndefined();
+    expect(out.text).toContain(v4GitUrlQueueRefusal(REPORTER_SEARCH_ID));
+    expect(out.text).toMatch(/install_custom_node\(source:'git'\)/);
+    expect(out.text).not.toMatch(/queued/i);
+  });
+
+  it("does not queue a repository URL on the v2 dialect either", async () => {
+    const out = await dispatchInstall({ repository: REPORTED_URL }, "v2");
+    expect(out.isError).toBe(true);
+    expect(out.sent).toBeUndefined();
+    expect(out.text).toMatch(/Refusing to queue/i);
+  });
+
+  it("still queues a registry id on v4", async () => {
+    const out = await dispatchInstall({ id: "comfyui-kjnodes" }, "v2");
+    expect(out.isError).not.toBe(true);
+    expect(out.sent?.cmd).toBe("nodes_install");
+    expect(out.sent?.id).toBe("comfyui-kjnodes");
+    expect(out.sent?.repository).toBeUndefined();
+  });
+
+  it("still queues a git URL on legacy Manager 3.x", async () => {
+    const out = await dispatchLegacyInstall({ id: REPORTER_SEARCH_ID });
+    expect(out.sent.cmd).toBe("nodes_install");
+    expect(out.sent.repository).toBe(REPORTER_SEARCH_ID);
   });
 });
 

--- a/src/__tests__/orchestrator/install-node-git-expectation.test.ts
+++ b/src/__tests__/orchestrator/install-node-git-expectation.test.ts
@@ -99,9 +99,13 @@ afterEach(() => resetManagerApiCacheForTests());
 
 async function dispatchInstall(
   args: Record<string, unknown>,
-  dialect: "legacy" | "v2" | "v2-batch" = "legacy",
+  dialect: "legacy" | "v2" | "v2-batch" | "unknown" = "legacy",
 ): Promise<{ sent: Record<string, unknown> | undefined; text: string; isError: boolean }> {
-  resetManagerApiCacheForTests(dialect);
+  // "unknown" primes NOTHING, so detectManagerApi has to probe — and with no
+  // Manager behind it, that probe fails. That is the shape this file needs to
+  // cover: dialect UNDETERMINED, which is not the same as dialect v4.
+  if (dialect === "unknown") resetManagerApiCacheForTests();
+  else resetManagerApiCacheForTests(dialect);
   let sent: Record<string, unknown> | undefined;
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {
@@ -142,6 +146,27 @@ async function dispatchLegacyInstall(
   if (!out.sent) throw new Error("nodes_install was never dispatched");
   return { sent: out.sent, text: out.text };
 }
+
+describe("the v4 git-URL refusal requires POSITIVE evidence of v4 (#1539)", () => {
+  it("does not refuse when the Manager dialect could not be determined", async () => {
+    // Regression: the guard first read `catch { api = "v2" }`, so ANY failure to
+    // reach the Manager was treated as proof of v4. That refused legacy 3.x
+    // `files:[url]` installs that still work, told the caller the wrong cause,
+    // and broke nine tests in the #1129 suite — which installs by `repository`
+    // and stubs no Manager at all. An unknown dialect is not evidence of v4.
+    const out = await dispatchInstall({ repository: REPORTED_URL }, "unknown");
+    expect(out.text).not.toContain("Refusing to queue");
+    expect(out.text).not.toContain(v4GitUrlQueueRefusal(REPORTED_URL));
+  });
+
+  it("still refuses once v4 is actually detected", async () => {
+    // The other direction, so the test above cannot be satisfied by deleting the
+    // guard outright.
+    const out = await dispatchInstall({ repository: REPORTED_URL }, "v2");
+    expect(out.isError).toBe(true);
+    expect(out.text).toContain("Refusing to queue");
+  });
+});
 
 describe("legacy direct-URL normalization remains intact (#1539)", () => {
   it("normalizes the reporter's URL for the legacy direct-URL route", () => {

--- a/src/__tests__/orchestrator/panel-manager-fetch-fail.test.ts
+++ b/src/__tests__/orchestrator/panel-manager-fetch-fail.test.ts
@@ -84,7 +84,7 @@ describe("panel_search_nodes (#2492 Manager transport Failed to fetch)", () => {
     };
     expect(body.count).toBe(1);
     expect(body.source).toBe("host_http");
-    expect(body.note).toBe(HOST_HTTP_SEARCH_NOTE);
+    expect(body.note).toContain(HOST_HTTP_SEARCH_NOTE);
   });
 
   it("names both causes when host mappings also fail, not a missing pack", async () => {

--- a/src/__tests__/services/manager-node-search.test.ts
+++ b/src/__tests__/services/manager-node-search.test.ts
@@ -10,7 +10,11 @@ import {
   isManagerMappingsServerError,
   isManagerTransportFetchFailure,
   managerMappingsOutageResult,
+  GIT_ONLY_SEARCH_NOTE,
+  gitMappingRepoName,
+  isRawGitUrlInstallId,
   parseNodeMappings,
+  sanitizeSearchInstallIds,
   searchNodesViaMappings,
   searchPanelNodes,
   setFetchMappingsForTests,
@@ -138,7 +142,8 @@ describe("searchNodesViaMappings (#1669)", () => {
       }),
     });
     expect(res.count).toBe(1);
-    expect(res.results[0]?.id).toContain("SolAttn");
+    expect(res.results[0]?.id).toBe("ComfyUI-SolAttn");
+    expect(res.results[0]?.id).not.toMatch(/^https?:\/\//i);
     expect(res.requested_mode).toBe("remote");
     expect(res.degraded_from).toBe("cache");
     expect(res.message).toMatch(/Manager outage/i);
@@ -232,6 +237,46 @@ describe("searchPanelNodes (#1669)", () => {
     });
     expect(out).toEqual({ via: "panel", value: panel });
   });
+
+  it("rewrites a panel hit whose id is the reporter GitHub URL (#1539)", async () => {
+    const url = "https://github.com/Slimy-Comfy/Slimy_ImageComparer";
+    const panel = {
+      count: 1,
+      results: [{ id: url, title: "ImageComparer", description: "compare images" }],
+    };
+    const out = await searchPanelNodes({
+      query: "ImageComparer",
+      panelSearch: async () => panel,
+      fetchMappings: async () => {
+        throw new Error("fallback must not run");
+      },
+    });
+    expect(out.via).toBe("panel");
+    if (out.via !== "panel") throw new Error("expected panel");
+    const value = out.value as {
+      results: Array<{ id: string; repository?: string; git?: true }>;
+      note?: string;
+    };
+    expect(value.results[0]?.id).toBe("Slimy_ImageComparer");
+    expect(isRawGitUrlInstallId(value.results[0]!.id)).toBe(false);
+    expect(value.results[0]?.repository).toBe(url);
+    expect(value.results[0]?.git).toBe(true);
+    expect(value.note).toBe(GIT_ONLY_SEARCH_NOTE);
+  });
+});
+
+describe("sanitizeSearchInstallIds (#1539)", () => {
+  it("rewrites Git URL ids inside a ToolResult JSON body", () => {
+    const url = "https://github.com/Slimy-Comfy/Slimy_ImageComparer";
+    const sanitized = sanitizeSearchInstallIds({
+      content: [{ type: "text", text: JSON.stringify({ count: 1, results: [{ id: url, title: "ImageComparer", description: "" }] }) }],
+    }) as { content: Array<{ text: string }> };
+    const body = JSON.parse(sanitized.content[0]!.text) as {
+      results: Array<{ id: string; git?: true }>;
+    };
+    expect(body.results[0]?.id).toBe(gitMappingRepoName(url));
+    expect(body.results[0]?.git).toBe(true);
+  });
 });
 
 describe("searchPanelNodes (#2492 transport Failed to fetch)", () => {
@@ -247,7 +292,7 @@ describe("searchPanelNodes (#2492 transport Failed to fetch)", () => {
     expect(out.via).toBe("fallback");
     if (out.via !== "fallback") throw new Error("expected fallback");
     expect(out.value.source).toBe("host_http");
-    expect(out.value.note).toBe(HOST_HTTP_SEARCH_NOTE);
+    expect(out.value.note).toContain(HOST_HTTP_SEARCH_NOTE);
     expect(out.value.note).toMatch(/not a Manager outage/i);
     expect(out.value.note).not.toMatch(/does not exist|not found/i);
     expect(out.value.manager_outage).toBeUndefined();
@@ -305,17 +350,53 @@ describe("searchPanelNodes (#2492 transport Failed to fetch)", () => {
 });
 
 describe("parseNodeMappings / outage copy", () => {
-  it("uses the repo-URL key as id, never the display title", () => {
+  it("does not return a raw Git URL as the install id (#1539)", () => {
     const res = parseNodeMappings(CATALOGUE, "SolAttn", 15);
-    expect(res.results[0]?.id).toBe("https://github.com/someone/ComfyUI-SolAttn");
+    expect(res.results[0]?.id).toBe("ComfyUI-SolAttn");
+    expect(res.results[0]?.id).not.toMatch(/^https?:\/\//i);
+    expect(res.results[0]?.repository).toBe("https://github.com/someone/ComfyUI-SolAttn");
+    expect(res.results[0]?.git).toBe(true);
     expect(res.results[0]?.title).toBe("SolAttn");
+    expect(res.note).toBe(GIT_ONLY_SEARCH_NOTE);
+  });
+
+  it("prefers a CNR id over the git mapping key", () => {
+    const res = parseNodeMappings(
+      {
+        "https://github.com/ltdrdata/ComfyUI-Impact-Pack": [
+          ["ImpactSomething"],
+          { id: "comfyui-impact-pack", title: "ComfyUI-Impact-Pack", description: "impact pack" },
+        ],
+      },
+      "impact",
+      15,
+    );
+    expect(res.results[0]?.id).toBe("comfyui-impact-pack");
+    expect(res.results[0]?.git).toBeUndefined();
+    expect(res.results[0]?.repository).toBe("https://github.com/ltdrdata/ComfyUI-Impact-Pack");
+  });
+
+  it("does not return the reporter's ImageComparer GitHub URL as id", () => {
+    const url = "https://github.com/Slimy-Comfy/Slimy_ImageComparer";
+    const res = parseNodeMappings(
+      {
+        [url]: [["ImageComparer"], { title: "Slimy Image Comparer", description: "compare images" }],
+      },
+      "ImageComparer",
+      15,
+    );
+    expect(res.count).toBe(1);
+    expect(res.results[0]?.id).toBe("Slimy_ImageComparer");
+    expect(isRawGitUrlInstallId(res.results[0]!.id)).toBe(false);
+    expect(res.results[0]?.repository).toBe(url);
+    expect(res.results[0]?.git).toBe(true);
   });
 
   it("matches a node CLASS name in the mappings first array", () => {
     // The reporter searched SolAttnPatch — a class_type, not a pack title.
     const res = parseNodeMappings(CATALOGUE, "SolAttnPatch", 15);
     expect(res.count).toBe(1);
-    expect(res.results[0]?.id).toContain("SolAttn");
+    expect(res.results[0]?.id).toBe("ComfyUI-SolAttn");
   });
 
   it("outage copy names Manager, not a missing pack", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -56,8 +56,12 @@ import { settleUntilStable } from "../services/vram-settle.js";
 import type { SettledRead } from "../services/vram-settle.js";
 import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
 import {
+  detectManagerApi,
   findPackOnDisk,
+  managerDialectQueuesGitUrlAsRegistryLookup,
   nodesInstallCommandArgs,
+  v4GitUrlQueueRefusal,
+  type ManagerApi,
 } from "../services/node-management.js";
 import {
   getModelInventoryDisclosure,
@@ -26576,7 +26580,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_search_nodes",
-      "Search installable custom-node packs via the user's BUILT-IN ComfyUI Manager (the same source the Manager UI uses). Returns matching packs {id, title, description}. Use the `id` with panel_install_node. Prefer this over the headless search_custom_nodes tool — it works against the user's actual (Desktop) Manager. If Manager's cache mappings endpoint returns HTTP 5xx, this retries remote/local and still searches; a remaining 5xx is a Manager outage, not proof the pack is missing. If the panel tab is live but the browser Manager request does not complete (Failed to fetch), the search is served from host Manager HTTP instead of dying as a transport error — that is a panel-origin failure, not a Manager outage.",
+      "Search installable custom-node packs via the user's BUILT-IN ComfyUI Manager (the same source the Manager UI uses). Returns matching packs {id, title, description}. `id` is a Manager registry id, never a raw Git URL — use it with panel_install_node. Hits that only have a git repository set git:true and are not v4-installable this way; use install_custom_node(source:'git') for those when the local target is the same ComfyUI. Prefer this over the headless search_custom_nodes tool — it works against the user's actual (Desktop) Manager. If Manager's cache mappings endpoint returns HTTP 5xx, this retries remote/local and still searches; a remaining 5xx is a Manager outage, not proof the pack is missing. If the panel tab is live but the browser Manager request does not complete (Failed to fetch), the search is served from host Manager HTTP instead of dying as a transport error — that is a panel-origin failure, not a Manager outage.",
       { query: z.string().describe("Search text, e.g. 'kjnodes', 'controlnet', 'ipadapter'."), limit: z.number().int().min(1).max(40).optional().describe("Max results to return, 1-40 (default 15). Requests above 40 are refused; the panel also clamps to 40 and discloses limit_cap.") },
       async (args: A, ctx) => {
         // #1669 — the panel asks getmappings?mode=cache and used to fail the
@@ -26640,9 +26644,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // spellings (registry id and git URL) — see panel-pin-guard.
         assertPanelNotTargetedUnverifiable("panel_install_node", args.id);
         assertPanelNotTargetedUnverifiable("panel_install_node", args.repository);
-        // The panel owns dialect detection and enforces the v4 Git-URL refusal;
-        // these normalized fields remain here so legacy Manager 3.x can receive
-        // its direct `files:[url]` request shape.
+        // Legacy Manager 3.x / v2-batch still receive the direct `files:[url]`
+        // shape. Manager v4 is refused above before this dispatch.
         // #789 — a search result whose `id` is a repository URL (the Manager's
         // legacy/repository-style entries) cannot install as id+"latest": the
         // Manager resolves that as a registry version and rejects it ("not
@@ -26650,6 +26653,21 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // repository install that works, and disclose the rewrite.
         const { conflict, note, ...cmdArgs } = nodesInstallCommandArgs(args);
         if (conflict) return fail(conflict);
+        // #1539 — do not send a git URL through Manager v4's registry lookup.
+        // The panel is supposed to refuse this too; the 0.52.179 recurrence still
+        // queued `{repository: url}` and Manager resolved the bare name. Legacy
+        // 3.x / v2-batch keep the direct `files:[url]` path.
+        if (typeof cmdArgs.repository === "string" && cmdArgs.repository.length > 0) {
+          let api: ManagerApi;
+          try {
+            api = await detectManagerApi();
+          } catch {
+            api = "v2";
+          }
+          if (managerDialectQueuesGitUrlAsRegistryLookup(api)) {
+            return fail(v4GitUrlQueueRefusal(cmdArgs.repository));
+          }
+        }
         // #1129 — the panel identity is captured BEFORE dispatch, because a
         // takeover during the install is exactly what the follow-up read must not
         // be attributed to.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -26658,13 +26658,17 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // queued `{repository: url}` and Manager resolved the bare name. Legacy
         // 3.x / v2-batch keep the direct `files:[url]` path.
         if (typeof cmdArgs.repository === "string" && cmdArgs.repository.length > 0) {
-          let api: ManagerApi;
+          let api: ManagerApi | undefined;
           try {
             api = await detectManagerApi();
           } catch {
-            api = "v2";
+            // The dialect is UNKNOWN, not v4. Refusing here would be an unproven
+            // claim — and it would block a legacy 3.x `files:[url]` install that
+            // still works, with a message naming the wrong cause. Fall through and
+            // let the dispatch below report whatever actually failed.
+            api = undefined;
           }
-          if (managerDialectQueuesGitUrlAsRegistryLookup(api)) {
+          if (api !== undefined && managerDialectQueuesGitUrlAsRegistryLookup(api)) {
             return fail(v4GitUrlQueueRefusal(cmdArgs.repository));
           }
         }

--- a/src/services/manager-node-search.ts
+++ b/src/services/manager-node-search.ts
@@ -11,6 +11,10 @@ export interface NodeSearchHit {
   id: string;
   title: string;
   description: string;
+  /** Present when the mapping's only identifier was a git URL. */
+  repository?: string;
+  /** True when `id` was derived from a git mapping key, not a registry id. */
+  git?: true;
 }
 
 export interface NodeSearchResult {
@@ -34,6 +38,102 @@ export const HOST_HTTP_SEARCH_NOTE =
   "Searched via ComfyUI-Manager HTTP because the panel's browser request to " +
   "Manager getmappings did not complete. Live canvas reads still work; this is a " +
   "panel-origin transport failure, not a Manager outage or a missing pack.";
+
+export const GIT_ONLY_SEARCH_NOTE =
+  "Hits with git:true are git repositories, not Manager registry ids. " +
+  "panel_install_node cannot install those on Manager v4 because v4 ignores the " +
+  "repository URL and resolves by bare name. Use install_custom_node(source:'git') " +
+  "only when its local target is the same ComfyUI as this panel.";
+
+/** A raw git clone URL — never a valid panel_install_node registry id (#1539). */
+export function isRawGitUrlInstallId(id: string): boolean {
+  const s = id.trim();
+  return /^(https?|ssh|git):\/\//i.test(s) || /^git\+/i.test(s) || /^git@/i.test(s);
+}
+
+export function gitMappingRepoName(url: string): string {
+  const trimmed = url.trim().replace(/\.git$/i, "").replace(/\/+$/, "");
+  const parts = trimmed.split(/[/:]/).filter(Boolean);
+  const last = parts[parts.length - 1];
+  return last && !/^(github\.com|gitlab\.com|bitbucket\.org)$/i.test(last) ? last : trimmed;
+}
+
+function joinNotes(...parts: Array<string | undefined>): string | undefined {
+  const joined = parts.filter((p): p is string => typeof p === "string" && p.length > 0).join(" ");
+  return joined || undefined;
+}
+
+function mappingInstallId(candidates: unknown[]): Pick<NodeSearchHit, "id" | "repository" | "git"> {
+  const strings = candidates
+    .map((c) => (c == null || c === "" ? "" : String(c)))
+    .filter((s) => s.length > 0);
+  const registry = strings.find((s) => !isRawGitUrlInstallId(s));
+  const url = strings.find((s) => isRawGitUrlInstallId(s));
+  if (registry) return url ? { id: registry, repository: url } : { id: registry };
+  if (url) return { id: gitMappingRepoName(url), repository: url, git: true };
+  return { id: strings[0] ?? "" };
+}
+
+function withGitSearchNote<T extends { note?: string; results?: NodeSearchHit[] }>(result: T): T {
+  if (!result.results?.some((hit) => hit.git)) return result;
+  const note = joinNotes(result.note, GIT_ONLY_SEARCH_NOTE);
+  return note === result.note ? result : { ...result, note };
+}
+
+function rewriteGitUrlHit(hit: NodeSearchHit): NodeSearchHit {
+  if (!isRawGitUrlInstallId(hit.id)) return hit;
+  return {
+    ...hit,
+    id: gitMappingRepoName(hit.id),
+    repository: hit.repository ?? hit.id,
+    git: true,
+  };
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Rewrite a search payload (object or ToolResult JSON) so `id` is never a raw
+ * Git URL. Panel nodes_search still keys some hits on the mapping URL; passing
+ * that `id` to panel_install_node queues a Manager v4 registry lookup (#1539).
+ */
+export function sanitizeSearchInstallIds(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  const rec = value as { isError?: boolean; content?: Array<{ type?: string; text?: string }>; results?: unknown };
+  if (Array.isArray(rec.content)) {
+    if (rec.isError === true) return value;
+    let changed = false;
+    const content = rec.content.map((block) => {
+      if (!block || block.type !== "text" || typeof block.text !== "string") return block;
+      const parsed = tryParseJson(block.text);
+      if (parsed === undefined) return block;
+      const sanitized = sanitizeSearchInstallIds(parsed);
+      if (sanitized === parsed) return block;
+      changed = true;
+      return { ...block, text: JSON.stringify(sanitized, null, 2) };
+    });
+    return changed ? { ...rec, content } : value;
+  }
+  if (!Array.isArray(rec.results)) return value;
+  let changed = false;
+  const results = rec.results.map((raw) => {
+    if (!raw || typeof raw !== "object") return raw;
+    const hit = raw as NodeSearchHit;
+    if (typeof hit.id !== "string") return raw;
+    const next = rewriteGitUrlHit(hit);
+    if (next !== hit) changed = true;
+    return next;
+  });
+  const payload = changed ? { ...rec, results } : rec;
+  const noted = withGitSearchNote(payload as { note?: string; results?: NodeSearchHit[] });
+  return noted === value ? value : noted;
+}
 
 export type FetchMappings = (mode: MappingsMode) => Promise<unknown>;
 
@@ -135,20 +235,32 @@ export function catalogueSize(data: unknown): number {
 /**
  * Normalize a ComfyUI-Manager `/customnode/getmappings` payload into
  * `{ count, results:[{id,title,description}] }`. Mirrors the panel parser
- * (array or repo-key map). `id` is cnr/reference or the map key — never title.
+ * (array or repo-key map). `id` is a CNR/reference id or the repo name derived
+ * from a git mapping key — never a raw Git URL, never title (#1539).
  */
 export function parseNodeMappings(data: unknown, query: string, limit?: number): NodeSearchResult {
   const terms = queryTerms(query);
   const out: NodeSearchHit[] = [];
-  const push = (id: unknown, title: unknown, desc: unknown, classNames?: unknown) => {
-    if (id == null || id === "") return;
-    const idStr = String(id);
-    const titleStr = title == null ? idStr : String(title);
+  const push = (
+    candidates: unknown[],
+    title: unknown,
+    desc: unknown,
+    classNames?: unknown,
+  ) => {
+    const install = mappingInstallId(candidates);
+    if (!install.id) return;
+    const titleStr = title == null ? install.id : String(title);
     const descStr = String(desc ?? "").slice(0, 160);
     const classes = Array.isArray(classNames) ? classNames.map(String).join(" ") : "";
-    const hay = `${idStr} ${titleStr} ${descStr} ${classes}`.toLowerCase();
+    const hay = `${candidates.join(" ")} ${install.id} ${titleStr} ${descStr} ${classes}`.toLowerCase();
     if (matchesAllTerms(hay, terms)) {
-      out.push({ id: idStr, title: titleStr, description: descStr });
+      out.push({
+        id: install.id,
+        title: titleStr,
+        description: descStr,
+        ...(install.repository ? { repository: install.repository } : {}),
+        ...(install.git ? { git: true } : {}),
+      });
     }
   };
   if (Array.isArray(data)) {
@@ -162,7 +274,12 @@ export function parseNodeMappings(data: unknown, query: string, limit?: number):
         description?: unknown;
         nodename?: unknown;
       };
-      push(pack.id ?? pack.reference ?? pack.title, pack.title ?? pack.title_aux, pack.description, pack.nodename);
+      push(
+        [pack.id, pack.reference, pack.title],
+        pack.title ?? pack.title_aux,
+        pack.description,
+        pack.nodename,
+      );
     }
   } else if (data && typeof data === "object") {
     for (const [key, val] of Object.entries(data as Record<string, unknown>)) {
@@ -172,16 +289,16 @@ export function parseNodeMappings(data: unknown, query: string, limit?: number):
         meta && typeof meta === "object"
           ? (meta as { id?: unknown; reference?: unknown; title?: unknown; title_aux?: unknown; description?: unknown })
           : {};
-      push(m.id ?? m.reference ?? key, m.title ?? m.title_aux, m.description, classes);
+      push([m.id, m.reference, key], m.title ?? m.title_aux, m.description, classes);
     }
   }
   const requested = Number(limit) || 15;
   const max = Math.min(requested, SEARCH_LIMIT_CAP);
-  const result: NodeSearchResult = {
+  const result: NodeSearchResult = withGitSearchNote({
     count: out.length,
     results: out.slice(0, max),
     catalogue_size: catalogueSize(data),
-  };
+  });
   if (requested > SEARCH_LIMIT_CAP) result.limit_cap = SEARCH_LIMIT_CAP;
   return result;
 }
@@ -288,7 +405,7 @@ async function hostSearchAfterTransport(
         manager_outage: true,
       };
     }
-    return { ...parsed, source: "host_http", note: HOST_HTTP_SEARCH_NOTE };
+    return { ...parsed, source: "host_http", note: joinNotes(HOST_HTTP_SEARCH_NOTE, parsed.note) };
   } catch (hostErr) {
     return dualCauseSearchFailure(opts.query, panelErr, hostErr);
   }
@@ -313,7 +430,7 @@ export async function searchPanelNodes(opts: {
 }): Promise<{ via: "panel"; value: unknown } | { via: "fallback"; value: NodeSearchResult }> {
   try {
     const value = await opts.panelSearch();
-    if (!shouldHostSearch(value)) return { via: "panel", value };
+    if (!shouldHostSearch(value)) return { via: "panel", value: sanitizeSearchInstallIds(value) };
     if (isManagerTransportFetchFailure(value)) {
       return { via: "fallback", value: await hostSearchAfterTransport(opts, value) };
     }

--- a/src/services/manager-node-search.ts
+++ b/src/services/manager-node-search.ts
@@ -98,15 +98,15 @@ type SearchEnvelope = {
   note?: string;
 };
 
-function isSearchEnvelope(value: object): value is SearchEnvelope {
+function isSearchEnvelope(value: SearchEnvelope | NodeSearchHit[] | SearchTextBlock[]): value is SearchEnvelope {
   return !Array.isArray(value);
 }
 
 function tryParseSearchEnvelope(text: string): SearchEnvelope | undefined {
   try {
-    const parsed: object = JSON.parse(text);
+    const parsed = JSON.parse(text);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
-    return parsed;
+    return parsed as SearchEnvelope;
   } catch {
     return undefined;
   }
@@ -117,7 +117,7 @@ function tryParseSearchEnvelope(text: string): SearchEnvelope | undefined {
  * Git URL. Panel nodes_search still keys some hits on the mapping URL; passing
  * that `id` to panel_install_node queues a Manager v4 registry lookup (#1539).
  */
-export function sanitizeSearchInstallIds(value: object): object {
+export function sanitizeSearchInstallIds(value: SearchEnvelope): SearchEnvelope {
   if (!isSearchEnvelope(value)) return value;
   if (Array.isArray(value.content)) {
     if (value.isError === true) return value;
@@ -444,7 +444,9 @@ export async function searchPanelNodes(opts: {
     const value = await opts.panelSearch();
     if (!shouldHostSearch(value)) {
       const sanitized =
-        value && typeof value === "object" ? sanitizeSearchInstallIds(value) : value;
+        value && typeof value === "object" && !Array.isArray(value)
+          ? sanitizeSearchInstallIds(value as SearchEnvelope)
+          : value;
       return { via: "panel", value: sanitized };
     }
     if (isManagerTransportFetchFailure(value)) {

--- a/src/services/manager-node-search.ts
+++ b/src/services/manager-node-search.ts
@@ -90,9 +90,23 @@ function rewriteGitUrlHit(hit: NodeSearchHit): NodeSearchHit {
   };
 }
 
-function tryParseJson(text: string): unknown {
+type SearchTextBlock = { type?: string; text?: string };
+type SearchEnvelope = {
+  isError?: boolean;
+  content?: SearchTextBlock[];
+  results?: NodeSearchHit[];
+  note?: string;
+};
+
+function isSearchEnvelope(value: object): value is SearchEnvelope {
+  return !Array.isArray(value);
+}
+
+function tryParseSearchEnvelope(text: string): SearchEnvelope | undefined {
   try {
-    return JSON.parse(text);
+    const parsed: object = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    return parsed;
   } catch {
     return undefined;
   }
@@ -103,35 +117,33 @@ function tryParseJson(text: string): unknown {
  * Git URL. Panel nodes_search still keys some hits on the mapping URL; passing
  * that `id` to panel_install_node queues a Manager v4 registry lookup (#1539).
  */
-export function sanitizeSearchInstallIds(value: unknown): unknown {
-  if (!value || typeof value !== "object") return value;
-  const rec = value as { isError?: boolean; content?: Array<{ type?: string; text?: string }>; results?: unknown };
-  if (Array.isArray(rec.content)) {
-    if (rec.isError === true) return value;
+export function sanitizeSearchInstallIds(value: object): object {
+  if (!isSearchEnvelope(value)) return value;
+  if (Array.isArray(value.content)) {
+    if (value.isError === true) return value;
     let changed = false;
-    const content = rec.content.map((block) => {
+    const content = value.content.map((block) => {
       if (!block || block.type !== "text" || typeof block.text !== "string") return block;
-      const parsed = tryParseJson(block.text);
+      const parsed = tryParseSearchEnvelope(block.text);
       if (parsed === undefined) return block;
       const sanitized = sanitizeSearchInstallIds(parsed);
       if (sanitized === parsed) return block;
       changed = true;
       return { ...block, text: JSON.stringify(sanitized, null, 2) };
     });
-    return changed ? { ...rec, content } : value;
+    return changed ? { ...value, content } : value;
   }
-  if (!Array.isArray(rec.results)) return value;
+  if (!Array.isArray(value.results)) return value;
   let changed = false;
-  const results = rec.results.map((raw) => {
+  const results = value.results.map((raw) => {
     if (!raw || typeof raw !== "object") return raw;
-    const hit = raw as NodeSearchHit;
-    if (typeof hit.id !== "string") return raw;
-    const next = rewriteGitUrlHit(hit);
-    if (next !== hit) changed = true;
+    if (typeof raw.id !== "string") return raw;
+    const next = rewriteGitUrlHit(raw);
+    if (next !== raw) changed = true;
     return next;
   });
-  const payload = changed ? { ...rec, results } : rec;
-  const noted = withGitSearchNote(payload as { note?: string; results?: NodeSearchHit[] });
+  const payload = changed ? { ...value, results } : value;
+  const noted = withGitSearchNote(payload);
   return noted === value ? value : noted;
 }
 
@@ -430,7 +442,11 @@ export async function searchPanelNodes(opts: {
 }): Promise<{ via: "panel"; value: unknown } | { via: "fallback"; value: NodeSearchResult }> {
   try {
     const value = await opts.panelSearch();
-    if (!shouldHostSearch(value)) return { via: "panel", value: sanitizeSearchInstallIds(value) };
+    if (!shouldHostSearch(value)) {
+      const sanitized =
+        value && typeof value === "object" ? sanitizeSearchInstallIds(value) : value;
+      return { via: "panel", value: sanitized };
+    }
     if (isManagerTransportFetchFailure(value)) {
       return { via: "fallback", value: await hostSearchAfterTransport(opts, value) };
     }

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -6700,6 +6700,28 @@ function gitInstallSubstitutionNote(channel: string, url: string): string {
  * the call site — because a rerouted git URL must DROP `id`, and a
  * `norm.id ?? args.id` merge silently restores it (codex gate round 4).
  */
+/**
+ * #1539 recurrence — Manager v4 (`v2` dialect) ignores `repository` and looks
+ * the pack up by bare name in its registry. Queueing a git URL there is the
+ * unlisted-URL failure the reporter still hits. Legacy 3.x / v2-batch still
+ * clone `files:[url]`.
+ */
+export function v4GitUrlQueueRefusal(url: string): string {
+  return (
+    `Refusing to queue "${url}" as a Manager v4 install. Manager v4 ignores the supplied ` +
+    `repository and resolves by bare name against its registry, so a Git URL is not a ` +
+    `successful v4 from-source install. Use a registry id from panel_search_nodes; or ` +
+    `install_custom_node(source:'git') only when its local target is the same ComfyUI as ` +
+    `this panel. If the panel drives another machine, install the repository on the ` +
+    `ComfyUI host instead.`
+  );
+}
+
+/** True when this dialect would send a git URL through v4's registry lookup. */
+export function managerDialectQueuesGitUrlAsRegistryLookup(api: ManagerApi): boolean {
+  return api === "v2";
+}
+
 export function nodesInstallCommandArgs(args: {
   id?: string;
   repository?: string;


### PR DESCRIPTION
Fixes #1539

## Recurrence
On mcp 0.52.179 / panel 0.15.159, `panel_search_nodes("ImageComparer")` still returned `https://github.com/Slimy-Comfy/Slimy_ImageComparer` as `id`. Passing that id to `panel_install_node` queued a Manager v4 registry lookup. v4 ignores `repository` and resolves by bare name, so the pack never landed. Headless `install_custom_node(source:"git")` still worked.

Prior PRs #1611 / #2123 / #1686 narrowed the contract and relied on the panel to refuse v4 Git URLs. Search still advertised a Git URL as an install id, and MCP still dispatched it.

## Change
- `panel_search_nodes` no longer returns a raw Git URL as `id`. Mapping keys that are clone URLs become a repo name (or a CNR id when present), with `repository` + `git:true` and a note pointing at `install_custom_node(source:'git')`.
- `panel_install_node` refuses Git URLs on the Manager `v2` dialect **before** `nodes_install` is queued. Legacy 3.x / `v2-batch` keep the direct `files:[url]` path.

## Tests
Targeted vitest: 6 files, 138 passed.
