### PR TITLE
docs(2221): stop claiming a panel counterpart that does not exist

### DIFF
--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -243,7 +243,15 @@ export async function ensureConnected(): Promise<Client> {
 /** True when a decoded /system_stats body has the recognizable ComfyUI shape (a
  *  `system` object and/or a `devices` array). A bare 2xx carrying an API
  *  gateway's own JSON envelope is NOT ComfyUI and must not be handed on as
- *  stats — the same predicate the panel's reboot certification uses. */
+ *  stats.
+ *
+ *  This comment used to say the panel-side reboot certification uses the same
+ *  predicate. It does not — panel#2221. Every panel /system_stats consumer takes
+ *  the body as-is; the two that exist read defensively (`data?.devices?.[0]`, and
+ *  an unknown platform falling back to POSIX), so they fail safe rather than
+ *  certifying the document. The claim is recorded here because a false provenance
+ *  is worse than none: someone syncing the two sides looks for the counterpart,
+ *  finds nothing, and either duplicates it or assumes the panel already guards. */
 function looksLikeSystemStats(body: unknown): boolean {
   if (!body || typeof body !== "object") return false;
   const b = body as { system?: unknown; devices?: unknown };


### PR DESCRIPTION
Addresses half of artokun/comfyui-mcp-panel#2221 — the half that lives in this repo. The panel-side half stays open there.

`looksLikeSystemStats`'s doc comment claimed it was *"the same predicate the panel's reboot certification uses"*. There is no such predicate. I searched every `/system_stats` consumer in the panel: both take the decoded body as-is.

The comment now says what is actually true on the other side, and cites the issue so the asymmetry stays findable.

## Why bother with a comment

A false provenance is worse than none. Someone syncing the two sides looks for the counterpart, finds nothing, and either duplicates the predicate or concludes the panel already guards and moves on. The second outcome is how an asymmetry stays invisible.

## A correction to the issue I filed

The issue implies the panel is exposed to a gateway's `200 {"error": …}` envelope. Having now read both consumers, that is overstated — **both already fail safe**:

- `cmcp-training-ui.js` → `data?.devices?.[0]`, and returns `null` when absent.
- `comfyui-mcp-panel.js` → an unknown platform falls back to POSIX separators, which is the deliberate fail-closed direction documented right there.

So the panel does accept any 2xx as stats, but nothing downstream trusts it. That makes the panel-side predicate a clarity improvement — a clear "that was not ComfyUI" instead of a silent `undefined` — rather than the bug fix I implied when filing. I have said so on the issue rather than quietly narrowing it here.

Comment only, no behaviour change, so no changelog entry — which is deliberate, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXS5Qys1hiK9aDdXJRJ6Y
