### PR TITLE
fix(2786): accept MiniMax H3 text_to_video adapter mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### MCP
 #### Fixed
+- **manga-director-codex MiniMax H3 adapter accepts documented `text_to_video`.** Native H3 T2V is `MiniMaxH3ImageToVideo` with both image sockets empty; the adapter omitted that mode and compilation refused a valid prompt spec. `text_to_video` is declared; I2V / FL2VA / L2VA / R2V modes are unchanged (#2786).
 - **`panel_slice_workflow` seeds outputs inside nested overlapping groups (#2780).** Membership used the first containing box only, so a SaveImage inside both an outer group and a nested inner group was missed when slicing by the inner title. Any matching containing group now seeds, and a miss lists every containing title.
 
 ## [0.52.182] - 2026-09-03

--- a/plugin/skills/minimax-h3-video/SKILL.md
+++ b/plugin/skills/minimax-h3-video/SKILL.md
@@ -156,6 +156,9 @@ optional first_frame / last_frame ─────→   → CONDITIONING + LATENT
 
 `MiniMaxH3ImageToVideo` **is** T2V when both image sockets are empty, I2V with
 `first_frame`, FL2VA with both frames. Do not add a second T2V-only node.
+The manga-director-codex MiniMax H3 prompt adapter
+(`prompt_adapters/minimax_h3.json`) declares that as mode `text_to_video`
+alongside I2V / FL2VA / L2VA / R2V (#2786).
 
 R2V replaces the UNet with **ref2va** and the conditioner with
 `MiniMaxH3ReferenceToVideo`. Do not load fl2va into an R2V graph.

--- a/plugin/skills/minimax-h3-video/prompt_adapters/minimax_h3.json
+++ b/plugin/skills/minimax-h3-video/prompt_adapters/minimax_h3.json
@@ -1,0 +1,11 @@
+{
+  "adapter": "minimax_h3",
+  "adapter_version": "1.0.2",
+  "supported_modes": [
+    "text_to_video",
+    "image_to_video",
+    "first_last_frame",
+    "last_frame_to_video",
+    "reference_to_video"
+  ]
+}

--- a/src/__tests__/services/minimax-h3-prompt-adapter.test.ts
+++ b/src/__tests__/services/minimax-h3-prompt-adapter.test.ts
@@ -1,0 +1,103 @@
+// #2786 — manga-director-codex MiniMax H3 adapter omitted text_to_video from
+// supported_modes, so compile_prompt_package refused a valid local H3 T2V spec.
+// Native T2V is MiniMaxH3ImageToVideo with both image sockets empty.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ComfyUIError } from "../../utils/errors.js";
+import {
+  MINIMAX_H3_ADAPTER_ID,
+  MINIMAX_H3_MODES,
+  adapterDeclaresMode,
+  compilePromptPackage,
+  formatCompilePass,
+  parseMiniMaxH3Adapter,
+  readBundledMiniMaxH3Adapter,
+  type MiniMaxH3PromptAdapter,
+} from "../../services/minimax-h3-prompt-adapter.js";
+
+const SKILL_URL = new URL("../../../plugin/skills/minimax-h3-video/SKILL.md", import.meta.url);
+const ADAPTER_URL = new URL(
+  "../../../plugin/skills/minimax-h3-video/prompt_adapters/minimax_h3.json",
+  import.meta.url,
+);
+
+const SKILL = readFileSync(SKILL_URL, "utf8").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+function spec(mode: string, adapter = MINIMAX_H3_ADAPTER_ID) {
+  return {
+    prompt_id: "VIDEO-CAL-PB01-H3-T2V-TEST-V1",
+    model_target: { adapter, mode },
+  };
+}
+
+function withoutMode(adapter: MiniMaxH3PromptAdapter, mode: string): MiniMaxH3PromptAdapter {
+  return {
+    ...adapter,
+    supported_modes: adapter.supported_modes.filter((declared) => declared !== mode),
+  };
+}
+
+describe("#2786 manga-director-codex MiniMax H3 adapter accepts text_to_video", () => {
+  const bundled = readBundledMiniMaxH3Adapter();
+
+  it("ships adapter_version 1.0.2 at the bundled prompt_adapters path", () => {
+    const fromDisk = parseMiniMaxH3Adapter(readFileSync(ADAPTER_URL, "utf8"));
+    expect(fromDisk).toEqual(bundled);
+    expect(bundled.adapter).toBe("minimax_h3");
+    expect(bundled.adapter_version).toBe("1.0.2");
+  });
+
+  it("declares every MiniMax H3 mode, including documented text_to_video", () => {
+    expect(bundled.supported_modes).toEqual([...MINIMAX_H3_MODES]);
+    expect(adapterDeclaresMode(bundled, "text_to_video")).toBe(true);
+  });
+
+  it("compiles a valid text_to_video prompt spec", () => {
+    const result = compilePromptPackage(spec("text_to_video"));
+    expect(formatCompilePass(result)).toBe(
+      "PASS: prompt compiled with generation=0 adapter=minimax_h3 prompt_id=VIDEO-CAL-PB01-H3-T2V-TEST-V1",
+    );
+  });
+
+  it("still compiles the other MiniMax H3 modes", () => {
+    for (const mode of MINIMAX_H3_MODES) {
+      if (mode === "text_to_video") continue;
+      const result = compilePromptPackage(spec(mode), bundled);
+      expect(result).toEqual({
+        ok: true,
+        generation: 0,
+        adapter: "minimax_h3",
+        prompt_id: "VIDEO-CAL-PB01-H3-T2V-TEST-V1",
+      });
+    }
+  });
+
+  it("rejects text_to_video when the adapter omits it — the #2786 regression", () => {
+    const omitted = withoutMode(bundled, "text_to_video");
+    expect(adapterDeclaresMode(omitted, "text_to_video")).toBe(false);
+    try {
+      compilePromptPackage(spec("text_to_video"), omitted);
+      throw new Error("compile should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ComfyUIError);
+      if (!(err instanceof ComfyUIError)) throw err;
+      expect(err.code).toBe("BLOCKED_PROMPT_ADAPTER_MISMATCH");
+      expect(err.message).toBe(
+        "BLOCKED_PROMPT_ADAPTER_MISMATCH: minimax_h3 does not declare mode text_to_video",
+      );
+    }
+  });
+
+  it("still rejects a mode the adapter does not declare", () => {
+    expect(() => compilePromptPackage(spec("wan_flf"), bundled)).toThrow(
+      /BLOCKED_PROMPT_ADAPTER_MISMATCH: minimax_h3 does not declare mode wan_flf/,
+    );
+  });
+
+  it("keeps the skill's native T2V contract next to the adapter mode name", () => {
+    expect(SKILL).toContain("MiniMaxH3ImageToVideo");
+    expect(SKILL).toMatch(/both image sockets are empty/);
+    expect(SKILL).toContain("text_to_video");
+    expect(SKILL).toContain("prompt_adapters/minimax_h3.json");
+  });
+});

--- a/src/services/minimax-h3-prompt-adapter.ts
+++ b/src/services/minimax-h3-prompt-adapter.ts
@@ -1,0 +1,169 @@
+// #2786 — manga-director-codex MiniMax H3 prompt adapter.
+// Native H3 T2V is MiniMaxH3ImageToVideo with both image sockets empty
+// (plugin/skills/minimax-h3-video). compile_prompt_package must accept
+// model_target.mode=text_to_video when adapter=minimax_h3.
+
+import { readFileSync } from "node:fs";
+import { ComfyUIError } from "../utils/errors.js";
+
+export const MINIMAX_H3_ADAPTER_ID = "minimax_h3";
+
+export const MINIMAX_H3_MODES = [
+  "text_to_video",
+  "image_to_video",
+  "first_last_frame",
+  "last_frame_to_video",
+  "reference_to_video",
+] as const;
+
+export type MiniMaxH3Mode = (typeof MINIMAX_H3_MODES)[number];
+
+export interface MiniMaxH3PromptAdapter {
+  adapter: typeof MINIMAX_H3_ADAPTER_ID;
+  adapter_version: string;
+  supported_modes: MiniMaxH3Mode[];
+}
+
+export interface MiniMaxH3PromptSpec {
+  prompt_id: string;
+  model_target: {
+    adapter: string;
+    mode: string;
+  };
+}
+
+export interface MiniMaxH3CompilePass {
+  ok: true;
+  generation: 0;
+  adapter: typeof MINIMAX_H3_ADAPTER_ID;
+  prompt_id: string;
+}
+
+export const MINIMAX_H3_ADAPTER_URL = new URL(
+  "../../plugin/skills/minimax-h3-video/prompt_adapters/minimax_h3.json",
+  import.meta.url,
+);
+
+export function isMiniMaxH3Mode(value: string): value is MiniMaxH3Mode {
+  for (const mode of MINIMAX_H3_MODES) {
+    if (mode === value) return true;
+  }
+  return false;
+}
+
+function isModeList(value: unknown): value is MiniMaxH3Mode[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== "string" || !isMiniMaxH3Mode(item) || seen.has(item)) return false;
+    seen.add(item);
+  }
+  return true;
+}
+
+export function parseMiniMaxH3Adapter(raw: string): MiniMaxH3PromptAdapter {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ComfyUIError(
+      "minimax_h3 adapter JSON is not parseable",
+      "BLOCKED_PROMPT_ADAPTER_MISMATCH",
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new ComfyUIError(
+      "minimax_h3 adapter JSON is not an object",
+      "BLOCKED_PROMPT_ADAPTER_MISMATCH",
+    );
+  }
+  const rec = parsed;
+  const adapter = "adapter" in rec ? rec.adapter : undefined;
+  const adapter_version = "adapter_version" in rec ? rec.adapter_version : undefined;
+  const supported_modes = "supported_modes" in rec ? rec.supported_modes : undefined;
+  if (
+    adapter !== MINIMAX_H3_ADAPTER_ID ||
+    typeof adapter_version !== "string" ||
+    adapter_version.length === 0 ||
+    !isModeList(supported_modes)
+  ) {
+    throw new ComfyUIError(
+      "minimax_h3 adapter JSON is missing adapter, adapter_version, or supported_modes",
+      "BLOCKED_PROMPT_ADAPTER_MISMATCH",
+    );
+  }
+  return { adapter, adapter_version, supported_modes };
+}
+
+export function readBundledMiniMaxH3Adapter(): MiniMaxH3PromptAdapter {
+  return parseMiniMaxH3Adapter(readFileSync(MINIMAX_H3_ADAPTER_URL, "utf8"));
+}
+
+function promptSpecOf(value: unknown): MiniMaxH3PromptSpec {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ComfyUIError(
+      "prompt spec is not an object",
+      "BLOCKED_PROMPT_ADAPTER_MISMATCH",
+    );
+  }
+  const rec = value;
+  const prompt_id = "prompt_id" in rec ? rec.prompt_id : undefined;
+  const model_target = "model_target" in rec ? rec.model_target : undefined;
+  if (typeof prompt_id !== "string" || prompt_id.length === 0) {
+    throw new ComfyUIError("prompt spec is missing prompt_id", "BLOCKED_PROMPT_ADAPTER_MISMATCH");
+  }
+  if (typeof model_target !== "object" || model_target === null || Array.isArray(model_target)) {
+    throw new ComfyUIError(
+      "prompt spec is missing model_target",
+      "BLOCKED_PROMPT_ADAPTER_MISMATCH",
+    );
+  }
+  const adapter = "adapter" in model_target ? model_target.adapter : undefined;
+  const mode = "mode" in model_target ? model_target.mode : undefined;
+  if (
+    typeof adapter !== "string" ||
+    adapter.length === 0 ||
+    typeof mode !== "string" ||
+    mode.length === 0
+  ) {
+    throw new ComfyUIError(
+      "prompt spec model_target needs adapter and mode",
+      "BLOCKED_PROMPT_ADAPTER_MISMATCH",
+    );
+  }
+  return { prompt_id, model_target: { adapter, mode } };
+}
+
+export function adapterDeclaresMode(
+  adapter: MiniMaxH3PromptAdapter,
+  mode: string,
+): mode is MiniMaxH3Mode {
+  return adapter.supported_modes.some((declared) => declared === mode);
+}
+
+export function compilePromptPackage(
+  spec: unknown,
+  adapter: MiniMaxH3PromptAdapter = readBundledMiniMaxH3Adapter(),
+): MiniMaxH3CompilePass {
+  const prompt = promptSpecOf(spec);
+  const { adapter: adapterId, mode } = prompt.model_target;
+  if (adapterId !== adapter.adapter || !adapterDeclaresMode(adapter, mode)) {
+    throw new ComfyUIError(
+      `BLOCKED_PROMPT_ADAPTER_MISMATCH: ${adapterId} does not declare mode ${mode}`,
+      "BLOCKED_PROMPT_ADAPTER_MISMATCH",
+    );
+  }
+  return {
+    ok: true,
+    generation: 0,
+    adapter: adapter.adapter,
+    prompt_id: prompt.prompt_id,
+  };
+}
+
+export function formatCompilePass(result: MiniMaxH3CompilePass): string {
+  return (
+    `PASS: prompt compiled with generation=${result.generation} ` +
+    `adapter=${result.adapter} prompt_id=${result.prompt_id}`
+  );
+}


### PR DESCRIPTION
Fixes #2786.

The manga-director-codex MiniMax H3 adapter rejected a valid local H3 text-to-video prompt spec because supported_modes omitted text_to_video. Native T2V is MiniMaxH3ImageToVideo with both image sockets empty (bundled minimax-h3-video skill).

## Fix
- Bundle prompt_adapters/minimax_h3.json at adapter_version 1.0.2 with text_to_video declared.
- Keep I2V / FL2VA / L2VA / R2V (image_to_video, first_last_frame, last_frame_to_video, reference_to_video).
- Compile still throws BLOCKED_PROMPT_ADAPTER_MISMATCH for a mode the adapter does not declare.

## Tests
Targeted vitest:
- src/__tests__/services/minimax-h3-prompt-adapter.test.ts (7)
- src/__tests__/orchestrator/minimax-h3-skill.test.ts (6)
- src/__tests__/orchestrator/skill-authoring-limits.test.ts (261)

274 passed in that set.
