### PR TITLE
fix(2768): rebind session to Save-As dest canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- **`panel_save_workflow(name)` rebinds the session onto the Save-As dest canvas (#2768).** After a named save the live instance is dest, but the source tab id can still `canReach`; staying there left `panel_list_workflows` and `panel_set_workflow_target({mode:"current"})` stamped for the replaced instance. Dest is followed when this save replaced the session canvas, and dest's command stamp is refreshed from the save reply.
 - **`list_local_models` `action:"remove"` resolves against the same launch-proven extra-path files as inventory, including ComfyUI Desktop's `extra_models_config.yaml` (#2739).** Removal previously searched only the Desktop shared models yaml from argv, so a listed LTX file under another active extra root could not be deleted. Desktop extra roots are included only when the connected snapshot already named a Desktop extra-path config — never by probing a guessed :8188 origin — and still fail closed when that file cannot be proven unchanged since launch.
 
 

--- a/src/__tests__/orchestrator/save-as-rebinds-live-instance.test.ts
+++ b/src/__tests__/orchestrator/save-as-rebinds-live-instance.test.ts
@@ -1,0 +1,215 @@
+// #2768 — Save-As left the session fenced to the replaced source instance.
+//
+// panel_save_workflow(name) writes the copy and the panel makes dest active
+// (new tab id, new workflow_uuid). The source tab id can still canReach —
+// original file stays on disk, and the old route is not yet dead. Routing
+// used to treat that as a live pin (#1917) and stay on the source. Then
+// panel_list_workflows / panel_set_workflow_target({mode:"current"}) were
+// stamped for the source instance and refused: workflow instance mismatch.
+//
+// After Save-As the session must follow dest and restamp dest. #1917 still
+// applies only when dest is not the canvas this save replaced.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const NEW_UUID = "11111111-2222-4333-8444-555555555555";
+const PRIOR_UUID = "99999999-8888-4777-a666-555555555555";
+const OLD_TAB = "wf:src-route:workflows/original.json";
+const NEW_TAB = "wf:dest-route:workflows/photo_to_anime_main.json";
+const DEST_PATH = "workflows/photo_to_anime_main.json";
+const SOURCE_PATH = "workflows/original.json";
+const SCOPE = "orchestrator::codex";
+
+const SAVE_AS_REPLY = {
+  saved: true,
+  saved_as: true,
+  workflow: "photo_to_anime_main",
+  copied_from: "original",
+  original_on_disk: true,
+  routing_key: "wf:workflows/photo_to_anime_main.json",
+  workflow_uuid: NEW_UUID,
+  workflow_instance_changed: true,
+};
+
+const MISMATCH =
+  `workflow instance mismatch: this command was issued for workflow instance ${PRIOR_UUID}, ` +
+  `and the active canvas reports ${NEW_UUID}`;
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? (c as { text: string }).text : "")).join("\n");
+
+function toolNamed(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  return def;
+}
+
+let stamps: Map<string, string>;
+let liveUuid: Map<string, string>;
+let sent: Array<Record<string, unknown>>;
+let sentTab: string[];
+let liveTabs: Array<{ tab_id: string; title: string; connected_at: number }>;
+let reachable: Set<string>;
+let scopePin: string;
+let scopeRepins: Array<{ scope: string; path: string }>;
+
+function afterSaveAsBothTabsLive(): void {
+  liveTabs = [
+    { tab_id: OLD_TAB, title: "original", connected_at: 0 },
+    { tab_id: NEW_TAB, title: "photo_to_anime_main", connected_at: 1 },
+  ];
+  reachable = new Set([OLD_TAB, NEW_TAB]);
+  liveUuid.set(OLD_TAB, PRIOR_UUID);
+  liveUuid.set(NEW_TAB, NEW_UUID);
+}
+
+function mismatchIfStale(tabId: string): void {
+  const stamp = stamps.get(tabId);
+  const live = liveUuid.get(tabId);
+  if (stamp && live && stamp !== live) throw new Error(MISMATCH);
+}
+
+function destListPayload(): Record<string, unknown> {
+  return {
+    active: {
+      path: DEST_PATH,
+      filename: "photo_to_anime_main.json",
+      routing_key: "wf:workflows/photo_to_anime_main.json",
+      workflow_uuid: NEW_UUID,
+    },
+    active_confirmed: true,
+    workflows: [
+      {
+        path: SOURCE_PATH,
+        filename: "original.json",
+        routing_key: OLD_TAB,
+        active: false,
+      },
+      {
+        path: DEST_PATH,
+        filename: "photo_to_anime_main.json",
+        routing_key: "wf:workflows/photo_to_anime_main.json",
+        active: true,
+      },
+    ],
+  };
+}
+
+function bridgeFor(): PanelToolCtx["bridge"] {
+  return {
+    send: async (c: Record<string, unknown>, extra?: { tabId?: string }) => {
+      sent.push(c);
+      const tab = typeof extra?.tabId === "string" && extra.tabId ? extra.tabId : OLD_TAB;
+      sentTab.push(tab);
+      if (c.cmd === "workflow_save_as") {
+        afterSaveAsBothTabsLive();
+        return SAVE_AS_REPLY;
+      }
+      if (c.cmd === "workflow_list" || c.cmd === "graph_query") {
+        const routed = tab === SCOPE ? scopePin : tab;
+        mismatchIfStale(routed);
+        if (c.cmd === "workflow_list") return destListPayload();
+        return { nodes: [] };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => {
+      if (id === SCOPE) return reachable.has(scopePin);
+      return reachable.has(id);
+    },
+    liveTabIdFor: (id: string) => {
+      if (id === SCOPE) return reachable.has(scopePin) ? scopePin : undefined;
+      return reachable.has(id) ? id : undefined;
+    },
+    isHeadless: () => false,
+    tabs: () => liveTabs,
+    resolveActiveTabId: () => NEW_TAB,
+    workflowUuidFor: (tabId: string) => {
+      const key = tabId === SCOPE ? scopePin : tabId;
+      const uuid = stamps.get(key);
+      return { known: true, uuid };
+    },
+    refreshWorkflowUuid: (tabId: string, uuid: string) => {
+      const key = tabId === SCOPE ? scopePin : tabId;
+      stamps.set(key, uuid);
+      if (tabId === SCOPE) stamps.set(SCOPE, uuid);
+      return true;
+    },
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    tabCanMutateGraph: () => true,
+    repinScopeToWorkflow: (scope: string, path: string) => {
+      scopeRepins.push({ scope, path });
+      scopePin = NEW_TAB;
+      return NEW_TAB;
+    },
+  } as PanelToolCtx["bridge"];
+}
+
+beforeEach(() => {
+  stamps = new Map([
+    [OLD_TAB, PRIOR_UUID],
+    [SCOPE, PRIOR_UUID],
+  ]);
+  liveUuid = new Map([[OLD_TAB, PRIOR_UUID]]);
+  sent = [];
+  sentTab = [];
+  liveTabs = [{ tab_id: OLD_TAB, title: "original", connected_at: 0 }];
+  reachable = new Set([OLD_TAB]);
+  scopePin = OLD_TAB;
+  scopeRepins = [];
+});
+
+describe("#2768 Save-As rebinds the session onto the dest instance", () => {
+  it("moves a real-tab session off the still-reachable source onto dest", async () => {
+    const targets = new WorkflowTargetStore();
+    targets.set(OLD_TAB, { mode: "current" });
+    const ctx = makePanelToolCtx(bridgeFor(), OLD_TAB, targets);
+
+    const res = await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    expect(res.isError, textOf(res)).toBeFalsy();
+    expect(ctx.tabId).toBe(NEW_TAB);
+    expect(stamps.get(NEW_TAB)).toBe(NEW_UUID);
+    expect(stamps.get(NEW_TAB)).not.toBe(PRIOR_UUID);
+  });
+
+  it("panel_list_workflows and mode:current then observe dest, not a stale fence", async () => {
+    const ctx = makePanelToolCtx(bridgeFor(), OLD_TAB, new WorkflowTargetStore());
+    await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    sent = [];
+    sentTab = [];
+    const listed = await toolNamed("panel_list_workflows").handler({}, ctx);
+    expect(listed.isError, textOf(listed)).toBeFalsy();
+    expect(textOf(listed)).not.toMatch(/workflow instance mismatch/);
+    expect(sentTab.every((id) => id === NEW_TAB)).toBe(true);
+
+    const bound = await toolNamed("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    expect(bound.isError, textOf(bound)).toBeFalsy();
+    expect(textOf(bound)).not.toMatch(/did NOT restore this session's graph binding/);
+    expect(textOf(bound)).not.toMatch(/workflow instance mismatch/);
+  });
+
+  it("re-pins a SCOPE session whose source pin still reaches onto dest", async () => {
+    const ctx = makePanelToolCtx(bridgeFor(), SCOPE, new WorkflowTargetStore());
+    const res = await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    expect(res.isError, textOf(res)).toBeFalsy();
+    expect(scopeRepins).toEqual([{ scope: SCOPE, path: DEST_PATH }]);
+    expect(scopePin).toBe(NEW_TAB);
+    expect(stamps.get(NEW_TAB)).toBe(NEW_UUID);
+
+    sent = [];
+    const listed = await toolNamed("panel_list_workflows").handler({}, ctx);
+    expect(listed.isError, textOf(listed)).toBeFalsy();
+  });
+});

--- a/src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts
+++ b/src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts
@@ -8,9 +8,10 @@
 //
 // The two updates are separate. The fence is already repaired. This file
 // drives the ROUTING half: re-point the session onto the dest tab when the
-// current address is dead, aliases onto dest, or is the unsaved tmp:
-// predecessor of dest. A live pin on a different saved tab is left alone
-// (#1917 / #884).
+// current address is dead, aliases onto dest, is the unsaved tmp:
+// predecessor of dest, or this Save-As replaced the session canvas (#2768).
+// A live pin on a different saved tab that this save did not replace is
+// left alone (#1917 / #884).
 //
 // Workaround that already worked: panel_set_workflow_target({mode:"current"}).
 // That tool is the only writer of the routing target; this makes Save-As do
@@ -217,6 +218,27 @@ describe("#2419 Save-As re-points a dead real-tab address onto the dest canvas",
 
     expect(res.isError).toBeFalsy();
     expect(ctx.tabId).toBe(OLD_TAB);
+  });
+
+  it("follows dest when Save-As replaces this canvas even if the source id still reaches (#2768)", async () => {
+    const b = bridgeFor({ keepOldTab: true });
+    const origSend = b.send;
+    b.send = async (c, extra) => {
+      const out = await origSend(c, extra);
+      if (c.cmd === "workflow_save_as") {
+        liveTabs = [
+          { tab_id: OLD_TAB, title: "Untitled 1", connected_at: 0 },
+          { tab_id: NEW_TAB, title: "photo_to_anime_main", connected_at: 1 },
+        ];
+        reachable = new Set([OLD_TAB, NEW_TAB]);
+      }
+      return out;
+    };
+    const ctx = makePanelToolCtx(b, OLD_TAB, new WorkflowTargetStore());
+    const res = await toolNamed("panel_save_workflow").handler({ name: "photo_to_anime_main" }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(ctx.tabId).toBe(NEW_TAB);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -12254,7 +12254,20 @@ function refreshFenceFromOwnReply(ctx: PanelToolCtx, reply: ToolResult): Workflo
   const uuid = responseWorkflowUuid(parsed);
   if (!uuid) return null;
   try {
-    return refreshWorkflowUuid(ctx, parsed) ? { status: "refreshed", uuid, before } : null;
+    const destPath = saveDestWorkflowPath(parsed);
+    const destTab = destPath ? uniqueLiveTabForSaveDest(ctx, destPath) : undefined;
+    const adopted = refreshWorkflowUuid(ctx, parsed);
+    // #2768 — a SCOPE ctx.tabId never becomes dest. workflow_list stamps the
+    // routed tab's advertised identity (#1815), so dest must hold the new uuid
+    // or the next list/current-mode call is refused as a stale instance.
+    if (destTab && destTab !== ctx.tabId) {
+      try {
+        ctx.bridge.refreshWorkflowUuid?.(destTab, uuid);
+      } catch {
+        // dest restamp is best-effort; the session fence is the ctx adoption
+      }
+    }
+    return adopted ? { status: "refreshed", uuid, before } : null;
   } catch {
     return null; // never surface a throw here as worse than the existing fallback
   }
@@ -12337,6 +12350,30 @@ function routingIsUnsavedPredecessor(ctx: PanelToolCtx): boolean {
   return typeof pin?.path === "string" && pin.path.startsWith("tmp:");
 }
 
+/** The saved path this session was bound to before Save-As, if any. */
+function sessionSavedPath(ctx: PanelToolCtx): string | undefined {
+  const pin = ctx.workflowTarget?.get(ctx.tabId);
+  if (typeof pin?.path === "string" && pin.path.trim() && !pin.path.startsWith("tmp:")) {
+    return canonicalSavedWorkflowPath(pin.path) ?? pin.path.trim();
+  }
+  return savedPathFromTabId(ctx.tabId) ?? undefined;
+}
+
+/**
+ * #2768 — this Save-As replaced the canvas this session was editing.
+ * `workflow_instance_changed` is the panel's own signal; dest path ≠ the
+ * session's saved path is the same fact on a reply that omits the flag.
+ */
+function saveReplacedSessionCanvas(
+  ctx: PanelToolCtx,
+  parsed: Record<string, unknown>,
+  destPath: string,
+): boolean {
+  if (parsed.workflow_instance_changed === true) return true;
+  const from = sessionSavedPath(ctx);
+  return Boolean(from && from !== destPath);
+}
+
 function destPinnedTarget(
   pinned: { path?: string; filename?: string },
   destPath: string,
@@ -12381,9 +12418,14 @@ function adoptPinnedDestPath(
  * (`panel_set_todo`, `panel_canvas`) still address the old id.
  *
  * Follow dest when the current address is dead, when it already aliases onto
- * dest (same-socket tmp:→wf: / Save-As rename), or when it is the unsaved
+ * dest (same-socket tmp:→wf: / Save-As rename), when it is the unsaved
  * predecessor of dest (pinned tmp: canvas whose first save published a
- * `workflows/…` routing key). A live pin on a DIFFERENT saved tab is left
+ * `workflows/…` routing key), or when this Save-As replaced the canvas this
+ * session was editing (#2768 — dest path differs, or the panel set
+ * `workflow_instance_changed`). Leaving the session on the source id after
+ * that is a stale fence: dest is live, the source id may still canReach, and
+ * panel_list_workflows / mode:"current" then fail with instance mismatch.
+ * A live pin on a DIFFERENT saved tab that this save did not replace is left
  * alone — that is #1917 / #884.
  *
  * Matching is on the dest path the save reply proved, and only when exactly
@@ -12405,7 +12447,10 @@ function repointRoutingAfterSave(ctx: PanelToolCtx, reply: ToolResult): void {
   }
   const live = liveRoutingTab(ctx);
   const follow =
-    !live || live === destTab || routingIsUnsavedPredecessor(ctx);
+    !live ||
+    live === destTab ||
+    routingIsUnsavedPredecessor(ctx) ||
+    saveReplacedSessionCanvas(ctx, parsed, destPath);
   if (!follow) return;
   if (isScopeAddress(ctx.tabId)) {
     try {
@@ -25146,13 +25191,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // attempting rebindWorkflowFence's independent workflow_list round trip,
         // which can be refused by the exact fence this repairs.
         //
-        // #2419 — BEFORE the fence refresh so the stamp lands on the dest
-        // address. Save-As mints a new tab id; the fence repair re-stamps
-        // graph commands, but session-scoped commands (set_todo, graph_canvas)
-        // still address the old id unless routing is re-pointed. Follow dest
-        // when the current address is dead, aliases onto dest, or is the
-        // unsaved tmp: predecessor of dest. A live pin on a different saved
-        // tab is left alone (#1917 / #884).
+        // #2419 / #2768 — BEFORE the fence refresh so the stamp lands on the
+        // dest address. Save-As mints a new tab id; the fence repair re-stamps
+        // graph commands, but session-scoped commands (set_todo, graph_canvas,
+        // workflow_list) still address the old id unless routing is re-pointed.
+        // Follow dest when the current address is dead, aliases onto dest, is
+        // the unsaved tmp: predecessor of dest, or this Save-As replaced the
+        // canvas this session was editing. A live pin on a different saved tab
+        // that this save did not replace is left alone (#1917 / #884).
         repointRoutingAfterSave(ctx, res);
         const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
         let canMutateNow: boolean | undefined;


### PR DESCRIPTION
Fixes #2768

## What was still broken

`panel_save_workflow(name)` succeeds (Save-As COPY). The panel then makes dest the live canvas (new tab id, new `workflow_uuid`). The source tab id can still `canReach` — original file stays on disk, old route not yet dead.

Routing treated that as a live pin (#1917) and stayed on the source. The command fence was refreshed on the source address, dest kept the carried source uuid. Then:

- `panel_list_workflows` and `panel_set_workflow_target({mode:"current"})` were stamped for the replaced instance
- both failed with `workflow instance mismatch`
- mode:"current" could not recover because its probe is that same list

## Fix

After a successful named save, follow dest when this save replaced the session canvas (`workflow_instance_changed`, or dest path ≠ the session's saved path). Restamp dest from the save reply so `workflow_list` (#1815 stamps the routed tab) is not refused.

A live pin on a **different** saved tab that this save did not replace is still left alone (#1917 / #884). Dest is not guessed when two live tabs match the dest path.

## Tests

`src/__tests__/orchestrator/save-as-rebinds-live-instance.test.ts`

- real-tab session moves off a still-reachable source onto dest
- `panel_list_workflows` and mode:"current" then succeed (no stale fence)
- SCOPE session whose source pin still reaches is re-pinned onto dest

`src/__tests__/orchestrator/save-as-todo-canvas-route.test.ts`

- dest listed next to a still-reachable source follows dest (#2768)
- dest-not-listed source still stays put (#1917)

Targeted: **23 passed** (`save-as-rebinds-live-instance` 3, `save-as-todo-canvas-route` 12, `fence-trusts-own-reply` 8)
Related: **15 passed** (`load-workflow-stale-path`, `codex-reconnect-rebind`)
