### PR TITLE
chore: release v0.52.184

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.184] - 2026-09-03
+
 ### MCP
 
 #### Fixed
-- **`panel_restart_comfyui` restarts the panel's bound remote ComfyUI via Manager instead of refusing it as a foreign local instance (#2804).** A live tab whose server-observed Origin is a concrete non-loopback host no longer requires `COMFYUI_MCP_FORCE_REMOTE`; the busy guard still applies, a guessed origin is never restarted, and unbound/local identity confirmation is unchanged.
-- **`upload_image` concurrent `action:"stage"` POSTs no longer die as outcome-unknown EPIPE (#2801).** Uploads to one ComfyUI target run one at a time. A write EPIPE/ECONNRESET is settled against `/view` of the intended input before the tool returns: matching bytes count as committed, a 404 is retried once, and only an unprovable miss stays unknown.
-- **`panel_set_widget` writes the official Qwen Image subgraph prompt from the host input/widget mapping (#2791).** Live host node 76 lists input label `prompt` on widget `text`, but an incomplete promoted-terminal witness refused the STRING write. The unique host mapping (and `proxyWidgets` inner CLIPTextEncode) now authorizes the enclosing subgraph widget; official subgraphs are not unpacked. Still unverifiable mappings stay fail-closed.
-- **`panel_set_widget` MiniMaxH3Director prompt workaround recommends PrimitiveStringMultiline, not PrimitiveNode (#2790).** The panel correctly refuses a direct `prompt` / `builder_state` / `timeline_data` write, but its recovery instruction used to name a frontend PrimitiveNode for `external_prompt_overwrite`; `panel_connect` rejects that forceInput-only STRING. The producer advice now shares the same helper as `panel_connect`.
-- **`panel_ui_render` documents the four-Image cap the validator already enforces (#2796).** The declared manual listed the 64-component ceiling but omitted `maxImages: 4`, so a valid-looking five-image card was rejected as `too many images (5 > 4)` after an avoidable retry.
+- **`panel_restart_comfyui` restarts the panel's bound remote ComfyUI via Manager instead of refusing it as a foreign local instance (#2804, #2821).** A live tab whose server-observed Origin is a concrete non-loopback host no longer requires `COMFYUI_MCP_FORCE_REMOTE`; the busy guard still applies, a guessed origin is never restarted, and unbound/local identity confirmation is unchanged.
+- **`upload_image` concurrent `action:"stage"` POSTs no longer die as outcome-unknown EPIPE (#2801, #2820).** Uploads to one ComfyUI target run one at a time. A write EPIPE/ECONNRESET is settled against `/view` of the intended input before the tool returns: matching bytes count as committed, a 404 is retried once, and only an unprovable miss stays unknown.
+- **`panel_set_widget` writes the official Qwen Image subgraph prompt from the host input/widget mapping (#2791, #2822).** Live host node 76 lists input label `prompt` on widget `text`, but an incomplete promoted-terminal witness refused the STRING write. The unique host mapping (and `proxyWidgets` inner CLIPTextEncode) now authorizes the enclosing subgraph widget; official subgraphs are not unpacked. Still unverifiable mappings stay fail-closed.
+- **`panel_set_widget` MiniMaxH3Director prompt workaround recommends PrimitiveStringMultiline, not PrimitiveNode (#2790, #2819).** The panel correctly refuses a direct `prompt` / `builder_state` / `timeline_data` write, but its recovery instruction used to name a frontend PrimitiveNode for `external_prompt_overwrite`; `panel_connect` rejects that forceInput-only STRING. The producer advice now shares the same helper as `panel_connect`.
+- **`panel_ui_render` documents the four-Image cap the validator already enforces (#2796, #2818).** The declared manual listed the 64-component ceiling but omitted `maxImages: 4`, so a valid-looking five-image card was rejected as `too many images (5 > 4)` after an avoidable retry.
 
 
 ## [0.52.183] - 2026-09-03

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.183",
+  "version": "0.52.184",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.183",
+      "version": "0.52.184",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.183",
+  "version": "0.52.184",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.52.184 covering swarm 37 P2s since v0.52.183:

- #2804 / #2821 — panel_restart_comfyui restarts the bound remote ComfyUI via Manager
- #2801 / #2820 — upload_image concurrent stage EPIPE settled against /view
- #2791 / #2822 — panel_set_widget writes official Qwen Image promoted prompt
- #2790 / #2819 — MiniMaxH3Director prompt workaround recommends PrimitiveStringMultiline
- #2796 / #2818 — panel_ui_render documents the four-Image cap