### PR TITLE
fix(2855): accept named node ids the graph readers print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`panel_set_widget` / other mutations accept named node ids the graph readers print (#2855).** API-style graphs use string ids (`sampler`, `mac_studio_vlm`). `panel_graph_outline` already returned those; writes refused them at MCP validation (`NODE_ID_PATTERN` was integer / `120:104` only). Named ids stay strings on the wire — they are never `parseInt`'d. `"42px"` is still refused so it cannot become node 42.
+
 ## [0.52.190] - 2026-09-04
 
 ### MCP

--- a/src/__tests__/orchestrator/node-id-and-canvas-args.test.ts
+++ b/src/__tests__/orchestrator/node-id-and-canvas-args.test.ts
@@ -119,11 +119,22 @@ describe("#845(4): an id the tools printed is accepted back", () => {
   });
 
   it("refuses other non-integer strings", async () => {
-    for (const bad of ["42px", "4.5", "", "abc", "1:", ":1", "1::2", "1:-2"]) {
+    for (const bad of ["42px", "4.5", "", "1:", ":1", "1::2", "1:-2"]) {
       sent = [];
       const res = await callTool("panel_select_nodes", { node_ids: [bad] });
       expect(res.isError, bad).toBe(true);
     }
+  });
+
+  it("#2855 accepts a named id the readers printed and forwards it VERBATIM", async () => {
+    const res = await callTool("panel_set_widget", {
+      node_id: "sampler",
+      widget: "seed",
+      value: 1,
+    });
+    expect(res.isError).toBeFalsy();
+    expect(sent[0].node_id).toBe("sampler");
+    expect(sent[0].node_id).not.toBeNaN();
   });
 });
 

