### PR TITLE
fix(2845): harvest custom-key history media refs like dexter_video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **History/completion harvests a ComfyUI media ref under an unrecognised key (`dexter_video`, `nkd_video`) instead of only `images`/`videos`/`video`/`gifs` (#2845).** SaveVideoDexter emits `{filename, subfolder?, type?}` as a single object (or a one-item array); `buildCompletionNotification` / the panel_run watchdog now collect that one-level shape and classify by extension so completion names the mp4. Nested non-media values stay ignored. Panel v0.15.163 already collects the array form of this shape (#2128).
+
+
 ## [0.52.188] - 2026-09-03
 
 ### MCP

--- a/src/__tests__/orchestrator/run-completion-watchdog.test.ts
+++ b/src/__tests__/orchestrator/run-completion-watchdog.test.ts
@@ -538,6 +538,26 @@ describe("#1853: a dropped panel frame still yields the completed prompt's histo
     expect(refs.some((img) => img.filename === "still.png")).toBe(true);
     expect(refs.some((img) => img.filename === VIDEO_FILENAME && img.subfolder === VIDEO_SUBFOLDER)).toBe(true);
   });
+
+  it("#2845 historyOutputRefsFromEntry collects SaveVideoDexter dexter_video", () => {
+    const entry = {
+      prompt: {},
+      outputs: {
+        "6335": {
+          dexter_video: {
+            filename: "ComfyUI_00067_.mp4",
+            subfolder: "video",
+            type: "output",
+          },
+        },
+      },
+      status: { status_str: "success", completed: true, messages: [] },
+    } as HistoryEntry;
+    const refs = historyOutputRefsFromEntry(PID, entry);
+    expect(refs).toEqual([
+      { filename: "ComfyUI_00067_.mp4", subfolder: "video", type: "output" },
+    ]);
+  });
 });
 
 describe("#1556: reconnect reconciles owed panel_run ids against ComfyUI history immediately", () => {

--- a/src/__tests__/services/job-watcher.test.ts
+++ b/src/__tests__/services/job-watcher.test.ts
@@ -220,6 +220,81 @@ describe("buildCompletionNotification", () => {
     ]);
   });
 
