### PR TITLE
fix(2864): bound connected-panel image relay to one hop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+
+- **`get_image(action:"get")` connected-panel image relay is one hop: one `fetch_image` after the headless `/view` is unreachable, then one bounded error (#2864).** An unreachable headless `127.0.0.1:8188` used to wrap `PANEL_FETCH_FAILED` / `MALFORMED_REPLY` until `Maximum call stack size exceeded` while the live panel stayed connected. Nested fallback into `fetchImage` is refused. Published diagnostic origins are still not dialed as `/view` targets.
+
+
 ## [0.52.195] - 2026-09-04
 
 ### MCP

--- a/src/__tests__/comfyui/panel-read-fallback.test.ts
+++ b/src/__tests__/comfyui/panel-read-fallback.test.ts
@@ -449,3 +449,79 @@ describe("connected-panel read fallback origin/API base (#2836)", () => {
     },
   );
 });
+
+describe("connected-panel image relay one hop (#2864)", () => {
+  const JPEG = {
+    base64: "AQID",
+    mimeType: "image/jpeg",
+    bytes: 3,
+  };
+
+  it("does not dial a published diagnostic origin as a /view target (#2149)", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8189"]);
+    panelImage.mockResolvedValue(JPEG);
+    const fetchMock = vi.fn(async () => {
+      throw transportFailure();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchImage("render.png", "output", "shots")).resolves.toEqual({
+      base64: JPEG.base64,
+      mimeType: JPEG.mimeType,
+    });
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes("8189"))).toBe(false);
+    expect(panelImage).toHaveBeenCalledTimes(1);
+    expect(panelImage).toHaveBeenCalledWith("render.png", "output", "shots");
+  });
+
+  it("relays through the panel once when the live tab is the dead loopback", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    panelImage.mockResolvedValue(JPEG);
+
+    await expect(fetchImage("render.png", "output", "shots")).resolves.toEqual({
+      base64: JPEG.base64,
+      mimeType: JPEG.mimeType,
+    });
+    expect(panelImage).toHaveBeenCalledTimes(1);
+    expect(panelImage).toHaveBeenCalledWith("render.png", "output", "shots");
+  });
+
+  it("returns one structured error when the one-hop relay fails", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    panelImage.mockRejectedValue(
+      new PanelImageRelayError(
+        "The connected panel could not fetch that image.",
+        "PANEL_FETCH_FAILED",
+        false,
+        "Maximum call stack size exceeded",
+      ),
+    );
+
+    const failure = await fetchImage("render.png").then(
+      () => undefined,
+      (error: unknown) => error as Error,
+    );
+    expect(failure?.message).toContain("image relay failed safely (PANEL_FETCH_FAILED)");
+    expect(failure?.message).toContain("The panel reported: Maximum call stack size exceeded");
+    expect(failure?.message).not.toMatch(/image relay failed safely \(PANEL_FETCH_FAILED\).+image relay failed safely/);
+    expect(panelImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not recurse when the image relay loops back into fetchImage", async () => {
+    fetchApi.mockRejectedValue(transportFailure());
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    panelImage.mockImplementation(async () => fetchImage("render.png"));
+
+    const failure = await fetchImage("render.png").then(
+      () => undefined,
+      (error: unknown) => error as Error,
+    );
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure?.name).not.toBe("RangeError");
+    expect(String(failure?.message ?? failure)).not.toMatch(/Maximum call stack size exceeded/);
+    expect(panelImage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { Client } from "@stable-canvas/comfyui-client";
 import { LoopbackWebSocket } from "../transport/loopback-websocket.js";
 import {
@@ -387,6 +388,50 @@ async function panelReadFallback(
       { cause: error },
     );
   }
+}
+
+/** Nested fetchImage from a looping image relay must not wrap/retry again (#2864). */
+const panelImageRelayHop = new AsyncLocalStorage<true>();
+
+/**
+ * One authenticated `fetch_image` relay after the configured /view route failed
+ * at the transport layer (#2864). Diagnostic/published origins are not dialed
+ * here (#2149): they are not authorization to contact a /view target. Nested
+ * re-entry is refused by `panelImageRelayHop` in `fetchImage`.
+ */
+async function panelImageFallback(
+  filename: string,
+  type: "output" | "input" | "temp",
+  subfolder: string,
+  primaryError: unknown,
+  declined: string,
+): Promise<{ base64: string; mimeType: string } | undefined> {
+  const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+  try {
+    const relayed = await requestPanelImage(filename, type, subfolder);
+    if (relayed) return { base64: relayed.base64, mimeType: relayed.mimeType };
+  } catch (error) {
+    if (error instanceof PanelImageRelayError && error.unavailable) {
+      // The relay itself was unreachable; keep the original transport failure.
+    } else if (isUndefinedApiBaseFailure(error)) {
+      throw new ComfyUIError(
+        `${primary} The connected panel image relay failed safely (PANEL_API_BASE_UNAVAILABLE). ` +
+          `fetch_image could not read api_base because the panel's ComfyUI API object was undefined. ` +
+          `This is a transport diagnostic: the headless target was unreachable, and the panel image relay was not given a usable API base.`,
+        "PANEL_API_BASE_UNAVAILABLE",
+      );
+    } else if (error instanceof PanelImageRelayError) {
+      throw new Error(
+        `${primary} The connected panel image relay failed safely (${error.code}).` +
+          (error.reason ? ` The panel reported: ${error.reason}` : ""),
+        { cause: error },
+      );
+    }
+  }
+  if (declined) {
+    throw new Error(`${primary}${declined}`, { cause: primaryError });
+  }
+  return undefined;
 }
 
 /** Budget for the /system_stats probe. Short on purpose: this is a liveness
@@ -1746,6 +1791,9 @@ export async function fetchImage(
     validateViewResponseOrigin(res, configuredOrigin, "the configured ComfyUI target");
   } catch (primaryError) {
     if (!isComfyTransportFailure(primaryError)) throw primaryError;
+    // A looping fetch_image / get_image fallback must not wrap this failure
+    // again. One hop: one panel relay, then stop (#2864).
+    if (panelImageRelayHop.getStore()) throw primaryError;
 
     const choice = choosePanelFallbackOrigin(configuredTarget, connectedPanelFallbackOriginsNow());
     const declined = describeDeclinedPanelFallback(choice);
@@ -1755,56 +1803,39 @@ export async function fetchImage(
       // capability and asks the authenticated panel to fetch same-origin /view. The old
       // direct-origin seam remains injectable for focused fallback mechanics
       // tests, but it is never installed by production.
-      try {
-        const relayed = await requestPanelImage(filename, type, subfolder);
-        if (relayed) return { base64: relayed.base64, mimeType: relayed.mimeType };
-      } catch (relayError) {
-        if (relayError instanceof PanelImageRelayError && !relayError.unavailable) {
-          const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
-          // #2703 - the same collapse on the image relay's own dead end. Both
-          // codes are produced by ONE catch in the relay, so leaving this one
-          // bare would have left half the reports unactionable for the same
-          // reason the history path was.
-          throw new Error(
-            `${primary} The connected panel image relay failed safely (${relayError.code}).` +
-              (relayError.reason ? ` The panel reported: ${relayError.reason}` : ""),
-            { cause: relayError },
-          );
-        }
-      }
-      if (declined) {
-        const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
-        throw new Error(`${primary}${declined}`, { cause: primaryError });
-      }
-      throw primaryError;
-    }
-
-    const fallbackUrl = `${choice.origin}${fallbackPath}`;
-    try {
-      // The configured auth headers are for the headless target, not an origin
-      // selected from a browser handshake. Never send them to the fallback.
-      // A browser-only/tunnel origin can be unreachable from this process; do
-      // not add the full headless timeout on top of the failed primary request.
-      res = await fetch(fallbackUrl, {
-        redirect: "manual",
-        signal: options.signal
-          ? AbortSignal.any([options.signal, AbortSignal.timeout(8_000)])
-          : AbortSignal.timeout(8_000),
-      });
-      responseReadTimeoutMs = 8_000;
-    } catch (fallbackError) {
-      const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
-      const secondary = describeFetchFailure(fallbackError).message;
-      throw new Error(
-        `${primary} I then tried the ComfyUI a connected sidebar panel is on ` +
-          `(${fallbackUrl}), and that failed too: ${secondary}. The browser can reach ` +
-          `that origin — this process cannot — so something between them (a tunnel, a ` +
-          `container boundary, or a server bound to one interface) is in the way.`,
-        { cause: fallbackError },
+      const relayed = await panelImageRelayHop.run(true, () =>
+        panelImageFallback(filename, type, subfolder, primaryError, declined),
       );
+      if (relayed) return relayed;
+      throw primaryError;
+    } else {
+      const fallbackUrl = `${choice.origin}${fallbackPath}`;
+      try {
+        // The configured auth headers are for the headless target, not an origin
+        // selected from a browser handshake. Never send them to the fallback.
+        // A browser-only/tunnel origin can be unreachable from this process; do
+        // not add the full headless timeout on top of the failed primary request.
+        res = await fetch(fallbackUrl, {
+          redirect: "manual",
+          signal: options.signal
+            ? AbortSignal.any([options.signal, AbortSignal.timeout(8_000)])
+            : AbortSignal.timeout(8_000),
+        });
+        responseReadTimeoutMs = 8_000;
+      } catch (fallbackError) {
+        const primary = primaryError instanceof Error ? primaryError.message : String(primaryError);
+        const secondary = describeFetchFailure(fallbackError).message;
+        throw new Error(
+          `${primary} I then tried the ComfyUI a connected sidebar panel is on ` +
+            `(${fallbackUrl}), and that failed too: ${secondary}. The browser can reach ` +
+            `that origin — this process cannot — so something between them (a tunnel, a ` +
+            `container boundary, or a server bound to one interface) is in the way.`,
+          { cause: fallbackError },
+        );
+      }
+      validateViewResponseOrigin(res, choice.origin, "the connected panel's ComfyUI");
+      answeredByPanelOrigin = choice.origin;
     }
-    validateViewResponseOrigin(res, choice.origin, "the connected panel's ComfyUI");
-    answeredByPanelOrigin = choice.origin;
   }
   if (!res.ok) {
     const where = subfolder ? `${type}/${subfolder}` : type;


### PR DESCRIPTION
## What

After the configured ComfyUI `/view` route fails at the transport layer (`ECONNREFUSED` on `127.0.0.1:8188`), `get_image(action:"get")` / `fetchImage` attempts **one** authenticated `fetch_image` panel relay.

- Relayed bytes are returned on success.
- One bounded structured error is returned on failure (`PANEL_FETCH_FAILED` still names the panel-side cause).
- Nested re-entry into `fetchImage` (a looping relay) is refused, so wrapping cannot stack-overflow.
- Published diagnostic origins are still not dialed as `/view` targets (#2149). The injectable direct-origin seam for tests is unchanged.

## Why

#2836 / #2867 fixed history/health to use a unique proven origin+api_base instead of a recursive/crashy `fetch_comfyui_read`. The remaining hole was the image `/view` path: headless unreachable, live panel connected, then `PANEL_FETCH_FAILED` / `MALFORMED_REPLY` and `Maximum call stack size exceeded` from wrapping the same fetch failure.

Fixes #2864

## Tests

```
npx vitest run src/__tests__/comfyui/panel-read-fallback.test.ts src/__tests__/comfyui/fetch-image-panel-fallback.test.ts src/__tests__/services/panel-fallback-target.test.ts src/__tests__/tools/list-assets-logs-panel-fallback.test.ts
```

55 passed (4 files).
