### PR TITLE
0.52.201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.201] - 2026-09-07
+
 ### MCP
 
 #### Fixed
-- pi discovery now resolves in SOURCE ORDER and readiness asks the same question as the launch (#2835). Three from review: a shim anywhere on PATH could beat an explicit COMFYUI_MCP_PI_PATH executable, because the shim pre-pass ran over every candidate before any of them was considered as an executable; a quoted PATH entry concatenated into an invalid path and a dead UNC entry could block startup on an SMB timeout; and backend-readiness still called resolvePiBin, whose name list excludes .cmd on a premise this PR overturns -- so a .cmd-only install read ABSENT though it runs, and an unresolvable extensionless shim read PRESENT though it spawns ENOENT, which is #2835's own symptom
-- the npm POSIX shim now resolves too, not just the .cmd (#2835). npm's sh shim names the interpreter and the script on one line, so the permissive pattern anchored on the first `$basedir/` and captured a path with embedded quotes; it never existed, so that branch resolved nothing at all. Measured against the real npm shims on a Windows box: 0/10 before, 10/10 after, with the .cmd branch unchanged at 10/10
-- **the pi backend works when pi was installed from npm on Windows (#2835).** `npm i -g pi`
-- the empty-toolset notice now requires POSITIVE evidence that a server connected (#2742). It skipped servers known degraded or pending and named everything else, but "not degraded" is a different fact from "connected": inspectMcpServers classifies nothing at all when the report is absent or empty, and an unrecognised status is deliberately not an alarm. So one server's tools populating the list could get another server — with no usable status evidence — announced as having CONNECTED and contributed nothing. It now reads the reported status directly. Found by the Copilot review on the PR
-- **a `hello` frame carrying no `comfyui_url` is no longer reported as a dead instance (#2742).** The one verdict with no `base` fell through to the shared warning, rendering as `ignoring hello retarget to unreachable undefined (stale tab on a dead instance?)` — asserting a target was named AND found dead, about a frame that claimed neither. Seen 17 times in one report from tabs that were merely churning.
-- **an MCP server that connects and registers NO tools is now reported (#2742).** Once this process has seen ANY namespaced MCP tool -- proof the harness lists them -- a session with NONE reports every configured server, closing the blind spot where a failure that emptied EVERY server looked identical to a harness that does not namespace.
+- **npm-installed pi resolution now follows source order and uses the same readiness predicate as launch across explicit executables, `.cmd`, and POSIX shims (#2835, #2838).** This fixes explicit-path precedence, quoted/PATH and dead-UNC handling, `.cmd`-only Windows installs, and npm's POSIX shim format.
+- the empty-toolset notice now requires POSITIVE evidence that a server connected. It skipped servers known degraded or pending and named everything else, but "not degraded" is a different fact from "connected": inspectMcpServers classifies nothing at all when the report is absent or empty, and an unrecognised status is deliberately not an alarm. So one server's tools populating the list could get another server — with no usable status evidence — announced as having CONNECTED and contributed nothing. It now reads the reported status directly. Found by the Copilot review on the PR
+- **a `hello` frame carrying no `comfyui_url` is no longer reported as a dead instance.** The one verdict with no `base` fell through to the shared warning, rendering as `ignoring hello retarget to unreachable undefined (stale tab on a dead instance?)` — asserting a target was named AND found dead, about a frame that claimed neither. Seen 17 times in one report from tabs that were merely churning.
+- **an MCP server that connects and registers NO tools is now reported (#2774).** Once this process has seen ANY namespaced MCP tool -- proof the harness lists them -- a session with NONE reports every configured server, closing the blind spot where a failure that emptied EVERY server looked identical to a harness that does not namespace.
+
+- **`download_model` no longer falsely refuses split code/data model namespaces (#1147, #2906).** Model candidates are compared by resolved physical identity, including case aliases, while preserving fail-closed behavior for genuinely missing or ambiguous roots.
+
+#### Changed
+- ignore root agent scratch and vendored node packs (#2728)
+- stop claiming a panel counterpart that does not exist (#2852)
 
 
 ## [0.52.200] - 2026-09-07

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.200",
+  "version": "0.52.201",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.200",
+      "version": "0.52.201",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.200",
+  "version": "0.52.201",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release 0.52.201.\n\nIncludes merged MCP #1147/#2906 model-root identity repair and the current unreleased MCP fixes.\n\nLocal gates: build, anti-slop, vocabulary, changelog integrity. Hosted CI must pass on the exact release head before merge.