+  it("#2845 collects a SaveVideoDexter dexter_video object as a video output", () => {
+    const entry: HistoryEntry = {
+      prompt: {},
+      outputs: {
+        "6335": {
+          dexter_video: {
+            filename: "ComfyUI_00067_.mp4",
+            subfolder: "video",
+            type: "output",
+          },
+        },
+      },
+      status: {
+        status_str: "success",
+        completed: true,
+        messages: [["execution_success", { prompt_id: PROMPT_ID, timestamp: START }]],
+      },
+    };
+
+    const notification = buildCompletionNotification(PROMPT_ID, entry, START);
+
+    expect(notification.outputs).toEqual([]);
+    expect(notification.video_outputs).toEqual([
+      {
+        node_id: "6335",
+        videos: [
+          expect.objectContaining({
+            filename: "ComfyUI_00067_.mp4",
+            subfolder: "video",
+            type: "output",
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it("#2845 collects an nkd_video array the same way, and ignores nested non-media", () => {
+    const entry: HistoryEntry = {
+      prompt: {},
+      outputs: {
+        "44": {
+          nkd_video: [
+            { filename: "NKD_test__v012.mp4", subfolder: "unionen-time-machine/test", type: "output" },
+          ],
+        },
+        "50": {
+          wrapper: { inner: { filename: "hidden.mp4", subfolder: "video", type: "output" } },
+          notes: { filename: "readme.txt", type: "output" },
+          audio: [{ filename: "take.flac", subfolder: "", type: "output" }],
+        },
+      },
+      status: {
+        status_str: "success",
+        completed: true,
+        messages: [["execution_success", { prompt_id: PROMPT_ID, timestamp: START }]],
+      },
+    };
+
+    const notification = buildCompletionNotification(PROMPT_ID, entry, START);
+
+    expect(notification.outputs).toEqual([]);
+    expect(notification.video_outputs).toEqual([
+      {
+        node_id: "44",
+        videos: [
+          expect.objectContaining({
+            filename: "NKD_test__v012.mp4",
+            subfolder: "unionen-time-machine/test",
+            type: "output",
+          }),
+        ],
+      },
+    ]);
+  });
+
   it("#2512 interrupted duration/finished-at come from execution_interrupted, not delivery time", () => {
     const interruptAt = START + 21 * 60 * 1000 + 8 * 1000;
     const notification = buildCompletionNotification(

--- a/src/services/job-watcher.ts
+++ b/src/services/job-watcher.ts
@@ -142,10 +142,47 @@ interface HistoryMediaRef {
   type?: string;
 }
 
+const KNOWN_IMAGE_KEYS = new Set(["images"]);
+const KNOWN_VIDEO_KEYS = new Set(["videos", "video", "gifs"]);
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".bmp"]);
+const VIDEO_EXTS = new Set([".mp4", ".webm", ".mov", ".mkv", ".m4v", ".avi", ".gif", ".webp"]);
+
 function isHistoryMediaRef(value: unknown): value is HistoryMediaRef {
-  if (value === null || typeof value !== "object") return false;
-  const filename = (value as { filename?: unknown }).filename;
-  return typeof filename === "string" && filename.length > 0;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const rec = value as { filename?: unknown; subfolder?: unknown; type?: unknown };
+  if (typeof rec.filename !== "string" || rec.filename.length === 0) return false;
+  if (rec.subfolder != null && typeof rec.subfolder !== "string") return false;
+  if (rec.type != null && typeof rec.type !== "string") return false;
+  return true;
+}
+
+/** One-level bags only: a media ref, or an array of them. Nested objects are not walked. */
+function historyMediaRefs(value: unknown): HistoryMediaRef[] {
+  if (Array.isArray(value)) return value.filter(isHistoryMediaRef);
+  return isHistoryMediaRef(value) ? [value] : [];
+}
+
+function filenameExt(filename: string): string {
+  const base = filename.slice(Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\")) + 1);
+  const dot = base.lastIndexOf(".");
+  return dot >= 0 ? base.slice(dot).toLowerCase() : "";
+}
+
+function unknownKeyMediaKind(filename: string): "image" | "video" | null {
+  const ext = filenameExt(filename);
+  if (VIDEO_EXTS.has(ext)) return "video";
+  if (IMAGE_EXTS.has(ext)) return "image";
+  return null;
+}
+
+function toMediaOutput(ref: HistoryMediaRef): MediaOutput {
+  const type = normalizeAssetType(ref.type);
+  return {
+    filename: ref.filename,
+    subfolder: ref.subfolder ?? "",
+    type,
+    url: buildImageUrl(ref.filename, ref.subfolder ?? "", type),
+  };
 }
 
 export function buildCompletionNotification(
@@ -195,20 +232,10 @@ export function buildCompletionNotification(
     // Extract image outputs (SaveImage, PreviewImage) — malformed refs are
     // filtered BEFORE any use, so a bad /history entry can neither crash the
     // parse nor surface as an output with filename=undefined.
+    const images: MediaOutput[] = [];
     if (Array.isArray(out.images)) {
-      const images = (out.images as unknown[])
-        .filter(isHistoryMediaRef)
-        .map((img) => {
-          const type = normalizeAssetType(img.type);
-          return {
-            filename: img.filename,
-            subfolder: img.subfolder ?? "",
-            type,
-            url: buildImageUrl(img.filename, img.subfolder ?? "", type),
-          };
-        });
-      if (images.length > 0) {
-        outputs.push({ node_id: nodeId, images });
+      for (const img of out.images.filter(isHistoryMediaRef)) {
+        images.push(toMediaOutput(img));
       }
     }
 
@@ -217,18 +244,28 @@ export function buildCompletionNotification(
     // keys into a single entry per node, mirroring how images group once.
     // Adapted from jcd315's fork (jcd315/comfyui-mcp-muse, commit e13342ec).
     const videos: MediaOutput[] = [];
-    for (const videoKey of ["videos", "video", "gifs"] as const) {
+    for (const videoKey of KNOWN_VIDEO_KEYS) {
       const videoData = out[videoKey];
       if (!Array.isArray(videoData)) continue;
-      for (const vid of (videoData as unknown[]).filter(isHistoryMediaRef)) {
-        const type = normalizeAssetType(vid.type);
-        videos.push({
-          filename: vid.filename,
-          subfolder: vid.subfolder ?? "",
-          type,
-          url: buildImageUrl(vid.filename, vid.subfolder ?? "", type),
-        });
+      for (const vid of videoData.filter(isHistoryMediaRef)) {
+        videos.push(toMediaOutput(vid));
       }
+    }
+
+    // #2845 — SaveVideoDexter (`dexter_video`) and NKDVideoViewer (`nkd_video`)
+    // emit a `{filename, subfolder?, type?}` ref under a custom key, as a single
+    // object or a one-item array. Harvest that one level; nested bags stay closed.
+    for (const [key, raw] of Object.entries(out)) {
+      if (KNOWN_IMAGE_KEYS.has(key) || KNOWN_VIDEO_KEYS.has(key)) continue;
+      for (const ref of historyMediaRefs(raw)) {
+        const kind = unknownKeyMediaKind(ref.filename);
+        if (kind === "video") videos.push(toMediaOutput(ref));
+        else if (kind === "image") images.push(toMediaOutput(ref));
+      }
+    }
+
+    if (images.length > 0) {
+      outputs.push({ node_id: nodeId, images });
     }
     if (videos.length > 0) {
       video_outputs.push({ node_id: nodeId, videos });


### PR DESCRIPTION
## Summary

`panel_run` completion missed SaveVideoDexter's `dexter_video` output even though `/history` had a valid `{filename, subfolder, type:"output"}` MP4. MCP's history/completion parser (`buildCompletionNotification`, used by the panel_run watchdog) only harvested `images` / `videos` / `video` / `gifs`.

This PR collects a **one-level** unknown key whose value is a ComfyUI media ref (object **or** array of objects) and classifies by extension. Nested non-media bags stay ignored (fail-closed).

Closes #2845.

## Remaining hole (why MCP, not panel)

Panel v0.15.163 already shipped #2128 / PR 2207: a `{filename, subfolder, type:"output"}` MP4 under an **array** bag (`nkd_video: [{…}]`) is collected in `collectNodeOutputMedia` (`web/js/lib/node-output-media.js` on panel origin/main). That path still requires `Array.isArray(bag)`.

Production `get_history` for this issue printed a **single object**:

```
Node 6335: dexter_video: {"filename":"ComfyUI_00067_.mp4","subfolder":"video","type":"output"}
```

(`formatHistoryEntry` leftover JSON — an array would have been `[{…}]`.) MCP JobWatcher/watchdog never harvested custom keys at all, object or array. That is the remaining MCP hole.

## Tests

```
npx vitest run src/__tests__/services/job-watcher.test.ts src/__tests__/orchestrator/run-completion-watchdog.test.ts
```

62 passed (18 + 44).
