### PR TITLE
fix(1593): restart bound local panel ComfyUI on a different loopback port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`panel_restart_comfyui` restarts the panel's bound local ComfyUI when that origin is a proven loopback instance on a different port than `COMFYUI_URL` (#1593).** A live tab whose server-observed Origin is a concrete loopback host (and whose socket arrived on the local listener) is Manager-rebooted even if MCP is still configured for `:8188` while the panel is on `:8189`. The busy guard still applies, a guessed or DNS-ambiguous origin is never restarted, and a relayed tab stays fail-closed.
+
 ## [0.52.185] - 2026-09-03
 
 ### MCP

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -988,21 +988,29 @@ describe("panel_restart_comfyui — identity is resolved BEFORE the confirmation
     expect(out.note).toMatch(/no local boot endpoint/i);
   });
 
-  it("#2068 keeps the dynamic exception fail-closed when the server Origin differs", async () => {
+  it("#1593 restarts the bound local Origin when it differs from the configured target", async () => {
+    // Config points at the Desktop dynamic port; the live tab is still the
+    // boot loopback instance. Restart THAT tab via Manager — do not refuse
+    // and do not preflight/kill the configured other port.
     hoistedConfig.configBase.value = DYNAMIC_PANEL_BASE;
     __panelToolsTestHooks.setVerifiedProxyRestartTarget(async () => undefined);
     const preflight = vi.fn(async () => ({ ok: true }));
+    const healthProbe = vi.fn(async () => "healthy" as const);
     __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    __panelToolsTestHooks.setHealthProbe(healthProbe);
     const { ctx, sends } = makeCtx({ confirm: "yes", serverOrigin: BOOT_BASE });
     const confirm = vi.fn(async () => "yes" as const);
     ctx.confirm = confirm;
 
     const out = parse(await restartTool().handler({}, ctx));
 
-    expect(confirm).not.toHaveBeenCalled();
+    expect(confirm).toHaveBeenCalledOnce();
     expect(preflight).not.toHaveBeenCalled();
-    expect(sends).toEqual([]);
-    expect(out.refused).toBe(true);
+    expect(healthProbe).not.toHaveBeenCalled();
+    expect(sends.filter((cmd) => cmd.cmd === "comfy_reboot")).toHaveLength(1);
+    expect(out.refused).toBeUndefined();
+    expect(out.rebooting).toBe(true);
+    expect(out.confirmed_cycle).toBe(false);
   });
 
   it("a refused restart keeps the live tab and reports one terminal state, not a reconnect", async () => {
@@ -1044,7 +1052,7 @@ describe("panel_restart_comfyui — identity is resolved BEFORE the confirmation
       tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
       resolveActiveTabId: () => TAB,
       tabIsLocal: () => true,
-      tabServerOrigin: () => "http://127.0.0.1:8189",
+      tabServerOrigin: () => "http://localhost:8188",
       tabCanMutateGraph: () => true,
       tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     } as unknown as PanelToolCtx["bridge"];

--- a/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-identity-reason.test.ts
@@ -196,9 +196,12 @@ describe("panel#1546 — the identity refusal names the missing proof", () => {
   });
 
   it("a DIFFERENT host:port is named as a different server", async () => {
-    const note = await refusalNote({ serverOrigin: "http://127.0.0.1:8189" });
+    // DNS-ambiguous + a different port: resolving localhost never reconciles
+    // :8189 with the boot :8188, so this stays a refusal. A proven
+    // 127.0.0.1:8189 tab (server-trusted local) is the #1593 restart path.
+    const note = await refusalNote({ serverOrigin: "http://localhost:8189" });
 
-    expect(note).toMatch(/http:\/\/127\.0\.0\.1:8189/);
+    expect(note).toMatch(/http:\/\/localhost:8189/);
     expect(note).toMatch(/a different server/);
     expect(note).not.toMatch(/127\.0\.0\.1 or ::1/);
   });

--- a/src/__tests__/orchestrator/panel-restart-local-origin.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-local-origin.test.ts
@@ -1,0 +1,235 @@
+// #1593 — panel_restart_comfyui must restart the SAME local ComfyUI the live
+// panel controls when that instance is a proven loopback origin, even if the
+// port is not the configured COMFYUI_URL. Recurrence: panel bound to
+// http://127.0.0.1:8189 while MCP still targeted http://127.0.0.1:8188. The
+// identity gate refused and told the caller to use restart_comfyui, which
+// would have hit the other port.
+//
+// The shipped handler now uses the Manager reboot on the tab whose
+// server-observed Origin is a concrete loopback host AND whose socket arrived
+// on the local listener. It must not kill the configured 8188 process, must
+// not HTTP-probe a guessed origin, and must keep refusing unproven identity
+// (missing Origin, DNS-ambiguous localhost, relayed tab).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+const getQueueVerified = vi.fn(async () => {
+  throw new Error("getQueueVerified must not read the configured local queue for a mismatched panel origin");
+});
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  getQueueVerified: (...args: unknown[]) => getQueueVerified(...args),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const hoisted = vi.hoisted(() => ({
+  restart: vi.fn(async () => {
+    throw new Error("headless restartComfyUI must not run for a bound local panel origin");
+  }),
+}));
+
+vi.mock("../../services/process-control.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/process-control.js")>();
+  return { ...actual, restartComfyUI: hoisted.restart };
+});
+
+vi.mock("../../services/instance-witness.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../services/instance-witness.js")>()),
+  acquireInstanceWitness: async () => undefined,
+}));
+
+const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { getBootLocalComfyUIBaseUrl, getComfyUIBaseUrl } from "../../config.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+const PANEL_ORIGIN = (() => {
+  const u = new URL(BOOT_BASE);
+  u.port = String(Number(u.port || (u.protocol === "https:" ? "443" : "80")) + 1);
+  u.pathname = "";
+  return u.toString().replace(/\/+$/, "");
+})();
+
+const text = (res: ToolResult): string =>
+  res.content.find((c) => c.type === "text")!.text as string;
+const parse = (res: ToolResult): Record<string, unknown> => JSON.parse(text(res));
+
+function restartTool() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def;
+}
+
+function makeCtx(opts: {
+  serverOrigin?: string;
+  isLocal?: boolean;
+  dropOriginOnEnsure?: boolean;
+  rebootReply?: Record<string, unknown>;
+}): {
+  ctx: PanelToolCtx;
+  sends: Array<Record<string, unknown>>;
+  confirm: ReturnType<typeof vi.fn>;
+} {
+  const sends: Array<Record<string, unknown>> = [];
+  const origin = { current: opts.serverOrigin };
+  const confirm = vi.fn(async () => "yes" as const);
+  const ctx = {
+    call: async () => {
+      throw new Error("ctx.call must not be used by the restart handler");
+    },
+    confirm,
+    ensureReachable: () => {
+      if (opts.dropOriginOnEnsure) origin.current = undefined;
+    },
+    bridge: {
+      send: async (cmd: Record<string, unknown>) => {
+        sends.push(cmd);
+        if (cmd.cmd === "comfy_reboot") {
+          return opts.rebootReply ?? { rebooting: true };
+        }
+        return {};
+      },
+      tabOrigin: () => origin.current,
+      tabServerOrigin: () => origin.current,
+      tabIsLocal: () => opts.isLocal === true,
+      canReach: () => true,
+    } as PanelToolCtx["bridge"],
+    tabId: "local-tab",
+    panelConnectionIdentity: () => ({ generation: 1, tabSessionId: "browser-tab-local" }),
+    awaitPostRestartReachable: async () => true,
+    tabCanMutateGraph: () => true,
+  } as PanelToolCtx;
+  return { ctx, sends, confirm };
+}
+
+beforeEach(() => {
+  resetClient.mockClear();
+  resetObjectInfoCache.mockClear();
+  getQueueVerified.mockClear();
+  hoisted.restart.mockClear();
+  __panelToolsTestHooks.setVerifiedProxyRestartTarget(async () => undefined);
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => {
+    throw new Error("local restart preflight must not run for a mismatched bound local origin");
+  });
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 60,
+    intervalMs: 5,
+    probeTimeoutMs: 10,
+  });
+  __panelToolsTestHooks.setHealthProbe(async (base) => {
+    throw new Error(`must not health-probe ${String(base)} for a mismatched bound local origin`);
+  });
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setVerifiedProxyRestartTarget(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
+  __panelToolsTestHooks.setPanelRebootTiming(null);
+  __panelToolsTestHooks.setHealthProbe(null);
+});
+
+describe("panel_restart_comfyui bound local origin (#1593)", () => {
+  it("REPRO: already_authorized against a proven local Origin on a different loopback port dispatches Manager reboot", async () => {
+    expect(getComfyUIBaseUrl().replace(/\/+$/, "")).toBe(BOOT_BASE);
+    expect(PANEL_ORIGIN).not.toBe(BOOT_BASE);
+    const { ctx, sends, confirm } = makeCtx({
+      serverOrigin: PANEL_ORIGIN,
+      isLocal: true,
+    });
+
+    const out = parse(await restartTool().handler({ already_authorized: true }, ctx));
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(getQueueVerified).not.toHaveBeenCalled();
+    expect(sends.filter((cmd) => cmd.cmd === "comfy_reboot")).toEqual([
+      { cmd: "comfy_reboot", force: false },
+    ]);
+    expect(out.refused).toBeUndefined();
+    expect(out.rebooting).toBe(true);
+    expect(out.confirmed_cycle).toBe(false);
+    expect(String(out.note)).not.toMatch(/USE restart_comfyui/);
+    expect(String(out.note)).not.toMatch(/could not confirm that this panel's ComfyUI is/);
+  });
+
+  it("keeps the Manager busy guard — a busy refusal is returned verbatim and does not kill the configured instance", async () => {
+    const { ctx, sends } = makeCtx({
+      serverOrigin: PANEL_ORIGIN,
+      isLocal: true,
+      rebootReply: { rebooting: false, error: "Refused: a generation is in progress." },
+    });
+
+    const res = await restartTool().handler({ already_authorized: true }, ctx);
+    const bodyText = text(res);
+
+    expect(sends.filter((cmd) => cmd.cmd === "comfy_reboot")).toHaveLength(1);
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(bodyText).toMatch(/in progress/);
+    expect(bodyText).not.toMatch(/USE restart_comfyui/);
+    expect(resetClient).not.toHaveBeenCalled();
+  });
+
+  it("does not restart a guessed origin when the handshake Origin is lost at dispatch", async () => {
+    const { ctx, sends } = makeCtx({
+      serverOrigin: PANEL_ORIGIN,
+      isLocal: true,
+      dropOriginOnEnsure: true,
+    });
+
+    const out = parse(await restartTool().handler({ already_authorized: true }, ctx));
+
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
+    expect(sends.some((cmd) => cmd.cmd === "comfy_reboot")).toBe(false);
+    expect(hoisted.restart).not.toHaveBeenCalled();
+  });
+
+  it("still refuses a DNS-ambiguous localhost origin — locality is not a guessed-family bypass", async () => {
+    const { ctx, sends } = makeCtx({
+      serverOrigin: "http://localhost:8188",
+      isLocal: true,
+    });
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+
+    const out = parse(await restartTool().handler({ already_authorized: true }, ctx));
+
+    expect(out.refused).toBe(true);
+    expect(sends).toEqual([]);
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(String(out.note)).toMatch(/could not confirm that this panel's ComfyUI is/);
+  });
+
+  it("still refuses a relayed tab whose Origin is a concrete local loopback — unproven identity", async () => {
+    const { ctx, sends } = makeCtx({
+      serverOrigin: PANEL_ORIGIN,
+      isLocal: false,
+    });
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+
+    const out = parse(await restartTool().handler({ already_authorized: true }, ctx));
+
+    expect(out.refused).toBe(true);
+    expect(sends).toEqual([]);
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(String(out.note)).toMatch(/did not arrive on the local loopback listener/);
+  });
+
+  it("a missing handshake Origin is still unbound — nothing is guessed", async () => {
+    const { ctx, sends } = makeCtx({ isLocal: true });
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+
+    const out = parse(await restartTool().handler({ already_authorized: true }, ctx));
+
+    expect(out.refused).toBe(true);
+    expect(sends).toEqual([]);
+    expect(hoisted.restart).not.toHaveBeenCalled();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3468,12 +3468,45 @@ function currentPanelRestartTarget(ctx: PanelToolCtx): string | null {
 }
 
 /**
+ * #1593 — a live panel tab whose SERVER-OBSERVED handshake Origin is a proven
+ * local loopback ComfyUI, even when that port is not COMFYUI_URL (the
+ * recurrence: panel on :8189, MCP on :8188). Authorizes only the Manager reboot
+ * on THIS tab — never a guessed origin, never a local kill of the configured
+ * 8188 process. Requires the tab socket to have arrived on the server-trusted
+ * local listener, and a concrete loopback family literal (not `localhost`).
+ * DNS-ambiguous / missing / relayed origins stay fail-closed.
+ */
+function currentPanelBoundLocalRestartOrigin(ctx: PanelToolCtx): string | null {
+  if (ctx.bridge?.tabIsLocal?.(ctx.tabId) !== true) return null;
+  const origin = ctx.bridge?.tabServerOrigin?.(ctx.tabId);
+  if (!origin) return null;
+  if (isDnsAmbiguousLoopback(origin) || !isLoopbackOrigin(origin)) return null;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    if (!u.hostname) return null;
+  } catch {
+    return null;
+  }
+  return origin.replace(/\/+$/, "");
+}
+
+function stillBoundPanelLocalRestartOrigin(
+  ctx: PanelToolCtx,
+  previous: string | undefined,
+): string | undefined {
+  if (previous == null) return undefined;
+  const next = currentPanelBoundLocalRestartOrigin(ctx);
+  return next != null && sameHttpBase(next, previous) ? next : undefined;
+}
+
+/**
  * #2804 — a live panel tab whose SERVER-OBSERVED handshake Origin is a concrete
  * non-loopback ComfyUI. The Manager reboot is sent to THIS tab, never to a
  * guessed URL, and never via a local process restart of the configured
- * 127.0.0.1 target. Loopback / `localhost` origins stay on the existing
- * local-instance confirmation (including the tunnelled-loopback FORCE_REMOTE
- * case).
+ * 127.0.0.1 target. DNS-ambiguous `localhost` stays fail-closed. A proven
+ * local loopback Origin (even on a different port than COMFYUI_URL) is
+ * currentPanelBoundLocalRestartOrigin (#1593), not this path.
  */
 function currentPanelRemoteRestartOrigin(ctx: PanelToolCtx): string | null {
   const origin = ctx.bridge?.tabServerOrigin?.(ctx.tabId);
@@ -26868,7 +26901,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_restart_comfyui",
-      "Restart the user's ComfyUI server via the built-in Manager — needed to load newly installed/updated custom nodes. CALL THIS DIRECTLY when a restart is needed: it pops a confirm card and only restarts on a yes (don't ask separately first). If the user has already explicitly authorized automatic restarts in the conversation, pass already_authorized:true to skip only that card; this does NOT imply force and does not bypass any target, relaunch, or busy guard. When this panel tab is authoritatively bound to a remote ComfyUI (server-observed non-loopback Origin), the restart is the Manager reboot of THAT instance — not a local 127.0.0.1 process, and not a guessed origin. Unbound local tabs still require local-instance confirmation. ComfyUI and this agent go down briefly, then the panel auto-reconnects and you resume. ⚠️ BUSY GUARD: a restart ABORTS any in-progress or queued generation — if ComfyUI is generating, this tool REFUSES and tells you (it does NOT restart). When that happens, tell the user a render is running and WAIT for it (poll panel_node_queue_status), or pass force:true ONLY if the user explicitly confirms they want to kill the running generation. Best practice: before restarting after an install, check the queue is idle first. Only call when a restart is actually needed. If a crash takes the panel bridge offline so the confirmation card cannot be shown, this tool falls back to a headless restart of the configured local process (or COMFYUI_RESTART_COMMAND) instead of depending on the dead bridge — it still refuses a readable busy queue without force:true, and still refuses when a relaunch cannot be proven. On an externally-managed install whose relaunch can't be proven from here (e.g. Pinokio), the restart is REFUSED before anything is stopped — restart from the launcher that owns the server instead, or set COMFYUI_RESTART_COMMAND to the exact command that restarts the instance (e.g. `docker restart <container>`): the restart then runs through that command (the busy guard above still applies) instead of needing the launch path.",
+      "Restart the user's ComfyUI server via the built-in Manager — needed to load newly installed/updated custom nodes. CALL THIS DIRECTLY when a restart is needed: it pops a confirm card and only restarts on a yes (don't ask separately first). If the user has already explicitly authorized automatic restarts in the conversation, pass already_authorized:true to skip only that card; this does NOT imply force and does not bypass any target, relaunch, or busy guard. When this panel tab is authoritatively bound to a ComfyUI — a server-observed non-loopback Origin, or a proven local loopback instance even on a different port than COMFYUI_URL — the restart is the Manager reboot of THAT instance, not a guessed origin and not the configured 127.0.0.1 process unless it is that same origin. Unbound or DNS-ambiguous local tabs still require local-instance confirmation. ComfyUI and this agent go down briefly, then the panel auto-reconnects and you resume. ⚠️ BUSY GUARD: a restart ABORTS any in-progress or queued generation — if ComfyUI is generating, this tool REFUSES and tells you (it does NOT restart). When that happens, tell the user a render is running and WAIT for it (poll panel_node_queue_status), or pass force:true ONLY if the user explicitly confirms they want to kill the running generation. Best practice: before restarting after an install, check the queue is idle first. Only call when a restart is actually needed. If a crash takes the panel bridge offline so the confirmation card cannot be shown, this tool falls back to a headless restart of the configured local process (or COMFYUI_RESTART_COMMAND) instead of depending on the dead bridge — it still refuses a readable busy queue without force:true, and still refuses when a relaunch cannot be proven. On an externally-managed install whose relaunch can't be proven from here (e.g. Pinokio), the restart is REFUSED before anything is stopped — restart from the launcher that owns the server instead, or set COMFYUI_RESTART_COMMAND to the exact command that restarts the instance (e.g. `docker restart <container>`): the restart then runs through that command (the busy guard above still applies) instead of needing the launch path.",
       { force: z.boolean().optional(), already_authorized: z.boolean().optional() },
       // panel#1554 — `note` rides WHICHEVER reply this handler returns, so a decision
       // recovered from an earlier confirmation card is disclosed on every branch, not
@@ -26906,10 +26939,16 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // authenticated relative Manager dispatch; it is never a health or
         // headless-restart target.
         let panelRestartTarget: string | undefined;
+        // #1593: a live tab whose handshake Origin is a proven local loopback
+        // ComfyUI on a different port than COMFYUI_URL. Authorizes only the
+        // Manager reboot on THIS tab — never a guessed origin and never a
+        // local kill of the configured 8188 process.
+        let panelLocalRestartOrigin: string | undefined;
         // #2804: a live tab whose handshake Origin is a concrete non-loopback
         // ComfyUI. Authorizes only the Manager reboot on THIS tab — never a
         // guessed origin and never a local kill of the configured 127.0.0.1
-        // target. Loopback tabs stay on the local-instance confirmation below.
+        // target. DNS-ambiguous localhost stays fail-closed; proven local
+        // loopback is panelLocalRestartOrigin above.
         let panelRemoteRestartOrigin: string | undefined;
         // #1819: resolve instance identity BEFORE the confirmation card. Asking the
         // user to confirm a restart, then refusing because we cannot tell which
@@ -26934,6 +26973,13 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               panelRestartTarget = currentPanelRestartTarget(ctx) ?? undefined;
             }
             if (proxyRestartTarget == null && panelRestartTarget == null) {
+              panelLocalRestartOrigin = currentPanelBoundLocalRestartOrigin(ctx) ?? undefined;
+            }
+            if (
+              proxyRestartTarget == null &&
+              panelRestartTarget == null &&
+              panelLocalRestartOrigin == null
+            ) {
               panelRemoteRestartOrigin = currentPanelRemoteRestartOrigin(ctx) ?? undefined;
             }
             const tabStillHere =
@@ -26944,6 +26990,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               tabStillHere &&
               proxyRestartTarget == null &&
               panelRestartTarget == null &&
+              panelLocalRestartOrigin == null &&
               panelRemoteRestartOrigin == null
             ) {
               return restartRefusedPreservingBinding(
@@ -27588,6 +27635,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           configuredRestartCommand &&
           !isRemoteMode() &&
           !isCloudMode() &&
+          panelLocalRestartOrigin == null &&
           panelRemoteRestartOrigin == null
         ) {
           if (proxyRestartTarget != null) {
@@ -27749,6 +27797,16 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               : undefined;
         }
         if (proxyRestartTarget == null && panelRestartTarget == null) {
+          panelLocalRestartOrigin = stillBoundPanelLocalRestartOrigin(
+            ctx,
+            panelLocalRestartOrigin,
+          );
+        }
+        if (
+          proxyRestartTarget == null &&
+          panelRestartTarget == null &&
+          panelLocalRestartOrigin == null
+        ) {
           panelRemoteRestartOrigin = stillBoundPanelRemoteRestartOrigin(
             ctx,
             panelRemoteRestartOrigin,
@@ -27762,7 +27820,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           panelRestartTarget != null ||
           (preflightHealthBase != null &&
             sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase));
-        const remotePanelBound = panelRemoteRestartOrigin != null;
+        const boundPanelOriginRestart =
+          panelLocalRestartOrigin != null || panelRemoteRestartOrigin != null;
         // #848: what the instance was OBSERVED running with, taken from the preflight
         // that already had to resolve it. Nothing new is probed before the dispatch —
         // the no-await invariant between the binding capture and the reboot stands.
@@ -27783,7 +27842,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         // local process to assess, and the Manager reboot is their ONLY restart path —
         // a supervised remote (the tunnelled Desktop app) restarts through it by
         // design, so refusing there would remove a path that works.
-        if (!preflightBound && !remotePanelBound && !isRemoteMode() && !isCloudMode()) {
+        if (!preflightBound && !boundPanelOriginRestart && !isRemoteMode() && !isCloudMode()) {
           // Identity was proven before the card; landing here means the binding
           // was lost during the confirm wait. Same refusal, and the tab that is
           // still here must stay usable (#1819).
@@ -27792,7 +27851,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             unboundLocalRestartRefusalNote(ctx, preflightHealthBase, preflightBinding.blocker),
           );
         }
-        if (preflightBound && !remotePanelBound) {
+        if (preflightBound && !boundPanelOriginRestart) {
           // Snapshot the target GENERATION at the decision (r11): a final-state
           // base comparison (A vs A) cannot detect an intervening A→B→A
           // retarget, so stability is judged by the monotonic epoch bumped on
@@ -27936,13 +27995,26 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
               : undefined;
         }
         if (proxyRestartTarget == null && panelRestartTarget == null) {
+          panelLocalRestartOrigin = stillBoundPanelLocalRestartOrigin(
+            ctx,
+            panelLocalRestartOrigin,
+          );
+        }
+        if (
+          proxyRestartTarget == null &&
+          panelRestartTarget == null &&
+          panelLocalRestartOrigin == null
+        ) {
           panelRemoteRestartOrigin = stillBoundPanelRemoteRestartOrigin(
             ctx,
             panelRemoteRestartOrigin,
           );
         }
         const healthBase =
-          proxyRestartTarget?.backendBase ?? captureRebootHealthBase(ctx);
+          proxyRestartTarget?.backendBase ??
+          (panelLocalRestartOrigin != null || panelRemoteRestartOrigin != null
+            ? null
+            : captureRebootHealthBase(ctx));
         // THE BINDING RULE APPLIES AT THE DISPATCH POINT, NOT ONLY BEFORE THE AWAIT.
         //
         // The check above happens before the preflight; a tab or connection rebind
@@ -27955,13 +28027,15 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
         //
         // Same rule, same exclusions: only a LOCAL target we cannot tie to the
         // instance this server accounts for is refused. A still-bound remote
-        // panel origin (#2804) is the Manager reboot of that tab, not a local
-        // process we have to identify.
+        // panel origin (#2804) or proven local loopback origin on a different
+        // port than COMFYUI_URL (#1593) is the Manager reboot of that tab, not
+        // a local process we have to identify from the configured URL.
         const dispatchBound =
           proxyRestartTarget != null ||
           (healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase)) ||
           (panelRestartTarget != null &&
             sameHttpBase(getComfyUIBaseUrl(), panelRestartTarget)) ||
+          panelLocalRestartOrigin != null ||
           panelRemoteRestartOrigin != null;
         if (!dispatchBound && !isRemoteMode() && !isCloudMode()) {
           return restartRefusedPreservingBinding(
@@ -28156,6 +28230,7 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           if (
             !isRemoteMode() &&
             panelRemoteRestartOrigin == null &&
+            panelLocalRestartOrigin == null &&
             rebootNoEndpoint(res) &&
             // ENDPOINT BINDING: restartComfyUI() acts on the orchestrator's GLOBAL config
             // target (a hello can retarget it). Only run it when the bound tab fronts our


### PR DESCRIPTION
Fixes #1593

## Problem

`panel_restart_comfyui` refused a live tab bound to a proven local loopback ComfyUI on a different port than `COMFYUI_URL` (panel on http://127.0.0.1:8189, MCP on http://127.0.0.1:8188) and told the caller to use `restart_comfyui`. That headless tool targets the configured URL, so the workaround either missed the panel instance or could stop the wrong one.

Originally closed as wording-only in v0.51.56; this is the recurrence: restart **that** bound local origin.

## Fix

When the panel tab is server-trusted local and its **server-observed** handshake Origin is a concrete loopback host (not DNS-ambiguous `localhost`), dispatch the Manager reboot (`comfy_reboot`) on **that bound tab**, even if the port is not `COMFYUI_URL`.

- Busy guard is unchanged (Manager refusal is returned verbatim; `force` is not implied).
- A guessed origin is never HTTP-probed or restarted; if the Origin is lost before dispatch, the call refuses.
- Headless `restartComfyUI` / local process kill of the configured :8188 is not used on this path.
- Relayed tabs, missing Origin, and `localhost` stay fail-closed.

## Tests

`src/__tests__/orchestrator/panel-restart-local-origin.test.ts` driving the shipped `panel_restart_comfyui` handler.
