### PR TITLE
fix(2783): accept complete subgraph envelope omitting truncated:false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`panel_set_widget` accepts a complete promoted-subgraph ownership envelope that omits `truncated:false` (#2783).** `graph_get_subgraph` already proves completeness when `node_count === nodes.length`; an omitted or null `truncated` flag is then `false`. An asserted `truncated:true`, or a list shorter than `node_count`, stays fail-closed.
+
 ## [0.52.184] - 2026-09-03
 
 ### MCP

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -4003,6 +4003,62 @@ describe("panel_set_widget promoted-subgraph recovery (#1655)", () => {
     expect(calls.map((c) => c.cmd)).not.toContain("graph_enter_subgraph");
   });
 
+  it.each([
+    ["omitted truncated", {}],
+    ["null truncated", { truncated: null }],
+  ])("writes a promoted BOOLEAN when the complete envelope has %s (#2783)", async (
+    _label,
+    truncatedField,
+  ) => {
+    const subgraph = {
+      subgraph_of: { node_id: 78, title: "Boolean pack" },
+      node_count: 1,
+      nodes: [
+        {
+          id: 12,
+          type: "PrimitiveBoolean",
+          widgets: { value: false },
+          inputs: [{ name: "value", type: "BOOLEAN" }],
+        },
+      ],
+      promoted_terminals: [
+        {
+          widget: "value_1",
+          parent_rail: { authoritative: true, widget: "value_1" },
+          immediate_node_id: 12,
+          immediate_widget: "value",
+          terminal_node_id: 12,
+          terminal_node_type: "PrimitiveBoolean",
+          terminal_widget: "value",
+          terminal_inputs: [{ name: "value", type: "BOOLEAN" }],
+          chain_depth: 0,
+        },
+      ],
+      ...truncatedField,
+    };
+    const { text, isError, calls, mutations } = await setWidget(
+      { node_id: 78, widget: "value_1", value: true },
+      {
+        firstWrite: "ok",
+        promotedTerminalWitnesses: true,
+        promotedDetail: {
+          text:
+            '1 match(es) of 1 in scope (viewing: 1 nodes)\n' +
+            '{"id":78,"type":"SubgraphNode","is_subgraph":true}',
+        },
+        subgraph,
+      },
+    );
+
+    expect(isError).toBe(false);
+    expect(mutations).toBe(1);
+    expect(text).not.toMatch(/truncated/);
+    expect(calls.filter((call) => call.cmd === "graph_enter_subgraph")).toHaveLength(0);
+    expect(calls.filter((call) => call.cmd === "graph_set_widget")).toEqual([
+      expect.objectContaining({ node_id: 78, widget: "value_1", value: true }),
+    ]);
+  });
+
   it("a failed subgraph read keeps the original refusal", async () => {
     const { text, isError, calls } = await setWidget(
       { node_id: 78, widget: "width", value: 1024 },
@@ -4508,6 +4564,16 @@ describe("#2688 describePromotedSubgraphEnvelope names the failed invariant", ()
     expect(describePromotedSubgraphEnvelope(VALID, 78).ok).toBe(true);
   });
 
+  // #2783 — a complete inner list is the completeness proof. The panel may omit
+  // `truncated:false` (or send JSON null) even though node_count === nodes.length.
+  it.each([
+    ["omitted truncated", { ...VALID, truncated: undefined }],
+    ["null truncated", { ...VALID, truncated: null }],
+  ])("accepts a complete envelope with %s", (_label, payload) => {
+    expect(describePromotedSubgraphEnvelope(payload, 78).ok).toBe(true);
+    expect(validatePromotedSubgraphEnvelope(payload, 78)).not.toBeNull();
+  });
+
   it.each([
     ["a non-object reply", "nope", 78, /the reply was not a JSON object/],
     [
@@ -4517,12 +4583,19 @@ describe("#2688 describePromotedSubgraphEnvelope names the failed invariant", ()
       /the reply's `truncated` flag was not `false`/,
     ],
     // A malformed flag is not evidence of a SHORT read, so the reason must not
-    // claim one. Same rejection, different established fact.
+    // claim one. Same rejection, different established fact. JSON null is
+    // omission (#2783), not this case.
     [
       "a malformed truncated flag",
-      { ...VALID, truncated: null },
+      { ...VALID, truncated: "yes" },
       78,
       /the reply's `truncated` flag was not `false`/,
+    ],
+    [
+      "an incomplete inner list even when truncated is omitted",
+      { ...VALID, truncated: undefined, node_count: 9 },
+      78,
+      /`node_count` claimed 9 inner node\(s\) but `nodes` carried 1/,
     ],
     [
       "a missing subgraph_of",
@@ -4620,6 +4693,7 @@ describe("#2688 describePromotedSubgraphEnvelope names the failed invariant", ()
       { ...VALID, viewing: undefined },
       { ...VALID, promoted_terminals: undefined },
       { ...VALID, truncated: undefined },
+      { ...VALID, truncated: null },
       { ...VALID, subgraph_of: { node_id: "78" } },
       withNodes([]),
       terminals([goodTerminal]),

--- a/src/orchestrator/promoted-widget.ts
+++ b/src/orchestrator/promoted-widget.ts
@@ -630,8 +630,9 @@ function envelopeInvariant(invariant: string): { ok: false; invariant: string } 
  *
  * A node list is useful for a promoted write only when it names the wrapper the
  * caller asked about and contains exactly the advertised number of inner nodes.
- * The panel currently emits `truncated:false` for complete reads, but omission
- * remains accepted for older compatible replies; any asserted truncation is not.
+ * When that completeness proof holds (`node_count === nodes.length`), an omitted
+ * or null `truncated` flag is `false`. An asserted `truncated:true`, or a list
+ * that is actually short of `node_count`, stays fail-closed.
  */
 export function describePromotedSubgraphEnvelope(
   subgraph: Record<string, unknown> | null | undefined,
@@ -639,12 +640,6 @@ export function describePromotedSubgraphEnvelope(
 ): PromotedSubgraphEnvelopeResult {
   if (!isRecord(subgraph)) {
     return envelopeInvariant("the reply was not a JSON object");
-  }
-  if (subgraph.truncated !== undefined && subgraph.truncated !== false) {
-    return envelopeInvariant(
-      "the reply's `truncated` flag was not `false`, so the inner node list it carried " +
-        "cannot be taken as the whole subgraph",
-    );
   }
 
   const viewing = Object.prototype.hasOwnProperty.call(subgraph, "viewing")
@@ -697,6 +692,14 @@ export function describePromotedSubgraphEnvelope(
   if (nodes.length !== nodeCount) {
     return envelopeInvariant(
       `\`node_count\` claimed ${nodeCount as number} inner node(s) but \`nodes\` carried ${nodes.length}`,
+    );
+  }
+  // Completeness is proven from the list, not from the flag. Omitted/null
+  // `truncated` is then false; an asserted or malformed flag is not.
+  if (subgraph.truncated != null && subgraph.truncated !== false) {
+    return envelopeInvariant(
+      "the reply's `truncated` flag was not `false`, so the inner node list it carried " +
+        "cannot be taken as the whole subgraph",
     );
   }
 


### PR DESCRIPTION
Fixes #2783

## Problem
`panel_set_widget` refused a promoted subgraph widget (e.g. BOOLEAN `value_1`) before `graph_set_widget` dispatch. The ownership-envelope validator required `graph_get_subgraph.truncated === false`, so a complete inner list (`node_count === nodes.length`) that omitted that flag (or sent JSON `null`) failed the completeness invariant: the reply's truncated flag was not false.

#2791 (official Qwen Image host mapping, v0.52.184) does not cover this hole.

## Fix
Prove completeness from the inner list first. When `node_count === nodes.length`, an omitted or null `truncated` flag is `false`. An asserted `truncated:true`, a malformed flag, or a list shorter than `node_count` stays fail-closed.

## Tests
`src/__tests__/orchestrator/promoted-widget.test.ts` — 5 new tests (234 total in the file). Drive shipped `describePromotedSubgraphEnvelope` / `validatePromotedSubgraphEnvelope` and `panel_set_widget`.
