### PR TITLE
fix(2730): refresh subgraph mapping after queue-busy widget refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- **`panel_set_widget` writes ordinary root widgets after a queue-busy refusal without a manual `panel_graph_outline` (#2730).** A correct queue-busy fence left the panel's subgraph registry stale, so the next idle `graph_set_widget` treated root `UNETLoader` nodes as unverifiable promoted containers. Mapping-unknown now refreshes once (or after the busy refusal clears) and retries the guard; still unverifiable stays fail-closed.
 - **`panel_save_workflow(name)` rebinds the session onto the Save-As dest canvas (#2768).** After a named save the live instance is dest, but the source tab id can still `canReach`; staying there left `panel_list_workflows` and `panel_set_workflow_target({mode:"current"})` stamped for the replaced instance. Dest is followed when this save replaced the session canvas, and dest's command stamp is refreshed from the save reply.
 - **`list_local_models` `action:"remove"` resolves against the same launch-proven extra-path files as inventory, including ComfyUI Desktop's `extra_models_config.yaml` (#2739).** Removal previously searched only the Desktop shared models yaml from argv, so a listed LTX file under another active extra root could not be deleted. Desktop extra roots are included only when the connected snapshot already named a Desktop extra-path config — never by probing a guessed :8188 origin — and still fail closed when that file cannot be proven unchanged since launch.
 

--- a/src/__tests__/orchestrator/queue-busy-subgraph-mapping.test.ts
+++ b/src/__tests__/orchestrator/queue-busy-subgraph-mapping.test.ts
@@ -1,0 +1,246 @@
+// #2730 — after queue-busy correctly refuses panel_set_widget, an idle retry
+// still refused ordinary root UNETLoader writes because graph_get_subgraph
+// could not tell whether they were promoted containers. panel_graph_outline
+// refreshed the mapping; the same writes then succeeded.
+//
+// The shipped handler must refresh that mapping itself (after the busy
+// refusal clears, or once on a mapping-unknown root read) and fail closed
+// if the node is still unverifiable.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetStaleSubgraphMappingForTest,
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:2730-unet-root";
+const NODE_ID = 12;
+const ROOT_GRAPH_IDENTITY = "graph:2730-root";
+const WORKFLOW_UUID = "27300000-0000-4000-8000-000000000012";
+const NODE_IDENTITY = "node-incarnation:12:unet";
+const UNET_NAME = "flux1-dev.safetensors";
+const MAPPING_UNKNOWN =
+  "Cannot read node 12 (UNETLoader) because the subgraph mapping is not loaded";
+
+type QMPriv = {
+  url: string | null;
+  stopped: boolean;
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    currentNode: string | null;
+    queueRemaining: number;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+const qm = QueueMonitor as QMPriv;
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+function textOf(result: ToolResult): string {
+  return result.content.map((block) => (block as { text?: string }).text ?? "").join(" ");
+}
+
+function startRender(promptId = "p-in-flight"): void {
+  qm.state.runningPromptId = promptId;
+  qm.state.currentNode = "UNETLoader";
+  qm.state.queueRemaining = 1;
+}
+
+function stopRender(): void {
+  qm.state.runningPromptId = null;
+  qm.state.currentNode = null;
+  qm.state.queueRemaining = 0;
+}
+
+beforeEach(() => {
+  __resetStaleSubgraphMappingForTest();
+  qm.url = "http://127.0.0.1:9999";
+  qm.stopped = false;
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.connected = true;
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.currentNode = null;
+  qm.state.queueRemaining = 0;
+  qm.state.lastServerAliveTs = Date.now();
+  qm.state.lastFrameTs = Date.now();
+});
+
+afterEach(() => {
+  __resetStaleSubgraphMappingForTest();
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.runningPromptId = null;
+  qm.state.currentNode = null;
+  qm.state.queueRemaining = 0;
+  qm.stopped = true;
+  qm.url = null;
+});
+
+function makeMappingBridge(opts?: { outlineHelps?: boolean; mappingReady?: boolean }) {
+  const calls: Array<Record<string, unknown>> = [];
+  let writes = 0;
+  let mappingReady = opts?.mappingReady === true;
+  const outlineHelps = opts?.outlineHelps !== false;
+  const viewing = {
+    scope: "root" as const,
+    workflow_uuid: WORKFLOW_UUID,
+    graph_identity: ROOT_GRAPH_IDENTITY,
+  };
+
+  const unetRow = (ready: boolean) => ({
+    id: NODE_ID,
+    type: "UNETLoader",
+    ...(ready ? { is_subgraph: false, node_identity: NODE_IDENTITY } : {}),
+    widgets: { unet_name: "old.safetensors" },
+  });
+
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push({ ...cmd });
+      if (cmd.cmd === "graph_outline") {
+        if (outlineHelps) mappingReady = true;
+        return { viewing, node_count: 1, outline: "12 UNETLoader" };
+      }
+      if (cmd.cmd === "graph_query") {
+        return { viewing, nodes: [unetRow(mappingReady)] };
+      }
+      if (cmd.cmd === "graph_get_subgraph") {
+        if (mappingReady) {
+          throw new Error("Node 12 (UNETLoader) is not a subgraph");
+        }
+        throw new Error(MAPPING_UNKNOWN);
+      }
+      if (cmd.cmd === "graph_set_widget") {
+        writes += 1;
+        return {
+          set: {
+            node_id: cmd.node_id,
+            widget: cmd.widget,
+            previous: "old.safetensors",
+            value: cmd.value,
+          },
+        };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    tabConnectionIdentity: () => ({ generation: 1, tabSessionId: "browser-tab-2730" }),
+    tabExpectedNodeTypeFenceCapability: () => true,
+    tabExpectedNodeIdentityFenceCapability: () => true,
+    tabExpectedScopeGraphIdentityFenceCapability: () => true,
+    tabPromotedTerminalWitnessCapability: () => true,
+    tabPromotedParentRailFenceCapability: () => true,
+    tabReceiverResolvable: () => true,
+    workflowUuidFor: () => ({ known: true, uuid: WORKFLOW_UUID }),
+    refreshWorkflowUuid: () => true,
+    corroborateTabStamp: () => true,
+    promotedScopeFor: () => ({
+      known: true as const,
+      scope: "root" as const,
+      ownerNodeId: null,
+      workflowUuid: WORKFLOW_UUID,
+      graphIdentity: ROOT_GRAPH_IDENTITY,
+    }),
+  } as PanelToolCtx["bridge"];
+
+  return {
+    bridge,
+    calls,
+    get writes() {
+      return writes;
+    },
+    goStale() {
+      mappingReady = false;
+    },
+  };
+}
+
+async function setUnet(ctx: PanelToolCtx, value = UNET_NAME) {
+  return defByName("panel_set_widget").handler(
+    { node_id: NODE_ID, widget: "unet_name", value } as never,
+    ctx,
+  );
+}
+
+describe("ordinary root UNETLoader write after queue-busy (#2730)", () => {
+  it("THE REPORTED CASE: queue-busy refuse, idle retry writes without a manual outline", async () => {
+    const harness = makeMappingBridge({ mappingReady: true });
+    const ctx = makePanelToolCtx(harness.bridge, TAB, new WorkflowTargetStore());
+
+    startRender();
+    const busy = await setUnet(ctx);
+    expect(busy.isError).toBe(true);
+    expect(textOf(busy)).toMatch(/QUEUE BUSY/);
+    expect(harness.calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(harness.writes).toBe(0);
+
+    stopRender();
+    harness.goStale();
+
+    const idle = await setUnet(ctx);
+    expect(textOf(idle)).not.toMatch(/could not determine whether the addressed node is a promoted container/);
+    expect(idle.isError).toBeFalsy();
+    expect(harness.calls.filter((call) => call.cmd === "graph_outline")).toHaveLength(1);
+    expect(harness.calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({
+        node_id: NODE_ID,
+        widget: "unet_name",
+        value: UNET_NAME,
+        expected_node_type: "UNETLoader",
+      }),
+    ]);
+    expect(harness.writes).toBe(1);
+  });
+
+  it("mapping-unknown at a proven root refreshes once and then writes", async () => {
+    const harness = makeMappingBridge({ mappingReady: false });
+    const ctx = makePanelToolCtx(harness.bridge, TAB, new WorkflowTargetStore());
+
+    const written = await setUnet(ctx);
+    expect(written.isError).toBeFalsy();
+    expect(textOf(written)).not.toMatch(/could not determine whether the addressed node is a promoted container/);
+    expect(harness.calls.map((call) => call.cmd)).toEqual([
+      "graph_query",
+      "graph_get_subgraph",
+      "graph_outline",
+      "graph_query",
+      "graph_set_widget",
+    ]);
+    expect(harness.writes).toBe(1);
+  });
+
+  it("fails closed when the mapping is still unverifiable after one refresh", async () => {
+    const harness = makeMappingBridge({ mappingReady: false, outlineHelps: false });
+    const ctx = makePanelToolCtx(harness.bridge, TAB, new WorkflowTargetStore());
+
+    const refused = await setUnet(ctx);
+    expect(refused.isError).toBe(true);
+    expect(textOf(refused)).toMatch(/could not determine whether the addressed node is a promoted container/);
+    expect(harness.calls.filter((call) => call.cmd === "graph_outline")).toHaveLength(1);
+    expect(harness.calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+    expect(harness.writes).toBe(0);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7321,6 +7321,35 @@ function forgetStaleSubgraphIdentity(ctx: PanelToolCtx): void {
   ctx.bridge?.clearPromotedSubgraphIdentity?.(ctx.tabId);
 }
 
+/** Tabs whose promoted-container mapping is unverified after a queue-busy
+ * mutation refusal. `graph_get_subgraph` can stay indeterminate for ordinary
+ * root nodes until something walks the live graph (#2730). */
+const staleSubgraphMappingTabs = new Set<string>();
+
+function noteStaleSubgraphMapping(tabId: string): void {
+  if (tabId) staleSubgraphMappingTabs.add(tabId);
+}
+
+export function __resetStaleSubgraphMappingForTest(): void {
+  staleSubgraphMappingTabs.clear();
+}
+
+/** Root graph identity from a live query even when `is_subgraph` is missing.
+ * A missing container bit is indeterminate, but a published root identity is
+ * still enough to spend one mapping refresh before failing closed (#2730). */
+function parseRootGraphIdentity(payload: Record<string, unknown> | null): string | null {
+  if (!payload) return null;
+  const viewing = payload.viewing;
+  if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return null;
+  const rec = viewing as Record<string, unknown>;
+  if (rec.scope !== "root") return null;
+  const graphIdentity = rec.graph_identity;
+  if (typeof graphIdentity !== "string" || graphIdentity.length === 0 || graphIdentity.length > 256) {
+    return null;
+  }
+  return graphIdentity;
+}
+
 /** Read the active viewing scope and node's explicit container bit before
  * attempting promoted-widget resolution. The pinpoint detail projection carries
  * the node bit even when the widget list is empty (which is how a fresh rgthree
@@ -8225,23 +8254,31 @@ const PROMOTED_PREFLIGHT_READ_OPTIONS: PanelToolCallOptions = {
   maxBridgeReconnectRetries: 0,
 };
 
+type PromotedTargetProbe = {
+  scope: QueriedNodeScope | null;
+  rootGraphIdentity: string | null;
+};
+
 async function readPromotedTargetScope(
   ctx: PanelToolCtx,
   nodeId: unknown,
   options: PanelToolCallOptions = PROMOTED_PREFLIGHT_READ_OPTIONS,
-): Promise<QueriedNodeScope | null> {
+): Promise<PromotedTargetProbe> {
   const probe = await ctx.call({
     cmd: "graph_query",
     ids: [nodeId],
     fields: "detail",
     limit: 1,
   }, undefined, undefined, undefined, options);
-  if (probe.isError) return null;
+  if (probe.isError) return { scope: null, rootGraphIdentity: null };
   const payload = parseToolResultJson(probe);
   if (parseViewingScope(payload?.viewing)?.scope === "root") {
     rememberLiveRootViewing(ctx, payload?.viewing);
   }
-  return parseVerifiedQueriedNodeScope(payload, nodeId);
+  return {
+    scope: parseVerifiedQueriedNodeScope(payload, nodeId),
+    rootGraphIdentity: parseRootGraphIdentity(payload),
+  };
 }
 
 function currentPromotedBindingError(
@@ -8865,16 +8902,57 @@ async function preparePromotedWidgetWrite(
     }
   }
 
+  // #2730 — after a queue-busy mutation refusal the panel's subgraph registry
+  // can stay stale until a graph walk. Refresh once before classifying, then
+  // re-probe so an ordinary root node can take the fast path without a manual
+  // panel_graph_outline.
+  let mappingRefreshed = false;
+  const refreshSubgraphMapping = async (): Promise<ToolResult | null> => {
+    if (mappingRefreshed) return null;
+    mappingRefreshed = true;
+    const outline = await ctx.call(
+      { cmd: "graph_outline" },
+      undefined,
+      undefined,
+      undefined,
+      PROMOTED_PREFLIGHT_READ_OPTIONS,
+    );
+    if (outline.isError) {
+      return promotedWriteRefusal(widget, "graph_outline could not refresh the subgraph mapping");
+    }
+    staleSubgraphMappingTabs.delete(ctx.tabId);
+    const payload = parseToolResultJson(outline);
+    if (parseViewingScope(payload?.viewing)?.scope === "root") {
+      rememberLiveRootViewing(ctx, payload?.viewing);
+      forgetStaleSubgraphIdentity(ctx);
+    }
+    const drift = panelBindingDriftReason(
+      ctx,
+      "after the subgraph mapping refresh",
+      hasIdentityApi,
+      identityBefore,
+      tabBefore,
+    );
+    if (drift) return ordinaryBindingRefusal(widget, drift);
+    return null;
+  };
+  if (staleSubgraphMappingTabs.has(ctx.tabId)) {
+    const refreshError = await refreshSubgraphMapping();
+    if (refreshError) return refreshError;
+  }
+
   // #2394 — a root-level rgthree Power Lora Loader may have no lora_N widget
   // yet. Prove the addressed node is an ordinary root node before asking the
   // promoted-container classifier to resolve a target that is intentionally
   // absent. An unreadable scope probe is not permission for an outer write;
   // it falls through to the existing conservative graph_get_subgraph path.
-  const targetScope = await readPromotedTargetScope(
+  let targetProbe = await readPromotedTargetScope(
     ctx,
     nodeId,
     PROMOTED_PREFLIGHT_READ_OPTIONS,
   );
+  let targetScope = targetProbe.scope;
+  const rootGraphIdentity = targetProbe.rootGraphIdentity;
   // #2518 — a live root query names the current root workflow instance. Do not
   // enter the promoted-subgraph identity path for an ordinary (or unproven)
   // root node; a truncated StringConcatenate pinpoint used to fall through,
@@ -8954,6 +9032,31 @@ async function preparePromotedWidgetWrite(
       );
     }
     if (firstReadKind === "permanent") {
+      // #2730 — a stale subgraph registry is a permanent-looking miss for an
+      // ordinary root node. Refresh the mapping once and re-probe. Still
+      // unverifiable → refuse. Do not spend the transient subgraph re-read on
+      // a permanent application error.
+      if (!mappingRefreshed && rootGraphIdentity !== null) {
+        const refreshError = await refreshSubgraphMapping();
+        if (refreshError) return refreshError;
+        targetProbe = await readPromotedTargetScope(
+          ctx,
+          nodeId,
+          PROMOTED_PREFLIGHT_READ_OPTIONS,
+        );
+        targetScope = targetProbe.scope;
+        if (targetScope?.activeView === "root" && targetScope.node === "ordinary") {
+          const driftAfterMapping = panelBindingDriftReason(
+            ctx,
+            "after the subgraph mapping refresh",
+            hasIdentityApi,
+            identityBefore,
+            tabBefore,
+          );
+          if (driftAfterMapping) return ordinaryBindingRefusal(widget, driftAfterMapping);
+          return ordinaryWritePlanFromScope(widget, targetScope, tabBefore, identityBefore);
+        }
+      }
       return promotedSubgraphReadRefusal(
         widget,
         sub,
@@ -17067,7 +17170,13 @@ export function makePanelToolCtx(
       // panel#1489 — reads are NOT refused here: they carry no unknown outcome,
       // so they are dispatched on the bounded budget above instead.
       const blocked = graphCmdBlockedByRunningPrompt(cmd);
-      if (blocked) return fail(blocked);
+      if (blocked) {
+        // #2730 — a fenced mutation never reached the panel, so the subgraph
+        // registry can stay stale until something walks the live graph. Mark
+        // this tab so the next idle write refreshes mapping once.
+        noteStaleSubgraphMapping(ctx.tabId);
+        return fail(blocked);
+      }
       // #2527 — a timed-out mutation may still be applying. Graph reads wait for
       // that settlement (or disclose the outstanding receipt) so they cannot
       // certify a stale widget value as current.


### PR DESCRIPTION
Fixes #2730

## What was still broken

After a render, `panel_set_widget` correctly refused while the queue was busy. Once the queue was idle, the same write to ordinary root `UNETLoader` nodes still refused:

> graph_get_subgraph could not determine whether the addressed node is a promoted container

The live canvas stayed bound. One `panel_graph_outline` refreshed the subgraph registry; the identical writes then succeeded. Four root nodes reproduced it.

## Fix

- A queue-busy mutation refusal marks the tab's subgraph mapping stale.
- The next idle `panel_set_widget` walks the graph (`graph_outline`) once, then re-probes.
- Mapping-unknown at a proven root also refreshes once and retries the guard.
- Still unverifiable stays fail-closed. No write is dispatched on an unclassifiable node.

## Tests

`src/__tests__/orchestrator/queue-busy-subgraph-mapping.test.ts`

- reported case: queue-busy refuse, idle retry writes without a manual outline
- mapping-unknown at a proven root refreshes once and then writes
- still refuses when the mapping is unverifiable after one refresh

Targeted: **3 passed / 0 failed** (`queue-busy-subgraph-mapping.test.ts`)
Related suites: **267 passed** (that file + `promoted-widget`, `graph-read-during-render`, `root-widget-promoted-misclass`, `queue-busy-unconfirmed`)