### PR TITLE
fix(2836): resolve panel origin before history/stats fallback reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`get_history` and `get_system_stats` resolve the connected panel origin and API base before the read fallback, and fail closed with a named error when that origin is unproven (#2836).** An unreachable headless `127.0.0.1:8188` used to dispatch `fetch_comfyui_read` and then throw `Cannot read properties of undefined (reading api_base)`, which blocked diagnosis of the live-canvas run. The original transport failure is kept; an undefined `api_base` is reported as `PANEL_API_BASE_UNAVAILABLE` rather than a TypeError.
+
 ## [0.52.186] - 2026-09-03
 
 ### MCP

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -71,12 +71,15 @@ import {
   resetObjectInfoCache,
   resetClient,
 } from "../../comfyui/client.js";
+import { setConnectedPanelOrigins } from "../../comfyui/fetch.js";
 import {
   PanelComfyUIReadRelayError,
   PanelImageRelayError,
   PANEL_COMFYUI_READ_MAX_BYTES,
   PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES,
 } from "../../services/panel-image-relay.js";
+import { resolvePanelReadOrigin } from "../../services/panel-fallback-target.js";
+import { ComfyUIError } from "../../utils/errors.js";
 
 function transportFailure(): TypeError {
   return new TypeError(
@@ -95,6 +98,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setConnectedPanelOrigins(null);
   vi.unstubAllGlobals();
 });
 
@@ -288,4 +292,81 @@ describe("authenticated panel-backed ComfyUI read fallback (#2283)", () => {
     expect(failure?.message).toContain("read fallback failed safely (PANEL_FETCH_FAILED).");
     expect(failure?.message).not.toContain("The panel reported:");
   });
+});
+
+describe("connected-panel read fallback origin/API base (#2836)", () => {
+  it("does not throw when api_base is undefined — origin stays unproven", () => {
+    expect(resolvePanelReadOrigin(["http://127.0.0.1:8188"], undefined)).toEqual({
+      kind: "unproven",
+    });
+  });
+
+  function apiBaseCrash(): PanelComfyUIReadRelayError {
+    return new PanelComfyUIReadRelayError(
+      "The connected panel could not read ComfyUI.",
+      "PANEL_FETCH_FAILED",
+      false,
+      "Cannot read properties of undefined (reading api_base)",
+    );
+  }
+
+  it.each(["getHistory", "getSystemStats"] as const)(
+    "%s fails closed when the published panel origin is unproven",
+    async (name) => {
+      fetchApi.mockRejectedValue(transportFailure());
+      setConnectedPanelOrigins(() => ["not-an-origin", "ws://localhost:8188"]);
+
+      const err = await (name === "getHistory" ? getHistory() : getSystemStats()).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect(err).toBeInstanceOf(ComfyUIError);
+      expect(err).toMatchObject({
+        code: "PANEL_ORIGIN_UNPROVEN",
+        message: expect.stringMatching(/ECONNREFUSED|fetch failed/),
+      });
+      expect(String(err instanceof Error ? err.message : err)).toContain("fetch_comfyui_read was not dispatched");
+      expect(panelRead).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still reads history through the panel when the origin is proven", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    const body = '{"prompt-1":{"status":{"status_str":"success"}}}';
+    panelRead.mockResolvedValue({
+      operation: "history",
+      body,
+      contentType: "application/json",
+      bytes: Buffer.byteLength(body, "utf8"),
+    });
+
+    await expect(getHistory()).resolves.toEqual({
+      "prompt-1": { status: { status_str: "success" } },
+    });
+    expect(panelRead).toHaveBeenCalledWith("history");
+  });
+
+  it.each(["getHistory", "getSystemStats"] as const)(
+    "%s names a transport diagnostic instead of throwing on undefined api_base",
+    async (name) => {
+      fetchApi.mockRejectedValue(transportFailure());
+      setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+      panelRead.mockRejectedValue(apiBaseCrash());
+
+      const err = await (name === "getHistory" ? getHistory() : getSystemStats()).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect(err).toBeInstanceOf(ComfyUIError);
+      expect(err).toMatchObject({
+        code: "PANEL_API_BASE_UNAVAILABLE",
+        message: expect.stringMatching(/ECONNREFUSED|fetch failed/),
+      });
+      const message = String(err instanceof Error ? err.message : err);
+      expect(message).toContain("transport diagnostic");
+      expect(message).not.toContain("The panel reported:");
+      expect(panelRead).toHaveBeenCalledWith(name === "getHistory" ? "history" : "system_stats");
+    },
+  );
 });

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -18,6 +18,7 @@ import {
 import {
   comfyuiFetch,
   connectedPanelFallbackOriginsNow,
+  connectedPanelOriginsNow,
   comfyHttpTimeoutSeconds,
   deliveryDoubt,
   describeMissingInputMediaDrift,
@@ -32,6 +33,8 @@ import {
   choosePanelFallbackOrigin,
   describeDeclinedPanelFallback,
   httpOriginOf,
+  isUndefinedApiBaseFailure,
+  resolvePanelReadOrigin,
 } from "../services/panel-fallback-target.js";
 import {
   PanelComfyUIReadRelayError,
@@ -282,16 +285,37 @@ function panelReadResponse(read: PanelComfyUIReadSuccess): Response {
 }
 
 /** Ask the authenticated panel only after the configured headless route failed
- * at the transport layer. No browser origin is selected or contacted here. */
+ * at the transport layer. Resolve the connected panel origin and API base
+ * first (#2836): an unproven origin is never a guessed fetch_comfyui_read
+ * target, and an undefined api_base is a named transport diagnostic. */
 async function panelReadFallback(
   operation: "history" | "system_stats" | "logs" | "object_info",
   primaryError: unknown,
 ): Promise<PanelComfyUIReadSuccess | undefined> {
+  const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+  const resolved = resolvePanelReadOrigin(connectedPanelOriginsNow(), getComfyUIBasePath());
+  if (resolved.kind === "unproven") {
+    throw new ComfyUIError(
+      `${primary} The connected panel ComfyUI read fallback was not attempted (PANEL_ORIGIN_UNPROVEN). ` +
+        `The panel origin is unproven, so fetch_comfyui_read was not dispatched. A guessed origin is never contacted.`,
+      "PANEL_ORIGIN_UNPROVEN",
+    );
+  }
   try {
     return await requestPanelComfyUIRead(operation);
   } catch (error) {
     if (error instanceof PanelComfyUIReadRelayError && error.unavailable) return undefined;
-    const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+    if (isUndefinedApiBaseFailure(error)) {
+      throw new ComfyUIError(
+        `${primary} The connected panel ComfyUI read fallback failed safely (PANEL_API_BASE_UNAVAILABLE). ` +
+          `fetch_comfyui_read could not read api_base because the panel's ComfyUI API object was undefined. ` +
+          `This is a transport diagnostic: the headless target was unreachable, and the panel read was not given a usable API base.`,
+        "PANEL_API_BASE_UNAVAILABLE",
+        resolved.kind === "proven"
+          ? { origin: resolved.origin, api_base: resolved.apiBase }
+          : undefined,
+      );
+    }
     const code = error instanceof PanelComfyUIReadRelayError ? error.code : "RELAY_ERROR";
     // #2703 - the code alone was the whole answer, and PANEL_FETCH_FAILED does
     // not distinguish "the read exceeded the relay's byte ceiling" from "the

--- a/src/services/panel-fallback-target.ts
+++ b/src/services/panel-fallback-target.ts
@@ -117,3 +117,50 @@ export function describeDeclinedPanelFallback(choice: PanelFallbackChoice): stri
   }
   return "";
 }
+
+/** #2836 — a published origin set that cannot be proven is not a guessed target. */
+export type PanelReadOriginResolution =
+  | { kind: "unknown" }
+  | { kind: "unproven" }
+  | { kind: "proven"; origin: string; apiBase: string };
+
+const UNDEFINED_API_BASE_RE =
+  /Cannot read propert(?:y|ies) of undefined \(reading ['"]?api_base['"]?\)|Cannot read property ['"]?api_base['"]? of undefined/i;
+
+/** Resolve the connected panel origin and API base before a fallback read. */
+export function resolvePanelReadOrigin(
+  origins: readonly string[],
+  apiBase: string | undefined,
+): PanelReadOriginResolution {
+  if (origins.length === 0) return { kind: "unknown" };
+  const proven: string[] = [];
+  for (const raw of origins) {
+    const origin = normalizePanelOrigin(raw);
+    if (origin === undefined) return { kind: "unproven" };
+    proven.push(origin);
+  }
+  if (proven.length === 0) return { kind: "unproven" };
+  if (typeof apiBase !== "string") return { kind: "unproven" };
+  return { kind: "proven", origin: proven[0], apiBase };
+}
+
+/** True when the panel-side crash was `undefined.api_base`, not a transport result. */
+export function isUndefinedApiBaseFailure(error: unknown): boolean {
+  const parts: string[] = [];
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    if (typeof current === "string") {
+      parts.push(current);
+      break;
+    }
+    if (!(current instanceof Error)) break;
+    parts.push(current.message);
+    if ("reason" in current && typeof current.reason === "string") {
+      parts.push(current.reason);
+    }
+    current = current.cause;
+  }
+  return parts.some((part) => UNDEFINED_API_BASE_RE.test(part));
+}


### PR DESCRIPTION
Fixes #2836

## Problem

`get_history` and `get_system_stats` returned ECONNREFUSED for `127.0.0.1:8188`. The connected-panel fallback then dispatched `fetch_comfyui_read` and threw `Cannot read properties of undefined (reading api_base)`, which blocked diagnosis of the live-canvas run.

## Fix

Resolve the connected panel origin and API base **before** the authenticated panel read fallback.

- Published origins that do not normalize stay fail-closed as `PANEL_ORIGIN_UNPROVEN`; `fetch_comfyui_read` is not dispatched and a guessed origin is never contacted.
- An undefined `api_base` is `PANEL_API_BASE_UNAVAILABLE`, not a TypeError. The original transport failure is kept in the message.
- An empty origin set is unchanged (unknown): the relay may still answer.

## Tests

`src/__tests__/comfyui/panel-read-fallback.test.ts` driving the shipped `panelReadFallback` via `getHistory` / `getSystemStats`.
