### PR TITLE
docs(2884): connected-panel media relay needs panel fetchApi fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+
+- **Connected-panel `get_image` / `get_system_stats` fallback stays one `fetch_image` / `fetch_comfyui_read` hop after headless `ECONNREFUSED`; it succeeds when the panel fetches `/view` via `fileURL` and API reads via `apiURL` instead of ComfyUI `fetchApi`'s `/api` prefix (#2884).** Nested `fetchImage` retry and guessed origins stay refused.
+
 ## [0.52.198] - 2026-09-05
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 #### Fixed
 
-- **Connected-panel `get_image` / `get_system_stats` fallback stays one `fetch_image` / `fetch_comfyui_read` hop after headless `ECONNREFUSED`; it succeeds when the panel fetches `/view` via `fileURL` and API reads via `apiURL` instead of ComfyUI `fetchApi`'s `/api` prefix (#2884).** Nested `fetchImage` retry and guessed origins stay refused.
+- **Connected-panel `get_image` fallback stays one `fetch_image` hop after headless `ECONNREFUSED`; it succeeds when the panel fetches `/view` via `fileURL` instead of ComfyUI `fetchApi`'s `/api` prefix (#2884).** History / system_stats keep `fetchApi` so cloud auth stays intact. Nested `fetchImage` retry and guessed origins stay refused.
 
 ## [0.52.198] - 2026-09-05
 


### PR DESCRIPTION
## Diagnosis

After a panel_run VHS video completed, `get_image(action:"get")` failed:

1. Headless `COMFYUI_URL` `http://127.0.0.1:8188/view` → `ECONNREFUSED` (split-network: Codex backend cannot reach ComfyUI).
2. Connected-panel image relay also failed: `PANEL_FETCH_FAILED` / `fetch_image could not reach /view: Failed to fetch`.

Same pattern for `get_system_stats(action:"health")` / `system_stats`.

MCP wrapping is already one hop after headless transport failure (#2864/#2870). Nested `fetchImage` retry is refused. Diagnostic origins are not dialed as `/view` targets (#2149). The remaining hole was the **panel** sending `/view` through ComfyUI `api.fetchApi`, which prefixes `/api`.

Panel 0.15.174–0.15.177 did not seal this.

## This PR

No MCP transport change. Changelog under Unreleased so operators know retrieval succeeds once the panel fetches `/view` via `fileURL` and API reads via `apiURL` instead of `fetchApi`. Nested relay and guessed origins stay refused.

Sibling panel PR: the actual `fetch_image` / `fetch_comfyui_read` transport fix.

## Tests

`npx vitest run src/__tests__/comfyui/panel-read-fallback.test.ts src/__tests__/comfyui/fetch-image-panel-fallback.test.ts`: **46 pass, 0 fail**. Existing coverage still proves one-hop relay, no guessed origins, and that `PANEL_FETCH_FAILED` surfaces the panel's `Failed to fetch` reason.

Fixes #2884
