### PR TITLE
fix(2858): save ZIP input attachments from get_image action:get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+
+- get_image(action:"get") saves an existing ZIP from ComfyUI input/ instead of misreporting IMAGE_NOT_FOUND when /view returned 2xx application/zip. IMAGE_NOT_FOUND stays reserved for a missing or failed /view. (#2858)
+
 ## [0.52.191] - 2026-09-04
 
 ### MCP

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -186,6 +186,122 @@ describe("getOutputImage — happy path (legitimate ComfyUI references)", () => 
   });
 });
 
+describe("getOutputImage — ZIP attachments (#2858)", () => {
+  const zipLocal = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00]);
+  const zipEmptyArchive = Buffer.from([0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00]);
+  const zipSpanned = Buffer.from([0x50, 0x4b, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00]);
+  const zipFilename = "PCIDOL_Smart_Save_Suite_Image_v0.6.3_Video_v0.6.6.zip";
+
+  it("accepts a ZIP labeled application/zip with PK local-file magic", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: zipLocal.toString("base64"),
+      mimeType: "application/zip",
+    });
+
+    await expect(
+      getOutputImage(zipFilename, "input", "", { allowAttachment: true }),
+    ).resolves.toMatchObject({
+      base64: zipLocal.toString("base64"),
+      mimeType: "application/zip",
+      filename: zipFilename,
+    });
+  });
+
+  it("accepts application/x-zip-compressed with PK magic", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: zipLocal.toString("base64"),
+      mimeType: "application/x-zip-compressed",
+    });
+
+    await expect(
+      getOutputImage("suite.zip", "input", "", { allowAttachment: true }),
+    ).resolves.toMatchObject({
+      mimeType: "application/x-zip-compressed",
+      filename: "suite.zip",
+    });
+  });
+
+  it("accepts application/octet-stream ZIP with PK magic", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: zipLocal.toString("base64"),
+      mimeType: "application/octet-stream",
+    });
+
+    await expect(
+      getOutputImage("suite.zip", "input", "", { allowAttachment: true }),
+    ).resolves.toMatchObject({
+      mimeType: "application/octet-stream",
+      filename: "suite.zip",
+    });
+  });
+
+  it.each([
+    ["empty-archive EOCD", zipEmptyArchive],
+    ["spanned archive", zipSpanned],
+  ])("accepts PK %s signature", async (_label, bytes) => {
+    fetchImageMock.mockResolvedValue({
+      base64: bytes.toString("base64"),
+      mimeType: "application/zip",
+    });
+
+    await expect(
+      getOutputImage("empty.zip", "input", "", { allowAttachment: true }),
+    ).resolves.toMatchObject({ filename: "empty.zip", mimeType: "application/zip" });
+  });
+
+  it.each([
+    ["HTML login page", Buffer.from("<html>login</html>", "utf8").toString("base64")],
+    ["JSON error envelope", Buffer.from('{"error":"not found"}', "utf8").toString("base64")],
+  ])("refuses a ZIP-labeled %s as IMAGE_NOT_FOUND", async (_label, base64) => {
+    fetchImageMock.mockResolvedValue({ base64, mimeType: "application/zip" });
+
+    await expect(
+      getOutputImage("suite.zip", "input", "", { allowAttachment: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("refuses an empty ZIP body as IMAGE_NOT_FOUND", async () => {
+    fetchImageMock.mockResolvedValue({ base64: "", mimeType: "application/zip" });
+
+    await expect(
+      getOutputImage("suite.zip", "input", "", { allowAttachment: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("refuses a real ZIP without allowAttachment as ATTACHMENT_TYPE_UNSUPPORTED", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: zipLocal.toString("base64"),
+      mimeType: "application/zip",
+    });
+
+    await expect(getOutputImage("suite.zip", "input", "")).rejects.toMatchObject({
+      code: "ATTACHMENT_TYPE_UNSUPPORTED",
+    });
+  });
+
+  it("still refuses model/obj MIME on an OBJ even when ZIP MIME is accepted", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from("# mesh\n", "utf8").toString("base64"),
+      mimeType: "model/obj",
+    });
+
+    await expect(
+      getOutputImage("mesh.obj", "output", "", { allowAttachment: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("does not treat foo.txt labeled application/zip as an attachment", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: zipLocal.toString("base64"),
+      mimeType: "application/zip",
+    });
+
+    await expect(
+      getOutputImage("foo.txt", "input", "", { allowAttachment: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+});
+
 describe("getOutputImage — local fallback for ComfyUI's 400 rejection (#2194)", () => {
   const filename = "dreamina-2026-08-12-1653-Locked-off camera, static 16_9 frame.smo....mp4";
   const mp4 = Buffer.from([

--- a/src/__tests__/tools/get-image-binary-safe.test.ts
+++ b/src/__tests__/tools/get-image-binary-safe.test.ts
@@ -162,3 +162,43 @@ describe("get_image — video/audio save-to-disk (#663)", () => {
     expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
   });
 });
+
+describe("get_image — ZIP save-to-disk (#2858)", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("saves a ZIP to disk and returns text only (no inline image)", async () => {
+    const base64 = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00]).toString(
+      "base64",
+    );
+    const filename = "PCIDOL_Smart_Save_Suite_Image_v0.6.3_Video_v0.6.6.zip";
+    getOutputImageMock.mockResolvedValue({
+      base64,
+      mimeType: "application/zip",
+      filename,
+    });
+
+    const out = await getHandler("get_image")({
+      action: "get",
+      filename,
+      type: "input",
+      save_dir: "/tmp/x",
+    });
+
+    expect(out.isError).toBeUndefined();
+    expect(getOutputImageMock).toHaveBeenCalledWith(filename, "input", "", {
+      allowMedia: true,
+      allowAttachment: true,
+      allowJson: true,
+      forInlinePreview: true,
+    });
+    expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
+      join(resolve("/tmp/x"), filename),
+      Buffer.from(base64, "base64"),
+    );
+    expect(out.content.find((c) => c.type === "image")).toBeUndefined();
+    const text = out.content.map((c) => c.text ?? "").join("");
+    expect(text).toContain(filename);
+    expect(text).toContain("application/zip");
+    expect(text).toContain("not rendered inline");
+  });
+});

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -981,8 +981,9 @@ const IMAGE_EXTENSIONS = new Set([
 
 /**
  * Attachment extensions that get_image may save when ComfyUI serves the file
- * as an opaque octet-stream. This is deliberately an explicit, small allowlist
- * rather than an extension-shaped bypass for the image-content guard.
+ * as an opaque octet-stream (mesh/material) or a ZIP. This is deliberately an
+ * explicit, small allowlist rather than an extension-shaped bypass for the
+ * image-content guard.
  */
 const ATTACHMENT_EXTENSIONS = new Set([
   ".obj",
@@ -992,7 +993,29 @@ const ATTACHMENT_EXTENSIONS = new Set([
   ".ply",
   ".stl",
   ".mtl",
+  ".zip",
 ]);
+
+/** MIME labels a ZIP /view may arrive with. Mesh/material still require octet-stream. */
+const ZIP_ATTACHMENT_MIMES = new Set([
+  "application/zip",
+  "application/x-zip-compressed",
+  "application/octet-stream",
+]);
+
+/** Local-file, empty-archive, and spanned ZIP signatures (#2858). */
+function sniffZipMagic(base64: string): boolean {
+  if (base64.length === 0) return false;
+  const head = Buffer.from(base64.slice(0, 8), "base64");
+  if (head.length < 4) return false;
+  return (
+    head[0] === 0x50 &&
+    head[1] === 0x4b &&
+    ((head[2] === 0x03 && head[3] === 0x04) ||
+      (head[2] === 0x05 && head[3] === 0x06) ||
+      (head[2] === 0x07 && head[3] === 0x08))
+  );
+}
 
 /**
  * The history reconciler needs stronger evidence than an image/* header. Keep
@@ -1070,9 +1093,10 @@ export async function getOutputImage(
   {
     allowMedia = false,
     /**
-     * Accept a known mesh/material attachment for get_image (action:"get").
-     * ComfyUI serves these files as application/octet-stream, so there is no
-     * reliable MIME subtype to sniff. The caller must opt in explicitly and the
+     * Accept a known mesh/material or ZIP attachment for get_image (action:"get").
+     * Meshes are served as application/octet-stream with no reliable subtype to
+     * sniff. ZIPs may also be application/zip or application/x-zip-compressed
+     * and must sniff as PK magic. The caller must opt in explicitly and the
      * requested filename must use the narrow attachment extension allowlist.
      */
     allowAttachment = false,
@@ -1181,14 +1205,18 @@ export async function getOutputImage(
       MEDIA_FORMAT_BY_MIME[mime] === sniffedFormat);
   // ComfyUI serves mesh/material outputs as opaque octet-streams. There is no
   // MIME subtype or universal magic header to validate, so acceptance is gated
-  // by the caller plus the explicit filename allowlist above. This option is
-  // used only by get_image (action:"get"); image analysis/conversion keep the
-  // default refusal behavior.
+  // by the caller plus the explicit filename allowlist above. ZIP is the
+  // exception: /view often labels it application/zip, so those MIME values are
+  // accepted only with a PK local-file / empty-archive / spanned signature.
+  // This option is used only by get_image (action:"get"); image analysis/
+  // conversion keep the default refusal behavior.
+  const isZipAttachment =
+    ext === ".zip" && ZIP_ATTACHMENT_MIMES.has(mime) && sniffZipMagic(result.base64);
   const isAttachment =
     allowAttachment &&
     ATTACHMENT_EXTENSIONS.has(ext) &&
-    mime === "application/octet-stream" &&
-    result.base64.length > 0;
+    result.base64.length > 0 &&
+    (isZipAttachment || (ext !== ".zip" && mime === "application/octet-stream"));
   // A `.json` request whose bytes parse as JSON is accepted whatever the server called
   // them (#1373). Gated on the REQUESTED extension so this can never widen the image or
   // media paths, and on a successful parse so the rejection this function exists for is
@@ -1203,18 +1231,21 @@ export async function getOutputImage(
   // is the server reporting an ABSENT FILE, and calling that a content refusal sends the
   // caller to inspect a payload when the filename is the thing to look at.
   const contentRejected = jsonRefusal?.kind === "content";
-  // An OBJ is a real attachment, but it is not an image, supported media, or JSON
-  // attachment that get_image can save. ComfyUI commonly serves it as the generic
-  // octet-stream type, so do not send a successful non-empty response down the
-  // missing-file path.
-  const unsupportedObjAttachment =
-    ext === ".obj" &&
-    mime === "application/octet-stream" &&
-    result.base64.length > 0 &&
+  // An OBJ/ZIP is a real attachment, but it is not an image, supported media,
+  // or JSON attachment that this caller opted to save. Do not send a successful
+  // non-empty response down the missing-file path.
+  const unsupportedAttachmentKind =
     !allowAttachment &&
+    result.base64.length > 0 &&
     !isImage &&
     !isMedia &&
-    !isJson;
+    !isJson
+      ? ext === ".obj" && mime === "application/octet-stream"
+        ? "OBJ"
+        : isZipAttachment
+          ? "ZIP"
+          : null
+      : null;
 
   if ((!isImage && !isMedia && !isJson && !isAttachment) || !imageContentOk || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
@@ -1225,10 +1256,10 @@ export async function getOutputImage(
           ? `invalid image content labeled "${result.mimeType}"`
           : `content-type "${result.mimeType}"`;
     throw new ComfyUIError(
-      unsupportedObjAttachment
-        ? `ComfyUI /view returned an existing OBJ attachment for "${filename}" (${where}), ` +
+      unsupportedAttachmentKind
+        ? `ComfyUI /view returned an existing ${unsupportedAttachmentKind} attachment for "${filename}" (${where}), ` +
           `but get_image cannot save this type. Nothing was saved. ` +
-          `Use ComfyUI's file browser or another raw-file download path for OBJ attachments.`
+          `Use ComfyUI's file browser or another raw-file download path for ${unsupportedAttachmentKind} attachments.`
         : contentRejected
         ? // NAME THE ACTUAL REASON (#1373). "The file may not exist" for a body that
           // arrived and was rejected on its CONTENT sends the caller to re-check a
@@ -1251,7 +1282,7 @@ export async function getOutputImage(
       // having one — still read IMAGE_NOT_FOUND and went off to re-check a filename that
       // was never wrong. That is the same wrong-cause failure as the prose, one layer
       // down, and it is the layer that automation reads.
-      unsupportedObjAttachment
+      unsupportedAttachmentKind
         ? "ATTACHMENT_TYPE_UNSUPPORTED"
         : contentRejected
           ? "ATTACHMENT_CONTENT_REJECTED"


### PR DESCRIPTION
## What

`get_image(action:"get")` can now save an existing ZIP from ComfyUI `input/` (or output/temp) instead of misreporting `IMAGE_NOT_FOUND` when `/view` returned 2xx `application/zip`.

## Why

`getOutputImage` accepted attachments only when `allowAttachment` was set, the extension was in a mesh/material allowlist (no `.zip`), **and** the MIME was exactly `application/octet-stream`. ComfyUI serves ZIPs as `application/zip`, so even adding `.zip` to the set was not enough.

## Fix

- Add `.zip` to `ATTACHMENT_EXTENSIONS`.
- Accept ZIP MIME `application/zip`, `application/x-zip-compressed`, or `application/octet-stream`. Mesh/material types still require `application/octet-stream`.
- Sniff PK magic (`PK\x03\x04`, `PK\x05\x06`, `PK\x07\x08`) on decoded bytes so an HTML/JSON error page labeled as a ZIP is still refused.
- Empty / junk / wrong-extension bodies stay `IMAGE_NOT_FOUND`. A real ZIP without `allowAttachment` is `ATTACHMENT_TYPE_UNSUPPORTED` (same class as OBJ).
- The tool handler already saves non-`image/*` to disk without inlining; ZIP follows that path.

Fixes #2858

## Tests

```
npx vitest run src/__tests__/services/image-management-traversal.test.ts src/__tests__/tools/get-image-binary-safe.test.ts src/__tests__/tools/image-assets.test.ts
```

181 passed (3 files): 108 traversal + 5 binary-safe + 68 image-assets.

Do not merge from this PR; parent overlay-merges after CI.