--- a/src/__tests__/orchestrator/node-id-union-message.test.ts
+++ b/src/__tests__/orchestrator/node-id-union-message.test.ts
@@ -119,7 +119,7 @@ describe("#1889 the message an agent actually receives over MCP", () => {
     // Every spelling #845/#1425/#1497 fought for still validates. A union-level
     // `error` that accidentally narrowed the union would be a far worse bug than
     // the one being fixed, and it would not show up in any message assertion.
-    for (const id of [42, "42", "120:104", "120:113:78", -20, "-20", "-20:3"]) {
+    for (const id of [42, "42", "120:104", "120:113:78", -20, "-20", "-20:3", "sampler"]) {
       const r = await client.callTool({
         name: "panel_set_node_title",
         arguments: { node_id: id, title: "t" },
@@ -130,7 +130,7 @@ describe("#1889 the message an agent actually receives over MCP", () => {
       );
     }
     // …and what was refused is still refused.
-    for (const id of ["4.5", "", "abc", "1:", ":1", "1::2", "1:-2"]) {
+    for (const id of ["4.5", "", "42px", "1:", ":1", "1::2", "1:-2"]) {
       const text = await errorText("panel_set_node_title", { node_id: id, title: "t" });
       expect(text, JSON.stringify(id)).toContain(NODE_ID_MESSAGE);
     }
@@ -179,7 +179,7 @@ describe("#1889 the advertised input schema is untouched", () => {
     expect(json.properties.node_id).toEqual({
       anyOf: [
         { type: "integer", minimum: -9007199254740991, maximum: 9007199254740991 },
-        { type: "string", pattern: "^-?\\d+(?::\\d+)*$" },
+        { type: "string", pattern: "^(?:-?\\d+(?::\\d+)*|[A-Za-z_][A-Za-z0-9_-]*)$" },
       ],
     });
   });

--- a/src/__tests__/orchestrator/node-id.test.ts
+++ b/src/__tests__/orchestrator/node-id.test.ts
@@ -32,9 +32,30 @@ describe("#1425 which strings name a node", () => {
   });
 
   it("still rejects what #845 rejected", () => {
-    for (const v of ["42px", "4.5", "", " ", "abc", "1:", ":1", "1::2", "1:2:", "1:-2", "1: 2"]) {
+    for (const v of ["42px", "4.5", "", " ", "1:", ":1", "1::2", "1:2:", "1:-2", "1: 2"]) {
       expect(isNodeIdString(v)).toBe(false);
     }
+  });
+});
+
+describe("#2855 named ids the graph readers print", () => {
+  it("accepts named ids like sampler / mac_studio_vlm", () => {
+    for (const v of ["sampler", "mac_studio_vlm", "KSampler", "node_1", "t2i-encoder"]) {
+      expect(isNodeIdString(v)).toBe(true);
+      expect(isQualifiedNodeId(v)).toBe(false);
+    }
+  });
+
+  it("a named id is passed through UNTOUCHED — parseInt would be NaN", () => {
+    expect(normalizeNodeId("sampler")).toBe("sampler");
+    expect(normalizeNodeId("mac_studio_vlm")).toBe("mac_studio_vlm");
+    expect(Number.parseInt("sampler", 10)).toBeNaN();
+    expect(normalizeNodeId("sampler")).not.toBeNaN();
+  });
+
+  it("still refuses 42px so it cannot become node 42", () => {
+    expect(isNodeIdString("42px")).toBe(false);
+    expect(Number.parseInt("42px", 10)).toBe(42);
   });
 
   it("a plain id is not a qualified one", () => {
@@ -67,7 +88,7 @@ describe("#1425 what goes on the wire", () => {
   });
 
   it("never returns NaN — an unparseable id must not reach the panel as one", () => {
-    for (const v of ["42", "-20", "263:78", "120:113:78"]) {
+    for (const v of ["42", "-20", "263:78", "120:113:78", "sampler"]) {
       const out = normalizeNodeId(v);
       expect(typeof out === "number" ? Number.isNaN(out) : false).toBe(false);
     }
@@ -95,6 +116,8 @@ describe("#1425 what the tool schema ADVERTISES", () => {
     const advertised = new RegExp(schema.properties.node_id.pattern!);
     expect(advertised.test("263:78")).toBe(true);
     expect(advertised.test("42")).toBe(true);
+    expect(advertised.test("sampler")).toBe(true);
     expect(advertised.test("1:-2")).toBe(false);
+    expect(advertised.test("42px")).toBe(false);
   });
 });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1311,7 +1311,8 @@ describe("panel-tools: subgraph I/O (expose rails + unpack)", () => {
     // from_node_id is an int like the other per-node tools.
     const fromNode = def.schema.from_node_id as { safeParse: (v: unknown) => { success: boolean } };
     expect(fromNode.safeParse(3).success).toBe(true);
-    expect(fromNode.safeParse("x").success).toBe(false);
+    expect(fromNode.safeParse("x").success).toBe(true);
+    expect(fromNode.safeParse("42px").success).toBe(false);
     // from_output is a string|number slot ref.
     const fromOut = def.schema.from_output as { safeParse: (v: unknown) => { success: boolean } };
     expect(fromOut.safeParse("IMAGE").success).toBe(true);
@@ -1337,7 +1338,8 @@ describe("panel-tools: subgraph I/O (expose rails + unpack)", () => {
     expect(Object.keys(def.schema).sort()).toEqual(["name", "retry_of", "to_input", "to_node_id"]);
     const toNode = def.schema.to_node_id as { safeParse: (v: unknown) => { success: boolean } };
     expect(toNode.safeParse(3).success).toBe(true);
-    expect(toNode.safeParse("x").success).toBe(false);
+    expect(toNode.safeParse("x").success).toBe(true);
+    expect(toNode.safeParse("42px").success).toBe(false);
     const toIn = def.schema.to_input as { safeParse: (v: unknown) => { success: boolean } };
     expect(toIn.safeParse("model").success).toBe(true);
     expect(toIn.safeParse(1).success).toBe(true);

--- a/src/__tests__/orchestrator/promoted-widget.test.ts
+++ b/src/__tests__/orchestrator/promoted-widget.test.ts
@@ -3661,7 +3661,7 @@ describe("resolveInnerPromotedTarget", () => {
     ["wrong node_count", { ...SUBGRAPH, node_count: 1 }],
     ["non-integer node_count", { ...SUBGRAPH, node_count: "2" }],
     ["truncated envelope", { ...SUBGRAPH, truncated: true }],
-    ["malformed inner node id", { ...SUBGRAPH, nodes: [{ ...SUBGRAPH.nodes[0], id: "not-a-node" }, SUBGRAPH.nodes[1]] }],
+    ["malformed inner node id", { ...SUBGRAPH, nodes: [{ ...SUBGRAPH.nodes[0], id: "42px" }, SUBGRAPH.nodes[1]] }],
   ])("rejects a %s instead of trusting its inner mapping", (_name, malformed) => {
     expect(validatePromotedSubgraphEnvelope(malformed, 78)).toBeNull();
     expect(resolveInnerPromotedTarget(malformed, "width", 78)).toBeNull();
@@ -4609,7 +4609,7 @@ describe("#2688 describePromotedSubgraphEnvelope names the failed invariant", ()
       78,
       /`subgraph_of\.node_id` was missing or not a node id/,
     ],
-    ["an unusable addressed id", VALID, "not-an-id", /the addressed node id was not a usable node id/],
+    ["an unusable addressed id", VALID, "42px", /the addressed node id was not a usable node id/],
     [
       "a non-integer node_count",
       { ...VALID, node_count: 1.5 },

--- a/src/orchestrator/node-id.ts
+++ b/src/orchestrator/node-id.ts
@@ -45,14 +45,23 @@ export const PLAIN_NODE_ID_PATTERN = /^-?\d+$/;
 const QUALIFIED = /^-?\d+(?::\d+)+$/;
 
 /**
- * Both spellings in ONE pattern, so it can be handed to `z.string().regex()`.
+ * #2855 — a named id the graph readers print for API-style / string-id graphs
+ * (`sampler`, `mac_studio_vlm`). Must start with a letter or underscore so it
+ * cannot collide with the integer/`42px` cases: `42px` is still refused, never
+ * truncated via parseInt.
+ */
+const NAMED = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+/**
+ * Integer, subgraph-qualified, and named spellings in ONE pattern, so it can be
+ * handed to `z.string().regex()`.
  *
  * That matters beyond tidiness: `.regex()` puts a `pattern` on the advertised MCP
  * input schema, while `.refine()` renders as a bare `{"type":"string"}` (measured
  * with zod 4's toJSONSchema). Validating through a refine would therefore have told
  * every client LESS about a node id than the old integer-only rule did.
  */
-export const NODE_ID_PATTERN = /^-?\d+(?::\d+)*$/;
+export const NODE_ID_PATTERN = /^(?:-?\d+(?::\d+)*|[A-Za-z_][A-Za-z0-9_-]*)$/;
 
 /** Does this string name a node at all — either spelling? */
 export function isNodeIdString(v: string): boolean {
@@ -68,20 +77,21 @@ export function isQualifiedNodeId(v: string): boolean {
  * Normalize an accepted id to what goes on the wire.
  *
  * A plain id becomes the NUMBER the panel has always received, so nothing about
- * the existing surface changes. A qualified id is returned VERBATIM — parsing it
- * is precisely the bug. Callers must therefore treat a node id as `number | string`
- * rather than assuming the number.
+ * the existing surface changes. A qualified id and a named id are returned
+ * VERBATIM — parsing them is precisely the bug. Callers must therefore treat a
+ * node id as `number | string` rather than assuming the number.
  */
 export function normalizeNodeId(v: number | string): number | string {
   if (typeof v === "number") return v;
   if (QUALIFIED.test(v)) return v;
+  if (NAMED.test(v)) return v;
   return Number.parseInt(v, 10);
 }
 
-/** The message a rejected id gets. Names the qualified shape explicitly, because a
- *  caller holding `263:78` needs to know whether it is unsupported or malformed. */
+/** The message a rejected id gets. Names the qualified and named shapes, because a
+ *  caller holding `263:78` or `sampler` needs to know whether it is unsupported or malformed. */
 export const NODE_ID_MESSAGE =
-  "a node id must be an integer (e.g. 42) or a subgraph-qualified id (e.g. 120:104)";
+  "a node id must be an integer (e.g. 42), a subgraph-qualified id (e.g. 120:104), or a named id the graph readers printed (e.g. sampler)";
 
 /**
  * #1889 — a bare `z.union` renders as the word `Invalid input` and nothing else.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -20120,8 +20120,9 @@ function validatePanelEditNodeArgs(args: Record<string, unknown>): string | null
  * number the wire has always carried, so the round trip closes.
  *
  * STRICT about what counts as a node id: an integer, a string that is exactly an
- * integer, or a subgraph-qualified id (`"120:104"`). `"42px"`, `"4.5"` and `""`
- * are still rejected.
+ * integer, a subgraph-qualified id (`"120:104"`), or a named id the readers print
+ * (`"sampler"`). `"42px"`, `"4.5"` and `""` are still rejected. Named ids stay
+ * strings — `Number.parseInt("sampler")` is NaN and must not reach the panel.
  *
  * #1425 added the qualified shape — the "separate, deliberate change to the wire
  * contract" this comment used to defer. Unpacking a subgraph leaves genuine ROOT


### PR DESCRIPTION
## Diagnosis

On API-style / named-id graphs, `panel_graph_outline` prints ids like `sampler` and `mac_studio_vlm`. `panel_set_widget` (and every other mutation using `nodeId()`) refused them at MCP validation:

`a node id must be an integer (e.g. 42) or a subgraph-qualified id (e.g. 120:104)`

`NODE_ID_PATTERN` was `/^-?\d+(?::\d+)*$/` — #1425's colon-qualified shape, not named strings.

## What this does **not** re-ship

- #1425 / colon-qualified `120:104` (already on main)
- `panel_run.to_node_id` stays a **plain integer** (#1497) — execution roots are still numeric

## Fix

Widen `NODE_ID_PATTERN` to also admit `/^[A-Za-z_][A-Za-z0-9_-]*$/`. Named ids are forwarded **verbatim** (`normalizeNodeId("sampler") === "sampler"`). `"42px"` still fails so `parseInt` cannot silently retarget node 42.

## Tests

- `#2855 named ids the graph readers print`
- `panel_set_widget` forwards `sampler` verbatim
- advertised MCP schema pattern updated
- existing #845 / #1425 / #1889 suites still pass (91)

CHANGELOG: Unreleased only; overlay keep.

Closes #2855
