### PR TITLE
fix(2861): inline remote panel_show_media refs the MCP client can fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 
-- panel_show_media inlines a remote ComfyUI /view ref the configured MCP client can fetch, so a browser-facing /view 404 no longer paints an empty card when get_image succeeds (#2861)
+- **`panel_show_media` inlines a remote ComfyUI output through `fetchImage` (the same client `get_image` uses) instead of handing the browser a `/view` that 404s (#2861).** Local canvas tabs still get a viewRef. A remote/cloud tab that cannot be inlined (MCP 404, non-media, over the 20 MB cap) is refused rather than painted empty. Same-named local workspace files are never substituted (#877/#899).
 
 ## [0.52.192] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+
+- panel_show_media inlines a remote ComfyUI /view ref the configured MCP client can fetch, so a browser-facing /view 404 no longer paints an empty card when get_image succeeds (#2861)
+
 ## [0.52.192] - 2026-09-04
 
 ### MCP

--- a/src/__tests__/orchestrator/panel-show-media-remote-view.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-remote-view.test.ts
@@ -95,7 +95,7 @@ function makeCtx(opts?: {
     tabId: "wf:workflows/a.json",
     bridge: {
       isHeadless: opts?.isHeadless ?? (() => false),
-    } as unknown as PanelToolCtx["bridge"],
+    },
   } as PanelToolCtx;
   return { ctx, calls };
 }

--- a/src/__tests__/orchestrator/panel-show-media-remote-view.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-remote-view.test.ts
@@ -1,20 +1,39 @@
 // #2861 — panel_show_media forwarded a ComfyUI /view ref to a browser panel
-// whose same-origin /view 404'd, while get_image (the configured MCP client)
-// fetched the same filename from the remote target. painted: 0, empty card.
+// whose same-origin /view 404'd, while get_image (fetchImage, the configured
+// MCP client) fetched the same filename from the remote target. painted: 0.
 //
 // A local canvas still gets a viewRef (same-origin /view works). A remote or
-// cloud interactive tab is proxied through the MCP client and inlined under
-// the existing 20 MB cap — the bytes come from /view via comfyuiFetch, never
-// from a same-named file on the orchestrator disk (#877/#899). Headless
-// inlining (#2012) is unchanged. Unroutable stays a viewRef.
+// cloud interactive tab is proxied through fetchImage and inlined under the
+// existing 20 MB cap. Bytes come from that client, never a same-named file on
+// the orchestrator disk (#877/#899). Headless inlining (#2012) is unchanged.
+// If the MCP client cannot paint the item, the tool fails closed — it does
+// not forward a viewRef the panel will drop.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { ComfyUIError } from "../../utils/errors.js";
 
 const state = vi.hoisted(() => ({
   remote: false,
   cloud: false,
+  fetchImage: null as
+    | ((
+        filename: string,
+        type?: string,
+        subfolder?: string,
+        options?: { maxBytes?: number },
+      ) => Promise<{ base64: string; mimeType: string }>)
+    | null,
+  fetchImageCalls: [] as Array<{
+    filename: string;
+    type: string | undefined;
+    subfolder: string | undefined;
+    options: { maxBytes?: number } | undefined;
+  }>,
   impl: null as
     | ((url: string, init?: { method?: string }) => Promise<{
         ok: boolean;
@@ -36,15 +55,38 @@ vi.mock("../../config.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../comfyui/fetch.js", () => ({
-  comfyuiFetch: (url: string, init?: { method?: string }) => {
-    state.urls.push(url);
-    if (!state.impl) {
-      return Promise.reject(new Error("comfyuiFetch was not stubbed"));
-    }
-    return state.impl(url, init);
-  },
-}));
+vi.mock("../../comfyui/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/client.js")>();
+  return {
+    ...actual,
+    fetchImage: async (
+      filename: string,
+      type?: string,
+      subfolder?: string,
+      options?: { maxBytes?: number },
+    ) => {
+      state.fetchImageCalls.push({ filename, type, subfolder, options });
+      if (!state.fetchImage) {
+        throw new Error("fetchImage was not stubbed");
+      }
+      return state.fetchImage(filename, type, subfolder, options);
+    },
+  };
+});
+
+vi.mock("../../comfyui/fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/fetch.js")>();
+  return {
+    ...actual,
+    comfyuiFetch: (url: string, init?: { method?: string }) => {
+      state.urls.push(url);
+      if (!state.impl) {
+        return Promise.reject(new Error("comfyuiFetch was not stubbed"));
+      }
+      return state.impl(url, init);
+    },
+  };
+});
 
 const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
 
@@ -56,6 +98,8 @@ const PNG_BYTES = Buffer.from(
 afterEach(() => {
   state.remote = false;
   state.cloud = false;
+  state.fetchImage = null;
+  state.fetchImageCalls = [];
   state.impl = null;
   state.urls = [];
 });
@@ -82,9 +126,7 @@ function mediaFetch(mime: string, bytes: Buffer, ok = true, status = 200): typeo
 
 type Cmd = Record<string, unknown>;
 
-function makeCtx(opts?: {
-  isHeadless?: (id: string) => boolean;
-}): { ctx: PanelToolCtx; calls: Cmd[] } {
+function makeCtx(): { ctx: PanelToolCtx; calls: Cmd[] } {
   const calls: Cmd[] = [];
   const ctx = {
     call: async (cmd: Cmd) => {
@@ -94,7 +136,7 @@ function makeCtx(opts?: {
     confirm: async () => "yes" as const,
     tabId: "wf:workflows/a.json",
     bridge: {
-      isHeadless: opts?.isHeadless ?? (() => false),
+      isHeadless: () => false,
     },
   } as PanelToolCtx;
   return { ctx, calls };
@@ -117,20 +159,29 @@ function dispatchedItems(calls: Cmd[]): Array<Record<string, unknown>> {
   return sent.items as Array<Record<string, unknown>>;
 }
 
-describe("#2861 remote interactive panel_show_media inlines via the MCP client", () => {
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
+
+describe("#2861 remote interactive panel_show_media inlines via fetchImage", () => {
   it("a remote canvas tab gets inlined bytes, not a /view ref the browser 404s", async () => {
     state.remote = true;
     const mp4 = Buffer.alloc(64, 1);
-    state.impl = mediaFetch("video/mp4", mp4);
+    state.fetchImage = async () => ({
+      base64: mp4.toString("base64"),
+      mimeType: "video/mp4",
+    });
     const { ctx, calls } = makeCtx();
-    await showMedia(ctx);
+    const res = await showMedia(ctx);
+    expect(res.isError).toBeFalsy();
     const items = dispatchedItems(calls);
     expect(items).toHaveLength(1);
     expect(items[0].kind).toBe("video");
-    expect(String(items[0].dataUrl)).toMatch(/^data:video\/mp4;base64,/);
+    expect(String(items[0].dataUrl)).toBe(`data:video/mp4;base64,${mp4.toString("base64")}`);
     expect(items[0].viewRef).toBeUndefined();
-    expect(state.urls.some((u) => u.includes("/view?") && u.includes("filename=clip.mp4"))).toBe(true);
-    expect(state.urls.every((u) => !u.includes("C:") && !u.includes("/output/"))).toBe(true);
+    expect(state.fetchImageCalls).toEqual([
+      { filename: "clip.mp4", type: "output", subfolder: "", options: { maxBytes: 20 * 1024 * 1024 } },
+    ]);
+    expect(state.urls).toEqual([]);
   });
 
   it("a local canvas tab still gets a viewRef — same-origin /view works", async () => {
@@ -140,46 +191,96 @@ describe("#2861 remote interactive panel_show_media inlines via the MCP client",
     await showMedia(ctx);
     expect(dispatchedItems(calls)[0].kind).toBe("viewRef");
     expect(dispatchedItems(calls)[0].dataUrl).toBeUndefined();
+    expect(state.fetchImageCalls).toEqual([]);
   });
 
   it("a cloud canvas tab is inlined the same way", async () => {
     state.cloud = true;
-    state.impl = mediaFetch("image/png", PNG_BYTES);
+    state.fetchImage = async () => ({
+      base64: PNG_BYTES.toString("base64"),
+      mimeType: "image/png",
+    });
     const { ctx, calls } = makeCtx();
     await showMedia(ctx, [{ source: { filename: "plate.png", type: "output" } }]);
     expect(dispatchedItems(calls)[0].kind).toBe("image");
     expect(String(dispatchedItems(calls)[0].dataUrl)).toMatch(/^data:image\/png;base64,/);
+    expect(state.fetchImageCalls[0]?.filename).toBe("plate.png");
   });
 
-  it("when the MCP client /view 404s, the ref is still forwarded rather than inventing bytes", async () => {
+  it("when fetchImage 404s, the tool fails closed instead of forwarding a broken viewRef", async () => {
     state.remote = true;
-    state.impl = mediaFetch("video/mp4", Buffer.alloc(0), false, 404);
+    state.fetchImage = async () => {
+      throw new ComfyUIError(
+        'ComfyUI /view returned 404 for "clip.mp4" (output). No such file in the ComfyUI output directory.',
+        "IMAGE_NOT_FOUND",
+      );
+    };
     const { ctx, calls } = makeCtx();
-    await showMedia(ctx);
-    expect(dispatchedItems(calls)[0].kind).toBe("viewRef");
-    expect(dispatchedItems(calls)[0].viewRef).toEqual({
-      filename: "clip.mp4",
-      type: "output",
-    });
+    const res = await showMedia(ctx);
+    expect(res.isError).toBe(true);
+    expect(calls.find((c) => c.cmd === "show_media")).toBeUndefined();
+    const text = textOf(res);
+    expect(text).toContain("clip.mp4");
+    expect(text).toContain("painted:0");
+    expect(text).toContain("get_image");
+    expect(text).toContain("returned 404");
+    expect(text).toMatch(/did not substitute a same-named local workspace file/i);
   });
 
-  it("over-cap remote media stays a viewRef — the 20 MB inline ceiling is not raised", async () => {
+  it("over-cap remote media is refused — the 20 MB inline ceiling is not raised", async () => {
     state.remote = true;
-    const tooBig = Buffer.alloc(20 * 1024 * 1024 + 1, 2);
-    state.impl = mediaFetch("video/mp4", tooBig);
+    state.fetchImage = async (_f, _t, _s, options) => {
+      throw new ComfyUIError(
+        `ComfyUI /view response for "clip.mp4" exceeds the ${(options?.maxBytes ?? 0) / 1024 ** 2} MB safety limit.`,
+        "VIEW_TOO_LARGE",
+      );
+    };
     const { ctx, calls } = makeCtx();
-    await showMedia(ctx);
-    expect(dispatchedItems(calls)[0].kind).toBe("viewRef");
-    expect(dispatchedItems(calls)[0].dataUrl).toBeUndefined();
+    const res = await showMedia(ctx);
+    expect(res.isError).toBe(true);
+    expect(calls.find((c) => c.cmd === "show_media")).toBeUndefined();
+    expect(textOf(res)).toMatch(/20 MB inline cap/i);
   });
 
   it("does not read a same-named local file when proxying a remote ref", async () => {
     state.remote = true;
     const remoteBytes = Buffer.from("remote-mp4-bytes");
-    state.impl = mediaFetch("video/mp4", remoteBytes);
+    state.fetchImage = async () => ({
+      base64: remoteBytes.toString("base64"),
+      mimeType: "video/mp4",
+    });
     const { ctx, calls } = makeCtx();
     await showMedia(ctx);
     const dataUrl = String(dispatchedItems(calls)[0].dataUrl);
     expect(dataUrl).toBe(`data:video/mp4;base64,${remoteBytes.toString("base64")}`);
+    expect(dataUrl).not.toContain(Buffer.from("LOCAL-STALE-MIRROR").toString("base64"));
+  });
+
+  it("passes subfolder and type through to fetchImage the way get_image does", async () => {
+    state.remote = true;
+    state.fetchImage = async () => ({
+      base64: PNG_BYTES.toString("base64"),
+      mimeType: "image/png",
+    });
+    const { ctx, calls } = makeCtx();
+    await showMedia(ctx, [
+      { source: { filename: "plate.png", type: "temp", subfolder: "shots" } },
+    ]);
+    expect(state.fetchImageCalls).toEqual([
+      { filename: "plate.png", type: "temp", subfolder: "shots", options: { maxBytes: 20 * 1024 * 1024 } },
+    ]);
+    expect(dispatchedItems(calls)[0].kind).toBe("image");
+  });
+});
+
+describe("#2861 the call site uses fetchImage, not a local workspace read", () => {
+  it("panel_show_media's remote branch calls fetchImage", () => {
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../orchestrator/panel-tools.ts"),
+      "utf8",
+    );
+    expect(src).toMatch(/fetchImage\(/);
+    expect(src).toMatch(/remoteViewRefInlineFailedNote/);
+    expect(src).toMatch(/isRemoteMode\(\) \|\| isCloudMode\(\)/);
   });
 });

--- a/src/__tests__/orchestrator/panel-show-media-remote-view.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-remote-view.test.ts
@@ -1,0 +1,185 @@
+// #2861 — panel_show_media forwarded a ComfyUI /view ref to a browser panel
+// whose same-origin /view 404'd, while get_image (the configured MCP client)
+// fetched the same filename from the remote target. painted: 0, empty card.
+//
+// A local canvas still gets a viewRef (same-origin /view works). A remote or
+// cloud interactive tab is proxied through the MCP client and inlined under
+// the existing 20 MB cap — the bytes come from /view via comfyuiFetch, never
+// from a same-named file on the orchestrator disk (#877/#899). Headless
+// inlining (#2012) is unchanged. Unroutable stays a viewRef.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const state = vi.hoisted(() => ({
+  remote: false,
+  cloud: false,
+  impl: null as
+    | ((url: string, init?: { method?: string }) => Promise<{
+        ok: boolean;
+        status: number;
+        headers: { get: (name: string) => string | null };
+        arrayBuffer: () => Promise<ArrayBuffer>;
+      }>)
+    | null,
+  urls: [] as string[],
+}));
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    isRemoteMode: () => state.remote,
+    isCloudMode: () => state.cloud,
+    getComfyUIBaseUrl: () => "https://comfy.example:8188",
+  };
+});
+
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (url: string, init?: { method?: string }) => {
+    state.urls.push(url);
+    if (!state.impl) {
+      return Promise.reject(new Error("comfyuiFetch was not stubbed"));
+    }
+    return state.impl(url, init);
+  },
+}));
+
+const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
+
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+afterEach(() => {
+  state.remote = false;
+  state.cloud = false;
+  state.impl = null;
+  state.urls = [];
+});
+
+function mediaFetch(mime: string, bytes: Buffer, ok = true, status = 200): typeof state.impl {
+  return async (_url, init) => {
+    if (init?.method === "HEAD") {
+      return {
+        ok,
+        status,
+        headers: { get: () => mime },
+        arrayBuffer: async () => new ArrayBuffer(0),
+      };
+    }
+    const copy = Uint8Array.from(bytes);
+    return {
+      ok,
+      status,
+      headers: { get: () => mime },
+      arrayBuffer: async () => copy.buffer,
+    };
+  };
+}
+
+type Cmd = Record<string, unknown>;
+
+function makeCtx(opts?: {
+  isHeadless?: (id: string) => boolean;
+}): { ctx: PanelToolCtx; calls: Cmd[] } {
+  const calls: Cmd[] = [];
+  const ctx = {
+    call: async (cmd: Cmd) => {
+      calls.push(cmd);
+      return { content: [{ type: "text", text: JSON.stringify(cmd) }] } as ToolResult;
+    },
+    confirm: async () => "yes" as const,
+    tabId: "wf:workflows/a.json",
+    bridge: {
+      isHeadless: opts?.isHeadless ?? (() => false),
+    } as unknown as PanelToolCtx["bridge"],
+  } as PanelToolCtx;
+  return { ctx, calls };
+}
+
+async function showMedia(
+  ctx: PanelToolCtx,
+  items: Array<Record<string, unknown>> = [
+    { source: { filename: "clip.mp4", type: "output" } },
+  ],
+): Promise<ToolResult> {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
+  if (!def) throw new Error("panel_show_media not found");
+  return (await def.handler({ items }, ctx)) as ToolResult;
+}
+
+function dispatchedItems(calls: Cmd[]): Array<Record<string, unknown>> {
+  const sent = calls.find((c) => c.cmd === "show_media");
+  if (!sent) throw new Error("show_media was not dispatched");
+  return sent.items as Array<Record<string, unknown>>;
+}
+
+describe("#2861 remote interactive panel_show_media inlines via the MCP client", () => {
+  it("a remote canvas tab gets inlined bytes, not a /view ref the browser 404s", async () => {
+    state.remote = true;
+    const mp4 = Buffer.alloc(64, 1);
+    state.impl = mediaFetch("video/mp4", mp4);
+    const { ctx, calls } = makeCtx();
+    await showMedia(ctx);
+    const items = dispatchedItems(calls);
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe("video");
+    expect(String(items[0].dataUrl)).toMatch(/^data:video\/mp4;base64,/);
+    expect(items[0].viewRef).toBeUndefined();
+    expect(state.urls.some((u) => u.includes("/view?") && u.includes("filename=clip.mp4"))).toBe(true);
+    expect(state.urls.every((u) => !u.includes("C:") && !u.includes("/output/"))).toBe(true);
+  });
+
+  it("a local canvas tab still gets a viewRef — same-origin /view works", async () => {
+    state.remote = false;
+    state.impl = mediaFetch("video/mp4", Buffer.alloc(64, 1));
+    const { ctx, calls } = makeCtx();
+    await showMedia(ctx);
+    expect(dispatchedItems(calls)[0].kind).toBe("viewRef");
+    expect(dispatchedItems(calls)[0].dataUrl).toBeUndefined();
+  });
+
+  it("a cloud canvas tab is inlined the same way", async () => {
+    state.cloud = true;
+    state.impl = mediaFetch("image/png", PNG_BYTES);
+    const { ctx, calls } = makeCtx();
+    await showMedia(ctx, [{ source: { filename: "plate.png", type: "output" } }]);
+    expect(dispatchedItems(calls)[0].kind).toBe("image");
+    expect(String(dispatchedItems(calls)[0].dataUrl)).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("when the MCP client /view 404s, the ref is still forwarded rather than inventing bytes", async () => {
+    state.remote = true;
+    state.impl = mediaFetch("video/mp4", Buffer.alloc(0), false, 404);
+    const { ctx, calls } = makeCtx();
+    await showMedia(ctx);
+    expect(dispatchedItems(calls)[0].kind).toBe("viewRef");
+    expect(dispatchedItems(calls)[0].viewRef).toEqual({
+      filename: "clip.mp4",
+      type: "output",
+    });
+  });
+
+  it("over-cap remote media stays a viewRef — the 20 MB inline ceiling is not raised", async () => {
+    state.remote = true;
+    const tooBig = Buffer.alloc(20 * 1024 * 1024 + 1, 2);
+    state.impl = mediaFetch("video/mp4", tooBig);
+    const { ctx, calls } = makeCtx();
+    await showMedia(ctx);
+    expect(dispatchedItems(calls)[0].kind).toBe("viewRef");
+    expect(dispatchedItems(calls)[0].dataUrl).toBeUndefined();
+  });
+
+  it("does not read a same-named local file when proxying a remote ref", async () => {
+    state.remote = true;
+    const remoteBytes = Buffer.from("remote-mp4-bytes");
+    state.impl = mediaFetch("video/mp4", remoteBytes);
+    const { ctx, calls } = makeCtx();
+    await showMedia(ctx);
+    const dataUrl = String(dispatchedItems(calls)[0].dataUrl);
+    expect(dataUrl).toBe(`data:video/mp4;base64,${remoteBytes.toString("base64")}`);
+  });
+});

--- a/src/__tests__/services/comfy-view-ref.test.ts
+++ b/src/__tests__/services/comfy-view-ref.test.ts
@@ -76,8 +76,11 @@ const {
   oversizedInlineRefusal,
   forwardedByReferenceNote,
   unverifiedViewRefNote,
+  mediaKindFromMime,
+  remoteViewRefInlineFailedNote,
   stageFileIntoServedDir,
   stagedForDisplayNote,
+  viewRefTypeForFetch,
 } = await import("../../services/comfy-view-ref.js");
 
 let root: string;
@@ -520,6 +523,36 @@ describe("unverifiedViewRefNote (#941)", () => {
     const note = unverifiedViewRefNote(many);
     expect(note).toMatch(/…and 4 more/);
     expect(note).not.toContain("f11.png");
+  });
+});
+
+describe("#2861 remote inline helpers", () => {
+  it("mediaKindFromMime maps families and strips parameters", () => {
+    expect(mediaKindFromMime("image/png")).toBe("image");
+    expect(mediaKindFromMime("video/mp4; codecs=avc1")).toBe("video");
+    expect(mediaKindFromMime("audio/wav")).toBe("audio");
+    expect(mediaKindFromMime("text/html")).toBeNull();
+  });
+
+  it("viewRefTypeForFetch only keeps ComfyUI's three /view types", () => {
+    expect(viewRefTypeForFetch(undefined)).toBe("output");
+    expect(viewRefTypeForFetch("input")).toBe("input");
+    expect(viewRefTypeForFetch("temp")).toBe("temp");
+    expect(viewRefTypeForFetch("output")).toBe("output");
+    expect(viewRefTypeForFetch("other")).toBe("output");
+  });
+
+  it("remoteViewRefInlineFailedNote refuses a viewRef and a local mirror", () => {
+    const note = remoteViewRefInlineFailedNote({
+      filename: "clip.mp4",
+      detail: "ComfyUI /view returned 404.",
+      capBytes: 20 * 1024 * 1024,
+    });
+    expect(note).toContain("clip.mp4");
+    expect(note).toContain("painted:0");
+    expect(note).toMatch(/did not substitute a same-named local workspace file/i);
+    expect(note).toContain("get_image");
+    expect(note).toContain("20 MB inline cap");
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -28959,21 +28959,30 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             const filename = p.replace(/.*[\/]/, "");
             resolved.push({ kind, dataUrl, filename, caption: item.caption });
           } else {
-            // ComfyUI /view ref. A browser panel fetches it same-origin — but a
-            // HEADLESS (mobile/remote) client can't reach ComfyUI, so resolve the
-            // bytes HERE and inline them as a data URL. Best-effort: any failure
-            // (fetch error, non-media, too big) falls back to forwarding the ref,
-            // which the client renders as a caption card.
+            // ComfyUI /view ref. A local browser panel fetches it same-origin —
+            // but a HEADLESS client cannot, and a REMOTE/CLOUD browser panel's
+            // /view is a different route from the MCP client's authenticated
+            // fetch (the panel 404s while get_image succeeds — #2861). Resolve
+            // the bytes HERE via the configured client and inline them as a
+            // data URL. Best-effort: any failure (fetch error, non-media, too
+            // big) falls back to forwarding the ref.
             //
             // #2012 — judge the DESTINATION, not the address. `ctx.tabId` may be
             // a scope / prefix / alias; `isHeadless` on the address is a lookup
             // miss that answers false and a phone gets a /view URL it cannot
-            // fetch. Positive requirement: inline only a proven headless
-            // destination.
+            // fetch. Positive requirement: inline a proven headless destination,
+            // or a proven interactive destination whose ComfyUI is not local.
+            //
+            // #877/#899 — this fetch is the MCP client's /view of the configured
+            // target, never a same-named file on the orchestrator disk.
             let inlined = false;
-            if (resolveClientKind(ctx).kind === "headless") {
+            const dest = resolveClientKind(ctx);
+            const proxyViaMcpClient =
+              dest.kind === "headless" ||
+              (dest.kind === "interactive" && (isRemoteMode() || isCloudMode()));
+            if (proxyViaMcpClient) {
               try {
-                const base = (process.env.COMFYUI_URL ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+                const base = getComfyUIBaseUrl().replace(/\/+$/, "");
                 const qs = new URLSearchParams({ filename: src.filename, type: src.type ?? "output" });
                 if (src.subfolder) qs.set("subfolder", src.subfolder);
                 const resp = await comfyuiFetch(`${base}/view?${qs.toString()}`);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -36,13 +36,16 @@ import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSyn
 import type { Stats } from "node:fs";
 import {
   forwardedByReferenceNote,
+  mediaKindFromMime,
   oversizedInlineRefusal,
+  remoteViewRefInlineFailedNote,
   resolveServableViewRef,
   stageFileIntoServedDir,
   stagedForDisplayNote,
   readShowMediaAck,
   unaccountedShowMediaNote,
   unverifiedViewRefNote,
+  viewRefTypeForFetch,
   type DispatchedMediaItem,
   type ForwardedByReference,
   type StagedForDisplay,
@@ -464,6 +467,7 @@ import {
   type AskRecovery,
 } from "./ask-answer-journal.js";
 import {
+  fetchImage,
   getClient,
   getLogs,
   getQueueVerified,
@@ -28961,11 +28965,8 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
           } else {
             // ComfyUI /view ref. A local browser panel fetches it same-origin —
             // but a HEADLESS client cannot, and a REMOTE/CLOUD browser panel's
-            // /view is a different route from the MCP client's authenticated
-            // fetch (the panel 404s while get_image succeeds — #2861). Resolve
-            // the bytes HERE via the configured client and inline them as a
-            // data URL. Best-effort: any failure (fetch error, non-media, too
-            // big) falls back to forwarding the ref.
+            // /view is a different route from get_image's authenticated client
+            // (the panel 404s while get_image succeeds — #2861).
             //
             // #2012 — judge the DESTINATION, not the address. `ctx.tabId` may be
             // a scope / prefix / alias; `isHeadless` on the address is a lookup
@@ -28973,14 +28974,14 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
             // fetch. Positive requirement: inline a proven headless destination,
             // or a proven interactive destination whose ComfyUI is not local.
             //
-            // #877/#899 — this fetch is the MCP client's /view of the configured
-            // target, never a same-named file on the orchestrator disk.
+            // #877/#899 — remote bytes come from fetchImage (the get_image
+            // path), never a same-named file on the orchestrator disk. A remote
+            // interactive tab that cannot be inlined is refused rather than
+            // handed a viewRef the panel will drop (painted:0).
             let inlined = false;
             const dest = resolveClientKind(ctx);
-            const proxyViaMcpClient =
-              dest.kind === "headless" ||
-              (dest.kind === "interactive" && (isRemoteMode() || isCloudMode()));
-            if (proxyViaMcpClient) {
+            const remoteTarget = isRemoteMode() || isCloudMode();
+            if (dest.kind === "headless") {
               try {
                 const base = getComfyUIBaseUrl().replace(/\/+$/, "");
                 const qs = new URLSearchParams({ filename: src.filename, type: src.type ?? "output" });
@@ -28989,9 +28990,10 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 if (resp.ok) {
                   const mime = resp.headers.get("content-type") ?? "";
                   const buf = Buffer.from(await resp.arrayBuffer());
-                  if ((mime.startsWith("image/") || mime.startsWith("video/")) && buf.length <= MAX_BYTES) {
+                  const kindFromMime = mediaKindFromMime(mime);
+                  if (kindFromMime && kindFromMime !== "audio" && buf.length <= MAX_BYTES) {
                     resolved.push({
-                      kind: mime.startsWith("video/") ? "video" : "image",
+                      kind: kindFromMime,
                       dataUrl: `data:${mime};base64,${buf.toString("base64")}`,
                       filename: src.filename,
                       caption: item.caption,
@@ -29001,6 +29003,47 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
                 }
               } catch {
                 // fall through to the viewRef path
+              }
+            } else if (remoteTarget && dest.kind === "interactive") {
+              try {
+                const fetched = await fetchImage(
+                  src.filename,
+                  viewRefTypeForFetch(src.type),
+                  src.subfolder ?? "",
+                  { maxBytes: MAX_BYTES },
+                );
+                const mime = fetched.mimeType.split(";")[0]!.trim();
+                const buf = Buffer.from(fetched.base64, "base64");
+                const kindFromMime = mediaKindFromMime(mime);
+                if (kindFromMime && buf.length <= MAX_BYTES) {
+                  resolved.push({
+                    kind: kindFromMime,
+                    dataUrl: `data:${mime};base64,${fetched.base64}`,
+                    filename: src.filename,
+                    caption: item.caption,
+                  });
+                  inlined = true;
+                } else {
+                  const detail = !kindFromMime
+                    ? `The MCP client fetched it, but the body was not media (content-type "${mime || "unset"}").`
+                    : `The MCP client fetched it, but it is ${buf.length} bytes — over the ${MAX_BYTES} byte inline cap.`;
+                  return fail(
+                    remoteViewRefInlineFailedNote({
+                      filename: src.filename,
+                      detail,
+                      capBytes: MAX_BYTES,
+                    }),
+                  );
+                }
+              } catch (err) {
+                const detail = err instanceof Error ? err.message : String(err);
+                return fail(
+                  remoteViewRefInlineFailedNote({
+                    filename: src.filename,
+                    detail,
+                    capBytes: MAX_BYTES,
+                  }),
+                );
               }
             }
             if (!inlined) {

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -763,6 +763,47 @@ export type ViewRefProbe = {
   nonMedia: { filename: string; detail: string }[];
 };
 
+/** Map a /view Content-Type onto the panel painter kind, or null if not media. */
+export function mediaKindFromMime(mimeType: string): "image" | "video" | "audio" | null {
+  const mime = mimeType.split(";")[0]!.trim().toLowerCase();
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  if (mime.startsWith("audio/")) return "audio";
+  return null;
+}
+
+/** Narrow a caller-supplied ComfyUI type to what fetchImage accepts. */
+export function viewRefTypeForFetch(type: string | undefined): "output" | "input" | "temp" {
+  return type === "input" || type === "temp" ? type : "output";
+}
+
+/**
+ * #2861 — fail-closed copy when a REMOTE /view ref cannot be inlined.
+ *
+ * A browser panel probes `/view` in ITS session. That is not get_image's
+ * authenticated/configured route, and forwarding the ref paints 0 cards.
+ * The handler fetches through fetchImage instead. If that fetch cannot be
+ * painted (transport, non-media, over the inline cap), this is the reply —
+ * never a broken viewRef, and never a same-named local workspace file
+ * (#877/#899).
+ */
+export function remoteViewRefInlineFailedNote(args: {
+  filename: string;
+  detail: string;
+  capBytes: number;
+}): string {
+  const capMb = Math.round(args.capBytes / (1024 * 1024));
+  return (
+    `panel_show_media cannot paint "${args.filename}" as a ComfyUI /view reference ` +
+    `on this REMOTE target: the panel's browser-facing /view is not the same route ` +
+    `get_image uses, and forwarding the ref would return painted:0 (HTTP 404). ` +
+    `${args.detail} ` +
+    `I did not substitute a same-named local workspace file (that is a different machine). ` +
+    `If get_image(action:"get") already saved the bytes locally and they are under the ` +
+    `${capMb} MB inline cap, call panel_show_media with that absolute path.`
+  );
+}
+
 /**
  * The caveat a forwarded /view reference has to carry (#941).
  *


### PR DESCRIPTION
## Why

On a remote ComfyUI target, panel_show_media forwarded a /view reference the browser cannot fetch (HTTP 404, painted: 0) while get_image(action:get) on the same filename succeeded through the configured MCP client.

## What

For a proven interactive destination whose ComfyUI is remote or cloud, proxy the bytes through fetchImage (the same client get_image uses) and inline under the existing 20 MB cap. Headless inlining (#2012) is unchanged. A local canvas tab still gets a viewRef (same-origin /view works). If the MCP client cannot paint the item (404, non-media, over cap), the tool fails closed instead of forwarding a viewRef the panel will drop.

Does not inline a same-named file from the orchestrator disk (#877/#899).

## Tests

src/__tests__/orchestrator/panel-show-media-remote-view.test.ts — remote/cloud inline via fetchImage, local viewRef, MCP 404 fail-closed, over-cap refuse, subfolder/type forwarded, bytes come from the client not disk.

src/__tests__/services/comfy-view-ref.test.ts — #2861 remote inline helpers.

Parent merges after CI CLEAN. Do not steal a sibling release PR.

Fixes #2861