### PR TITLE
chore: release v0.52.185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.185] - 2026-09-03
+
 ### MCP
 
 #### Fixed
-- **Manager body-read timeouts fail closed with a named diagnosis instead of a bare `TimeoutError` (#2773).** After headers arrive, undici still aborts a stalled `Response.text()` on supported Node, but `comfyuiFetch`'s transport rewrite has already returned. `managerFetch` now races both body reads against its own ceiling (without threading a signal into `comfyuiFetch`, which would drop the transport-timeout message) and reports URL, method, and OUTCOME UNKNOWN on a mutation. The `raceAbort` comment no longer claims the fetch signal leaves `Response.text()` pending.
-- **`panel_call_tool` recovers a unique inner panel tool from a self-referential call (#2717).** `name: "panel_call_tool"` with the real tool on `tool` / `tool_name`, a nested key, or sibling fields unwraps once and runs that tool. Several inner names, a non-object keyed payload, or a nested router still fail closed; the refusal names the inner tool when it is unique. The schema now says `name` is the inner tool, never this router.
-- **`panel_set_widget` accepts a complete promoted-subgraph ownership envelope that omits `truncated:false` (#2783).** `graph_get_subgraph` already proves completeness when `node_count === nodes.length`; an omitted or null `truncated` flag is then `false`. An asserted `truncated:true`, or a list shorter than `node_count`, stays fail-closed.
+- **Manager body-read timeouts fail closed with a named diagnosis instead of a bare `TimeoutError` (#2773, #2827).** After headers arrive, undici still aborts a stalled `Response.text()` on supported Node, but `comfyuiFetch`'s transport rewrite has already returned. `managerFetch` now races both body reads against its own ceiling (without threading a signal into `comfyuiFetch`, which would drop the transport-timeout message) and reports URL, method, and OUTCOME UNKNOWN on a mutation. The `raceAbort` comment no longer claims the fetch signal leaves `Response.text()` pending.
+- **`panel_call_tool` recovers a unique inner panel tool from a self-referential call (#2717, #2826).** `name: "panel_call_tool"` with the real tool on `tool` / `tool_name`, a nested key, or sibling fields unwraps once and runs that tool. Several inner names, a non-object keyed payload, or a nested router still fail closed; the refusal names the inner tool when it is unique. The schema now says `name` is the inner tool, never this router.
+- **`panel_set_widget` accepts a complete promoted-subgraph ownership envelope that omits `truncated:false` (#2783, #2828).** `graph_get_subgraph` already proves completeness when `node_count === nodes.length`; an omitted or null `truncated` flag is then `false`. An asserted `truncated:true`, or a list shorter than `node_count`, stays fail-closed.
+
 
 ## [0.52.184] - 2026-09-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.184",
+  "version": "0.52.185",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.184",
+      "version": "0.52.185",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.184",
+  "version": "0.52.185",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release v0.52.185 covering swarm 38 since v0.52.184:

- #2773 / #2827 — Manager body-read timeouts fail closed with a named diagnosis
- #2717 / #2826 — panel_call_tool recovers a unique inner tool from a self-call
- #2783 / #2828 — panel_set_widget accepts a complete envelope that omits truncated:false