### PR TITLE
fix(2880): ack panel_save_workflow from a matching late receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 
-- **`panel_save_workflow` returns `saved:true` when a matching `late_save_receipts` entry proves the timed-out in-place save completed (#2880).** After the panel's 13s budget, settle used to also require `modified:false persisted:true` on top-level `active`, which live `workflow_list` does not carry (those flags are on the active open-tab row). A later `panel_list_workflows` already showed the rid-matched receipt. A current panel with no matching receipt stays OUTCOME UNKNOWN so a retry does not write twice.
+- **`panel_save_workflow` returns `saved:true` when a matching `late_save_receipts` entry proves the timed-out in-place save completed (#2880).** After the panel's 13s budget, settle used to also require `modified:false persisted:true` on top-level `active`, which live `workflow_list` does not carry (those flags are on the flagged-active `workflows[]` row). A later `panel_list_workflows` already showed the rid-matched receipt. A current panel with no matching receipt stays OUTCOME UNKNOWN so a retry does not write twice.
 
 ## [0.52.197] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+
+- **`panel_save_workflow` returns `saved:true` when a matching `late_save_receipts` entry proves the timed-out in-place save completed (#2880).** After the panel's 13s budget, settle used to also require `modified:false persisted:true` on top-level `active`, which live `workflow_list` does not carry (those flags are on the active open-tab row). A later `panel_list_workflows` already showed the rid-matched receipt. A current panel with no matching receipt stays OUTCOME UNKNOWN so a retry does not write twice.
+
 ## [0.52.197] - 2026-09-05
 
 ### MCP

--- a/src/__tests__/orchestrator/object-info-starvation.test.ts
+++ b/src/__tests__/orchestrator/object-info-starvation.test.ts
@@ -308,6 +308,64 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     expect(calls.map((c) => c.cmd)).toContain("workflow_list");
   });
 
+  it("#2880 THE REPORTED CASE: matching late receipt on the real workflow_list shape is saved, not unknown", async () => {
+    // Live panel puts modified/persisted on the active open[] row, never on
+    // top-level `active`. #2078 ANDed those missing flags with the receipt, so
+    // a list that already proved the same rid completed still returned
+    // OUTCOME UNKNOWN and the caller had to read panel_list_workflows again.
+    __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(0);
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd, _timeoutMs, onDispatchedRid) => {
+        calls.push(cmd);
+        if (cmd.cmd === "workflow_save") {
+          onDispatchedRid?.("save-rid");
+          return errorResult(
+            `workflow_save did not finish within 13s. OUTCOME UNKNOWN: the save was already in flight when this budget fired.`,
+          );
+        }
+        if (cmd.cmd === "workflow_list") {
+          return jsonResult({
+            active: {
+              path: "workflows/graph.json",
+              routing_key: "wf:workflows/graph.json",
+              filename: "graph",
+            },
+            open: [
+              {
+                path: "workflows/graph.json",
+                routing_key: "wf:workflows/graph.json",
+                filename: "graph",
+                active: true,
+                modified: false,
+                persisted: true,
+              },
+            ],
+            late_save_receipts: [
+              {
+                rid: "save-rid",
+                cmd: "workflow_save",
+                result: { saved: true, routing_key: "wf:workflows/graph.json" },
+              },
+            ],
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_save_workflow").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    const text = textOf(res);
+    expect(text).toMatch(/"saved": true/);
+    expect(text).toMatch(/"late_ack": true/);
+    expect(text).not.toMatch(/OUTCOME UNKNOWN/);
+    expect(calls.filter((c) => c.cmd === "workflow_save")).toHaveLength(1);
+  });
+
   it("#2078 THE REPORTED CASE: a list that is still dirty, then clean, is saved not unknown", async () => {
     // The 13s budget fires with modified:true. #2004 listed once, still saw
     // dirty, and returned OUTCOME UNKNOWN. The caller's next panel_list_workflows

--- a/src/__tests__/orchestrator/object-info-starvation.test.ts
+++ b/src/__tests__/orchestrator/object-info-starvation.test.ts
@@ -309,10 +309,10 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
   });
 
   it("#2880 THE REPORTED CASE: matching late receipt on the real workflow_list shape is saved, not unknown", async () => {
-    // Live panel puts modified/persisted on the active open[] row, never on
-    // top-level `active`. #2078 ANDed those missing flags with the receipt, so
-    // a list that already proved the same rid completed still returned
-    // OUTCOME UNKNOWN and the caller had to read panel_list_workflows again.
+    // Live panel puts modified/persisted on the flagged-active workflows[] row,
+    // never on top-level `active`. #2078 ANDed those missing flags with the
+    // receipt, so a list that already proved the same rid completed still
+    // returned OUTCOME UNKNOWN and the caller had to read panel_list_workflows.
     __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(0);
     const calls: Forwarded[] = [];
     const ctx: PanelToolCtx = {
@@ -331,7 +331,7 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
               routing_key: "wf:workflows/graph.json",
               filename: "graph",
             },
-            open: [
+            workflows: [
               {
                 path: "workflows/graph.json",
                 routing_key: "wf:workflows/graph.json",
@@ -364,6 +364,52 @@ describe("panel_save_workflow acknowledges a save that landed after the budget (
     expect(text).toMatch(/"late_ack": true/);
     expect(text).not.toMatch(/OUTCOME UNKNOWN/);
     expect(calls.filter((c) => c.cmd === "workflow_save")).toHaveLength(1);
+  });
+
+  it("#2880 an unmatched late receipt does not fail-open even when the canvas is clean", async () => {
+    __panelToolsTestHooks.setSaveTimeoutSettleGraceMs(0);
+    const ctx: PanelToolCtx = {
+      call: async (cmd, _timeoutMs, onDispatchedRid) => {
+        if (cmd.cmd === "workflow_save") {
+          onDispatchedRid?.("save-rid");
+          return errorResult(SAVE_TIMEOUT_2078);
+        }
+        if (cmd.cmd === "workflow_list") {
+          return jsonResult({
+            active: {
+              path: "workflows/graph.json",
+              routing_key: "wf:workflows/graph.json",
+              filename: "graph",
+            },
+            workflows: [
+              {
+                path: "workflows/graph.json",
+                routing_key: "wf:workflows/graph.json",
+                filename: "graph",
+                active: true,
+                modified: false,
+                persisted: true,
+              },
+            ],
+            late_save_receipts: [
+              {
+                rid: "other-rid",
+                cmd: "workflow_save",
+                result: { saved: true, routing_key: "wf:workflows/graph.json" },
+              },
+            ],
+          });
+        }
+        return jsonResult({ ok: true });
+      },
+      confirm: async () => "yes" as const,
+      bridge: {} as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+
+    const res = await defByName("panel_save_workflow").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/OUTCOME UNKNOWN/);
   });
 
   it("#2078 THE REPORTED CASE: a list that is still dirty, then clean, is saved not unknown", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6263,11 +6263,40 @@ function isWorkflowSaveBudgetTimeout(res: ToolResult): boolean {
  * proves the in-flight save marked the canvas clean. persisted:true alone is
  * the reporter's timeout snapshot (a previously-saved dirty workflow) and
  * must not be read as "the write landed".
+ *
+ * Live `workflow_list` publishes those flags on the active `open[]` row, not
+ * on top-level `active` (#2880). Prefer an explicit boolean on `active` when
+ * a test or older panel put it there; otherwise read the active open row.
  */
-function saveLandedAfterTimeout(list: Record<string, unknown> | null): boolean {
+function saveTimeoutFlagRecord(
+  list: Record<string, unknown> | null,
+): Record<string, unknown> | null {
   const active = list?.active;
-  if (!active || typeof active !== "object" || Array.isArray(active)) return false;
-  const rec = active as Record<string, unknown>;
+  if (active && typeof active === "object" && !Array.isArray(active)) {
+    const rec = active as Record<string, unknown>;
+    if (rec.modified === true || rec.modified === false) return rec;
+  }
+  const rows = Array.isArray(list?.open)
+    ? list.open
+    : Array.isArray(list?.workflows)
+      ? list.workflows
+      : null;
+  if (!rows) return null;
+  const activeRow = rows.find(
+    (row) =>
+      row &&
+      typeof row === "object" &&
+      !Array.isArray(row) &&
+      (row as Record<string, unknown>).active === true,
+  );
+  return activeRow && typeof activeRow === "object" && !Array.isArray(activeRow)
+    ? (activeRow as Record<string, unknown>)
+    : null;
+}
+
+function saveLandedAfterTimeout(list: Record<string, unknown> | null): boolean {
+  const rec = saveTimeoutFlagRecord(list);
+  if (!rec) return false;
   return rec.modified === false && rec.persisted === true;
 }
 
@@ -6277,6 +6306,9 @@ function saveLandedAfterTimeout(list: Record<string, unknown> | null): boolean {
  * rid, so only that receipt can bridge the identity change. If the receipt field
  * is absent or does not match, the outcome remains unknown rather than crediting
  * a clean workflow that may belong to a tab the user switched to.
+ *
+ * #2880 — a current panel's matching receipt is the save's own eventual success.
+ * Do not also require flags on `active`: that object does not carry them.
  */
 function saveProbeMatchesLateReceipt(
   saveRid: string | undefined,
@@ -6331,12 +6363,17 @@ function saveAckAfterTimeout(list: Record<string, unknown> | null): ToolResult {
 }
 
 /**
- * #2004 / #2078 — the panel's 13s budget fired while userdata PUT was still
- * running. A list that shows modified:false persisted:true is the save
- * completing. One snapshot is not enough: the timeout-time canvas is still
- * dirty, and the PUT can land between that read and the caller's next list.
- * Keep reading until the grace, then stay outcome-unknown. persisted:true
- * alone is the timeout-time snapshot of a previously-saved dirty tab, not proof.
+ * #2004 / #2078 / #2880 — the panel's 13s budget fired while userdata PUT was
+ * still running. A current panel publishes the save's eventual success under
+ * that command's rid in `late_save_receipts`; matching that receipt (and the
+ * active identity) is saved, not unknown. Older panels omit the field: then a
+ * list that shows modified:false persisted:true is the save completing. One
+ * snapshot is not enough: the timeout-time canvas is still dirty, and the PUT
+ * can land between that read and the caller's next list. Keep reading until
+ * the grace, then stay outcome-unknown. persisted:true alone is the
+ * timeout-time snapshot of a previously-saved dirty tab, not proof. A current
+ * panel with an empty receipt list stays unknown even if some other canvas is
+ * clean — that is a tab switch, not this save.
  */
 async function settleWorkflowSaveTimeout(
   res: ToolResult,
@@ -6349,10 +6386,11 @@ async function settleWorkflowSaveTimeout(
     try {
       const listRes = await ctx.call({ cmd: "workflow_list" }, 6000);
       const list = parseToolResultJson(listRes);
-      if (
-        saveLandedAfterTimeout(list) &&
-        saveProbeMatchesLateReceipt(saveRid, list)
-      ) {
+      if (saveProbeMatchesLateReceipt(saveRid, list)) {
+        return saveAckAfterTimeout(list);
+      }
+      // Older panel: no receipt field. Flags on the active row are the only probe.
+      if (!Array.isArray(list?.late_save_receipts) && saveLandedAfterTimeout(list)) {
         return saveAckAfterTimeout(list);
       }
     } catch {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6264,34 +6264,30 @@ function isWorkflowSaveBudgetTimeout(res: ToolResult): boolean {
  * the reporter's timeout snapshot (a previously-saved dirty workflow) and
  * must not be read as "the write landed".
  *
- * Live `workflow_list` publishes those flags on the active `open[]` row, not
- * on top-level `active` (#2880). Prefer an explicit boolean on `active` when
- * a test or older panel put it there; otherwise read the active open row.
+ * Live `workflow_list` publishes those flags on the flagged-active
+ * `workflows[]` row, not on top-level `active` (#2880). Prefer an explicit
+ * boolean on `active` when a test or older panel put it there.
  */
 function saveTimeoutFlagRecord(
   list: Record<string, unknown> | null,
 ): Record<string, unknown> | null {
-  const active = list?.active;
-  if (active && typeof active === "object" && !Array.isArray(active)) {
-    const rec = active as Record<string, unknown>;
-    if (rec.modified === true || rec.modified === false) return rec;
-  }
-  const rows = Array.isArray(list?.open)
-    ? list.open
-    : Array.isArray(list?.workflows)
-      ? list.workflows
+  const recOf = (value: unknown): Record<string, unknown> | null =>
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  const active = recOf(list?.active);
+  if (active && (active.modified === true || active.modified === false)) return active;
+  const rows = Array.isArray(list?.workflows)
+    ? list.workflows
+    : Array.isArray(list?.open)
+      ? list.open
       : null;
   if (!rows) return null;
-  const activeRow = rows.find(
-    (row) =>
-      row &&
-      typeof row === "object" &&
-      !Array.isArray(row) &&
-      (row as Record<string, unknown>).active === true,
-  );
-  return activeRow && typeof activeRow === "object" && !Array.isArray(activeRow)
-    ? (activeRow as Record<string, unknown>)
-    : null;
+  for (const row of rows) {
+    const rec = recOf(row);
+    if (rec?.active === true) return rec;
+  }
+  return null;
 }
 
 function saveLandedAfterTimeout(list: Record<string, unknown> | null): boolean {


### PR DESCRIPTION
Fixes #2880

## What
`panel_save_workflow` (no name) could still return OUTCOME UNKNOWN after the panel's 13s `workflow_save` budget even when a later `panel_list_workflows` already proved the same command completed: `modified:false`, `persisted:true`, and a `late_save_receipts` entry for that rid.

#2078 already settled after the budget, but it required **both** a matching late receipt **and** `modified:false persisted:true` on top-level `workflow_list.active`. Live panel `workflow_list` never puts those flags on `active` (they live on the flagged-active `workflows[]` row), so a present, rid-matched receipt was ignored for the whole 5s grace.

## Fix
Before returning OUTCOME UNKNOWN, credit a rid-matched `late_save_receipts` entry whose result is `saved:true` and whose identity matches the active canvas. Older panels that omit the field still use the dirty/persisted probe (including flags on the flagged-active `workflows[]` row). A current panel with no matching receipt stays unknown so a retry does not write twice.

## Evidence
`#2880 THE REPORTED CASE` in `src/__tests__/orchestrator/object-info-starvation.test.ts` uses the real `workflow_list` shape (`workflows[]`, flags not on `active`). A foreign rid on that same clean canvas stays OUTCOME UNKNOWN. Deleting the settle-path change makes the reported-case test fail (`isError` stays true).

Not merged. No release.