### PR TITLE
fix(2790): recommend PrimitiveStringMultiline for MiniMaxH3Director prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- **`panel_set_widget` MiniMaxH3Director prompt workaround recommends PrimitiveStringMultiline, not PrimitiveNode (#2790).** The panel correctly refuses a direct `prompt` / `builder_state` / `timeline_data` write, but its recovery instruction used to name a frontend PrimitiveNode for `external_prompt_overwrite`; `panel_connect` rejects that forceInput-only STRING. The producer advice now shares the same helper as `panel_connect`.
 - **`panel_ui_render` documents the four-Image cap the validator already enforces (#2796).** The declared manual listed the 64-component ceiling but omitted `maxImages: 4`, so a valid-looking five-image card was rejected as `too many images (5 > 4)` after an avoidable retry.
 
 

--- a/src/__tests__/orchestrator/set-widget-minimax-h3-director-prompt.test.ts
+++ b/src/__tests__/orchestrator/set-widget-minimax-h3-director-prompt.test.ts
@@ -1,0 +1,180 @@
+// #2790 — panel_set_widget correctly refuses MiniMaxH3Director.prompt, but the
+// panel's recovery instruction used to recommend a frontend PrimitiveNode for
+// external_prompt_overwrite. panel_connect refuses that forceInput-only STRING
+// and names PrimitiveStringMultiline. Tests drive the shipped panel_set_widget
+// handler so a missing rewrite stays red.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  backendStringProducerConnectAdvice,
+  primitiveForceInputRefusal,
+} from "../../services/primitive-force-input-connect.js";
+import {
+  miniMaxH3DirectorExternalPromptAdvice,
+  rewriteMiniMaxH3DirectorPrimitiveAdvice,
+} from "../../services/minimax-h3-director-widget.js";
+import {
+  buildPanelToolDefs,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const PANEL_SRC = readFileSync(
+  fileURLToPath(new URL("../../orchestrator/panel-tools.ts", import.meta.url)),
+  "utf8",
+);
+
+const NODE_ID = 17;
+
+/** Exact panel MiniMaxH3Director derived-widget refusal (comfyui-mcp-panel
+ *  `web/js/lib/minimax-h3-director.js` miniMaxH3DirectorPromptRefusal). */
+function panelMiniMaxH3DirectorRefusal(widgetName: string, nodeId: number): string {
+  return (
+    `panel_set_widget cannot drive "${widgetName}" on MiniMaxH3Director node ${nodeId}: ` +
+    `timeline_data, builder_state, and prompt are DERIVED write-backs of the node's in-memory ` +
+    `builderState. The Director editor parses timeline_data once at install, then emit() ` +
+    `regenerates all three from that closure, so a raw write shows in panel_query_graph while ` +
+    `prompt and builder_state stay stale and the next UI touch reverts it (#1935, #1679). ` +
+    `Python execute() prefers the builder_state widget over timeline_data.builder_state when ` +
+    `the widget is non-empty, so a successful timeline_data result does not mean the prompt ` +
+    `changed. Use the node's supported external_prompt_overwrite path instead: connect a ` +
+    `PrimitiveNode STRING output to "external_prompt_overwrite", then set the PrimitiveNode's ` +
+    `STRING value with panel_set_widget. The write was refused before any graph mutation; ` +
+    `other widgets and node types are unaffected.`
+  );
+}
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`${name} is not registered`);
+  return def;
+}
+
+function textOf(res: ToolResult): string {
+  return res.content.map((c) => ("text" in c ? (c.text ?? "") : "")).join(" ");
+}
+
+function errResult(text: string): ToolResult {
+  return { isError: true, content: [{ type: "text", text: `Error: ${text}` }] };
+}
+
+function okResult(body: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
+}
+
+async function runSetWidget(
+  call: PanelToolCtx["call"],
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  return defByName("panel_set_widget").handler(args as never, {
+    call,
+    confirm: async () => "yes" as const,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "t-2790",
+  } as PanelToolCtx);
+}
+
+describe("shared backend STRING producer advice (#2790 / #2536)", () => {
+  it("is the exact recovery clause in panel_connect's PrimitiveNode refusal", () => {
+    const advice = backendStringProducerConnectAdvice("external_prompt_overwrite");
+    expect(advice).toContain("PrimitiveStringMultiline");
+    expect(advice).not.toContain("PrimitiveNode");
+    const connect = primitiveForceInputRefusal({
+      fromNodeId: 12,
+      toNodeId: 5,
+      toType: "MiniMaxH3Director",
+      inputName: "external_prompt_overwrite",
+      inputType: "STRING",
+      disconnected: true,
+    });
+    expect(connect).toContain(advice);
+  });
+
+  it("is the exact recovery clause in the MiniMaxH3Director rewrite", () => {
+    const advice = backendStringProducerConnectAdvice("external_prompt_overwrite");
+    expect(miniMaxH3DirectorExternalPromptAdvice()).toContain(advice);
+    const rewritten = rewriteMiniMaxH3DirectorPrimitiveAdvice(
+      panelMiniMaxH3DirectorRefusal("prompt", NODE_ID),
+    );
+    expect(rewritten).toContain(advice);
+    expect(rewritten).not.toMatch(/connect a PrimitiveNode/);
+    expect(rewritten).not.toMatch(/set the PrimitiveNode's/);
+  });
+});
+
+describe("panel_set_widget MiniMaxH3Director prompt workaround (#2790)", () => {
+  it("handlers rewrite the panel refusal through rewriteMiniMaxH3DirectorPrimitiveAdvice", () => {
+    expect(PANEL_SRC).toMatch(/rewriteMiniMaxH3DirectorWidgetRefusal\(/);
+    expect(PANEL_SRC).toMatch(/rewriteMiniMaxH3DirectorPrimitiveAdvice\(/);
+  });
+
+  it("THE REPORTED CASE: prompt refusal recommends PrimitiveStringMultiline, not PrimitiveNode", async () => {
+    const cmds: string[] = [];
+    const panelText = panelMiniMaxH3DirectorRefusal("prompt", NODE_ID);
+    expect(panelText).toMatch(/connect a PrimitiveNode STRING output/);
+
+    const res = await runSetWidget(
+      async (cmd) => {
+        cmds.push(String(cmd.cmd));
+        if (cmd.cmd === "graph_set_widget") return errResult(panelText);
+        return okResult({});
+      },
+      { node_id: NODE_ID, widget: "prompt", value: "a new shot" },
+    );
+
+    const text = textOf(res);
+    expect(cmds).toContain("graph_set_widget");
+    expect(res.isError).toBe(true);
+    expect(text).toContain("MiniMaxH3Director");
+    expect(text).toContain("external_prompt_overwrite");
+    expect(text).toContain("PrimitiveStringMultiline");
+    expect(text).toContain(backendStringProducerConnectAdvice("external_prompt_overwrite"));
+    expect(text).not.toMatch(/connect a PrimitiveNode/);
+    expect(text).not.toMatch(/set the PrimitiveNode's/);
+  });
+
+  it.each(["builder_state", "timeline_data"] as const)(
+    "rewrites the %s derived-widget refusal the same way",
+    async (widget) => {
+      const res = await runSetWidget(
+        async (cmd) => {
+          if (cmd.cmd === "graph_set_widget") {
+            return errResult(panelMiniMaxH3DirectorRefusal(widget, NODE_ID));
+          }
+          return okResult({});
+        },
+        { node_id: NODE_ID, widget, value: "{}" },
+      );
+      const text = textOf(res);
+      expect(res.isError).toBe(true);
+      expect(text).toContain("PrimitiveStringMultiline");
+      expect(text).not.toMatch(/connect a PrimitiveNode/);
+    },
+  );
+
+  it("does not rewrite an unrelated PrimitiveNode error", async () => {
+    const other =
+      `Cannot set widget "text" on node 3: connect a PrimitiveNode STRING output ` +
+      `to "text", then set the PrimitiveNode's STRING value with panel_set_widget.`;
+    const res = await runSetWidget(
+      async (cmd) => {
+        if (cmd.cmd === "graph_set_widget") return errResult(other);
+        return okResult({});
+      },
+      { node_id: 3, widget: "text", value: "hello" },
+    );
+    expect(textOf(res)).toMatch(/connect a PrimitiveNode STRING output/);
+    expect(textOf(res)).not.toMatch(/PrimitiveStringMultiline/);
+  });
+
+  it("documents PrimitiveStringMultiline for MiniMaxH3Director on the tool itself", () => {
+    const description = defByName("panel_set_widget").description;
+    expect(description).toContain("MiniMaxH3Director");
+    expect(description).toContain("external_prompt_overwrite");
+    expect(description).toContain("PrimitiveStringMultiline");
+    expect(description).toContain("PrimitiveNode");
+  });
+});

--- a/src/__tests__/services/primitive-force-input-connect.test.ts
+++ b/src/__tests__/services/primitive-force-input-connect.test.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+  backendStringProducerConnectAdvice,
   findTargetConnectInput,
   hasSerializableWidgetBinding,
   isForceInputOnlyNonWidget,
@@ -136,6 +137,7 @@ describe("PrimitiveNode widget-binding helpers (#2536)", () => {
     expect(text).toMatch(/lora_path/);
     expect(text).toMatch(/forceInput-only/);
     expect(text).toMatch(/PrimitiveStringMultiline/);
+    expect(text).toContain(backendStringProducerConnectAdvice("lora_path"));
     expect(text).toMatch(/disconnected/);
     expect(text).toMatch(/#2536/);
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -21785,6 +21785,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           const written = rewriteMiniMaxH3DirectorWidgetRefusal(
             await ctx.call(
               {
+              cmd: "graph_set_widget",
               node_id: nodeId,
               widget,
               value,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -91,6 +91,7 @@ import {
 } from "../services/unexpose-host-link-shift.js";
 import { retryConnectAgainstLiveGraph } from "../services/connect-live-graph.js";
 import { verifyPrimitiveForceInputAfterConnect } from "../services/primitive-force-input-connect.js";
+import { rewriteMiniMaxH3DirectorPrimitiveAdvice } from "../services/minimax-h3-director-widget.js";
 import { retryRailSlotConnect } from "../services/rail-slot-connect.js";
 import { retryWildcardSlotConnect } from "../services/wildcard-slot-connect.js";
 import { retryExposeSubgraphInput } from "../services/expose-ae-wildcard.js";
@@ -6838,6 +6839,24 @@ function rewriteToolResultJson(
     ...res,
     content: res.content.map((c, i) =>
       i === idx && c.type === "text" ? { ...c, text: JSON.stringify(payload, null, 2) } : c,
+    ),
+  };
+}
+
+/** #2790 — the panel's MiniMaxH3Director derived-widget refusal still names a
+ *  frontend PrimitiveNode; rewrite that producer with panel_connect's helper. */
+function rewriteMiniMaxH3DirectorWidgetRefusal(res: ToolResult): ToolResult {
+  if (!res.isError) return res;
+  const idx = res.content.findIndex((c) => c.type === "text");
+  if (idx < 0) return res;
+  const block = res.content[idx];
+  if (block.type !== "text" || typeof block.text !== "string") return res;
+  const next = rewriteMiniMaxH3DirectorPrimitiveAdvice(block.text);
+  if (next === block.text) return res;
+  return {
+    ...res,
+    content: res.content.map((c, i) =>
+      i === idx && c.type === "text" ? { ...c, text: next } : c,
     ),
   };
 }
@@ -21667,7 +21686,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_widget",
-      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value (a string longer than 1000 chars is echoed as {chars, sha256, preview} so batched calls stay inside the outer tool-result budget — pass `echo: \"full\"` for the verbatim string). Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works). For the LTXDirector timeline node (WhatDreamsCost CSGlide), set `timeline_data` with the FULL timeline JSON (segments + global_prompt) to drive its custom timeline UI — this re-syncs the editor and regenerates its derived `local_prompts`/`segment_lengths`/`guide_strength` widgets; setting those derived widgets directly is refused (they are silently reverted). For AnimaRegionalCanvasInline / Krea2RegionalCanvasInline (LC123), quality/scene/red/green/blue/negative prompt writes are refused: the custom textarea and node.properties.animaPrompts overwrite widget.value on APPLY. Drive quality/scene/negative via a PrimitiveStringMultiline wired into quality_prompt_in / scene_prompt_in / negative_prompt_in; red/green/blue have no socket. DaSiWa_LTX2LoraLoader's `stack_data` write is also refused: its custom multi-row widget reserializes its own JS state over `widget.value`, so the echoed write would be a false success; edit the stack rows in the node UI instead.",
+      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value (a string longer than 1000 chars is echoed as {chars, sha256, preview} so batched calls stay inside the outer tool-result budget — pass `echo: \"full\"` for the verbatim string). Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works). For the LTXDirector timeline node (WhatDreamsCost CSGlide), set `timeline_data` with the FULL timeline JSON (segments + global_prompt) to drive its custom timeline UI — this re-syncs the editor and regenerates its derived `local_prompts`/`segment_lengths`/`guide_strength` widgets; setting those derived widgets directly is refused (they are silently reverted). For AnimaRegionalCanvasInline / Krea2RegionalCanvasInline (LC123), quality/scene/red/green/blue/negative prompt writes are refused: the custom textarea and node.properties.animaPrompts overwrite widget.value on APPLY. Drive quality/scene/negative via a PrimitiveStringMultiline wired into quality_prompt_in / scene_prompt_in / negative_prompt_in; red/green/blue have no socket. DaSiWa_LTX2LoraLoader's `stack_data` write is also refused: its custom multi-row widget reserializes its own JS state over `widget.value`, so the echoed write would be a false success; edit the stack rows in the node UI instead. For MiniMaxH3Director, prompt / builder_state / timeline_data writes are refused (they are derived write-backs of the in-memory builderState). Drive the prompt via a backend STRING producer such as PrimitiveStringMultiline wired into external_prompt_overwrite — not a frontend PrimitiveNode; panel_connect refuses that forceInput-only STRING.",
       {
         node_id: nodeId().describe("Node id from panel_graph_outline / panel_query_graph."),
         widget: z.string().describe("Widget name (e.g. 'steps', 'cfg', 'text')."),
@@ -21763,9 +21782,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           let mutationId: string | undefined;
           let dispatchTab = ctx.tabId;
           let dispatchConnection: SetWidgetReadbackConnection | undefined;
-          const written = await ctx.call(
-            {
-              cmd: "graph_set_widget",
+          const written = rewriteMiniMaxH3DirectorWidgetRefusal(
+            await ctx.call(
+              {
               node_id: nodeId,
               widget,
               value,
@@ -21837,6 +21856,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               }
             },
             beforeDispatch,
+            ),
           );
           const echoed = stripVerifiedLastObservedSchemaNote(
             summarizeSetWidgetEcho(written, echoFull),

--- a/src/services/minimax-h3-director-widget.ts
+++ b/src/services/minimax-h3-director-widget.ts
@@ -1,0 +1,44 @@
+/**
+ * #2790 — `panel_set_widget` forwards the panel's MiniMaxH3Director derived-widget
+ * refusal, which recommended a frontend PrimitiveNode for
+ * `external_prompt_overwrite`. `panel_connect` refuses that pairing (#2536)
+ * because the socket is forceInput-only. Rewrite the producer advice with the
+ * same helper `panel_connect` uses so the two tools cannot diverge.
+ */
+
+import { backendStringProducerConnectAdvice } from "./primitive-force-input-connect.js";
+
+export const MINIMAX_H3_DIRECTOR_TYPE = "MiniMaxH3Director";
+export const MINIMAX_H3_DIRECTOR_EXTERNAL_PROMPT_INPUT = "external_prompt_overwrite";
+
+const PANEL_PRIMITIVE_NODE_WORKAROUND =
+  /connect a PrimitiveNode STRING output to "external_prompt_overwrite", then set the PrimitiveNode's STRING value with panel_set_widget\.?/g;
+
+const PANEL_PRIMITIVE_NODE_WORKAROUND_SENTENCE =
+  /Use the node's supported external_prompt_overwrite path instead: connect a PrimitiveNode STRING output to "external_prompt_overwrite", then set the PrimitiveNode's STRING value with panel_set_widget\.?/g;
+
+export function miniMaxH3DirectorExternalPromptAdvice(): string {
+  return (
+    `Use the node's supported ${MINIMAX_H3_DIRECTOR_EXTERNAL_PROMPT_INPUT} path instead: ` +
+    backendStringProducerConnectAdvice(MINIMAX_H3_DIRECTOR_EXTERNAL_PROMPT_INPUT)
+  );
+}
+
+/**
+ * Replace a MiniMaxH3Director refusal's PrimitiveNode producer with the shared
+ * backend STRING producer. Leaves unrelated text (and other node types) alone.
+ */
+export function rewriteMiniMaxH3DirectorPrimitiveAdvice(text: string): string {
+  if (!text.includes(MINIMAX_H3_DIRECTOR_TYPE)) return text;
+  if (!text.includes(MINIMAX_H3_DIRECTOR_EXTERNAL_PROMPT_INPUT)) return text;
+  if (!text.includes("PrimitiveNode")) return text;
+  const sentence = text.replace(
+    PANEL_PRIMITIVE_NODE_WORKAROUND_SENTENCE,
+    miniMaxH3DirectorExternalPromptAdvice(),
+  );
+  if (sentence !== text) return sentence;
+  return text.replace(
+    PANEL_PRIMITIVE_NODE_WORKAROUND,
+    backendStringProducerConnectAdvice(MINIMAX_H3_DIRECTOR_EXTERNAL_PROMPT_INPUT),
+  );
+}

--- a/src/services/primitive-force-input-connect.ts
+++ b/src/services/primitive-force-input-connect.ts
@@ -24,6 +24,21 @@ import {
 
 export const FRONTEND_PRIMITIVE_NODE_TYPE = "PrimitiveNode";
 
+/** Backend STRING producer `panel_connect` accepts on a forceInput-only STRING. */
+export const BACKEND_STRING_PRODUCER_EXAMPLE = "PrimitiveStringMultiline";
+
+/**
+ * Shared recovery instruction for a forceInput-only / non-widget STRING.
+ * `panel_connect` and `panel_set_widget` (MiniMaxH3Director) both use this so
+ * they cannot recommend a frontend PrimitiveNode that the other tool refuses.
+ */
+export function backendStringProducerConnectAdvice(inputName: string): string {
+  return (
+    `Add a backend STRING producer such as ${BACKEND_STRING_PRODUCER_EXAMPLE}, set its ` +
+    `STRING widget, then panel_connect that STRING output to "${inputName}".`
+  );
+}
+
 const DETAIL_MAX_CHARS = 60000;
 const DETAIL_TIMEOUT_MS = 8000;
 
@@ -268,8 +283,7 @@ export function primitiveForceInputRefusal(opts: {
     `Error: panel_connect refused frontend PrimitiveNode #${from} → #${to} ${slot}. ` +
     `A PrimitiveNode only serializes through a target widget; this input is forceInput-only ` +
     `(no serializable widget binding), so panel_run would omit the required input from the ` +
-    `queued prompt. Add a backend STRING producer such as PrimitiveStringMultiline, set its ` +
-    `STRING widget, then panel_connect that STRING output to "${opts.inputName}". ${undo} ` +
+    `queued prompt. ${backendStringProducerConnectAdvice(opts.inputName)} ${undo} ` +
     `(artokun/comfyui-mcp#2536)`
   );
 }


### PR DESCRIPTION
## Summary

`panel_set_widget` correctly refuses a direct MiniMaxH3Director `prompt` / `builder_state` / `timeline_data` write, but the panel recovery text told the agent to connect a frontend PrimitiveNode to `external_prompt_overwrite`. Following that fails: `panel_connect` rejects PrimitiveNode on that forceInput-only STRING and recommends PrimitiveStringMultiline (#2536).

This rewrite uses `backendStringProducerConnectAdvice` — the same helper as `panel_connect` — so the two tools cannot recommend incompatible producers.

## Tests

- `src/__tests__/orchestrator/set-widget-minimax-h3-director-prompt.test.ts` (8) — drives shipped `panel_set_widget`

- `src/__tests__/services/primitive-force-input-connect.test.ts` (14) — helper is the exact `panel_connect` clause

Fixes #2790
