### PR TITLE
fix(2887): refuse unpack success without named-slot identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 #### Fixed
 
 - **`panel_set_widget` writes after `panel_load_workflow` without a manual `panel_set_workflow_target({mode:"current"})` rebind (#2886).** A successful load left leftover subgraph identity and a stale subgraph registry, so `graph_get_subgraph` could not classify a live H3 container or an ordinary root SaveVideo and refused before dispatch. Load now marks that mapping stale, and a mapping-unknown miss retries the subgraph read once after the walk; still unverifiable stays fail-closed.
+- **`panel_unpack_subgraph` does not accept a success that could not prove restored links landed on the named dynamic slots.** LiteGraph rewires unpack by slot index; after a MiniMax-style autogrow rebuild that can put an IMAGE on `ref_videos`. A current panel reseats by identity and rolls back if the slot is not unique; an older panel that only counts surviving wires is noted rather than trusted. (#2887)
 
 ## [0.52.199] - 2026-09-05
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1427,6 +1427,74 @@ describe("panel-tools: subgraph I/O (expose rails + unpack)", () => {
     await defByName("panel_unpack_subgraph").handler({ node_id: 42 }, ctx);
     expect(calls[0]).toMatchObject({ cmd: "graph_unpack_subgraph", node_id: 42 });
   });
+
+  it("panel_unpack_subgraph refuses a success that could not prove named-slot identity (#2887)", async () => {
+    const { ctx } = makeFakeCtx();
+    ctx.call = async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            unpacked: {
+              node_id: 42,
+              external_links_verified: 3,
+              external_links_identity_ok: false,
+            },
+          }),
+        },
+      ],
+    });
+    const res = await defByName("panel_unpack_subgraph").handler({ node_id: 42 }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringMatching(/named dynamic slots/),
+    });
+  });
+
+  it("panel_unpack_subgraph notes an older panel that only counted surviving wires (#2887)", async () => {
+    const { ctx } = makeFakeCtx();
+    ctx.call = async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            unpacked: { node_id: 42, external_links_verified: 3 },
+          }),
+        },
+      ],
+    });
+    const res = await defByName("panel_unpack_subgraph").handler({ node_id: 42 }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(res.content.map((c) => (c.type === "text" ? c.text : "")).join("\n")).toMatch(
+      /named dynamic-slot identity/,
+    );
+  });
+
+  it("panel_unpack_subgraph keeps a current-panel identity_ok success unchanged (#2887)", async () => {
+    const { ctx } = makeFakeCtx();
+    ctx.call = async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            unpacked: {
+              node_id: 42,
+              external_links_verified: 3,
+              external_links_identity_ok: true,
+            },
+          }),
+        },
+      ],
+    });
+    const res = await defByName("panel_unpack_subgraph").handler({ node_id: 42 }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toHaveLength(1);
+    expect(res.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("external_links_identity_ok"),
+    });
+  });
 });
 
 describe("panel-tools: panel_configure_app_mode (#1709)", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -620,6 +620,44 @@ function ok(value: unknown): ToolResult {
   };
 }
 
