### PR TITLE
fix(2876): do not advertise a nonexistent refresh_nodes install action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+
+- **`download_model` `action:"status"` does not advertise `install_comfyui action:"refresh_nodes"` when a just-landed file is on disk but not yet listed (#2876).** That action is not on `install_comfyui`. The note names `panel_refresh_nodes` only when the live panel bundle can run it; a tab behind the installed pack is told to hard-refresh first.
+
 ## [0.52.196] - 2026-09-04
 
 ### MCP

--- a/src/__tests__/services/placement-stale-listing.test.ts
+++ b/src/__tests__/services/placement-stale-listing.test.ts
@@ -15,9 +15,20 @@
 // listing, refresh. Outside ⇒ genuinely misplaced, move.
 
 import { describe, expect, it } from "vitest";
-import { isUnderRoot, notVisibleVerdict } from "../../services/model-resolver.js";
+import {
+  isUnderRoot,
+  notVisibleVerdict,
+  staleListingRefreshRemedy,
+} from "../../services/model-resolver.js";
 
-const BASE = { wanted: "example.safetensors", category: "loras", baseUrl: "http://127.0.0.1:8188" };
+const BASE = {
+  wanted: "example.safetensors",
+  category: "loras",
+  baseUrl: "http://127.0.0.1:8188",
+  // Pin the unknown-bundle branch so a live panel on this machine cannot
+  // rewrite the refresh sentence (#2876).
+  panelBundle: {},
+};
 
 describe("a file inside the server's own models root is not called misplaced", () => {
   // The reporter's exact shape: one path, spelled two ways.
@@ -44,7 +55,8 @@ describe("a file inside the server's own models root is not called misplaced", (
 
   it("names the actual cause and a remedy that can be followed", () => {
     expect(reported.note).toMatch(/cached loader options/);
-    expect(reported.note).toMatch(/refresh_nodes/);
+    expect(reported.note).not.toMatch(/install_comfyui \(action:"refresh_nodes"\)/);
+    expect(reported.note).toMatch(/hard-refresh the ComfyUI browser tab \(Ctrl\+Shift\+R\)/);
   });
 
   it("still reports not-visible — the verdict did not weaken", () => {
@@ -145,7 +157,7 @@ describe("a root the server never NAMED cannot vouch for the placement (#369)", 
   it("states BOTH candidate causes and the check that separates them", () => {
     expect(unvouched.note).toMatch(/STALE LISTING/);
     expect(unvouched.note).toMatch(/DIFFERENT INSTALL/);
-    expect(unvouched.note).toMatch(/refresh_nodes/);
+    expect(unvouched.note).not.toMatch(/install_comfyui \(action:"refresh_nodes"\)/);
     expect(unvouched.note).toMatch(/list_paths/);
   });
 
@@ -189,6 +201,71 @@ describe("a root the server never NAMED cannot vouch for the placement (#369)", 
     expect(outside.note).not.toMatch(/models directory that server reads/);
     // …but it still names the root, because that is where the bytes are.
     expect(outside.note).toMatch(/\/opt\/guessed\/models/);
+  });
+});
+
+describe("stale-listing refresh names a tool the live bundle can run (#2876)", () => {
+  const FAKE_INSTALL_ACTION = 'install_comfyui (action:"refresh_nodes")';
+  const BASE_VERDICT = {
+    ...BASE,
+    verifiedPath: "C:\\ComfyUI\\models\\loras\\example.safetensors",
+    liveModelsDir: "C:/ComfyUI/models",
+    liveModelsDirNamedByServer: true,
+  };
+
+  it("never advertises install_comfyui action:\"refresh_nodes\" — that action is not declared", () => {
+    expect(staleListingRefreshRemedy({})).not.toContain(FAKE_INSTALL_ACTION);
+    expect(staleListingRefreshRemedy({ liveVersion: "0.15.174", installedVersion: "0.15.174" })).not.toContain(
+      FAKE_INSTALL_ACTION,
+    );
+    expect(staleListingRefreshRemedy({ liveVersion: "0.15.173", installedVersion: "0.15.174" })).not.toContain(
+      FAKE_INSTALL_ACTION,
+    );
+    expect(notVisibleVerdict({ ...BASE_VERDICT, panelBundle: {} }).note).not.toContain(FAKE_INSTALL_ACTION);
+  });
+
+  it("names panel_refresh_nodes when the live tab can execute it", () => {
+    const note = staleListingRefreshRemedy({
+      liveVersion: "0.15.174",
+      installedVersion: "0.15.174",
+    });
+    expect(note).toMatch(/call panel_refresh_nodes/);
+    expect(note).not.toMatch(/Hard-refresh the ComfyUI browser tab first/);
+    const wired = notVisibleVerdict({
+      ...BASE_VERDICT,
+      panelBundle: { liveVersion: "0.15.174", installedVersion: "0.15.174" },
+    });
+    expect(wired.note).toMatch(/call panel_refresh_nodes/);
+    expect(wired.note).not.toContain(FAKE_INSTALL_ACTION);
+  });
+
+  it("the reporter's stale tab is told to hard-refresh first, not to call panel_refresh_nodes now", () => {
+    // tab 0.15.173, installed 0.15.174 — panel_refresh_nodes was blocked on the live bundle.
+    const note = staleListingRefreshRemedy({
+      liveVersion: "0.15.173",
+      installedVersion: "0.15.174",
+    });
+    expect(note).toMatch(/Hard-refresh the ComfyUI browser tab first \(Ctrl\+Shift\+R\)/);
+    expect(note).toMatch(/0\.15\.173/);
+    expect(note).toMatch(/0\.15\.174/);
+    const firstCall = note.search(/call panel_refresh_nodes/);
+    const hardRefresh = note.search(/Hard-refresh the ComfyUI browser tab first/);
+    expect(hardRefresh).toBeGreaterThanOrEqual(0);
+    expect(firstCall).toBeGreaterThan(hardRefresh);
+    const wired = notVisibleVerdict({
+      ...BASE_VERDICT,
+      panelBundle: { liveVersion: "0.15.173", installedVersion: "0.15.174" },
+    });
+    expect(wired.note).toMatch(/Hard-refresh the ComfyUI browser tab first \(Ctrl\+Shift\+R\)/);
+    expect(wired.note).not.toContain(FAKE_INSTALL_ACTION);
+  });
+
+  it("does not name panel_refresh_nodes when the live bundle is unknown or too old", () => {
+    expect(staleListingRefreshRemedy({})).not.toMatch(/call panel_refresh_nodes/);
+    expect(staleListingRefreshRemedy({ liveVersion: "0.11.20", installedVersion: "0.11.20" })).not.toMatch(
+      /call panel_refresh_nodes/,
+    );
+    expect(staleListingRefreshRemedy({})).toMatch(/hard-refresh the ComfyUI browser tab \(Ctrl\+Shift\+R\)/);
   });
 });
 

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -59,6 +59,9 @@ import {
   redactUrlForLogs,
   type DownloadAuth,
 } from "./download-auth.js";
+import { compareSemver } from "./self-update.js";
+import { getUiBridge, minPanelVersionForCmd, SEMVER_RE } from "./ui-bridge.js";
+import { verifiedPanelDiskVersion } from "./panel-workspace.js";
 
 export const MODEL_SUBDIRS = [
   "checkpoints",
@@ -2402,6 +2405,72 @@ export async function verifyLandedModel(
  * same tests as the wording; a branch chosen upstream and passed in as a boolean
  * would be exactly the untested wiring this repo keeps getting caught by.
  */
+
+function parseablePanelVersion(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed && SEMVER_RE.test(trimmed) ? trimmed : undefined;
+}
+
+/**
+ * Lowest parseable advertised hello version among connected panel tabs, plus
+ * the on-disk pack version when that can be confirmed. Used only to word a
+ * followable refresh — never to invent a listing.
+ */
+function observeLivePanelBundle(): {
+  liveVersion?: string;
+  installedVersion?: string;
+} {
+  let liveVersion: string | undefined;
+  try {
+    for (const raw of getUiBridge()?.advertisedPanelVersions() ?? []) {
+      const version = parseablePanelVersion(raw);
+      if (!version) continue;
+      if (!liveVersion || compareSemver(version, liveVersion) < 0) liveVersion = version;
+    }
+  // unknown-ok: a missing or throwing bridge is an unobserved bundle, not a listing.
+  } catch {
+    liveVersion = undefined;
+  }
+  return { liveVersion, installedVersion: parseablePanelVersion(verifiedPanelDiskVersion()) };
+}
+
+/**
+ * How to refresh loader options after a download is on disk but not listed (#2876).
+ *
+ * `install_comfyui` has no `refresh_nodes` action. `panel_refresh_nodes` is named
+ * only when the live tab is on a bundle that can run it. A tab behind the
+ * installed pack is told to hard-refresh first.
+ */
+export function staleListingRefreshRemedy(
+  bundle: { liveVersion?: string; installedVersion?: string } = {},
+): string {
+  const live = parseablePanelVersion(bundle.liveVersion);
+  const installed = parseablePanelVersion(bundle.installedVersion);
+  const refreshMin = minPanelVersionForCmd("refresh_nodes");
+  const recheck = "then re-check with list_local_models";
+
+  if (live && installed && compareSemver(live, installed) < 0) {
+    return (
+      `Hard-refresh the ComfyUI browser tab first (Ctrl+Shift+R) — this tab is running ` +
+      `panel ${live} while the installed pack is ${installed}, so the live bundle cannot ` +
+      `execute panel_refresh_nodes yet. After the tab loads the installed pack, call ` +
+      `panel_refresh_nodes, or restart ComfyUI, ${recheck}.`
+    );
+  }
+
+  if (live && SEMVER_RE.test(refreshMin) && compareSemver(live, refreshMin) >= 0) {
+    return (
+      `Refresh the node/model definitions — call panel_refresh_nodes — or restart ` +
+      `ComfyUI, ${recheck}.`
+    );
+  }
+
+  return (
+    `Refresh the node/model definitions — hard-refresh the ComfyUI browser tab ` +
+    `(Ctrl+Shift+R), or restart ComfyUI — ${recheck}.`
+  );
+}
+
 export function notVisibleVerdict(args: {
   verifiedPath: string;
   liveModelsDir: string | undefined;
@@ -2424,8 +2493,17 @@ export function notVisibleVerdict(args: {
    *  install (#369). Omitted ⇒ NOT named, because an unstated provenance is an
    *  unknown one. */
   liveModelsDirNamedByServer?: boolean;
+  /**
+   * Live vs installed panel versions for the refresh wording (#2876). When
+   * omitted, observed from the connected tab hello and the on-disk pack.
+   * Pass `{}` in tests to pin the unknown-bundle branch.
+   */
+  panelBundle?: { liveVersion?: string; installedVersion?: string };
 }): { liveVisible: "not-visible"; note: string } {
   const { verifiedPath, liveModelsDir, wanted, category, baseUrl } = args;
+  const refreshRemedy = staleListingRefreshRemedy(
+    "panelBundle" in args ? (args.panelBundle ?? {}) : observeLivePanelBundle(),
+  );
   const insideLexically = liveModelsDir !== undefined && isUnderRoot(verifiedPath, liveModelsDir);
   const rootIsServerNamed = args.liveModelsDirNamedByServer === true;
   // Containment ALONE is not readership. It counts only when the root it is
@@ -2455,8 +2533,7 @@ export function notVisibleVerdict(args: {
         `scans, which is #369 and is how multi-GB downloads get reported as landed and are ` +
         `never seen again.\n\n` +
         `Do not move it on the strength of this message alone, and do not treat it as placed ` +
-        `either. SEPARATE THE TWO: refresh the node/model definitions — install_comfyui ` +
-        `(action:"refresh_nodes"), or the panel's refresh — then re-check with list_local_models. ` +
+        `either. SEPARATE THE TWO: ${refreshRemedy} ` +
         `If it STILL does not appear, it is case 2: list_local_models (action:"list_paths") ` +
         `reports the roots the running server actually reads — move the file into the one for ` +
         `"${category}". To make future downloads verifiable, point COMFYUI_PATH at the install ` +
@@ -2482,9 +2559,7 @@ export function notVisibleVerdict(args: {
             `outside that directory is the layout working as intended, not a misplacement. `) +
         `That server does not list "${wanted}" under "${category}" YET, which almost always ` +
         `means its cached loader options have not been re-read since the write (ComfyUI ` +
-        `invalidates them on the directory's mtime). Do NOT move the file. Refresh the ` +
-        `node/model definitions — install_comfyui (action:"refresh_nodes"), or the panel's ` +
-        `refresh — or restart ComfyUI, then check list_local_models again.`
+        `invalidates them on the directory's mtime). Do NOT move the file. ${refreshRemedy}`
       : `The file IS on disk at ${verifiedPath}, but the connected ComfyUI ` +
         `(${baseUrl}) does NOT list "${wanted}" under "${category}" — it will not be ` +
         `usable in a workflow from there.` +

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -5464,6 +5464,19 @@ export class UiBridge {
     }));
   }
 
+  /**
+   * Parseable panel versions THIS connection advertised in its own hello.
+   * Inherited reconnect values are omitted — those are not the live bundle.
+   */
+  advertisedPanelVersions(): string[] {
+    const versions: string[] = [];
+    for (const conn of this.conns.values()) {
+      const version = connPanelVersionReading(conn).version;
+      if (version) versions.push(version);
+    }
+    return versions;
+  }
+
   /** True once a real CANVAS-OWNING panel tab has connected during this bridge's
    *  lifetime. When a later state has zero tabs, this distinguishes "the pack is
    *  installed and a tab merely dropped" (typically a ComfyUI restart or a browser-tab


### PR DESCRIPTION
## What

`download_model` `action:"status"` no longer tells the agent to call `install_comfyui (action:"refresh_nodes")` when a just-landed file is on disk but not yet in the live listing.

- That action is not on `install_comfyui`'s schema.
- The note names `panel_refresh_nodes` only when the live panel bundle can execute it (advertised tab version ≥ the `refresh_nodes` floor, and not behind the installed pack).
- A stale tab (reporter: live 0.15.173, installed 0.15.174) is told to hard-refresh first (`Ctrl+Shift+R`); `panel_refresh_nodes` is only the follow-up after the tab loads the installed bundle.
- An unobserved or too-old live bundle gets hard-refresh / restart, not a tool it cannot run.

## Why

#2876: status reported ipadapter files on disk but not visible, then instructed `install_comfyui action:"refresh_nodes"`. `describe_tool` has no such action. The real `panel_refresh_nodes` call was blocked because the open tab was one patch behind the installed panel, so the advertised remediation was impossible.

Fixes #2876

## Tests

```
npx vitest run src/__tests__/services/placement-stale-listing.test.ts
```

26 passed. New cases fail on main (they require the fake install action to be gone, `panel_refresh_nodes` only when the live bundle can run it, and hard-refresh first for tab 0.15.173 vs installed 0.15.174).
