### PR TITLE
fix(2787): accept proven extra-path base_path as shared model_root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### MCP
 #### Fixed
+- **parallel CivitAI downloads accept a proven shared extra-path `base_path` as `model_root` (#2787).** Category expansion still lists `E:\models\poses (poses)`, but omitting the configured group `base_path` made concurrent `download_model` `action:"download_civitai"` calls reject that same valid root while siblings wrote into it. Known-root discovery stays request-local, never probes a guessed `:8188` origin, and still refuses an unproven invented path.
 - **manga-director-codex MiniMax H3 adapter accepts documented `text_to_video`.** Native H3 T2V is `MiniMaxH3ImageToVideo` with both image sockets empty; the adapter omitted that mode and compilation refused a valid prompt spec. `text_to_video` is declared; I2V / FL2VA / L2VA / R2V modes are unchanged (#2786).
 - **`panel_slice_workflow` seeds outputs inside nested overlapping groups (#2780).** Membership used the first containing box only, so a SaveImage inside both an outer group and a nested inner group was missed when slicing by the inner title. Any matching containing group now seeds, and a miss lists every containing title.
 - panel_search_nodes no longer returns a raw Git URL as an install `id`, and panel_install_node refuses Git URLs before Manager v4 queueing rather than sending an unlisted URL as a registry lookup (#1539)

--- a/src/__tests__/services/download-extra-root-selector.test.ts
+++ b/src/__tests__/services/download-extra-root-selector.test.ts
@@ -191,6 +191,80 @@ describe("#2499 extra-model root selector when the live server is unreachable", 
     ).rejects.toThrow(/not a known model root/);
   });
 
+  it("lands under the extra-path group base_path when that is the model_root (#2787)", async () => {
+    const comfy = await trackTmp();
+    const extraModels = await trackTmp();
+    await mkdir(join(comfy, "models", "poses"), { recursive: true });
+    await mkdir(join(extraModels, "poses"), { recursive: true });
+    await writeFile(
+      join(comfy, "extra_model_paths.yaml"),
+      `shared:\n  base_path: ${yamlPath(extraModels)}\n  poses: poses/\n`,
+      "utf-8",
+    );
+    config.comfyuiPath = comfy;
+    process.env.COMFYUI_PATH = comfy;
+
+    const res = await resolveDownloadTarget(
+      URL_,
+      "poses",
+      "pose.safetensors",
+      extraModels,
+    );
+    expect(res.targetDir).toBe(resolve(extraModels, "poses"));
+    expect(res.targetPath).toBe(resolve(extraModels, "poses", "pose.safetensors"));
+  });
+
+  it("accepts that same proven base_path from concurrent download resolutions (#2787)", async () => {
+    const comfy = await trackTmp();
+    const extraModels = await trackTmp();
+    await mkdir(join(comfy, "models", "poses"), { recursive: true });
+    await mkdir(join(extraModels, "poses"), { recursive: true });
+    await writeFile(
+      join(comfy, "extra_model_paths.yaml"),
+      `shared:\n  base_path: ${yamlPath(extraModels)}\n  poses: poses/\n`,
+      "utf-8",
+    );
+    config.comfyuiPath = comfy;
+    process.env.COMFYUI_PATH = comfy;
+
+    const results = await Promise.all(
+      Array.from({ length: 11 }, (_, i) =>
+        resolveDownloadTarget(URL_, "poses", `pose-${i}.safetensors`, extraModels),
+      ),
+    );
+    for (const res of results) {
+      expect(res.targetDir).toBe(resolve(extraModels, "poses"));
+    }
+  });
+
+  it("still refuses an unproven invented path while siblings accept the shared base_path (#2787)", async () => {
+    const comfy = await trackTmp();
+    const extraModels = await trackTmp();
+    await mkdir(join(comfy, "models", "poses"), { recursive: true });
+    await mkdir(join(extraModels, "poses"), { recursive: true });
+    await writeFile(
+      join(comfy, "extra_model_paths.yaml"),
+      `shared:\n  base_path: ${yamlPath(extraModels)}\n  poses: poses/\n`,
+      "utf-8",
+    );
+    config.comfyuiPath = comfy;
+    process.env.COMFYUI_PATH = comfy;
+    const invented = resolve(await trackTmp(), "not-a-known-root");
+
+    const [ok, bad] = await Promise.allSettled([
+      resolveDownloadTarget(URL_, "poses", "ok.safetensors", extraModels),
+      resolveDownloadTarget(URL_, "poses", "bad.safetensors", invented),
+    ]);
+    expect(ok.status).toBe("fulfilled");
+    if (ok.status === "fulfilled") {
+      expect(ok.value.targetDir).toBe(resolve(extraModels, "poses"));
+    }
+    expect(bad.status).toBe("rejected");
+    if (bad.status === "rejected") {
+      expect(String(bad.reason)).toMatch(/not a known model root/);
+    }
+  });
+
   it("refuses a category extra root that does not match the target subfolder", async () => {
     const comfy = await trackTmp();
     const extra = await trackTmp();

--- a/src/__tests__/services/extra-paths-observed-live-root.test.ts
+++ b/src/__tests__/services/extra-paths-observed-live-root.test.ts
@@ -171,6 +171,7 @@ describe("extra-paths resolves the live root the OS can see (#1621)", () => {
     hoisted.liveProcess.mockReturnValue({ pid: 99, python: nestedPython });
 
     await expect(getExtraModelRoots()).resolves.toEqual([
+      { category: "models", dir: resolve(models), group: "mine" },
       { category: "loras", dir: resolve(models, "loras"), group: "mine" },
     ]);
   });

--- a/src/__tests__/services/live-extra-roots.test.ts
+++ b/src/__tests__/services/live-extra-roots.test.ts
@@ -250,6 +250,49 @@ describe("getLiveExtraModelRoots — fail-closed authorization", () => {
     expect(res.roots).toContainEqual({ category: "loras", dir: external, group: "grp" });
   });
 
+  it("retains the configured group base_path as a generic models root (#2787)", async () => {
+    const liveRoot = await trackTmp();
+    const extraModels = resolve("/Volumes/Shared/models");
+    await writeFile(
+      join(liveRoot, "extra_model_paths.yaml"),
+      ["shared:", `  base_path: ${extraModels}`, "  poses: poses/"].join("\n"),
+      "utf-8",
+    );
+    const res = await getLiveExtraModelRoots(reachable(["python", join(liveRoot, "main.py")]));
+    expect(res.authoritative).toBe(true);
+    expect(res.roots).toContainEqual({
+      category: "models",
+      dir: extraModels,
+      group: "shared",
+    });
+    expect(res.roots).toContainEqual({
+      category: "poses",
+      dir: resolve(extraModels, "poses"),
+      group: "shared",
+    });
+  });
+
+  it("does not treat a custom_nodes-only group base_path as a models download root (#2787)", async () => {
+    const liveRoot = await trackTmp();
+    const codeRoot = resolve("/opt/custom-nodes-base");
+    await writeFile(
+      join(liveRoot, "extra_model_paths.yaml"),
+      ["code:", `  base_path: ${codeRoot}`, "  custom_nodes: nodes/"].join("\n"),
+      "utf-8",
+    );
+    const res = await getLiveExtraModelRoots(reachable(["python", join(liveRoot, "main.py")]));
+    expect(res.roots).toContainEqual({
+      category: "custom_nodes",
+      dir: resolve(codeRoot, "nodes"),
+      group: "code",
+    });
+    expect(res.roots).not.toContainEqual({
+      category: "models",
+      dir: codeRoot,
+      group: "code",
+    });
+  });
+
   it("resolves a RELATIVE base_path against the config file's OWN dir (like ComfyUI), not the MCP cwd", async () => {
     const liveRoot = await trackTmp();
     await writeFile(

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -207,6 +207,33 @@ function joinCategoryEntryToBase(base: string, entry: string): string {
 const RESERVED_KEYS = new Set(["base_path", "is_default"]);
 const SAFE_KEY_RE = /^[A-Za-z0-9_.-]+$/;
 const CONTROL_RE = /[\x00\r\n]/;
+/** YAML / extra-paths key for a generic models tree (not a per-category folder). */
+const GENERIC_MODELS_CATEGORY = "models";
+const CODE_EXTRA_CATEGORIES = new Set(["custom_nodes"]);
+
+function isProvenAbsolutePath(p: string): boolean {
+  return isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith("\\\\");
+}
+
+function groupServesModelDownloads(categories: readonly ExtraPathCategory[]): boolean {
+  return categories.some((c) => !CODE_EXTRA_CATEGORIES.has(c.category.trim().toLowerCase()));
+}
+
+/**
+ * list_paths reports each group's configured `base_path`. Category expansion
+ * still happens; omitting the base made concurrent `download_civitai` calls
+ * reject that same proven model_root while siblings accepted it (#2787).
+ * Relative bases stay out — they are unproven from this process.
+ */
+function pushProvenGroupBase(
+  roots: ExtraModelRoot[],
+  group: string,
+  categories: readonly ExtraPathCategory[],
+  base: string | undefined,
+): void {
+  if (!base || !groupServesModelDownloads(categories) || !isProvenAbsolutePath(base)) return;
+  roots.push({ category: GENERIC_MODELS_CATEGORY, dir: resolve(base), group });
+}
 
 function assertSafeKey(value: string, label: string): string {
   const trimmed = value.trim();
@@ -1384,6 +1411,7 @@ export async function getExtraModelRoots(
   const roots: ExtraModelRoot[] = [];
   for (const group of info.groups) {
     const base = group.base_path?.trim();
+    pushProvenGroupBase(roots, group.name, group.categories, base);
     for (const category of group.categories) {
       for (const p of category.paths) {
         const dir = isAbsolute(p)
@@ -1611,6 +1639,7 @@ export async function getLiveExtraModelRoots(
         if (expanded === undefined) continue; // unresolvable base_path → skip this group
         base = isAbsolute(expanded) ? resolve(expanded) : resolve(cfgDir, expanded);
       }
+      pushProvenGroupBase(roots, name, group.categories, base);
       for (const category of group.categories) {
         for (const p of category.paths) {
           // With a base_path, EVERY entry is os.path.join'd to it (incl. the Windows

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2566,6 +2566,10 @@ async function listKnownDownloadModelRoots(
     known.push({ dir: resolved, category: cat });
   };
   try {
+    // Request-local: each download builds its own list. Extra roots include
+    // category dirs AND each group's proven base_path as a generic models
+    // root, so parallel download_civitai calls share the same list_paths
+    // model_root (#2787). Live extras use THIS snapshot — never a guessed :8188.
     for (const er of await getExtraModelRoots()) add(er.dir, er.category);
   } catch {
     // Extra roots are additive; an unreadable config just contributes none.


### PR DESCRIPTION
## Summary
Parallel `download_model` `action:\"download_civitai\"` calls that all passed the same valid extra-path `base_path` as `model_root` could intermittently reject it. Known-root discovery listed only category-expanded dirs (`E:\models\poses (poses)`) and dropped the configured group `base_path` (`E:\models`) that `list_paths` reports.

Each proven group `base_path` is now retained as a generic `models` root alongside those category dirs. Discovery stays request-local (no shared mutable cache), uses the connected snapshot rather than a guessed `:8188` origin, and still fails closed for an unproven invented path.

Fixes #2787

## Tests
- `npx vitest run src/__tests__/services/download-extra-root-selector.test.ts src/__tests__/services/live-extra-roots.test.ts src/__tests__/services/extra-paths-observed-live-root.test.ts`
- 3 files, 41 tests passed