### PR TITLE
fix(2889): keep gpt-6-astra in the Codex model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 
 - **`panel_set_widget` writes after `panel_load_workflow` without a manual `panel_set_workflow_target({mode:"current"})` rebind (#2886).** A successful load left leftover subgraph identity and a stale subgraph registry, so `graph_get_subgraph` could not classify a live H3 container or an ordinary root SaveVideo and refused before dispatch. Load now marks that mapping stale, and a mapping-unknown miss retries the subgraph read once after the walk; still unverifiable stays fail-closed.
+- **Codex sidebar picker keeps `gpt-6-astra` when the account catalog also lists GPT-5.6 (#2889).** `listModels()` dropped any id that did not start with `gpt-5.6` as soon as one 5.6 entry existed, so Astra vanished even when Codex config selected it. The picker now prefers a catalog `deprecated`/`upgrade` signal when present, otherwise keeps `gpt-5.6*` and `gpt-6-astra`; older CLIs with no current family still get the full catalog.
 
 ## [0.52.199] - 2026-09-05
 

--- a/src/__tests__/orchestrator/codex-list-models-picker.test.ts
+++ b/src/__tests__/orchestrator/codex-list-models-picker.test.ts
@@ -1,0 +1,120 @@
+// #2889 — CodexBackend.listModels() hid gpt-6-astra whenever the account
+// catalog also contained any gpt-5.6* id. The picker must keep Astra (and
+// still hide pre-5.6 ids) and must not clamp liveCatalog, which answers
+// "can this account run X".
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { ModelChoice } from "../../orchestrator/agent-backend.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+type BackendModule = typeof import("../../orchestrator/codex-backend.js");
+type Backend = InstanceType<BackendModule["CodexBackend"]> & {
+  liveCatalog: ModelChoice[] | null;
+};
+
+let CodexBackend: BackendModule["CodexBackend"];
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ CodexBackend } = await import("../../orchestrator/codex-backend.js"));
+});
+
+type CatalogRow = {
+  id?: string;
+  model?: string;
+  displayName?: string;
+  hidden?: boolean;
+  deprecated?: boolean;
+  upgrade?: string | { id?: string; model?: string } | null;
+  upgradeInfo?: { model?: string } | null;
+  supportedReasoningEfforts?: Array<{ reasoningEffort?: string }>;
+};
+
+const MIXED_NO_SIGNAL: CatalogRow[] = [
+  { id: "gpt-6-astra", displayName: "GPT-6 Astra", hidden: false },
+  { id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol", hidden: false },
+  { id: "gpt-5.6-terra", hidden: false },
+  { id: "gpt-5.6-luna", hidden: false },
+  { id: "gpt-5.5", hidden: false },
+  { id: "gpt-5.4-mini", hidden: false },
+  { id: "gpt-5.5-codex", hidden: false },
+];
+
+function backendWithList(data: CatalogRow[] | "throw"): Backend {
+  const client = {
+    request: vi.fn(async (method: string) => {
+      if (method !== "model/list") throw new Error(`unexpected request: ${method}`);
+      if (data === "throw") throw new Error("model/list unavailable");
+      return { data };
+    }),
+  };
+  const backend = new CodexBackend({ model: "gpt-6-astra" }) as Backend;
+  Object.assign(backend, { client });
+  return backend;
+}
+
+describe("CodexBackend.listModels picker (#2889)", () => {
+  it("keeps gpt-6-astra beside GPT-5.6 and hides pre-5.6 ids when the catalog has no deprecation signal", async () => {
+    const backend = backendWithList(MIXED_NO_SIGNAL);
+    const ids = (await backend.listModels()).map((m) => m.id);
+    expect(ids).toContain("gpt-6-astra");
+    expect(ids).toContain("gpt-5.6-sol");
+    expect(ids).toContain("gpt-5.6-terra");
+    expect(ids).toContain("gpt-5.6-luna");
+    expect(ids).not.toContain("gpt-5.5");
+    expect(ids).not.toContain("gpt-5.4-mini");
+    expect(ids).not.toContain("gpt-5.5-codex");
+  });
+
+  it("keeps the full account catalog on liveCatalog so an Astra pin still clamps", async () => {
+    const backend = backendWithList(MIXED_NO_SIGNAL);
+    await backend.listModels();
+    const live = backend.liveCatalog?.map((m) => m.id) ?? [];
+    expect(live).toContain("gpt-6-astra");
+    expect(live).toContain("gpt-5.6-sol");
+    expect(live).toContain("gpt-5.5");
+  });
+
+  it("prefers catalog deprecated/upgrade over the gpt-5.6 prefix so a future current model is not dropped", async () => {
+    const backend = backendWithList([
+      { id: "gpt-6-astra", hidden: false },
+      { id: "gpt-5.6-sol", hidden: false },
+      { id: "gpt-7-foo", hidden: false },
+      { id: "gpt-5.5", hidden: false, upgrade: "gpt-5.6-sol" },
+      { id: "gpt-5.4-mini", hidden: false, deprecated: true },
+      { id: "gpt-5.2", hidden: false, upgradeInfo: { model: "gpt-5.6-sol" } },
+    ]);
+    const ids = (await backend.listModels()).map((m) => m.id);
+    expect(ids).toEqual(["gpt-6-astra", "gpt-5.6-sol", "gpt-7-foo"]);
+  });
+
+  it("returns the full catalog when the account has no current-family entry (older plan)", async () => {
+    const backend = backendWithList([
+      { id: "gpt-5.5", hidden: false },
+      { id: "gpt-5.4-mini", hidden: false },
+    ]);
+    const ids = (await backend.listModels()).map((m) => m.id);
+    expect(ids).toEqual(["gpt-5.5", "gpt-5.4-mini"]);
+  });
+
+  it("still omits hidden rows, including a hidden Astra", async () => {
+    const backend = backendWithList([
+      { id: "gpt-6-astra", hidden: true },
+      { id: "gpt-5.6-sol", hidden: false },
+      { id: "gpt-5.5", hidden: false },
+    ]);
+    const ids = (await backend.listModels()).map((m) => m.id);
+    expect(ids).toEqual(["gpt-5.6-sol"]);
+  });
+
+  it("falls back to the static family when model/list is unavailable", async () => {
+    const backend = backendWithList("throw");
+    const ids = (await backend.listModels()).map((m) => m.id);
+    expect(ids).toContain("gpt-5.6-sol");
+    expect(ids).toContain("gpt-5.5");
+    expect(ids).not.toContain("gpt-6-astra");
+  });
+});

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -535,19 +535,64 @@ const CODEX_EFFORT_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"
 // model family. The panel picker degrades gracefully on an empty list. Each entry
 // advertises the Codex effort scale so the panel enables the reasoning-effort
 // dropdown for these models (the backend applies effort to every turn anyway).
-// GPT-5.6 family ONLY (product decision 2026-07-20): older GPT-5.x are
-// deprecated — the live catalog is filtered to the 5.6 family and these
-// fallbacks match it. Per-variant effort ceilings from the live model/list.
+// The live picker prefers the catalog's deprecated/upgrade signal when present;
+// otherwise it keeps gpt-5.6* and gpt-6-astra. These static ids match the 5.6
+// family plus a pre-5.6 escape hatch — older CLIs cannot run Astra or 5.6.
 const CODEX_FALLBACK_MODELS: ModelChoice[] = [
   { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"] },
   { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"] },
   { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"] },
   // This static list only surfaces when model/list is UNAVAILABLE — i.e. an
   // older CLI resolved from PATH (bundled-install failure), which cannot run
-  // any 5.6 model. Keep one runnable pre-5.6 escape hatch there (codex
+  // any 5.6 / Astra model. Keep one runnable pre-5.6 escape hatch there (codex
   // review); accounts on the pinned bundled CLI never see this list.
   { id: "gpt-5.5", label: "GPT-5.5 (legacy CLI fallback)", supportsEffort: true, supportedEffortLevels: ["none", "minimal", "low", "medium", "high", "xhigh"] },
 ];
+
+/** App-server `model/list` row. `upgrade` / `deprecated` are the catalog's
+ *  current-vs-legacy signal when the CLI populates them. */
+type CodexModelListEntry = {
+  id?: string;
+  model?: string;
+  displayName?: string;
+  description?: string;
+  hidden?: boolean;
+  deprecated?: boolean;
+  upgrade?: string | { id?: string; model?: string } | null;
+  upgradeInfo?: { model?: string } | null;
+  supportedReasoningEfforts?: Array<{ reasoningEffort?: string }>;
+};
+
+function codexCatalogModelId(m: CodexModelListEntry): string | undefined {
+  const id = m.id ?? m.model;
+  return id || undefined;
+}
+
+function codexCatalogRowDeprecated(m: CodexModelListEntry): boolean {
+  if (m.deprecated === true) return true;
+  const upgrade = m.upgrade;
+  if (typeof upgrade === "string") return upgrade.length > 0;
+  if (upgrade && (upgrade.id || upgrade.model)) return true;
+  return Boolean(m.upgradeInfo?.model);
+}
+
+function isCodexHardcodedCurrentFamily(id: string): boolean {
+  return id.startsWith("gpt-5.6") || id === "gpt-6-astra";
+}
+
+/** Picker subset of the account catalog. Prefer a server-provided
+ *  deprecated/upgrade signal when any visible row carries one; otherwise keep
+ *  gpt-5.6* and gpt-6-astra. An account with no current-family entry keeps the
+ *  full catalog so an older plan/CLI is never bricked. */
+function filterCodexPickerEntries(visible: CodexModelListEntry[]): CodexModelListEntry[] {
+  const hasDeprecationSignal = visible.some(codexCatalogRowDeprecated);
+  const fam = visible.filter((m) => {
+    const id = codexCatalogModelId(m);
+    if (!id) return false;
+    return hasDeprecationSignal ? !codexCatalogRowDeprecated(m) : isCodexHardcodedCurrentFamily(id);
+  });
+  return fam.length ? fam : visible;
+}
 
 /** Does this id look like an OpenAI/Codex model (vs. a Claude panel model)? Used
  *  to ignore the Claude panel model PanelAgent unconditionally passes as
@@ -2667,32 +2712,26 @@ export class CodexBackend implements AgentBackend {
       await this.prepare();
       const client = this.client;
       if (client) {
-        const res = await client.request<{
-          data?: Array<{
-            id?: string;
-            model?: string;
-            displayName?: string;
-            description?: string;
-            hidden?: boolean;
-            supportedReasoningEfforts?: Array<{ reasoningEffort?: string }>;
-          }>;
-        }>("model/list", {});
-        const live = (res?.data ?? [])
-          .filter((m) => (m.id || m.model) && m.hidden !== true)
-          .map((m): ModelChoice => {
-            const efforts = (m.supportedReasoningEfforts ?? [])
-              .map((e) => e.reasoningEffort)
-              .filter((e): e is string => typeof e === "string" && (CODEX_EFFORT_LEVELS as readonly string[]).includes(e));
-            return {
-              id: (m.id ?? m.model) as string,
-              ...(m.displayName ? { label: m.displayName } : {}),
-              // Every Codex ModelChoice MUST advertise effort support so the
-              // panel enables the reasoning dropdown (the backend applies
-              // effort to every turn regardless). Prefer the model's own list.
-              supportsEffort: true,
-              supportedEffortLevels: efforts.length ? efforts : [...CODEX_EFFORT_LEVELS],
-            };
+        const res = await client.request<{ data?: CodexModelListEntry[] }>("model/list", {});
+        const visible: CodexModelListEntry[] = [];
+        const live: ModelChoice[] = [];
+        for (const m of res?.data ?? []) {
+          const id = codexCatalogModelId(m);
+          if (!id || m.hidden === true) continue;
+          visible.push(m);
+          const efforts = (m.supportedReasoningEfforts ?? [])
+            .map((e) => e.reasoningEffort)
+            .filter((e): e is string => typeof e === "string" && (CODEX_EFFORT_LEVELS as readonly string[]).includes(e));
+          live.push({
+            id,
+            ...(m.displayName ? { label: m.displayName } : {}),
+            // Every Codex ModelChoice MUST advertise effort support so the
+            // panel enables the reasoning dropdown (the backend applies
+            // effort to every turn regardless). Prefer the model's own list.
+            supportsEffort: true,
+            supportedEffortLevels: efforts.length ? efforts : [...CODEX_EFFORT_LEVELS],
           });
+        }
         if (live.length) {
           // liveCatalog keeps the FULL account catalog: it answers "can this
           // account run model X" for resolveTurnModel's clamp. The PICKER gets
@@ -2700,13 +2739,16 @@ export class CodexBackend implements AgentBackend {
           // picks must not force-switch an existing pin/resume that the
           // account can still legally run (codex review on this branch).
           this.liveCatalog = live;
-          // GPT-5.6-only policy: hide deprecated 5.x/codex ids from the picker
-          // when the account has the 5.6 family. Accounts WITHOUT any 5.6
-          // model keep their full catalog (never brick an older plan).
-          const fam = live.filter((m) => m.id.startsWith("gpt-5.6"));
+          // Hide deprecated 5.x/codex ids from the picker when a current
+          // family is available (catalog deprecated/upgrade signal, else
+          // gpt-5.6* + gpt-6-astra). Accounts without that family keep their
+          // full catalog (never brick an older plan).
+          const picker = filterCodexPickerEntries(visible);
+          const pickerIds = new Set(picker.map((m) => codexCatalogModelId(m)).filter((id): id is string => !!id));
+          const fam = live.filter((m) => pickerIds.has(m.id));
           if (fam.length && fam.length < live.length) {
             logger.debug(
-              `[codex-backend] hiding ${live.length - fam.length} deprecated pre-5.6 model(s) from the picker`,
+              `[codex-backend] hiding ${live.length - fam.length} deprecated model(s) from the picker`,
             );
           }
           return fam.length ? fam : live;


### PR DESCRIPTION
Fixes #2889

## What
`CodexBackend.listModels()` hard-filtered the account-aware live catalog to ids beginning with `gpt-5.6` whenever any GPT-5.6 entry existed. An account catalog that includes `gpt-6-astra` alongside Sol/Terra/Luna therefore dropped Astra from the sidebar picker even though Codex user config selected it.

## Fix
The picker still hides pre-5.6 ids when a current family is available, but it no longer keys current models to the `gpt-5.6` prefix alone:
- If any visible `model/list` row carries a catalog `deprecated` / `upgrade` / `upgradeInfo` signal, keep non-deprecated rows (Astra and future current models survive).
- Otherwise keep `gpt-5.6*` **and** `gpt-6-astra`.
- Accounts/CLIs with no current-family entry still get the full catalog. `liveCatalog` remains unfiltered so `resolveTurnModel()` can still clamp an Astra pin.

Static fallback for older CLIs is unchanged (no Astra there — those CLIs cannot run it).

## Evidence
`src/__tests__/orchestrator/codex-list-models-picker.test.ts` drives shipped `listModels()` with a fake app-server `model/list`:
- mixed catalog without a deprecation signal keeps Astra + 5.6 and hides 5.5
- `liveCatalog` still contains 5.5 for clamp
- catalog `upgrade`/`deprecated` keeps Astra and a future current id
- older-plan catalog and `model/list` failure keep the previous fallbacks

6 tests, 1 file. Not merged. No release.
