### PR TITLE
fix(2839): list_templates via bound panel when origin is unproven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`list_packs` `action:"list_templates"` uses the bound panel's `fetch_comfyui_read` relay when the template-index HTTP origin is unproven, and fails closed with `NO_PANEL_ORIGIN` when that origin stays unproven (#2839).** Compact `call_tool` listed templates through a loopback-only origin gate even while `panel_graph_outline` had a live bound canvas (`canvas_binding` / `graph_binding` bound). Native panel replies that carry the viewing witness are accepted; a unique published origin that matches the child's configured target may still be listed; mixed or malformed origin sets are not contacted.
+
 ## [0.52.187] - 2026-09-03
 
 ### MCP

--- a/src/__tests__/services/panel-fallback-target.test.ts
+++ b/src/__tests__/services/panel-fallback-target.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { provenPanelOriginMatchesConfiguredTarget } from "../../services/panel-fallback-target.js";
+
+describe("provenPanelOriginMatchesConfiguredTarget (#2839)", () => {
+  it("requires a unique published origin that matches the configured target", () => {
+    expect(
+      provenPanelOriginMatchesConfiguredTarget(
+        ["https://remote.example"],
+        "https://remote.example/comfyapi",
+      ),
+    ).toBe(true);
+    expect(
+      provenPanelOriginMatchesConfiguredTarget(
+        ["http://127.0.0.1:8188"],
+        "http://127.0.0.1:8188/comfyapi",
+      ),
+    ).toBe(true);
+  });
+
+  it("stays unproven for empty, mixed, malformed, or mismatched sets", () => {
+    expect(provenPanelOriginMatchesConfiguredTarget([], "https://remote.example/comfyapi")).toBe(false);
+    expect(
+      provenPanelOriginMatchesConfiguredTarget(
+        ["https://remote.example", "https://other.example"],
+        "https://remote.example/comfyapi",
+      ),
+    ).toBe(false);
+    expect(
+      provenPanelOriginMatchesConfiguredTarget(["not-an-origin"], "https://remote.example/comfyapi"),
+    ).toBe(false);
+    expect(
+      provenPanelOriginMatchesConfiguredTarget(
+        ["https://remote.example"],
+        "http://127.0.0.1:8188",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/services/panel-image-relay.test.ts
+++ b/src/__tests__/services/panel-image-relay.test.ts
@@ -1022,6 +1022,7 @@ describe("authenticated loopback panel image relay", () => {
     expect(isPanelComfyUIReadOperation("models/checkpoints")).toBe(true);
     expect(isPanelComfyUIReadOperation("models/../object_info")).toBe(false);
     expect(isPanelComfyUIReadOperation("object_info")).toBe(true);
+    expect(isPanelComfyUIReadOperation("workflow_templates")).toBe(true);
     const seen: Array<{ cmd: string; operation?: string }> = [];
     const body = JSON.stringify(["remote-ckpt.safetensors"]);
     const server = await startPanelImageRelayServer({

--- a/src/__tests__/services/panel-template-relay.test.ts
+++ b/src/__tests__/services/panel-template-relay.test.ts
@@ -266,6 +266,39 @@ describe("authenticated panel template relay (#2196)", () => {
     expect(remoteCalls).toEqual([]);
   });
 
+  it("accepts the panel viewing witness on a native template-index reply (#2839)", async () => {
+    const seen: Array<{ cmd: string; operation?: string }> = [];
+    const relay = await startPanelTemplateRelayServer({
+      bridge: {
+        canReach: () => true,
+        send: async (command) => {
+          seen.push(command);
+          return {
+            ...nativeIndex({ "bound-pack": [{ name: "from-viewing" }] }),
+            viewing: {
+              scope: "root",
+              workflow_uuid: "workflow-live-2839",
+              graph_identity: "graph:live-2839",
+            },
+          };
+        },
+      },
+      resolvePanelAgent: () => ({ agentKey: "shared::codex", secret: SECRET }),
+      resolvePanelTab: () => "tab-1",
+      resolveCurrentTarget: () => ({ url: "https://remote.example/comfyapi", generation: 0 }),
+      resolvePanelUrl: () => undefined,
+      resolveAllowedPanelOrigin: () => undefined,
+    });
+    servers.push(relay);
+    process.env.COMFYUI_MCP_RELAY_SECRET = SECRET;
+    process.env.COMFYUI_MCP_TEMPLATE_RELAY_URL = relay.endpointUrl;
+
+    await expect(requestPanelTemplateIndex()).resolves.toEqual({
+      "bound-pack": [{ name: "from-viewing" }],
+    });
+    expect(seen).toEqual([{ cmd: "fetch_comfyui_read", operation: "workflow_templates" }]);
+  });
+
   it("asks the live panel when localhost and 127.0.0.1 are a mixed pair (#2196)", async () => {
     const seen: string[] = [];
     const relay = await startPanelTemplateRelayServer({

--- a/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
+++ b/src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../comfyui/fetch.js", () => ({
     state.headlessCalls += 1;
     throw new Error("the panel-backed path must not use COMFYUI_URL");
   },
+  connectedPanelOriginsNow: () => [],
 }));
 
 vi.mock("../../services/api-nodes.js", () => ({

--- a/src/__tests__/tools/skills-access.test.ts
+++ b/src/__tests__/tools/skills-access.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   generateSkillCached: vi.fn(),
   checkWorkflowRuntime: vi.fn(),
   requestPanelTemplateIndex: vi.fn(),
+  requestPanelComfyUIRead: vi.fn(),
 }));
 
 const comfyui = vi.hoisted(() => ({
@@ -56,9 +57,21 @@ vi.mock("../../config.js", () => ({
   getComfyUIAuthHeaders: () => comfyui.authHeaders,
 }));
 
-vi.mock("../../services/panel-template-relay.js", () => ({
-  requestPanelTemplateIndex: (...args: unknown[]) => mocks.requestPanelTemplateIndex(...args),
-}));
+vi.mock("../../services/panel-template-relay.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/panel-template-relay.js")>();
+  return {
+    ...actual,
+    requestPanelTemplateIndex: (...args: unknown[]) => mocks.requestPanelTemplateIndex(...args),
+  };
+});
+
+vi.mock("../../services/panel-image-relay.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/panel-image-relay.js")>();
+  return {
+    ...actual,
+    requestPanelComfyUIRead: (...args: unknown[]) => mocks.requestPanelComfyUIRead(...args),
+  };
+});
 
 import {
   registerSkillsAccessTools,
@@ -68,6 +81,9 @@ import {
   describeMissingWorkflow,
   coercePackMeta,
 } from "../../tools/skills-access.js";
+import { PanelTemplateRelayError } from "../../services/panel-template-relay.js";
+import { PanelComfyUIReadRelayError } from "../../services/panel-image-relay.js";
+import { setConnectedPanelOrigins } from "../../comfyui/fetch.js";
 
 type Handler = (args: Record<string, any>) => Promise<{
   isError?: boolean;
@@ -134,6 +150,10 @@ beforeEach(() => {
 
 afterAll(() => {
   global.fetch = savedFetch;
+});
+
+afterEach(() => {
+  setConnectedPanelOrigins(null);
 });
 
 describe("list_packs registration", () => {
@@ -323,6 +343,78 @@ describe("actions call the same services with the same arguments", () => {
     const res = await handler()({ action: "list_templates" });
     expect(res.isError).toBe(true);
     expect(text(res)).toContain("panel template relay failed");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('action:"list_templates" uses the bound panel read relay after NO_PANEL_ORIGIN (#2839)', async () => {
+    mocks.requestPanelTemplateIndex.mockRejectedValueOnce(
+      new PanelTemplateRelayError("The connected panel template relay failed (NO_PANEL_ORIGIN).", "NO_PANEL_ORIGIN"),
+    );
+    const index = { "bound-pack": [{ name: "from-bound-panel" }] };
+    const body = JSON.stringify(index);
+    mocks.requestPanelComfyUIRead.mockResolvedValueOnce({
+      operation: "workflow_templates",
+      body,
+      contentType: "application/json",
+      bytes: Buffer.byteLength(body, "utf8"),
+    });
+
+    const res = await handler()({ action: "list_templates" });
+    expect(res.isError ?? false).toBe(false);
+    expect(JSON.parse(text(res))).toMatchObject({
+      source_count: 1,
+      template_count: 1,
+      templates: { "bound-pack": [{ name: "from-bound-panel" }] },
+    });
+    expect(mocks.requestPanelComfyUIRead).toHaveBeenCalledWith("workflow_templates");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('action:"list_templates" stays fail-closed on NO_PANEL_ORIGIN when the origin is unproven (#2839)', async () => {
+    mocks.requestPanelTemplateIndex.mockRejectedValueOnce(
+      new PanelTemplateRelayError("The connected panel template relay failed (NO_PANEL_ORIGIN).", "NO_PANEL_ORIGIN"),
+    );
+    mocks.requestPanelComfyUIRead.mockResolvedValueOnce(undefined);
+    setConnectedPanelOrigins(() => ["not-an-origin", "https://other.example"]);
+
+    const res = await handler()({ action: "list_templates" });
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain("NO_PANEL_ORIGIN");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('action:"list_templates" lists the configured target when the bound origin is proven (#2839)', async () => {
+    mocks.requestPanelTemplateIndex.mockRejectedValueOnce(
+      new PanelTemplateRelayError("The connected panel template relay failed (NO_PANEL_ORIGIN).", "NO_PANEL_ORIGIN"),
+    );
+    mocks.requestPanelComfyUIRead.mockRejectedValueOnce(
+      new PanelComfyUIReadRelayError("The connected panel could not read ComfyUI.", "PANEL_FETCH_FAILED"),
+    );
+    setConnectedPanelOrigins(() => ["http://comfy.test:8188"]);
+    const res = await handler()({ action: "list_templates" });
+    expect(res.isError ?? false).toBe(false);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://comfy.test:8188/api/workflow_templates",
+      expect.anything(),
+    );
+    expect(JSON.parse(text(res))).toMatchObject({
+      source_count: 1,
+      template_count: 1,
+    });
+  });
+
+  it('action:"list_templates" fails closed when the bound panel read relay reports a stale target (#2839)', async () => {
+    mocks.requestPanelTemplateIndex.mockRejectedValueOnce(
+      new PanelTemplateRelayError("The connected panel template relay failed (NO_PANEL_ORIGIN).", "NO_PANEL_ORIGIN"),
+    );
+    mocks.requestPanelComfyUIRead.mockRejectedValueOnce(
+      new PanelComfyUIReadRelayError("The connected panel ComfyUI read relay failed (STALE_TARGET).", "STALE_TARGET"),
+    );
+    setConnectedPanelOrigins(() => ["http://comfy.test:8188"]);
+
+    const res = await handler()({ action: "list_templates" });
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain("STALE_TARGET");
     expect(global.fetch).not.toHaveBeenCalled();
   });
 

--- a/src/services/panel-fallback-target.ts
+++ b/src/services/panel-fallback-target.ts
@@ -144,6 +144,29 @@ export function resolvePanelReadOrigin(
   return { kind: "proven", origin: proven[0], apiBase };
 }
 
+/**
+ * #2839 — the compact comfyui child may list templates from its configured
+ * target only when that target is the unique published panel origin. Mixed,
+ * malformed, or empty sets stay unproven so a guessed URL is never contacted.
+ */
+export function provenPanelOriginMatchesConfiguredTarget(
+  origins: readonly string[],
+  configuredTarget: string,
+): boolean {
+  const targetOrigin = httpOriginOf(configuredTarget);
+  const targetCanon = targetOrigin ? canonicalOrigin(targetOrigin) : undefined;
+  if (!targetCanon || origins.length === 0) return false;
+  const canons = new Set<string>();
+  for (const raw of origins) {
+    const origin = normalizePanelOrigin(raw);
+    if (origin === undefined) return false;
+    const canon = canonicalOrigin(origin);
+    if (canon === undefined) return false;
+    canons.add(canon);
+  }
+  return canons.size === 1 && canons.has(targetCanon);
+}
+
 /** True when the panel-side crash was `undefined.api_base`, not a transport result. */
 export function isUndefinedApiBaseFailure(error: unknown): boolean {
   const parts: string[] = [];

--- a/src/services/panel-image-relay.ts
+++ b/src/services/panel-image-relay.ts
@@ -43,7 +43,14 @@ const RELAY_ID_RE = /^[A-Za-z0-9_-]{16,80}$/;
 const RELAY_CAPABILITY_RE = /^[a-f0-9]{64}$/;
 const RELAY_SECRET_RE = /^[a-f0-9]{64}$/;
 const IMAGE_TYPES = new Set<PanelImageType>(["output", "input", "temp"]);
-const FIXED_READ_OPERATIONS = new Set<string>(["history", "system_stats", "logs", "object_info", "models"]);
+const FIXED_READ_OPERATIONS = new Set<string>([
+  "history",
+  "system_stats",
+  "logs",
+  "object_info",
+  "models",
+  "workflow_templates",
+]);
 const MODELS_FOLDER_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 const MIME_RE = /^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,62}$/;
 
@@ -54,9 +61,10 @@ export type PanelComfyUIReadOperation =
   | "logs"
   | "object_info"
   | "models"
+  | "workflow_templates"
   | `models/${string}`;
 
-/** Closed allowlist: the four diagnostics reads, `/models`, or `/models/<folder>`. */
+/** Closed allowlist: diagnostics reads, workflow templates, `/models`, or `/models/<folder>`. */
 export function isPanelComfyUIReadOperation(value: string): value is PanelComfyUIReadOperation {
   if (FIXED_READ_OPERATIONS.has(value)) return true;
   if (!value.startsWith("models/")) return false;

--- a/src/services/panel-template-relay.ts
+++ b/src/services/panel-template-relay.ts
@@ -660,11 +660,30 @@ function isUnsupportedPanelTemplateRead(error: unknown): boolean {
   );
 }
 
+function isPanelReadViewingWitness(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (!hasOnlyKeys(value, ["scope", "owner_node_id", "title", "workflow_uuid", "graph_identity"])) return false;
+  if (!("scope" in value) || (value.scope !== "root" && value.scope !== "subgraph")) return false;
+  if ("owner_node_id" in value) {
+    const owner = value.owner_node_id;
+    if (
+      owner !== null &&
+      !(typeof owner === "number" && Number.isSafeInteger(owner)) &&
+      !(typeof owner === "string" && isSafeText(owner, 256))
+    ) return false;
+  }
+  if ("title" in value && !isSafeText(value.title, 256)) return false;
+  if ("workflow_uuid" in value && !isSafeText(value.workflow_uuid, 256)) return false;
+  if ("graph_identity" in value && !isSafeText(value.graph_identity, 256)) return false;
+  return true;
+}
+
 function validatePanelTemplateReadPayload(value: unknown): string | undefined {
   if (!value || typeof value !== "object") return undefined;
   const record = value as Record<string, unknown>;
+  if ("viewing" in record && !isPanelReadViewingWitness(record.viewing)) return undefined;
   if (
-    !hasOnlyKeys(record, ["operation", "body", "contentType", "bytes"]) ||
+    !hasOnlyKeys(record, ["operation", "body", "contentType", "bytes", "viewing"]) ||
     record.operation !== PANEL_TEMPLATE_READ_OPERATION ||
     typeof record.body !== "string" ||
     record.body.length === 0 ||

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -7,8 +7,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parse as parseYaml } from "yaml";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { getComfyUIBaseUrl } from "../config.js";
-import { comfyuiFetch } from "../comfyui/fetch.js";
-import { requestPanelTemplateIndex } from "../services/panel-template-relay.js";
+import { comfyuiFetch, connectedPanelOriginsNow } from "../comfyui/fetch.js";
+import { provenPanelOriginMatchesConfiguredTarget } from "../services/panel-fallback-target.js";
+import {
+  PanelComfyUIReadRelayError,
+  requestPanelComfyUIRead,
+} from "../services/panel-image-relay.js";
+import { PanelTemplateRelayError, requestPanelTemplateIndex } from "../services/panel-template-relay.js";
 import { checkWorkflowRuntime, extractWorkflowClassTypes } from "../services/api-nodes.js";
 import {
   extractWorkflowDependencies,
@@ -691,6 +696,52 @@ function readPackManifestAction(rawName: string): ToolText {
   return { content: [{ type: "text" as const, text }] };
 }
 
+function isNoPanelOrigin(error: unknown): boolean {
+  return error instanceof PanelTemplateRelayError && error.code === "NO_PANEL_ORIGIN";
+}
+
+function templateIndexFromUnknown(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return Object.fromEntries(Object.entries(value));
+}
+
+/** Same bound-tab `fetch_comfyui_read` channel as get_history / panel_graph_outline. */
+async function readBoundPanelTemplateIndex(): Promise<Record<string, unknown> | undefined> {
+  try {
+    const read = await requestPanelComfyUIRead("workflow_templates");
+    if (!read) return undefined;
+    return templateIndexFromUnknown(JSON.parse(read.body));
+  } catch (error) {
+    if (
+      error instanceof PanelComfyUIReadRelayError &&
+      (error.code === "STALE_TARGET" || error.code === "NO_LIVE_PANEL" || error.code === "AMBIGUOUS_REQUESTER")
+    ) {
+      throw error;
+    }
+    return undefined;
+  }
+}
+
+async function resolveWorkflowTemplateIndex(): Promise<Record<string, unknown> | undefined> {
+  try {
+    const panelIndex = await requestPanelTemplateIndex();
+    if (panelIndex !== undefined) return panelIndex;
+  } catch (error) {
+    if (!isNoPanelOrigin(error)) throw error;
+    // Template-index HTTP is loopback-only. A live bound canvas still has the
+    // authenticated panel read relay used by mcp__panel__* tools (#2839).
+    const bound = await readBoundPanelTemplateIndex();
+    if (bound !== undefined) return bound;
+    if (!provenPanelOriginMatchesConfiguredTarget(connectedPanelOriginsNow(), getComfyUIBaseUrl())) {
+      throw error;
+    }
+    // Unique published origin matches this child's configured target: listing
+    // that URL is not a new destination. Mixed/malformed/empty stays thrown.
+    return undefined;
+  }
+  return undefined;
+}
+
 /** action:"list_templates" */
 async function listWorkflowTemplatesAction(): Promise<ToolText> {
   traceToolCall("list_packs", { action: "list_templates" });
@@ -700,7 +751,7 @@ async function listWorkflowTemplatesAction(): Promise<ToolText> {
   // children return undefined here and keep the established headless path.
   // Once a panel route exists, relay failures stay fail-closed: falling back
   // to COMFYUI_URL could silently list a different server's templates.
-  const panelIndex = await requestPanelTemplateIndex();
+  const panelIndex = await resolveWorkflowTemplateIndex();
   if (panelIndex !== undefined) return renderWorkflowTemplateIndex(panelIndex);
   // Canonical base URL + auth headers — same connected-ComfyUI path
   // enqueue_workflow (action:"template_schema") uses, so a proxied/authed


### PR DESCRIPTION
Fixes #2839

## Problem

`list_packs` `action:"list_templates"` through compact `call_tool` returned `The connected panel template relay failed (NO_PANEL_ORIGIN)` even when the same Codex session had a live bound canvas (`panel_graph_outline` reported `canvas_binding: bound`, `graph_binding: bound`, `backend_socket: up`).

The compact comfyui child talks to the template relay, whose HTTP path is loopback-only. A remote bound panel must use native `fetch_comfyui_read`, but a production panel reply includes the viewing witness and was treated as malformed; older panels then fell through to the origin gate and failed closed.

## Fix

- Accept the panel viewing witness on native template-index replies (same shape as the image/read relay).
- Admit `workflow_templates` on the bound-panel ComfyUI read relay used by `get_history` / `mcp__panel__*` tools.
- On `NO_PANEL_ORIGIN`, try that bound relay. If it is missing, list the child's configured target only when a unique published origin matches it. Mixed, malformed, or empty origin sets stay `NO_PANEL_ORIGIN`.

## Tests

- `src/__tests__/tools/skills-access.test.ts`
- `src/__tests__/services/panel-template-relay.test.ts`
- `src/__tests__/services/panel-fallback-target.test.ts`
- `src/__tests__/tools/skills-access-panel-template-relay.integration.test.ts`
