### PR TITLE
fix(2780): slice outputs inside nested overlapping groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 - **`panel_save_workflow(name)` rebinds the session onto the Save-As dest canvas (#2768).** After a named save the live instance is dest, but the source tab id can still `canReach`; staying there left `panel_list_workflows` and `panel_set_workflow_target({mode:"current"})` stamped for the replaced instance. Dest is followed when this save replaced the session canvas, and dest's command stamp is refreshed from the save reply.
 - **`list_local_models` `action:"remove"` resolves against the same launch-proven extra-path files as inventory, including ComfyUI Desktop's `extra_models_config.yaml` (#2739).** Removal previously searched only the Desktop shared models yaml from argv, so a listed LTX file under another active extra root could not be deleted. Desktop extra roots are included only when the connected snapshot already named a Desktop extra-path config — never by probing a guessed :8188 origin — and still fail closed when that file cannot be proven unchanged since launch.
-
+- **`panel_slice_workflow` seeds outputs inside nested overlapping groups (#2780).** Membership used the first containing box only, so a SaveImage inside both an outer group and a nested inner group was missed when slicing by the inner title. Any matching containing group now seeds, and a miss lists every containing title.
 
 ## [0.52.181] - 2026-09-03
 
@@ -19,7 +19,6 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 - **`panel_set_widget` creates a documented `lora_N` row on an ordinary Power Lora Loader inside a live subgraph (#2394, #2794).** Current panels flatten parentheses in the `graph_get_subgraph` "is not a subgraph" line, so a live `Power Lora Loader (rgthree)` was reported as `Power Lora Loader rgthree` and the identity-fenced ordinary write refused it as a type change. The two types are compared after that flatten; the write still fences the real unflattened type.
-
 
 ## [0.52.180] - 2026-09-03
 

--- a/src/__tests__/services/slice-miss-diagnostic.test.ts
+++ b/src/__tests__/services/slice-miss-diagnostic.test.ts
@@ -117,3 +117,43 @@ describe("slice miss explains itself (panel#690(4))", () => {
     expect(stats.seeds).toBe(1);
   });
 });
+
+describe("slice seeds from nested overlapping groups (#2780)", () => {
+  // Outer group listed FIRST so groups.find() would attribute the SaveImage to
+  // "Save Group" and miss a slice for the inner title.
+  const nestedOverlapWf = {
+    nodes: [
+      { id: 838, type: "SaveImage", pos: [50, 50] },
+      { id: 1, type: "CheckpointLoaderSimple", pos: [40, 40] },
+    ],
+    links: [[1, 1, 0, 838, 0, "IMAGE"]],
+    groups: [
+      { title: "Save Group", bounding: [0, 0, 200, 200] },
+      { title: "#Save Draft 📐", bounding: [25, 25, 75, 75] },
+    ],
+  } as unknown as UiWorkflow;
+
+  it("slices when the output is inside a nested inner group that overlaps a larger outer group", () => {
+    const { stats, workflow } = sliceWorkflow(nestedOverlapWf, ["save draft"]);
+    expect(stats.seeds).toBe(1);
+    expect(workflow.nodes?.some((n) => n.id === 838)).toBe(true);
+  });
+
+  it("still slices by the outer overlapping group title", () => {
+    const { stats } = sliceWorkflow(nestedOverlapWf, ["save group"]);
+    expect(stats.seeds).toBe(1);
+  });
+
+  it("lists every containing group on a miss, not only the first box", () => {
+    expect(() => sliceWorkflow(nestedOverlapWf, ["#Save Draft"])).not.toThrow();
+    try {
+      sliceWorkflow(nestedOverlapWf, ["does-not-match"]);
+      throw new Error("expected slice miss");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toContain("Save Group");
+      expect(msg).toContain("#Save Draft");
+      expect(msg).toContain("#838 SaveImage");
+    }
+  });
+});

--- a/src/__tests__/services/slice-miss-diagnostic.test.ts
+++ b/src/__tests__/services/slice-miss-diagnostic.test.ts
@@ -131,7 +131,7 @@ describe("slice seeds from nested overlapping groups (#2780)", () => {
       { title: "Save Group", bounding: [0, 0, 200, 200] },
       { title: "#Save Draft 📐", bounding: [25, 25, 75, 75] },
     ],
-  } as unknown as UiWorkflow;
+  } as UiWorkflow;
 
   it("slices when the output is inside a nested inner group that overlaps a larger outer group", () => {
     const { stats, workflow } = sliceWorkflow(nestedOverlapWf, ["save draft"]);

--- a/src/services/workflow-slicer.ts
+++ b/src/services/workflow-slicer.ts
@@ -76,12 +76,21 @@ export function sliceWorkflow(
   const links = new Map<number, WLink>(allLinks.map((l) => [l[0], l]));
   const groups = g.groups ?? [];
 
+  // #2780 — a node can sit inside several overlapping/nested boxes. `find`
+  // attributed it only to the first, so a SaveImage inside both "Save Group"
+  // and "#Save Draft" was missed when the caller asked for the inner title.
+  const groupsOf = (n: WNode): string[] =>
+    groups.filter((gr) => inBox(n.pos, gr.bounding)).map((gr) => gr.title ?? "");
+  const wantNode = (n: WNode): boolean =>
+    groupsOf(n).some((title) => {
+      const t = title.toLowerCase();
+      return want.some((w) => t.includes(w));
+    });
   const groupOf = (n: WNode): string =>
-    groups.find((gr) => inBox(n.pos, gr.bounding))?.title ?? "";
-  const wantNode = (n: WNode): boolean => {
-    const t = groupOf(n).toLowerCase();
-    return want.some((w) => t.includes(w));
-  };
+    groupsOf(n)
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .join(" / ");
 
   // Set/Get bus maps (keyed by the bus name in widgets_values[0]).
   const setByBus = new Map<unknown, number>();


### PR DESCRIPTION
## Summary
- `panel_slice_workflow` / `sliceWorkflow` attributed a node to only the first containing group box, so a SaveImage inside nested overlapping groups (outer "Save Group" + inner "#Save Draft") was missed when slicing by the inner title.
- Membership now matches any containing group title; a slice miss lists every containing title, not just the first box.
- Regression test covers the reporter's nested-overlap geometry.

Fixes #2780

## Test plan
- [x] `npx vitest run src/__tests__/services/slice-miss-diagnostic.test.ts` (12 passed)
