### PR TITLE
fix(2739): include Desktop extra_models_config.yaml in model removal roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`list_local_models` `action:"remove"` resolves against the same launch-proven extra-path files as inventory, including ComfyUI Desktop's `extra_models_config.yaml` (#2739).** Removal previously searched only the Desktop shared models yaml from argv, so a listed LTX file under another active extra root could not be deleted. Desktop extra roots are included only when the connected snapshot already named a Desktop extra-path config — never by probing a guessed :8188 origin — and still fail closed when that file cannot be proven unchanged since launch.
+
+
 ## [0.52.181] - 2026-09-03
 
 ### MCP

--- a/src/__tests__/services/live-extra-roots.test.ts
+++ b/src/__tests__/services/live-extra-roots.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, rm, stat as statFile, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat as statFile, utimes, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -7,14 +7,22 @@ import { join, resolve } from "node:path";
 // reachable, server-authoritative config may authorize an escaping-symlink download.
 // It takes the SINGLE live /system_stats snapshot the caller already used (one
 // consistent server state) and trusts ONLY: ABSOLUTE --extra-model-paths-config flag
-// files + the live install's own extra_model_paths.yaml (its main.py dir). A relative
-// flag value, a stale local workspace config, or an unreachable server authorize
-// nothing (codex P0d).
+// files + the live install's own extra_model_paths.yaml (its main.py dir) + Desktop's
+// extra_models_config.yaml when that snapshot already named a Desktop extra-path
+// config. A relative flag value, a stale local workspace config, or an unreachable
+// server authorize nothing (codex P0d).
 
 vi.mock("../../config.js", () => ({
   config: { comfyuiPath: undefined as string | undefined },
   isRemoteMode: () => false,
 }));
+
+// Pin win32 so Desktop extra_models_config.yaml is reached via APPDATA, not
+// ~/Library or XDG, and tests never read the developer's real extra-path file.
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, platform: () => "win32" };
+});
 
 import {
   getLaunchStateExtraModelRoots,
@@ -27,6 +35,7 @@ import {
 } from "../../services/workspace-env.js";
 
 let dirs: string[] = [];
+const originalAppData = process.env.APPDATA;
 async function trackTmp(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "comfyui-live-roots-"));
   dirs.push(dir);
@@ -38,12 +47,15 @@ const reachable = (argv: string[], cwd?: string): LiveServerSnapshot => ({
   cwd,
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   dirs = [];
   resetLocalComfyUILaunchState(); // default: server NOT MCP-launched → env untrusted
+  process.env.APPDATA = await trackTmp();
 });
 afterEach(async () => {
   resetLocalComfyUILaunchState();
+  if (originalAppData === undefined) delete process.env.APPDATA;
+  else process.env.APPDATA = originalAppData;
   await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
 });
 
