### PR TITLE
fix(2791): write official Qwen Image prompt from host mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- **`panel_set_widget` writes the official Qwen Image subgraph prompt from the host input/widget mapping (#2791).** Live host node 76 lists input label `prompt` on widget `text`, but an incomplete promoted-terminal witness refused the STRING write. The unique host mapping (and `proxyWidgets` inner CLIPTextEncode) now authorizes the enclosing subgraph widget; official subgraphs are not unpacked. Still unverifiable mappings stay fail-closed.
 - **`panel_set_widget` MiniMaxH3Director prompt workaround recommends PrimitiveStringMultiline, not PrimitiveNode (#2790).** The panel correctly refuses a direct `prompt` / `builder_state` / `timeline_data` write, but its recovery instruction used to name a frontend PrimitiveNode for `external_prompt_overwrite`; `panel_connect` rejects that forceInput-only STRING. The producer advice now shares the same helper as `panel_connect`.
 - **`panel_ui_render` documents the four-Image cap the validator already enforces (#2796).** The declared manual listed the 64-component ceiling but omitted `maxImages: 4`, so a valid-looking five-image card was rejected as `too many images (5 > 4)` after an avoidable retry.
 

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -31,6 +31,9 @@ import {
   parseSubgraphScopeRefusal,
   promotedInnerWidgetIsLinkDriven,
   resolveInnerPromotedTarget,
+  resolveHostPromotedWidgetMapping,
+  resolveInnerFromHostPromotedMapping,
+  isHostProvenPromotedStringWrite,
   describePromotedSubgraphEnvelope,
   validatePromotedSubgraphEnvelope,
 } from "../../orchestrator/promoted-widget.js";
@@ -1051,6 +1054,88 @@ const UNet_COMBO_TEMPLATE_DETAIL = {
   text:
     '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
     '{"id":472,"type":"SubgraphNode","is_subgraph":true}',
+};
+
+/** #2791 — official Comfy-Org Qwen Image host 76. Input label `prompt` maps to
+ * widget `text`; proxyWidgets names inner CLIPTextEncode 6. The negative
+ * CLIPTextEncode 7 also has a `text` widget, so same-name uniqueness fails
+ * unless the host mapping (or the rail) is used. */
+const QWEN_IMAGE_HOST_NODE = {
+  id: 76,
+  type: "SubgraphNode",
+  is_subgraph: true,
+  widgets: { text: "a vibrant street" },
+  inputs: [
+    { label: "prompt", name: "text", type: "STRING", widget: { name: "text" } },
+    { label: "lightning_lora", name: "lora_name", type: "COMBO", widget: { name: "lora_name" } },
+    { label: "enable_turbo_mode", name: "value", type: "BOOLEAN", widget: { name: "value" } },
+  ],
+  properties: {
+    proxyWidgets: [
+      ["6", "text"],
+      ["58", "width"],
+      ["3", "seed"],
+      ["37", "unet_name"],
+      ["73", "lora_name"],
+      ["86", "value"],
+    ],
+  },
+};
+
+const QWEN_IMAGE_HOST_DETAIL = {
+  nodes: [QWEN_IMAGE_HOST_NODE],
+};
+
+const QWEN_IMAGE_POSITIVE = {
+  id: 6,
+  type: "CLIPTextEncode",
+  widgets: { text: "a vibrant street" },
+  inputs: [
+    { name: "clip", type: "CLIP" },
+    { name: "text", type: "STRING", connected_from: { node_id: -10, output_slot: 0 } },
+  ],
+};
+
+const QWEN_IMAGE_NEGATIVE = {
+  id: 7,
+  type: "CLIPTextEncode",
+  widgets: { text: "" },
+  inputs: [{ name: "clip", type: "CLIP" }],
+};
+
+const QWEN_IMAGE_INCOMPLETE_TERMINALS = [
+  {
+    widget: "text",
+    immediate_node_id: 6,
+    immediate_widget: "text",
+    error: "the promoted parent rail was missing, externally linked, or not authoritative",
+  },
+  {
+    widget: "lora_name",
+    error:
+      "properties.proxyWidgets named a promoted relation that had no live node.widgets/_subgraphSlot projection",
+  },
+];
+
+const QWEN_IMAGE_PROMPT_SUBGRAPH = {
+  subgraph_of: { node_id: 76, title: "Text to Image (Qwen-Image)" },
+  node_count: 2,
+  nodes: [QWEN_IMAGE_POSITIVE, QWEN_IMAGE_NEGATIVE],
+  promoted_terminals: QWEN_IMAGE_INCOMPLETE_TERMINALS,
+};
+
+const QWEN_IMAGE_PROMPT_SUBGRAPH_NO_RAIL = {
+  ...QWEN_IMAGE_PROMPT_SUBGRAPH,
+  nodes: [
+    {
+      ...QWEN_IMAGE_POSITIVE,
+      inputs: [
+        { name: "clip", type: "CLIP" },
+        { name: "text", type: "STRING" },
+      ],
+    },
+    QWEN_IMAGE_NEGATIVE,
+  ],
 };
 
 /** #2488 — inner PrimitiveInt.length exposed as host frame_counts. The inner
@@ -4690,6 +4775,163 @@ describe("#2393 promoted COMBO unet_name after official template load", () => {
             UNet_COMBO_TEMPLATE_SUBGRAPH.nodes[1],
           ],
         },
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was incomplete or unresolved/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+});
+
+describe("#2791 official Qwen Image promoted prompt", () => {
+  it("maps host label prompt onto widget text and inner CLIPTextEncode 6", () => {
+    expect(resolveHostPromotedWidgetMapping(QWEN_IMAGE_HOST_NODE, "prompt")).toEqual({
+      hostWidget: "text",
+      label: "prompt",
+      type: "STRING",
+      innerNodeId: "6",
+    });
+    expect(resolveHostPromotedWidgetMapping(QWEN_IMAGE_HOST_NODE, "text")).toEqual({
+      hostWidget: "text",
+      label: "prompt",
+      type: "STRING",
+      innerNodeId: "6",
+    });
+    const inner = resolveInnerFromHostPromotedMapping(
+      QWEN_IMAGE_PROMPT_SUBGRAPH_NO_RAIL,
+      {
+        hostWidget: "text",
+        label: "prompt",
+        type: "STRING",
+        innerNodeId: "6",
+      },
+      76,
+    );
+    expect(inner).toEqual(
+      expect.objectContaining({
+        innerNodeId: 6,
+        widget: "text",
+        terminal: expect.objectContaining({
+          nodeId: 6,
+          nodeType: "CLIPTextEncode",
+          widget: "text",
+          chainDepth: 0,
+        }),
+      }),
+    );
+    expect(isHostProvenPromotedStringWrite(
+      { hostWidget: "text", type: "STRING", innerNodeId: "6" },
+      inner,
+    )).toBe(true);
+  });
+
+  it("stays fail-closed when the host input has no widget binding or is ambiguous", () => {
+    expect(
+      resolveHostPromotedWidgetMapping(
+        {
+          id: 76,
+          inputs: [{ label: "prompt", name: "text", type: "STRING" }],
+        },
+        "text",
+      ),
+    ).toBeNull();
+    expect(
+      resolveHostPromotedWidgetMapping(
+        {
+          id: 76,
+          inputs: [
+            { label: "prompt", name: "text", type: "STRING", widget: { name: "text" } },
+            { label: "text", name: "caption", type: "STRING", widget: { name: "caption" } },
+          ],
+        },
+        "text",
+      ),
+    ).toBeNull();
+  });
+
+  it.each(["text", "prompt"] as const)(
+    "writes the enclosing subgraph widget text when addressed as %s",
+    async (widget) => {
+      const { text, isError, calls, mutations } = await setWidget(
+        { node_id: 76, widget, value: "a red bicycle at dusk" },
+        {
+          ownerNodeId: 76,
+          firstWrite: "ok",
+          promotedTerminalWitnesses: true,
+          promotedDetail: QWEN_IMAGE_HOST_DETAIL,
+          subgraph: QWEN_IMAGE_PROMPT_SUBGRAPH_NO_RAIL,
+        },
+      );
+
+      expect(isError).toBe(false);
+      expect(mutations).toBe(1);
+      expect(calls.filter((call) => call.cmd === "graph_unpack_subgraph")).toHaveLength(0);
+      expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+      expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+        expect.objectContaining({ node_id: 76, widget: "text", value: "a red bicycle at dusk" }),
+      ]);
+      expect(calls.some((call) => Number(call.node_id) === 6)).toBe(false);
+      expect(text).toMatch(/enclosing subgraph node 76 widget "text"/);
+      expect(text).not.toMatch(/witness was incomplete or unresolved/);
+    },
+  );
+
+  it("still writes the host when the inner CLIPTextEncode is uniquely rail-backed", async () => {
+    const { isError, calls, mutations } = await setWidget(
+      { node_id: 76, widget: "text", value: "a red bicycle at dusk" },
+      {
+        ownerNodeId: 76,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: QWEN_IMAGE_HOST_DETAIL,
+        subgraph: QWEN_IMAGE_PROMPT_SUBGRAPH,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 76, widget: "text", value: "a red bicycle at dusk" }),
+    ]);
+    expect(calls.some((call) => Number(call.node_id) === 6)).toBe(false);
+  });
+
+  it("still refuses when the host detail does not prove the promoted STRING input", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 76, widget: "text", value: "a red bicycle at dusk" },
+      {
+        ownerNodeId: 76,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: {
+          nodes: [{ id: 76, type: "SubgraphNode", is_subgraph: true }],
+        },
+        subgraph: QWEN_IMAGE_PROMPT_SUBGRAPH_NO_RAIL,
+      },
+    );
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/witness was incomplete or unresolved/);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toHaveLength(0);
+  });
+
+  it("still refuses when proxyWidgets names an inner the envelope does not retain", async () => {
+    const { text, isError, calls } = await setWidget(
+      { node_id: 76, widget: "text", value: "a red bicycle at dusk" },
+      {
+        ownerNodeId: 76,
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: {
+          nodes: [
+            {
+              ...QWEN_IMAGE_HOST_NODE,
+              properties: { proxyWidgets: [["99", "text"]] },
+            },
+          ],
+        },
+        subgraph: QWEN_IMAGE_PROMPT_SUBGRAPH_NO_RAIL,
       },
     );
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -178,6 +178,9 @@ import {
   resolveLegacyInnerPromotedTarget,
   promotedInnerWidgetIsLinkDriven,
   resolveInnerPromotedTarget,
+  resolveHostPromotedWidgetMapping,
+  resolveInnerFromHostPromotedMapping,
+  isHostProvenPromotedStringWrite,
   describePromotedSubgraphEnvelope,
   isInnerLinkDrivenWriteWarning,
   shapeParentAuthoritativePromotedWrite,
@@ -8281,7 +8284,22 @@ const PROMOTED_PREFLIGHT_READ_OPTIONS: PanelToolCallOptions = {
 type PromotedTargetProbe = {
   scope: QueriedNodeScope | null;
   rootGraphIdentity: string | null;
+  hostNode: Record<string, unknown> | null;
 };
+
+function matchingQueriedHostNode(
+  nodes: unknown,
+  nodeId: unknown,
+): Record<string, unknown> | null {
+  if (!Array.isArray(nodes) || nodes.length !== 1) return null;
+  const row = nodes[0];
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const rec = row as Record<string, unknown>;
+  const id = canonicalQueriedNodeId(rec.id);
+  const requested = canonicalQueriedNodeId(nodeId);
+  if (!id || !requested || id !== requested) return null;
+  return rec;
+}
 
 async function readPromotedTargetScope(
   ctx: PanelToolCtx,
@@ -8294,14 +8312,16 @@ async function readPromotedTargetScope(
     fields: "detail",
     limit: 1,
   }, undefined, undefined, undefined, options);
-  if (probe.isError) return { scope: null, rootGraphIdentity: null };
+  if (probe.isError) return { scope: null, rootGraphIdentity: null, hostNode: null };
   const payload = parseToolResultJson(probe);
   if (parseViewingScope(payload?.viewing)?.scope === "root") {
     rememberLiveRootViewing(ctx, payload?.viewing);
   }
+  const normalized = normalizeGraphQueryResult(probe);
   return {
     scope: parseVerifiedQueriedNodeScope(payload, nodeId),
     rootGraphIdentity: parseRootGraphIdentity(payload),
+    hostNode: matchingQueriedHostNode(normalized.nodes, nodeId),
   };
 }
 
@@ -8976,6 +8996,7 @@ async function preparePromotedWidgetWrite(
     PROMOTED_PREFLIGHT_READ_OPTIONS,
   );
   let targetScope = targetProbe.scope;
+  let hostNode = targetProbe.hostNode;
   const rootGraphIdentity = targetProbe.rootGraphIdentity;
   // #2518 — a live root query names the current root workflow instance. Do not
   // enter the promoted-subgraph identity path for an ordinary (or unproven)
@@ -9069,6 +9090,7 @@ async function preparePromotedWidgetWrite(
           PROMOTED_PREFLIGHT_READ_OPTIONS,
         );
         targetScope = targetProbe.scope;
+        hostNode = targetProbe.hostNode;
         if (targetScope?.activeView === "root" && targetScope.node === "ordinary") {
           const driftAfterMapping = panelBindingDriftReason(
             ctx,
@@ -9278,23 +9300,39 @@ async function preparePromotedWidgetWrite(
       "graph_get_subgraph did not publish a verifiable workflow and viewing-scope identity",
     );
   }
-  const inner = resolvePromotedWriteTarget(
+  let inner = resolvePromotedWriteTarget(
     payload,
     widget,
     nodeId as number | string,
     publishesCompleteTerminalWitness,
   );
+  // #2791 — official Qwen Image host 76 lists input label `prompt` on widget
+  // `text`. When the terminal witness is incomplete, that unique host mapping
+  // (and optional proxyWidgets inner id) is the rail to write. Do not unpack.
+  const hostMapping = resolveHostPromotedWidgetMapping(hostNode, widget);
+  if (hostMapping && !inner?.parentRail) {
+    const mappedInner = resolveInnerFromHostPromotedMapping(
+      payload,
+      hostMapping,
+      nodeId as number | string,
+    );
+    if (mappedInner) inner = mappedInner;
+  }
+  const hostProvenString = isHostProvenPromotedStringWrite(hostMapping, inner);
   const terminalEvidenceError = promotedTerminalEvidenceError(payload, widget);
   if (terminalEvidenceError) {
     // #2393 — an incomplete OWN entry may still uniquely name a rail-backed
-    // inner COMBO. Any other witness error, including an unadvertised duplicate
-    // that would otherwise fall through to the legacy same-name scan, stays a
+    // inner COMBO. #2791 — a host-proven STRING rail writes the enclosing
+    // subgraph widget instead of that inner. Any other witness error stays a
     // hard refusal.
     const railBackedCombo =
       terminalEvidenceError === "the promoted-terminal witness was incomplete or unresolved" &&
       inner?.terminal?.chainDepth === 0 &&
-      !inner.parentRail;
-    if (!railBackedCombo) return promotedWriteRefusal(widget, terminalEvidenceError);
+      !inner.parentRail &&
+      !hostProvenString;
+    if (!railBackedCombo && !hostProvenString) {
+      return promotedWriteRefusal(widget, terminalEvidenceError);
+    }
   }
   if (!inner) {
     if (publishesCompleteTerminalWitness) {
@@ -9413,18 +9451,22 @@ async function preparePromotedWidgetWrite(
   return {
     kind: "promoted-write",
     outerNodeId: nodeId as number | string,
-    hostWidget: inner.parentRail?.widget ?? widget,
+    hostWidget: hostProvenString && hostMapping
+      ? hostMapping.hostWidget
+      : inner.parentRail?.widget ?? widget,
     ...(outerScope ? { outerScope } : {}),
     ...(outerNodeType ? { outerNodeType } : {}),
     ...(outerNodeIdentity ? { outerNodeIdentity } : {}),
     inner,
     innerNodeType,
-    innerLinkDriven: promotedInnerWidgetIsLinkDriven(
-      innerNode,
-      inner.widget,
-      inner.terminal,
-      inner.parentRail,
-    ),
+    innerLinkDriven:
+      hostProvenString ||
+      promotedInnerWidgetIsLinkDriven(
+        innerNode,
+        inner.widget,
+        inner.terminal,
+        inner.parentRail,
+      ),
     ...(inner.terminal ? { terminal: inner.terminal } : {}),
     scope,
     binding: {

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -413,6 +413,151 @@ function canonicalPromotedNodeId(value: unknown): string | null {
     : normalized;
 }
 
+export type HostPromotedWidgetMapping = {
+  hostWidget: string;
+  label?: string;
+  type?: string;
+  innerNodeId?: number | string;
+};
+
+function hostInputWidgetName(record: Record<string, unknown>): string | null {
+  const widget = record.widget;
+  if (typeof widget === "string" && widget.length > 0) return widget;
+  if (isRecord(widget) && typeof widget.name === "string" && widget.name.length > 0) {
+    return widget.name;
+  }
+  return null;
+}
+
+/**
+ * #2791 — official Qwen Image host node 76 lists input label `prompt` mapped to
+ * widget `text`. A unique host input that actually carries a widget binding is
+ * the promoted rail to write when the terminal witness is incomplete. Name,
+ * label, and widget-name aliases are accepted; two distinct host widgets that
+ * all match the request are not.
+ */
+export function resolveHostPromotedWidgetMapping(
+  hostNode: Record<string, unknown> | null | undefined,
+  requestedWidget: string,
+): HostPromotedWidgetMapping | null {
+  if (!isRecord(hostNode) || requestedWidget.length === 0) return null;
+  const inputs = hostNode.inputs;
+  if (!Array.isArray(inputs)) return null;
+  const wanted = requestedWidget.toLowerCase();
+  const hits: HostPromotedWidgetMapping[] = [];
+  for (const raw of inputs) {
+    if (!isRecord(raw)) continue;
+    const widgetName = hostInputWidgetName(raw);
+    if (!widgetName) continue;
+    const name = typeof raw.name === "string" && raw.name.length > 0 ? raw.name : null;
+    const label = typeof raw.label === "string" && raw.label.length > 0 ? raw.label : undefined;
+    const aliases = [name, label, widgetName];
+    if (!aliases.some((alias) => alias !== null && alias !== undefined && alias.toLowerCase() === wanted)) {
+      continue;
+    }
+    const type = typeof raw.type === "string" && raw.type.length > 0 ? raw.type : undefined;
+    hits.push({
+      hostWidget: widgetName,
+      ...(label ? { label } : {}),
+      ...(type ? { type } : {}),
+    });
+  }
+  if (hits.length === 0) return null;
+  const hostWidgets = new Set(hits.map((hit) => hit.hostWidget.toLowerCase()));
+  if (hostWidgets.size !== 1) return null;
+  const hit = hits[0];
+  const properties = isRecord(hostNode.properties) ? hostNode.properties : null;
+  const proxyWidgets = properties?.proxyWidgets;
+  if (Array.isArray(proxyWidgets)) {
+    const innerIds: Array<number | string> = [];
+    for (const relation of proxyWidgets) {
+      if (!Array.isArray(relation) || relation.length < 2) continue;
+      const innerId = relation[0];
+      const innerWidget = relation[1];
+      if (!isNodeId(innerId) || typeof innerWidget !== "string" || innerWidget.length === 0) continue;
+      if (innerWidget.toLowerCase() !== hit.hostWidget.toLowerCase()) continue;
+      innerIds.push(innerId);
+    }
+    if (innerIds.length === 1) hit.innerNodeId = innerIds[0];
+  }
+  return hit;
+}
+
+function innerTargetFromEnvelopeNode(
+  node: Record<string, unknown>,
+  widget: string,
+): InnerPromotedTarget | null {
+  const id = innerNodeId(node);
+  if (id == null) return null;
+  const nodeType = node.type;
+  if (typeof nodeType !== "string" || nodeType.length === 0) return null;
+  const matched =
+    matchListedName(widget, widgetNamesOnInner(node)) ??
+    (innerHasNamedInput(node, widget) ? widget : null);
+  if (!matched) return null;
+  const inputs = terminalInputsFromInnerNode(node);
+  if (!inputs) return null;
+  return {
+    innerNodeId: id,
+    widget: matched,
+    ...(typeof node.node_identity === "string" ? { nodeIdentity: node.node_identity } : {}),
+    terminal: {
+      nodeId: id,
+      nodeType,
+      widget: matched,
+      inputs,
+      chainDepth: 0,
+    },
+  };
+}
+
+/**
+ * Map a host-proven promoted STRING onto the unique inner terminal named by
+ * `proxyWidgets` or, failing that, the unique rail-backed inner widget. A miss
+ * is not an ordinary-widget proof.
+ */
+export function resolveInnerFromHostPromotedMapping(
+  subgraph: Record<string, unknown> | null | undefined,
+  mapping: HostPromotedWidgetMapping,
+  ownerNodeId: number | string,
+): InnerPromotedTarget | null {
+  const envelope = validatePromotedSubgraphEnvelope(subgraph, ownerNodeId);
+  if (!envelope) return null;
+  if (mapping.innerNodeId !== undefined) {
+    const targetId = canonicalPromotedNodeId(mapping.innerNodeId);
+    if (!targetId) return null;
+    const node = envelope.nodes.find((candidate) => {
+      const candidateId = innerNodeId(candidate);
+      return candidateId !== null && canonicalPromotedNodeId(candidateId) === targetId;
+    });
+    if (!node) return null;
+    return innerTargetFromEnvelopeNode(node, mapping.hostWidget);
+  }
+  return resolveRailBackedInnerFromEnvelope(envelope, mapping.hostWidget);
+}
+
+/** #2791 — host detail uniquely proved a STRING rail, and the inner terminal
+ * agrees with that widget. Incomplete witnesses may then write the host. */
+export function isHostProvenPromotedStringWrite(
+  mapping: HostPromotedWidgetMapping | null | undefined,
+  inner: InnerPromotedTarget | null | undefined,
+): boolean {
+  if (!mapping || !inner) return false;
+  if (mapping.type !== "STRING") return false;
+  if (inner.widget.toLowerCase() !== mapping.hostWidget.toLowerCase()) return false;
+  if (!inner.terminal || inner.terminal.chainDepth !== 0) return false;
+  if (mapping.innerNodeId !== undefined) {
+    const mapped = canonicalPromotedNodeId(mapping.innerNodeId);
+    const innerId = canonicalPromotedNodeId(inner.innerNodeId);
+    if (!mapped || !innerId || mapped !== innerId) return false;
+  }
+  const named = inner.terminal.inputs.find(
+    (input) => input.name.toLowerCase() === inner.widget.toLowerCase(),
+  );
+  if (named?.type !== undefined && named.type !== "STRING") return false;
+  return true;
+}
+
 /** Parse the panel's structured current-graph identity without accepting a
  * prose/detail fallback. The panel deliberately omits workflow_uuid when the
  * live workflow identity cannot be read; owner_node_id remains the required


### PR DESCRIPTION
Fixes #2791

## Problem
`panel_set_widget` refused a valid promoted STRING on the official Comfy-Org Qwen Image subgraph (host 76). Live detail listed input label `prompt` mapped to widget `text`, but the mutation stopped because the promoted-terminal witness was incomplete or unresolved. No `graph_set_widget` was dispatched. The only working in-canvas workaround was unpacking the official subgraph and editing inner CLIPTextEncode.

## Fix
When the terminal witness is incomplete, resolve the unique host subgraph input/widget mapping (`prompt` → `text`, plus `proxyWidgets` inner CLIPTextEncode 6) and write the enclosing subgraph widget. Official subgraphs are not unpacked. COMBO inner writes from #2393 are unchanged. Still unverifiable mappings stay fail-closed.

## Tests
`src/__tests__/orchestrator/promoted-widget.test.ts` — 7 new tests in `#2791 official Qwen Image promoted prompt` (229 total in the file). Drive shipped `panel_set_widget`.
