### PR TITLE
fix(2865): expose overwrite on panel_save_subgraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+
+- panel_save_subgraph accepts overwrite:true so a user-blueprint name collision can replace in place instead of being rejected as an unrecognized key (#2865)
+
 ## [0.52.193] - 2026-09-04
 
 ### MCP

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -140,6 +140,24 @@ describe("panel-tools: copy/paste + subgraph blueprints", () => {
     });
   });
 
+  it("panel_save_subgraph accepts overwrite:true and forwards it (#2865)", async () => {
+    const def = defByName("panel_save_subgraph");
+    const parsed = z.object(def.schema).strict().safeParse({
+      node_id: 7,
+      name: "MyBlock",
+      overwrite: true,
+    });
+    expect(parsed.success).toBe(true);
+    const { ctx, calls } = makeFakeCtx();
+    await def.handler({ node_id: 7, name: "MyBlock", overwrite: true }, ctx);
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_save_subgraph",
+      node_id: 7,
+      name: "MyBlock",
+      overwrite: true,
+    });
+  });
+
   it("panel_list_subgraphs forwards graph_list_subgraphs", async () => {
     const { ctx, calls } = makeFakeCtx();
     await defByName("panel_list_subgraphs").handler({}, ctx);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -26280,13 +26280,22 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_save_subgraph",
-      "Save a SUBGRAPH node to the user's reusable blueprint LIBRARY (publish), so it can be dropped into any workflow later. Pass node_id to pick the subgraph node (else a single selected subgraph node is used) and name to title the blueprint (defaults to the node's title). Runs programmatically — NO save dialog pops. The blueprint becomes the addable type 'SubgraphBlueprint.<name>' (use panel_add_subgraph or panel_list_subgraphs). Returns {saved: {name, type}}.",
+      "Save a SUBGRAPH node to the user's reusable blueprint LIBRARY (publish), so it can be dropped into any workflow later. Pass node_id to pick the subgraph node (else a single selected subgraph node is used) and name to title the blueprint (defaults to the node's title). On a name collision with an existing USER blueprint, pass overwrite:true to replace it in place (the panel already implements this; without the flag the call is refused and names overwrite:true as the remedy). Bundled/global blueprints cannot be overwritten. Runs programmatically — NO save dialog pops. The blueprint becomes the addable type 'SubgraphBlueprint.<name>' (use panel_add_subgraph or panel_list_subgraphs). Returns {saved: {name, type}}.",
       {
         node_id: nodeId().optional().describe("Subgraph node id to publish (is_subgraph=true). Omit to use the selected subgraph node."),
         name: z.string().optional().describe("Blueprint name. Defaults to the subgraph node's title."),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe(
+            "Replace an existing USER blueprint of the same name in place. Required on a name collision; omitted/false refuses. Bundled/global blueprints stay refused.",
+          ),
       },
       async (args: A, ctx) =>
-        ctx.call({ cmd: "graph_save_subgraph", node_id: args.node_id, name: args.name }, 20000),
+        ctx.call(
+          { cmd: "graph_save_subgraph", node_id: args.node_id, name: args.name, overwrite: args.overwrite },
+          20000,
+        ),
     ),
     def(
       "panel_list_subgraphs",


### PR DESCRIPTION
## Why

`panel_save_subgraph` collision text tells the caller to pass `overwrite:true`, but the MCP zod schema only declared `node_id` and `name`. The panel already implements overwrite (#1122).

## What

Add optional `overwrite` to the tool schema and forward it on `graph_save_subgraph`. Bundled/global overwrite remains a panel-side refusal.

## Tests

`panel_save_subgraph accepts overwrite:true and forwards it (#2865)`

Fixes #2865