### PR TITLE
fix(2796): disclose panel_ui_render four-image cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`panel_ui_render` documents the four-Image cap the validator already enforces (#2796).** The declared manual listed the 64-component ceiling but omitted `maxImages: 4`, so a valid-looking five-image card was rejected as `too many images (5 > 4)` after an avoidable retry.
+
+
 ## [0.52.183] - 2026-09-03
 
 ### MCP

--- a/src/__tests__/orchestrator/panel-ui-render-image-cap.test.ts
+++ b/src/__tests__/orchestrator/panel-ui-render-image-cap.test.ts
@@ -1,0 +1,75 @@
+// #2796 — panel_ui_render's declared manual listed the 64-component ceiling but
+// omitted the validator's four-Image cap. A valid-looking five-image approval
+// card was rejected as `too many images (5 > 4)` after the caller had already
+// authored it from the tool description.
+//
+// This pins the two surfaces to the SAME number: the shipped description must
+// name A2UI_CAPS.maxImages, and the shipped handler must reject one more.
+import { describe, expect, it } from "vitest";
+import { A2UI_CAPS } from "../../services/a2ui-spec.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+function uiRenderDef() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_ui_render");
+  if (!def) throw new Error("panel_ui_render is not registered");
+  return def;
+}
+
+function imageCard(n: number): Record<string, unknown> {
+  const ids = Array.from({ length: n }, (_, i) => `img${i}`);
+  return {
+    root: "root",
+    title: "Approve these",
+    components: [
+      { id: "root", type: "Column", children: ids },
+      ...ids.map((id) => ({ id, type: "Image", src: "/view?filename=x.png" })),
+    ],
+  };
+}
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => ("text" in c ? c.text : "")).join(" ");
+}
+
+describe("panel_ui_render Image cap (#2796)", () => {
+  it("the shipped description names the validator's Image cap", () => {
+    const desc = uiRenderDef().description;
+    const mentioned = desc.match(/≤(\d+) Image/);
+    expect(mentioned, "panel_ui_render must disclose the Image component cap").not.toBeNull();
+    expect(Number(mentioned![1])).toBe(A2UI_CAPS.maxImages);
+    expect(desc).toContain(`≤${A2UI_CAPS.maxComponents} components`);
+  });
+
+  it("rejects one more Image than the documented cap without reaching the panel", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const ctx = {
+      call: async (cmd: Record<string, unknown>) => {
+        calls.push(cmd);
+        return { content: [{ type: "text" as const, text: "ok" }] };
+      },
+    } as PanelToolCtx;
+    const n = A2UI_CAPS.maxImages + 1;
+    const res = await uiRenderDef().handler({ spec: imageCard(n) }, ctx);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain(`invalid a2ui spec: too many images (${n} > ${A2UI_CAPS.maxImages})`);
+    expect(calls).toEqual([]);
+  });
+
+  it("forwards a card at the documented Image cap", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const ctx = {
+      call: async (cmd: Record<string, unknown>) => {
+        calls.push(cmd);
+        return { content: [{ type: "text" as const, text: "ok" }] };
+      },
+    } as PanelToolCtx;
+    const res = await uiRenderDef().handler({ spec: imageCard(A2UI_CAPS.maxImages) }, ctx);
+    expect(res.isError).not.toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cmd).toBe("ui_render");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -506,7 +506,7 @@ import {
 } from "../config.js";
 import { normalizeInstallPathEnv } from "../utils/install-path-env.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
-import { validateA2UISpecServer } from "../services/a2ui-spec.js";
+import { A2UI_CAPS, validateA2UISpecServer } from "../services/a2ui-spec.js";
 import type { UiWorkflow } from "../comfyui/types.js";
 
 /** #1700 — orchestrator wires this so panel_reload can fork-respawn the agent
@@ -29184,7 +29184,9 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_ui_render",
-      "Render an INTERACTIVE UI CARD in the panel chat from an A2UI-subset JSON spec — choice buttons, forms (TextField/Select/Checkbox + a submit Button), node-wiring diagrams (comfy:graph), and bar/line charts (comfy:chart). Use a card whenever the user must pick between options, confirm a plan, fill in parameters, or would understand a wiring explanation better as a diagram. The card is non-blocking: this returns { card_id } immediately; when the user clicks a button (or submits a form) their choice arrives as a NORMAL chat message (the button's `reply` text; submit buttons append 'name: value' lines) — so after rendering a card that asks a question, END YOUR TURN and wait. Set surface:'wide' for diagram-heavy cards (the panel widens and restores automatically). Spec shape: { surface?, title?, root: '<id>', components: [ {id, type, ...} ] } with children referenced by id. Types: Text{text}, Heading{text,level?}, Button{label,reply?,submit?,style?:'primary'|'secondary'}, Row/Column/Card{children:[ids]}, Divider, Image{src:/view-URL,caption?}, TextField{label,name,value?,placeholder?}, Select{label,name,options:[{label,value?}],value?}, Checkbox{label,name,checked?}, 'comfy:graph'{nodes:[{id,label,color?}],edges:[{from,to,label?}],direction?:'lr'|'tb'}, 'comfy:chart'{kind:'bar'|'line',series:[{label,values:[num]}],x?:[labels]}. Caps: ≤64 components, ≤30 graph nodes, ≤8×256 chart points. On a validation error, FIX the spec and retry.",
+      "Render an INTERACTIVE UI CARD in the panel chat from an A2UI-subset JSON spec — choice buttons, forms (TextField/Select/Checkbox + a submit Button), node-wiring diagrams (comfy:graph), and bar/line charts (comfy:chart). Use a card whenever the user must pick between options, confirm a plan, fill in parameters, or would understand a wiring explanation better as a diagram. The card is non-blocking: this returns { card_id } immediately; when the user clicks a button (or submits a form) their choice arrives as a NORMAL chat message (the button's `reply` text; submit buttons append 'name: value' lines) — so after rendering a card that asks a question, END YOUR TURN and wait. Set surface:'wide' for diagram-heavy cards (the panel widens and restores automatically). Spec shape: { surface?, title?, root: '<id>', components: [ {id, type, ...} ] } with children referenced by id. Types: Text{text}, Heading{text,level?}, Button{label,reply?,submit?,style?:'primary'|'secondary'}, Row/Column/Card{children:[ids]}, Divider, Image{src:/view-URL,caption?}, TextField{label,name,value?,placeholder?}, Select{label,name,options:[{label,value?}],value?}, Checkbox{label,name,checked?}, 'comfy:graph'{nodes:[{id,label,color?}],edges:[{from,to,label?}],direction?:'lr'|'tb'}, 'comfy:chart'{kind:'bar'|'line',series:[{label,values:[num]}],x?:[labels]}. Caps: ≤64 components, ≤" +
+        A2UI_CAPS.maxImages +
+        " Image components, ≤30 graph nodes, ≤8×256 chart points. On a validation error, FIX the spec and retry.",
       {
         spec: z
           .record(z.string(), z.unknown())


### PR DESCRIPTION
The `panel_ui_render` manual documented a 64-component ceiling but omitted the validator's four-Image cap. A valid-looking five-image approval card was rejected as `too many images (5 > 4)` after an avoidable retry.

The shipped description now interpolates `A2UI_CAPS.maxImages`, and a consistency test drives `buildPanelToolDefs()` plus the live handler: the description must name that cap, five Images fail before the panel is called, four Images still forward `ui_render`. The validator cap is unchanged.

Fixes #2796