### PR TITLE
fix(2836): use proven panel origin+api_base for history/health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **`get_history` / `get_system_stats` read the unique proven connected-panel origin+api_base after the headless target is unreachable, instead of only dispatching `fetch_comfyui_read` (#2836).** On 0.52.193 the named `PANEL_API_BASE_UNAVAILABLE` path still left history/health unavailable while `panel_run` worked: the live tab origin was never contacted, and the panel API object's undefined `api_base` crashed the relay. Mixed or unproven origins stay fail-closed (`PANEL_ORIGIN_UNPROVEN`); a guessed origin is never dialed. Same-origin dead loopback still uses one panel relay; an undefined panel `api_base` remains `PANEL_API_BASE_UNAVAILABLE`.
+
+
 ## [0.52.194] - 2026-09-04
 
 ### MCP

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -301,6 +301,22 @@ describe("connected-panel read fallback origin/API base (#2836)", () => {
     });
   });
 
+  it("does not pick the first origin when two proven origins differ", () => {
+    expect(
+      resolvePanelReadOrigin(["http://127.0.0.1:8188", "http://127.0.0.1:8189"], ""),
+    ).toEqual({ kind: "unproven" });
+  });
+
+  it("treats loopback aliases as one proven origin", () => {
+    expect(
+      resolvePanelReadOrigin(["http://127.0.0.1:8188", "http://localhost:8188"], "/comfyapi"),
+    ).toEqual({
+      kind: "proven",
+      origin: "http://127.0.0.1:8188",
+      apiBase: "/comfyapi",
+    });
+  });
+
   function apiBaseCrash(): PanelComfyUIReadRelayError {
     return new PanelComfyUIReadRelayError(
       "The connected panel could not read ComfyUI.",
@@ -367,6 +383,69 @@ describe("connected-panel read fallback origin/API base (#2836)", () => {
       expect(message).toContain("transport diagnostic");
       expect(message).not.toContain("The panel reported:");
       expect(panelRead).toHaveBeenCalledWith(name === "getHistory" ? "history" : "system_stats");
+    },
+  );
+
+  // Recurrence on 0.52.193: the live tab origin is not 8188, panel_run works,
+  // but history/health still dispatched fetch_comfyui_read and died on
+  // undefined api_base. The unique proven origin+api_base must be read
+  // instead — this fails if that hop is skipped and only the relay runs.
+  it.each(["getHistory", "getSystemStats"] as const)(
+    "%s uses the unique proven panel origin+api_base when the relay has no api_base",
+    async (name) => {
+      fetchApi.mockRejectedValue(transportFailure());
+      setConnectedPanelOrigins(() => ["http://127.0.0.1:8189"]);
+      panelRead.mockRejectedValue(apiBaseCrash());
+      const historyBody = '{"prompt-1":{"status":{"status_str":"success"}}}';
+      const statsBody = '{"system":{"os":"windows"},"devices":[]}';
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.startsWith("http://127.0.0.1:8189/comfyapi/")) {
+          expect(new Headers(init?.headers).get("authorization")).toBeNull();
+          const body = name === "getHistory" ? historyBody : statsBody;
+          return new Response(body, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        throw transportFailure();
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      if (name === "getHistory") {
+        await expect(getHistory()).resolves.toEqual({
+          "prompt-1": { status: { status_str: "success" } },
+        });
+        expect(fetchMock.mock.calls.some(([input]) => String(input) === "http://127.0.0.1:8189/comfyapi/history")).toBe(true);
+      } else {
+        await expect(getSystemStats()).resolves.toMatchObject({
+          system: { os: "windows" },
+          devices: [],
+        });
+        expect(fetchMock.mock.calls.some(([input]) => String(input) === "http://127.0.0.1:8189/comfyapi/system_stats")).toBe(true);
+      }
+      expect(panelRead).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["getHistory", "getSystemStats"] as const)(
+    "%s does not guess when two proven panel origins differ",
+    async (name) => {
+      fetchApi.mockRejectedValue(transportFailure());
+      setConnectedPanelOrigins(() => ["http://127.0.0.1:8188", "http://127.0.0.1:8189"]);
+      const fetchMock = vi.fn(async () => {
+        throw transportFailure();
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const err = await (name === "getHistory" ? getHistory() : getSystemStats()).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect(err).toBeInstanceOf(ComfyUIError);
+      expect(err).toMatchObject({ code: "PANEL_ORIGIN_UNPROVEN" });
+      expect(panelRead).not.toHaveBeenCalled();
+      expect(fetchMock.mock.calls.some(([input]) => String(input).includes("8189"))).toBe(false);
     },
   );
 });

--- a/src/__tests__/services/panel-fallback-target.test.ts
+++ b/src/__tests__/services/panel-fallback-target.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { provenPanelOriginMatchesConfiguredTarget } from "../../services/panel-fallback-target.js";
+import {
+  provenPanelOriginMatchesConfiguredTarget,
+  resolvePanelReadOrigin,
+} from "../../services/panel-fallback-target.js";
 
 describe("provenPanelOriginMatchesConfiguredTarget (#2839)", () => {
   it("requires a unique published origin that matches the configured target", () => {
@@ -34,5 +37,26 @@ describe("provenPanelOriginMatchesConfiguredTarget (#2839)", () => {
         "http://127.0.0.1:8188",
       ),
     ).toBe(false);
+  });
+});
+
+describe("resolvePanelReadOrigin (#2836)", () => {
+  it("stays unproven for mixed origins or a missing api_base", () => {
+    expect(resolvePanelReadOrigin(["http://127.0.0.1:8188"], undefined)).toEqual({
+      kind: "unproven",
+    });
+    expect(
+      resolvePanelReadOrigin(["http://127.0.0.1:8188", "http://127.0.0.1:8189"], ""),
+    ).toEqual({ kind: "unproven" });
+  });
+
+  it("collapses loopback aliases to one proven origin", () => {
+    expect(
+      resolvePanelReadOrigin(["http://127.0.0.1:8188", "http://localhost:8188"], "/comfyapi"),
+    ).toEqual({
+      kind: "proven",
+      origin: "http://127.0.0.1:8188",
+      apiBase: "/comfyapi",
+    });
   });
 });

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -284,22 +284,76 @@ function panelReadResponse(read: PanelComfyUIReadSuccess): Response {
   return new Response(read.body, { status: 200, headers });
 }
 
-/** Ask the authenticated panel only after the configured headless route failed
- * at the transport layer. Resolve the connected panel origin and API base
- * first (#2836): an unproven origin is never a guessed fetch_comfyui_read
- * target, and an undefined api_base is a named transport diagnostic. */
+const PANEL_READ_PATHS = {
+  history: "/history",
+  system_stats: "/system_stats",
+  logs: "/internal/logs",
+  object_info: "/object_info",
+} as const;
+
+/**
+ * One HTTP GET against a unique proven loopback panel origin (#2836 recurrence).
+ * Configured auth stays on the headless target. A guessed origin is never
+ * contacted — the caller already required choosePanelFallbackOrigin kind "use".
+ */
+async function fetchProvenPanelRead(
+  origin: string,
+  apiBase: string,
+  operation: keyof typeof PANEL_READ_PATHS,
+): Promise<PanelComfyUIReadSuccess | undefined> {
+  const url = `${origin}${apiBase.replace(/\/+$/, "")}${PANEL_READ_PATHS[operation]}`;
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      redirect: "error",
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) return undefined;
+    const body = await res.text();
+    const bytes = Buffer.byteLength(body, "utf8");
+    const max =
+      operation === "object_info"
+        ? PANEL_COMFYUI_READ_OBJECT_INFO_MAX_BYTES
+        : PANEL_COMFYUI_READ_MAX_BYTES;
+    if (bytes > max) return undefined;
+    return {
+      operation,
+      body,
+      contentType: res.headers.get("content-type"),
+      bytes,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Ask the connected panel after the configured headless route failed at the
+ * transport layer. Resolve origin+api_base first (#2836): an unproven origin
+ * is never contacted. A unique proven loopback origin that differs from the
+ * dead target is fetched here (the panel's own api_base object can be
+ * undefined, so fetch_comfyui_read is not the first hop). Same-origin or
+ * unknown still uses one panel relay; an undefined panel api_base is a named
+ * transport diagnostic. */
 async function panelReadFallback(
   operation: "history" | "system_stats" | "logs" | "object_info",
   primaryError: unknown,
 ): Promise<PanelComfyUIReadSuccess | undefined> {
   const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
-  const resolved = resolvePanelReadOrigin(connectedPanelOriginsNow(), getComfyUIBasePath());
+  const origins = connectedPanelOriginsNow();
+  const resolved = resolvePanelReadOrigin(origins, getComfyUIBasePath());
   if (resolved.kind === "unproven") {
     throw new ComfyUIError(
       `${primary} The connected panel ComfyUI read fallback was not attempted (PANEL_ORIGIN_UNPROVEN). ` +
         `The panel origin is unproven, so fetch_comfyui_read was not dispatched. A guessed origin is never contacted.`,
       "PANEL_ORIGIN_UNPROVEN",
     );
+  }
+  if (resolved.kind === "proven") {
+    const choice = choosePanelFallbackOrigin(getComfyUIBaseUrl(), origins);
+    if (choice.kind === "use") {
+      const fromOrigin = await fetchProvenPanelRead(choice.origin, resolved.apiBase, operation);
+      if (fromOrigin) return fromOrigin;
+    }
   }
   try {
     return await requestPanelComfyUIRead(operation);

--- a/src/services/panel-fallback-target.ts
+++ b/src/services/panel-fallback-target.ts
@@ -127,20 +127,28 @@ export type PanelReadOriginResolution =
 const UNDEFINED_API_BASE_RE =
   /Cannot read propert(?:y|ies) of undefined \(reading ['"]?api_base['"]?\)|Cannot read property ['"]?api_base['"]? of undefined/i;
 
-/** Resolve the connected panel origin and API base before a fallback read. */
+/**
+ * Resolve the connected panel origin and API base before a fallback read.
+ * Mixed, malformed, or missing-prefix sets stay unproven so a guessed
+ * origin is never contacted. Loopback aliases of one host collapse to one.
+ */
 export function resolvePanelReadOrigin(
   origins: readonly string[],
   apiBase: string | undefined,
 ): PanelReadOriginResolution {
   if (origins.length === 0) return { kind: "unknown" };
+  if (typeof apiBase !== "string") return { kind: "unproven" };
   const proven: string[] = [];
+  const canons = new Set<string>();
   for (const raw of origins) {
     const origin = normalizePanelOrigin(raw);
     if (origin === undefined) return { kind: "unproven" };
+    const canon = canonicalOrigin(origin);
+    if (canon === undefined) return { kind: "unproven" };
+    canons.add(canon);
     proven.push(origin);
   }
-  if (proven.length === 0) return { kind: "unproven" };
-  if (typeof apiBase !== "string") return { kind: "unproven" };
+  if (proven.length === 0 || canons.size !== 1) return { kind: "unproven" };
   return { kind: "proven", origin: proven[0], apiBase };
 }
 


### PR DESCRIPTION
Fixes #2836

## Problem

Swarm 40 / PR #2837 named the post-dispatch `undefined.api_base` TypeError as `PANEL_API_BASE_UNAVAILABLE`, but history/health still failed on 0.52.193 / panel 0.15.173. A connected local panel could `panel_run` and graph-edit while `get_history` / `get_system_stats` hit ECONNREFUSED on dead `http://127.0.0.1:8188` and then dispatched `fetch_comfyui_read`, which crashes when the panel ComfyUI API object is undefined.

#2837 also picked `proven[0]` from a mixed origin set and never used the proven origin for the read.

## Fix

After the headless transport failure:

- Resolve the connected panel origin+api_base. Mixed, malformed, or missing-prefix sets stay fail-closed (`PANEL_ORIGIN_UNPROVEN`); a guessed origin is never contacted.
- When there is a unique proven loopback origin that **differs** from the dead target, GET `{origin}{api_base}/history` (or `/system_stats`) from this process. Configured auth stays on the headless target.
- Same-origin or unknown still uses one `fetch_comfyui_read` relay. An undefined panel `api_base` remains `PANEL_API_BASE_UNAVAILABLE`.

## Tests

`src/__tests__/comfyui/panel-read-fallback.test.ts` — history/health succeed against the unique proven origin while the relay is mocked to throw the `api_base` crash (fails if reverted to relay-only). Mixed origins stay unproven with no dial.