@@ -105,6 +117,97 @@ describe("getLiveExtraModelRoots — fail-closed authorization", () => {
 
     expect(res.authoritative).toBe(false);
     expect(res.roots).toEqual([]);
+  });
+
+  it("includes Desktop extra_models_config.yaml when argv already named a Desktop extra-path config", async () => {
+    const appData = process.env.APPDATA!;
+    const desktopDir = join(appData, "Comfy Desktop");
+    const sharedCfg = join(desktopDir, "shared_model_paths.yaml");
+    const extraCfg = join(appData, "ComfyUI", "extra_models_config.yaml");
+    const sharedRoot = resolve("/ComfyUI-Shared/models/diffusion_models");
+    const extraRoot = resolve("/user-extra/models/diffusion_models");
+    await mkdir(desktopDir, { recursive: true });
+    await mkdir(join(appData, "ComfyUI"), { recursive: true });
+    await writeFile(sharedCfg, ["desktop:", `  diffusion_models: ${sharedRoot}`].join("\n"), "utf-8");
+    await writeFile(extraCfg, ["user_extra:", `  diffusion_models: ${extraRoot}`].join("\n"), "utf-8");
+    const created = await statFile(extraCfg);
+    const processStartedAtMs = Math.max(created.mtimeMs, created.ctimeMs) + 1;
+
+    const res = await getLaunchStateExtraModelRoots({
+      ...reachable(["python", "main.py", "--extra-model-paths-config", sharedCfg]),
+      processStartedAtMs,
+    });
+
+    expect(res.authoritative).toBe(true);
+    expect(res.roots).toContainEqual({
+      category: "diffusion_models",
+      dir: sharedRoot,
+      group: "desktop",
+    });
+    expect(res.roots).toContainEqual({
+      category: "diffusion_models",
+      dir: extraRoot,
+      group: "user_extra",
+    });
+  });
+
+  it("does not invent Desktop extra_models_config.yaml from a non-Desktop extra-path flag", async () => {
+    const appData = process.env.APPDATA!;
+    const extraCfg = join(appData, "ComfyUI", "extra_models_config.yaml");
+    const extraRoot = resolve("/user-extra/models/diffusion_models");
+    await mkdir(join(appData, "ComfyUI"), { recursive: true });
+    await writeFile(extraCfg, ["user_extra:", `  diffusion_models: ${extraRoot}`].join("\n"), "utf-8");
+    const cfgDir = await trackTmp();
+    const cfgPath = join(cfgDir, "shared_model_paths.yaml");
+    const sharedRoot = resolve("/not-desktop/models/diffusion_models");
+    await writeFile(cfgPath, ["comfyui:", `  diffusion_models: ${sharedRoot}`].join("\n"), "utf-8");
+
+    const res = await getLiveExtraModelRoots(
+      reachable(["python", "main.py", "--extra-model-paths-config", cfgPath]),
+    );
+    expect(res.roots).toContainEqual({
+      category: "diffusion_models",
+      dir: sharedRoot,
+      group: "comfyui",
+    });
+    expect(res.roots).not.toContainEqual({
+      category: "diffusion_models",
+      dir: extraRoot,
+      group: "user_extra",
+    });
+  });
+
+  it("does not authorize Desktop extra_models_config.yaml changed after launch", async () => {
+    const appData = process.env.APPDATA!;
+    const desktopDir = join(appData, "Comfy Desktop");
+    const sharedCfg = join(desktopDir, "shared_model_paths.yaml");
+    const extraCfg = join(appData, "ComfyUI", "extra_models_config.yaml");
+    const sharedRoot = resolve("/ComfyUI-Shared/models/diffusion_models");
+    await mkdir(desktopDir, { recursive: true });
+    await mkdir(join(appData, "ComfyUI"), { recursive: true });
+    await writeFile(sharedCfg, ["desktop:", `  diffusion_models: ${sharedRoot}`].join("\n"), "utf-8");
+    await writeFile(extraCfg, ["user_extra:", "  diffusion_models: /launch/extra"].join("\n"), "utf-8");
+    const sharedStat = await statFile(sharedCfg);
+    const extraStat = await statFile(extraCfg);
+    const processStartedAtMs =
+      Math.max(sharedStat.mtimeMs, sharedStat.ctimeMs, extraStat.mtimeMs, extraStat.ctimeMs) + 1;
+    await writeFile(extraCfg, ["user_extra:", "  diffusion_models: /mutable/extra"].join("\n"), "utf-8");
+    const changedAt = processStartedAtMs + 2_000;
+    await utimes(extraCfg, new Date(changedAt), new Date(changedAt));
+
+    const res = await getLaunchStateExtraModelRoots({
+      ...reachable(["python", "main.py", "--extra-model-paths-config", sharedCfg]),
+      processStartedAtMs,
+    });
+
+    expect(res.authoritative).toBe(true);
+    expect(res.roots).toContainEqual({
+      category: "diffusion_models",
+      dir: sharedRoot,
+      group: "desktop",
+    });
+    expect(res.roots.map((r) => r.dir)).not.toContain(resolve("/launch/extra"));
+    expect(res.roots.map((r) => r.dir)).not.toContain(resolve("/mutable/extra"));
   });
 
   it("does not authorize an implicit config beside an OS-observed root", async () => {

--- a/src/__tests__/services/model-resolver-roots.test.ts
+++ b/src/__tests__/services/model-resolver-roots.test.ts
@@ -192,6 +192,55 @@ describe("resolveExistingModelFile — multi-root resolution", () => {
     expect(getExtraModelRootsMock).not.toHaveBeenCalled();
   });
 
+  it("finds a listed model under a launch-named Desktop extra root that is not the shared models root", async () => {
+    const sharedRoot = resolve("/ComfyUI-Shared/models/diffusion_models");
+    const desktopExtraRoot = resolve("/user-extra/models/diffusion_models");
+    const snapshot = {
+      reachable: true,
+      argv: [
+        "python",
+        "ComfyUI/main.py",
+        "--extra-model-paths-config",
+        "/live/shared_model_paths.yaml",
+      ],
+      processStartedAtMs: 1_000,
+    };
+    resolveModelsDirWithBasesMock.mockResolvedValueOnce({
+      modelsDir: resolve("/stale/ComfyUI", "models"),
+      baseDirs: [],
+      snapshot,
+      source: "configured-base",
+    });
+    getLaunchStateExtraModelRootsMock.mockResolvedValueOnce({
+      authoritative: true,
+      roots: [
+        { category: "diffusion_models", dir: sharedRoot, group: "desktop" },
+        { category: "diffusion_models", dir: desktopExtraRoot, group: "user_extra" },
+      ],
+    });
+    fsFixture([
+      resolve(
+        desktopExtraRoot,
+        "ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors",
+      ),
+    ]);
+
+    const res = await resolveForRemoval(
+      "diffusion_models/ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors",
+    );
+
+    expect(res.path).toBe(
+      resolve(
+        desktopExtraRoot,
+        "ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors",
+      ),
+    );
+    expect(res.root).toBe(desktopExtraRoot);
+    expect(getLaunchStateExtraModelRootsMock).toHaveBeenCalledWith(snapshot);
+    expect(getLiveExtraModelRootsMock).not.toHaveBeenCalled();
+    expect(getExtraModelRootsMock).not.toHaveBeenCalled();
+  });
+
   it("finds a category-relative model in a launch-named shared extra root", async () => {
     const sharedRoot = resolve("/ComfyUI-Shared/models/diffusion_models");
     const snapshot = {

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -1414,10 +1414,16 @@ export async function getExtraModelRoots(
  *   - every ABSOLUTE `--extra-model-paths-config` file the server was LAUNCHED with
  *     (raw argv values; a RELATIVE flag value is SKIPPED — it can't be resolved to
  *     the live server's file from the MCP process, so trusting it would let a stale
- *     local same-named config authorize; fail closed); and
+ *     local same-named config authorize; fail closed);
  *   - `<live main.py root>/extra_model_paths.yaml` — ComfyUI's auto-loaded default,
  *     anchored to the server's OWN install root (its main.py dir from argv), NOT an
- *     arbitrary base dir or the local workspace.
+ *     arbitrary base dir or the local workspace; and
+ *   - ComfyUI Desktop's app-data `extra_models_config.yaml`, but ONLY when the
+ *     connected snapshot already named a Desktop extra-path config (the generated
+ *     `shared_model_paths.yaml` or that same extra_models_config file). Desktop
+ *     inventory can list a file from that user extra-path file while argv only
+ *     names the shared yaml (#2739). The file is still launch-state-stamped for
+ *     deletion. Never guessed from a default :8188 origin.
  *
  * Relative `base_path` / category paths are resolved against the CONFIG FILE's own
  * directory, exactly as ComfyUI resolves them — never against the MCP process CWD —
@@ -1523,6 +1529,17 @@ export async function getLiveExtraModelRoots(
   // Launched flag files — ABSOLUTE values only (relative → fail closed, see docblock).
   for (const raw of parseExtraModelPathsConfigsFromArgvRaw(argv)) {
     if (isAbsolute(raw)) configPaths.add(resolve(raw));
+  }
+  // Desktop's user extra-path file is not always repeated on argv. The connected
+  // snapshot must already have named a Desktop extra-path config; we never probe
+  // a guessed :8188 origin to discover it (#2739).
+  if (!isRemoteMode()) {
+    for (const named of configPaths) {
+      if (looksLikeDesktopConfig(named)) {
+        configPaths.add(resolve(desktopConfigPath()));
+        break;
+      }
+    }
   }
   // Auto-loaded default in the LIVE install root (its main.py dir). Skip in remote
   // mode: the live root is a path on the remote host.


### PR DESCRIPTION
## Summary
`list_local_models` `action:\"list\"` can report an LTX file from ComfyUI Desktop inventory while `action:\"remove\"` searched only the launch-named shared models yaml (`ComfyUI-Shared`). Desktop also uses app-data `extra_models_config.yaml` for additional extra roots, and that file is not always repeated on argv.

Removal now resolves against the same launch-proven extra-path files, including Desktop `extra_models_config.yaml` when the **connected** snapshot already named a Desktop extra-path config. It does not probe a guessed `:8188` origin. If that extra-path file cannot be proven unchanged since launch, those roots are skipped (fail closed).

Fixes #2739

## Tests
- `npx vitest run src/__tests__/services/live-extra-roots.test.ts src/__tests__/services/model-resolver-roots.test.ts src/__tests__/services/model-root-scope.test.ts`
- 3 files, 49 tests passed