+/**
+ * #2887 — litegraph unpacks by slot INDEX. After a MiniMax-style autogrow rebuild
+ * the same index can be a different named child, so a count of surviving wires is
+ * not proof they landed on ref_images rather than ref_videos. A current panel
+ * reseats by identity and sets `external_links_identity_ok: true`. `false` is a
+ * success that must not be accepted. A missing flag on a verified unpack is an
+ * older panel that cannot prove identity — noted, not trusted as a scramble-free
+ * graph.
+ */
+function refuseUnpackIdentityFailure(res: ToolResult): ToolResult {
+  if (res.isError) return res;
+  const parsed = parseToolResultJson(res);
+  const unpacked = parsed?.unpacked;
+  if (!unpacked || typeof unpacked !== "object" || Array.isArray(unpacked)) return res;
+  const payload = unpacked as Record<string, unknown>;
+  if (payload.external_links_identity_ok === false) {
+    return fail(
+      "panel_unpack_subgraph restored links but could not prove they landed on the named " +
+        "dynamic slots (including ref_images / ref_videos children). The graph was not " +
+        "accepted as unpacked. Upgrade the sidebar panel and retry, or unpack on the canvas " +
+        "and re-wire by name. (comfyui-mcp#2887)",
+    );
+  }
+  if (
+    typeof payload.external_links_verified === "number" &&
+    payload.external_links_verified > 0 &&
+    payload.external_links_identity_ok !== true
+  ) {
+    return appendReplyNote(
+      res,
+      "Note: this panel did not prove restored unpack links by named dynamic-slot identity. " +
+        "A MiniMax-style autogrow node can still have IMAGE land on ref_videos after unpack (#2887). " +
+        "Upgrade the sidebar panel so unpack reseats by name and refuses a scramble.",
+    );
+  }
+  return res;
+}
+
 function fail(err: unknown): ToolResult {
   const msg = err instanceof Error ? err.message : String(err);
   return { content: [{ type: "text", text: `Error: ${msg}` }], isError: true };
@@ -26824,9 +26862,12 @@ CHECKED FOR YOU: the graph read this message prescribes was just run, and it ` +
     ),
     def(
       "panel_unpack_subgraph",
-      "EXPAND / DISSOLVE a subgraph node on the user's open graph — inline its interior nodes back into the PARENT graph, rewire all external links to those now-inlined nodes, and remove the subgraph wrapper. This is the frontend's \"Unpack Subgraph\" (litegraph LGraph.unpackSubgraph) and the exact INVERSE of panel_create_subgraph. Use it to flatten a stage that was over-nested, or to edit interior nodes directly at the parent level. The interior nodes reappear on the parent canvas with their connections preserved. Undoable with Ctrl+Z.",
+      "EXPAND / DISSOLVE a subgraph node on the user's open graph — inline its interior nodes back into the PARENT graph, rewire all external links to those now-inlined nodes, and remove the subgraph wrapper. This is the frontend's \"Unpack Subgraph\" (litegraph LGraph.unpackSubgraph) and the exact INVERSE of panel_create_subgraph. Use it to flatten a stage that was over-nested, or to edit interior nodes directly at the parent level. The interior nodes reappear on the parent canvas with their connections preserved. Undoable with Ctrl+Z. Restored links are proven by named slot identity (including dynamic children like ref_images.ref_image_0); a scramble onto the wrong child is a refusal, not a success.",
       { node_id: nodeId().describe("Subgraph node id to unpack/dissolve (is_subgraph=true, from panel_graph_outline / panel_query_graph).") },
-      async (args: A, ctx) => ctx.call({ cmd: "graph_unpack_subgraph", node_id: args.node_id }, 15000),
+      async (args: A, ctx) =>
+        refuseUnpackIdentityFailure(
+          await ctx.call({ cmd: "graph_unpack_subgraph", node_id: args.node_id }, 15000),
+        ),
     ),
     def(
       "panel_search_nodes",


### PR DESCRIPTION
Fixes #2887

## What
`panel_unpack_subgraph` could return success after LiteGraph restored external links onto the wrong MiniMax-style dynamic children (`IMAGE` on `ref_videos`). #1665 only counted surviving wires, so a scramble was a silent graph.

## Fix
Wrap the panel unpack reply: `external_links_identity_ok: false` is a refusal; a current panel that reseated by named identity returns `true`; an older panel that only reports `external_links_verified` is noted rather than trusted.

Panel-side reseat/verify/rollback: https://github.com/artokun/comfyui-mcp-panel/pull/2279

## Evidence
`src/__tests__/orchestrator/panel-tools.test.ts` — identity_ok false is an error; missing flag on a verified unpack adds the upgrade note; identity_ok true is unchanged. vitest: 427 tests in panel-tools.test.ts + 54 in panel-prompt-budget.test.ts (481 passed).

Not merged. No release.