### PR TITLE
fix(2773): name Manager body-read timeouts; correct raceAbort comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Fixed
+- **Manager body-read timeouts fail closed with a named diagnosis instead of a bare `TimeoutError` (#2773).** After headers arrive, undici still aborts a stalled `Response.text()` on supported Node, but `comfyuiFetch`'s transport rewrite has already returned. `managerFetch` now races both body reads against its own ceiling (without threading a signal into `comfyuiFetch`, which would drop the transport-timeout message) and reports URL, method, and OUTCOME UNKNOWN on a mutation. The `raceAbort` comment no longer claims the fetch signal leaves `Response.text()` pending.
 - **`panel_call_tool` recovers a unique inner panel tool from a self-referential call (#2717).** `name: "panel_call_tool"` with the real tool on `tool` / `tool_name`, a nested key, or sibling fields unwraps once and runs that tool. Several inner names, a non-object keyed payload, or a nested router still fail closed; the refusal names the inner tool when it is unique. The schema now says `name` is the inner tool, never this router.
 - **`panel_set_widget` accepts a complete promoted-subgraph ownership envelope that omits `truncated:false` (#2783).** `graph_get_subgraph` already proves completeness when `node_count === nodes.length`; an omitted or null `truncated` flag is then `false`. An asserted `truncated:true`, or a list shorter than `node_count`, stays fail-closed.
 

--- a/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
+++ b/src/__tests__/services/install-git-manager-listed-but-absent-2714.test.ts
@@ -92,13 +92,15 @@ const manager = vi.hoisted(() => ({
   installed: {} as Record<string, unknown> | unknown[],
   calls: [] as string[],
 }));
-vi.mock("../../comfyui/fetch.js", () => {
+vi.mock("../../comfyui/fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/fetch.js")>();
   const json = (body: unknown) =>
     new Response(JSON.stringify(body), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
   return {
+    ...actual,
     comfyuiFetch: async (url: string) => {
       manager.calls.push(url);
       const { pathname } = new URL(url);

--- a/src/__tests__/services/manager-body-timeout-parity.test.ts
+++ b/src/__tests__/services/manager-body-timeout-parity.test.ts
@@ -1,0 +1,36 @@
+// #2773 — the Manager body-read deadline is derived a SECOND time.
+//
+// `managerBodyTimeoutSignal` cannot call `defaultComfyTimeoutSignal`: suites that
+// mock `comfyui/fetch.js` do not declare that export, so importing it would make
+// those files fail to load. The workaround is a local copy of the derivation —
+// and a copied constant with nothing comparing the two drifts silently. Raising
+// DEFAULT_COMFY_HTTP_TIMEOUT_S would leave the Manager body read at 120s with
+// every test still green.
+//
+// This is the comparison. It imports both REAL modules (no mocks) so it fails the
+// moment the two rules disagree.
+import { afterEach, describe, expect, it } from "vitest";
+import { comfyHttpTimeoutSeconds } from "../../comfyui/fetch.js";
+import { managerBodyTimeoutSeconds } from "../../services/node-management.js";
+
+const KEY = "COMFYUI_MCP_HTTP_TIMEOUT_S";
+const original = process.env[KEY];
+
+afterEach(() => {
+  if (original === undefined) delete process.env[KEY];
+  else process.env[KEY] = original;
+});
+
+describe("#2773 the Manager body deadline agrees with the shared HTTP deadline", () => {
+  it("matches on the DEFAULT, which is the value that silently drifts", () => {
+    delete process.env[KEY];
+    expect(managerBodyTimeoutSeconds()).toBe(comfyHttpTimeoutSeconds());
+  });
+
+  it("matches when the env var is set, and on each way of being invalid", () => {
+    for (const value of ["45", "0", "-1", "", "abc"]) {
+      process.env[KEY] = value;
+      expect(managerBodyTimeoutSeconds()).toBe(comfyHttpTimeoutSeconds());
+    }
+  });
+});

--- a/src/__tests__/services/manager-body-timeout.test.ts
+++ b/src/__tests__/services/manager-body-timeout.test.ts
@@ -1,0 +1,180 @@
+// #2773 — a Manager 2xx whose body stalls after headers used to escape as
+// `TimeoutError: The operation was aborted due to timeout` with no URL and no
+// method. comfyuiFetch's describeComfyTimeout rewrite cannot run: it has already
+// returned. These tests drive SHIPPED managerFetch callers (listInstalledNodes,
+// startManagerQueueForExternal) against a body that never finishes.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: "/fake/comfy",
+    resolvedPort: 8188,
+    comfyuiHost: "127.0.0.1",
+    comfyuiSsl: false,
+    githubToken: undefined as string | undefined,
+  };
+  return {
+    config,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+    getComfyuiTargetGeneration: () => 0,
+    getComfyUIAuthHeaders: () => ({}),
+    isLoopbackHost: (host?: string) => host === "127.0.0.1" || host === "localhost",
+    isRemoteMode: () => false,
+  };
+});
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 0, stdout: "{}", stderr: "" })),
+}));
+
+const {
+  NodeManagementError,
+  listInstalledNodes,
+  resetManagerApiCacheForTests,
+  startManagerQueueForExternal,
+} = await import("../../services/node-management.js");
+
+const BASE = "http://127.0.0.1:8188";
+
+/** Headers arrive; the body never enqueues and never closes. */
+function stallingBody(status = 200): Response {
+  return new Response(
+    new ReadableStream({
+      start() {
+        /* deliberately never enqueues and never closes */
+      },
+    }),
+    { status },
+  );
+}
+
+describe("managerFetch body-read timeout (#2773)", () => {
+  const previousTimeout = process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
+
+  beforeEach(() => {
+    process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = "0.3";
+    resetManagerApiCacheForTests("v2");
+  });
+
+  afterEach(() => {
+    if (previousTimeout === undefined) delete process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
+    else process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = previousTimeout;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    resetManagerApiCacheForTests();
+  });
+
+  it("names a GET whose body never finishes, instead of a bare TimeoutError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string): Promise<Response> => {
+        const path = new URL(url).pathname;
+        if (path.startsWith("/v2/customnode/installed")) return stallingBody();
+        return new Response("404: Not Found", { status: 404 });
+      }),
+    );
+
+    const started = Date.now();
+    const err = await listInstalledNodes().catch((e: unknown) => e);
+    expect(Date.now() - started).toBeLessThan(5_000);
+
+    expect(err).toBeInstanceOf(NodeManagementError);
+    if (!(err instanceof NodeManagementError)) throw new Error("expected NodeManagementError");
+    expect(err.name).not.toBe("TimeoutError");
+    expect(err.message).toMatch(/No reply from ComfyUI within 0\.3s/);
+    expect(err.message).toContain(`${BASE}/v2/customnode/installed?mode=default`);
+    expect(err.message).toMatch(/\(GET\)/);
+    expect(err.message).toMatch(/Headers had already arrived/);
+    expect(err.message).toMatch(/body did not finish/);
+    expect(err.message).toMatch(/Nothing was learned about the server/);
+    expect(err.message).not.toMatch(/OUTCOME UNKNOWN/);
+    expect(err.message).not.toMatch(/^The operation was aborted due to timeout$/);
+    expect(err.details).toEqual(
+      expect.objectContaining({
+        kind: "manager-body-timeout",
+        url: `${BASE}/v2/customnode/installed?mode=default`,
+      }),
+    );
+    // A structured status would let dialect-mismatch retry re-enqueue. This
+    // path has headers, not a 404/405, so it must carry none.
+    expect(err.details).not.toHaveProperty("status");
+  }, 20_000);
+
+  it("calls a mutating body stall OUTCOME UNKNOWN", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const path = new URL(url).pathname;
+        const method = init?.method ?? "GET";
+        if (path === "/v2/manager/queue/start" && method === "POST") return stallingBody();
+        return new Response("404: Not Found", { status: 404 });
+      }),
+    );
+
+    const started = Date.now();
+    const err = await startManagerQueueForExternal("v2").catch((e: unknown) => e);
+    expect(Date.now() - started).toBeLessThan(5_000);
+
+    expect(err).toBeInstanceOf(NodeManagementError);
+    if (!(err instanceof NodeManagementError)) throw new Error("expected NodeManagementError");
+    expect(err.message).toMatch(/No reply from ComfyUI within 0\.3s/);
+    expect(err.message).toContain(`${BASE}/v2/manager/queue/start`);
+    expect(err.message).toMatch(/\(POST\)/);
+    expect(err.message).toMatch(/OUTCOME UNKNOWN/);
+    expect(err.message).toMatch(/do NOT blindly re-issue/);
+    expect(err.message).not.toMatch(/Nothing was learned about the server/);
+    expect(err.details).toEqual(
+      expect.objectContaining({
+        kind: "manager-body-timeout",
+        url: `${BASE}/v2/manager/queue/start`,
+      }),
+    );
+  }, 20_000);
+
+  it("keeps the transport-timeout rewrite when headers never arrive", async () => {
+    // Passing a signal into comfyuiFetch would skip describeComfyTimeout
+    // (init.signal !== undefined) and leave a bare abort in the wrapper.
+    // Honour the signal the way undici does: the mock must reject when it fires,
+    // or this would hang for the same reason a fetch double that ignores abort
+    // hangs — which is not the production path under test.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          const fail = () => {
+            reject(
+              signal?.reason ??
+                Object.assign(new Error("The operation was aborted due to timeout"), {
+                  name: "TimeoutError",
+                }),
+            );
+          };
+          if (signal?.aborted) {
+            fail();
+            return;
+          }
+          signal?.addEventListener("abort", fail, { once: true });
+        });
+      }),
+    );
+
+    const started = Date.now();
+    const err = await listInstalledNodes().catch((e: unknown) => e);
+    expect(Date.now() - started).toBeLessThan(5_000);
+
+    expect(err).toBeInstanceOf(NodeManagementError);
+    if (!(err instanceof NodeManagementError)) throw new Error("expected NodeManagementError");
+    expect(err.message).toMatch(/ComfyUI-Manager API unreachable/);
+    expect(err.message).toMatch(/No reply from ComfyUI within 0\.3s/);
+    expect(err.message).toMatch(/while requesting .*\/v2\/customnode\/installed/);
+    expect(err.message).toMatch(/Whether a connection was ever established is NOT known/);
+    expect(err.message).not.toMatch(/Headers had already arrived/);
+    expect(err.details).not.toEqual(
+      expect.objectContaining({ kind: "manager-body-timeout" }),
+    );
+  }, 20_000);
+});

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -407,10 +407,10 @@ describe("#646 Manager API dialect cache invalidation", () => {
   });
 
   it("settles instead of hanging on a version body that never ends (#2754, gate round 4)", async () => {
-    // comfyuiFetch's ceiling cancels the exchange but not the body read (#1672,
-    // fetch.ts:575-584), so a 200 whose body never closes leaves managerFetch's
-    // `await res.text()` pending forever. Without raceAbort around these two
-    // probes this test does not fail — it HANGS, which is the point.
+    // A 200 whose body never closes must still settle: undici errors the body
+    // when the fetch signal fires, and raceAbort bounds the enclosing probe
+    // (#2773). Without a ceiling this test does not fail — it HANGS, which is
+    // the point.
     const previousTimeout = process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
     process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = "0.3";
     try {

--- a/src/__tests__/services/panel-pin-bypass.test.ts
+++ b/src/__tests__/services/panel-pin-bypass.test.ts
@@ -66,8 +66,11 @@ let managerFailAfterGate = false;
 // would hold the panel lock until the test times out, cascading into every
 // later lock-taking test.)
 let managerLegacyPersona = false;
-vi.mock("../../comfyui/fetch.js", () => ({
-  comfyuiFetch: vi.fn(async (url: string) => {
+vi.mock("../../comfyui/fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/fetch.js")>();
+  return {
+    ...actual,
+    comfyuiFetch: vi.fn(async (url: string) => {
     managerCalls.push(url);
     if (managerGate) await managerGate;
     if (managerFailAfterGate) throw new Error("test: Manager went away");
@@ -89,8 +92,9 @@ vi.mock("../../comfyui/fetch.js", () => ({
       }
     }
     return new Response("{}", { status: 200 });
-  }),
-}));
+    }),
+  };
+});
 
 import {
   fixCustomNode,

--- a/src/__tests__/services/panel-pin-cancel.test.ts
+++ b/src/__tests__/services/panel-pin-cancel.test.ts
@@ -53,12 +53,16 @@ const managerCalls: Array<{ url: string; method: string }> = [];
 let managerHandler: (url: string, init?: RequestInit) => Response = () =>
   new Response("not found", { status: 404 });
 
-vi.mock("../../comfyui/fetch.js", () => ({
-  comfyuiFetch: vi.fn(async (url: string, init?: RequestInit) => {
-    managerCalls.push({ url, method: init?.method ?? "GET" });
-    return managerHandler(url, init);
-  }),
-}));
+vi.mock("../../comfyui/fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/fetch.js")>();
+  return {
+    ...actual,
+    comfyuiFetch: vi.fn(async (url: string, init?: RequestInit) => {
+      managerCalls.push({ url, method: init?.method ?? "GET" });
+      return managerHandler(url, init);
+    }),
+  };
+});
 
 import { config } from "../../config.js";
 import {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -1923,11 +1923,11 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
   });
 
   it("bounds the version read when HEADERS arrive but the BODY stalls (#2320)", async () => {
-    // Codex gate r2, P1: AbortSignal.timeout only cancels the exchange up to
-    // headers. Once they land, res.text() keeps the caller pending for as long as
-    // the body takes — the #1672 failure mode raceAbort exists for. The previous
-    // test stalls BEFORE headers and cannot see this; here the response is fully
-    // formed and only its body never completes.
+    // Codex gate r2, P1: raceAbort bounds the enclosing version read when the
+    // body never completes. On supported Node undici errors the stream when the
+    // fetch signal fires, so this settles at the budget either way; the previous
+    // test stalls BEFORE headers and cannot see a headers-then-stall. Here the
+    // response is fully formed and only its body never completes.
     installRemoteRebootFixture();
     const fetchMock = vi.fn(async (url: unknown) => {
       const u = String(url);

--- a/src/__tests__/tools/system-stats-timeout-unwind.test.ts
+++ b/src/__tests__/tools/system-stats-timeout-unwind.test.ts
@@ -1,10 +1,11 @@
 // #1672 — get_system_stats(action:"stats") during a long VAE/audio decode
-// reported "The operation was aborted due to timeout" and then left the
-// enclosing call_tool cell pending until something killed it. The abort
-// cancelled fetch() after headers, but Response.text() / JSON.parse did not
-// observe it. These tests drive the SHIPPED path (call_tool → get_system_stats
-// → getSystemInfo → getSystemStats → fetch+decode) against a body that never
-// finishes, and assert call_tool settles promptly with a structured timeout.
+// reported "The operation was aborted due to timeout" but the enclosing
+// call_tool cell stayed pending until something killed it. The inner read
+// observed the abort; raceAbort exists to bound the enclosing promise.
+// JSON.parse is synchronous and unabortable. These tests drive the SHIPPED
+// path (call_tool → get_system_stats → getSystemInfo → getSystemStats →
+// fetch+decode) against a body that never finishes, and assert call_tool
+// settles promptly with a structured timeout.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -575,17 +575,18 @@ function abortReasonOf(signal: AbortSignal): unknown {
 /**
  * Reject as soon as `signal` aborts, even if `work` is still running.
  *
- * `AbortSignal.timeout` on `fetch` only cancels the HTTP exchange. Once headers
- * have arrived, `Response.text()` / `JSON.parse` can keep the caller pending for
- * as long as the body takes to finish — and a ComfyUI that is mid-decode
- * (VAEDecodeAudio, a long VAE, …) often accepts `/system_stats` and then stalls
- * on the body. The abort event IS fired; the decode does not observe it. Racing
- * the abort against the whole fetch+decode is what lets `call_tool` settle
- * instead of hanging until the decode ends or the process is killed (#1672).
+ * Bounds an enclosing promise whose inner work may not settle. On supported
+ * Node (`engines` is >=22) undici errors the response body stream when the
+ * `fetch` signal fires, so a pending `Response.text()` rejects at the deadline
+ * — the quoted "headers-only" story is false here. `raceAbort` still earns its
+ * place by bounding everything ELSE in `work`: a test double that ignores abort,
+ * a consumer that does not pass the signal through, or the enclosing `call_tool`
+ * cell. #1672's inner read DID reject ("The operation was aborted due to
+ * timeout"); the outer cell is what stayed pending. `JSON.parse` is genuinely
+ * unabortable, and racing it cannot preempt it because it blocks the same thread.
  *
- * The inner promise is attached so a late rejection (the decode finally
- * noticing the abort) cannot become an unhandledRejection after we already
- * settled.
+ * The inner promise is attached so a late rejection cannot become an
+ * unhandledRejection after we already settled.
  */
 export function raceAbort<T>(signal: AbortSignal | undefined, work: () => Promise<T>): Promise<T> {
   if (!signal) return work();
@@ -614,6 +615,38 @@ export function raceAbort<T>(signal: AbortSignal | undefined, work: () => Promis
   });
 }
 
+/** GET/HEAD learned nothing; a mutation that timed out is OUTCOME UNKNOWN. */
+function timeoutRetryClause(method: string): string {
+  if (method === "GET" || method === "HEAD") {
+    return (
+      `Nothing was learned about the server from this — a timeout is not a refusal and not a ` +
+      `"not found". `
+    );
+  }
+  return (
+    `OUTCOME UNKNOWN: this request may already have been received and acted on, so do NOT ` +
+    `blindly re-issue it — check the server's state first (for a queued prompt, queue ` +
+    `(action:"list") and get_history (action:"list")). `
+  );
+}
+
+/**
+ * Named diagnosis for a stall AFTER headers: `comfyuiFetch` has already returned,
+ * so its transport rewrite never runs and a raw `TimeoutError` would escape with
+ * no URL and no method (#2773). Distinct from the transport-timeout formatter:
+ * the connection DID happen; only the body failed to finish.
+ */
+export function describeComfyBodyTimeout(target: string, method: string): Error {
+  const seconds = comfyHttpTimeoutSeconds();
+  const err = new Error(
+    `No reply from ComfyUI within ${seconds}s — while reading the response body of ${target} (${method}). ` +
+      `Headers had already arrived; the body did not finish. ` +
+      timeoutRetryClause(method),
+  );
+  (err as { code?: string }).code = "COMFYUI_HTTP_BODY_TIMEOUT";
+  return err;
+}
+
 /**
  * Say what the ceiling did and did NOT establish.
  *
@@ -627,7 +660,6 @@ function describeComfyTimeout(input: string | URL | Request, init: RequestInit):
   const target = targetOf(input);
   const method = methodOf(input, init);
   const seconds = comfyHttpTimeoutSeconds();
-  const mutating = method !== "GET" && method !== "HEAD";
   // #1896 — the comparison the TRANSPORT path has made since #1553, on the path
   // that shares its cause.
   //
@@ -646,12 +678,7 @@ function describeComfyTimeout(input: string | URL | Request, init: RequestInit):
   const drift = classifyTargetDrift(target);
   const err = new Error(
     `No reply from ComfyUI within ${seconds}s — while requesting ${target} (${method}). ` +
-      (mutating
-        ? `OUTCOME UNKNOWN: this request may already have been received and acted on, so do NOT ` +
-          `blindly re-issue it — check the server's state first (for a queued prompt, queue ` +
-          `(action:"list") and get_history (action:"list")). `
-        : `Nothing was learned about the server from this — a timeout is not a refusal and not a ` +
-          `"not found". `) +
+      timeoutRetryClause(method) +
       // #1896 — this asserted "The connection was accepted but no answer arrived
       // in time". The ceiling covers the WHOLE exchange, connecting included, so
       // a black-holed SYN times out here having established no connection at all

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -11,7 +11,6 @@ import {
 import {
   comfyuiFetch,
   describeComfyBodyTimeout,
-  isTimeoutAbort,
   raceAbort,
 } from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
@@ -338,6 +337,10 @@ function managerBodyTimeoutSignal(): AbortSignal {
   return AbortSignal.timeout(Math.round(seconds * 1000));
 }
 
+function isManagerTimeoutAbort(err: unknown): boolean {
+  return err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+}
+
 async function managerFetch<T>(
   path: string,
   options: ManagerFetchOptions = {},
@@ -428,7 +431,7 @@ async function managerFetch<T>(
   try {
     raw = await readBody();
   } catch (err) {
-    if (isTimeoutAbort(err)) {
+    if (isManagerTimeoutAbort(err)) {
       if (soft) {
         onSoftFailure?.(undefined);
         onSoftTransportFailure?.();

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -10,7 +10,6 @@ import {
 } from "../config.js";
 import {
   comfyuiFetch,
-  defaultComfyTimeoutSignal,
   describeComfyBodyTimeout,
   isTimeoutAbort,
   raceAbort,
@@ -331,6 +330,14 @@ export function explainManagerAuthenticationRequired(status: number): string {
   );
 }
 
+/** Same 120s ceiling as fetch.ts, minted locally so tests that mock
+ *  `comfyui/fetch.js` without `defaultComfyTimeoutSignal` still load. */
+function managerBodyTimeoutSignal(): AbortSignal {
+  const raw = Number(process.env.COMFYUI_MCP_HTTP_TIMEOUT_S);
+  const seconds = Number.isFinite(raw) && raw > 0 ? raw : 120;
+  return AbortSignal.timeout(Math.round(seconds * 1000));
+}
+
 async function managerFetch<T>(
   path: string,
   options: ManagerFetchOptions = {},
@@ -354,7 +361,9 @@ async function managerFetch<T>(
   // comfyuiFetch: that helper rewrites a timeout into describeComfyTimeout only
   // when init.signal is undefined, so threading a signal through would silently
   // drop the transport-timeout diagnosis for every Manager call (#2773).
-  const budget = defaultComfyTimeoutSignal();
+  // Local AbortSignal — do not import defaultComfyTimeoutSignal from fetch.js;
+  // tests mock that module without this export.
+  const budget = managerBodyTimeoutSignal();
 
   let res: Response;
   try {
@@ -781,7 +790,7 @@ async function probeManagerVersionEvidence(base: string): Promise<ManagerVersion
   // these two probes so a late inner settlement cannot hold the diagnosis open
   // after this budget fires — this is the diagnosis a caller reached after
   // everything else had already failed.
-  const budget = defaultComfyTimeoutSignal();
+  const budget = managerBodyTimeoutSignal();
   for (const path of MANAGER_VERSION_ROUTES) {
     let kind: ManagerQueueStatusKind = "hard-error";
     // This route's own status. Recorded per-iteration, and promoted to

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -8,7 +8,13 @@ import {
   getComfyuiTargetGeneration,
   isRemoteMode,
 } from "../config.js";
-import { comfyuiFetch, defaultComfyTimeoutSignal, raceAbort } from "../comfyui/fetch.js";
+import {
+  comfyuiFetch,
+  defaultComfyTimeoutSignal,
+  describeComfyBodyTimeout,
+  isTimeoutAbort,
+  raceAbort,
+} from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
 import { parsePyproject } from "./node-authoring.js";
@@ -344,6 +350,12 @@ async function managerFetch<T>(
   const headers: Record<string, string> = {};
   if (body !== undefined) headers["Content-Type"] = "application/json";
 
+  // Mint the ceiling HERE and race only the body reads. Do NOT pass it into
+  // comfyuiFetch: that helper rewrites a timeout into describeComfyTimeout only
+  // when init.signal is undefined, so threading a signal through would silently
+  // drop the transport-timeout diagnosis for every Manager call (#2773).
+  const budget = defaultComfyTimeoutSignal();
+
   let res: Response;
   try {
     res = await comfyuiFetch(url, {
@@ -364,11 +376,13 @@ async function managerFetch<T>(
     );
   }
 
+  const readBody = (): Promise<string> => raceAbort(budget, () => res.text());
+
   if (!res.ok) {
     // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
     // HTTP status is reported either way, so an unreadable body costs detail in the
     // text, never a wrong conclusion. Verified there is no branch on this value.
-    const text = await res.text().catch(() => "");
+    const text = await readBody().catch(() => "");
     if (soft) {
       onSoftFailure?.(res.status);
       // A soft probe may ignore an absent route or a transient server error, but
@@ -399,7 +413,26 @@ async function managerFetch<T>(
   }
 
   // Some endpoints return empty bodies (e.g. queue ops). Parse defensively.
-  const raw = await res.text();
+  // Headers already arrived, so comfyuiFetch's describeComfyTimeout rewrite
+  // cannot run. A stall here used to escape as a bare TimeoutError (#2773).
+  let raw: string;
+  try {
+    raw = await readBody();
+  } catch (err) {
+    if (isTimeoutAbort(err)) {
+      if (soft) {
+        onSoftFailure?.(undefined);
+        onSoftTransportFailure?.();
+        return undefined;
+      }
+      const timeout = describeComfyBodyTimeout(url, method);
+      throw new NodeManagementError(timeout.message, {
+        url,
+        kind: "manager-body-timeout",
+      });
+    }
+    throw err;
+  }
   if (!raw.trim()) {
     if (soft) onSoftResponse?.(undefined);
     return undefined;
@@ -744,17 +777,10 @@ async function probeManagerVersionEvidence(base: string): Promise<ManagerVersion
   const kinds: ManagerQueueStatusKind[] = [];
   // ONE budget for the whole diagnosis, not one per route.
   //
-  // comfyuiFetch's default ceiling cancels the HTTP exchange but NOT the body
-  // read: once headers arrive, `await res.text()` inside managerFetch can stay
-  // pending for as long as the body takes, and the abort event fires without the
-  // read observing it. That is fetch.ts:575-584 (#1672), and raceAbort exists for
-  // exactly this. A ComfyUI mid-decode really does accept a request and then stall
-  // — and hanging HERE would be the worst place for it, because this is the
-  // diagnosis a caller reached after everything else had already failed.
-  //
-  // Scoped to the two probes this branch adds. managerFetch's unraced body read is
-  // pre-existing on every other call site in this file and is filed separately;
-  // fixing it there changes behaviour for every Manager operation.
+  // managerFetch now races its own body reads (#2773). raceAbort still wraps
+  // these two probes so a late inner settlement cannot hold the diagnosis open
+  // after this budget fires — this is the diagnosis a caller reached after
+  // everything else had already failed.
   const budget = defaultComfyTimeoutSignal();
   for (const path of MANAGER_VERSION_ROUTES) {
     let kind: ManagerQueueStatusKind = "hard-error";
@@ -789,12 +815,12 @@ async function probeManagerVersionEvidence(base: string): Promise<ManagerVersion
       // error with a secondary probe's — but classify it before moving on.
       //
       // NOT every throw here is an authentication refusal (codex gate round 3).
-      // Soft mode throws for 401/407, and it also lets a body-read rejection
-      // escape: `await res.text()` on a 2xx that stalls or resets is unguarded, so
-      // a `refused = true` in every catch would answer a broken pipe with
-      // "configure your gateway credentials". managerFetch runs onSoftFailure
-      // BEFORE the auth throw, and never runs it on a 2xx — so a status is here
-      // exactly when the response was a real, non-ok answer we can classify.
+      // Soft mode throws for 401/407, and a body-read rejection on a 2xx is not
+      // an auth status — a `refused = true` in every catch would answer a broken
+      // pipe with "configure your gateway credentials". managerFetch runs
+      // onSoftFailure BEFORE the auth throw, and never runs it on a 2xx — so a
+      // status is here exactly when the response was a real, non-ok answer we
+      // can classify.
       if (statusSeen !== undefined && explainManagerAuthenticationRequired(statusSeen) !== "") {
         refused = true;
         refusedStatus ??= statusSeen;

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -331,9 +331,13 @@ export function explainManagerAuthenticationRequired(status: number): string {
 
 /** Same 120s ceiling as fetch.ts, minted locally so tests that mock
  *  `comfyui/fetch.js` without `defaultComfyTimeoutSignal` still load. */
-function managerBodyTimeoutSignal(): AbortSignal {
+export function managerBodyTimeoutSeconds(): number {
   const raw = Number(process.env.COMFYUI_MCP_HTTP_TIMEOUT_S);
-  const seconds = Number.isFinite(raw) && raw > 0 ? raw : 120;
+  return Number.isFinite(raw) && raw > 0 ? raw : 120;
+}
+
+function managerBodyTimeoutSignal(): AbortSignal {
+  const seconds = managerBodyTimeoutSeconds();
   return AbortSignal.timeout(Math.round(seconds * 1000));
 }
 

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -5237,11 +5237,11 @@ async function probeManagerMajorForReport(base: string): Promise<number | undefi
   const signal = AbortSignal.timeout(REPORT_VERSION_PROBE_BUDGET_MS);
   for (const path of MANAGER_VERSION_ROUTES) {
     try {
-      // raceAbort covers the BODY too (codex gate r2, P1). AbortSignal.timeout only
-      // cancels the exchange up to headers — once they arrive, `res.text()` keeps the
-      // caller pending for as long as the body takes, which is the #1672 failure mode
-      // this helper exists for. A host that answers headers and then stalls the body
-      // is the same stalled proxy the budget is here to survive.
+      // raceAbort covers the enclosing read (codex gate r2, P1). On supported Node,
+      // undici errors the body stream when the fetch signal fires, so `res.text()`
+      // does reject at the deadline; raceAbort still bounds a consumer that does not
+      // observe abort. A host that answers headers and then stalls the body is the
+      // same stalled proxy the budget is here to survive.
       const major = await raceAbort(signal, async () => {
         const res = await comfyuiFetch(`${base}${path}`, { method: "GET", signal });
         if (!res.ok) return undefined;


### PR DESCRIPTION
## Summary

Fixes #2773 (split from #2764). Two parts, both documentation/diagnosis quality:

1. **`raceAbort` comment was false on supported Node.** `AbortSignal.timeout` on `fetch` does **not** leave `Response.text()` pending after headers: undici errors the body stream when the fetch signal fires. Measured on Node 22.23.2 and 24.16.0 (`engines` is `>=22`). `raceAbort` still bounds an enclosing promise whose inner work may not settle; `JSON.parse` is unabortable because it blocks the same thread. #1672's inner read already rejected; the outer `call_tool` cell is what hung.

2. **Manager 2xx body-read timeout escaped undiagnosed.** After headers, `comfyuiFetch` has already returned, so `describeComfyTimeout` never runs and the caller got a bare `TimeoutError` with no URL and no method. `managerFetch` now mints its own ceiling and races **only** the body reads — it does **not** pass a signal into `comfyuiFetch`, which would skip the transport-timeout rewrite (`init.signal === undefined`). A stall fails closed as `manager-body-timeout` with URL, method, and OUTCOME UNKNOWN on mutations. No status field, so dialect-mismatch retry cannot re-enqueue.

## Tests

- `src/__tests__/services/manager-body-timeout.test.ts` — GET `listInstalledNodes` names the stall; POST `startManagerQueueForExternal` is OUTCOME UNKNOWN; a headers-never-arrive hang still gets the transport rewrite.
- Existing dialect-cache / fetch-timeout / #1672 unwind suites still pass.

## Changelog

Unreleased → MCP → Fixed.