### PR TITLE
chore: final release — archive notice, report_issue stub, docs homepage in every language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Changed
+- **This project is archived.** ComfyUI now ships official agent and MCP tooling (Comfy Agent and Comfy MCP, by Comfy-Org) — https://docs.comfy.org/agent-tools. `report_issue` is now a stub that files nothing and contacts no service, returning a notice that points at the official tooling; the `report-bug` skill says the same. The docs homepage carries the notice in every language. Issues and pull requests are closed.
+
 ## [0.52.202] - 2026-09-07
 
 ### MCP

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **لم يعد هذا المشروع قيد الصيانة.** يوفّر ComfyUI الآن أدوات وكيل و MCP رسمية — **Comfy Agent** و **Comfy MCP** — من تطوير ودعم فريق Comfy-Org، بتكامل أعمق مما يمكن لمشروع مجتمعي تقديمه. استخدم الأدوات الرسمية بدلاً من ذلك: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). يبقى هذا الموقع كمرجع فقط؛ لن تُضاف ميزات جديدة أو إصلاحات أو تحديثات للاعتماديات.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** هو **مستوى التحكّم المحلي أولًا والمصمَّم أصلًا للوكلاء** الخاص بـ

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **لم يعد هذا المشروع قيد الصيانة.** يوفّر ComfyUI الآن أدوات وكيل و MCP رسمية — **Comfy Agent** و **Comfy MCP** — من تطوير ودعم فريق Comfy-Org، بتكامل أعمق مما يمكن لمشروع مجتمعي تقديمه. استخدم الأدوات الرسمية بدلاً من ذلك: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). يبقى هذا الموقع كمرجع فقط؛ لن تُضاف ميزات جديدة أو إصلاحات أو تحديثات للاعتماديات.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** هو **مستوى التحكّم المحلي أولًا والمصمَّم أصلًا للوكلاء** الخاص بـ

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -4,6 +4,10 @@ description: "مستوى التحكّم المحلي أولًا والمصمَّ
 icon: "house"
 ---
 
+<Warning>
+**لم يعد هذا المشروع قيد الصيانة.** يوفّر ComfyUI الآن أدوات وكيل و MCP رسمية — **Comfy Agent** و **Comfy MCP** — من تطوير ودعم فريق Comfy-Org، بتكامل أعمق مما يمكن لمشروع مجتمعي تقديمه. استخدم الأدوات الرسمية بدلاً من ذلك: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). يبقى هذا الموقع كمرجع فقط؛ لن تُضاف ميزات جديدة أو إصلاحات أو تحديثات للاعتماديات.
+</Warning>
+
 **ComfyUI MCP** هو **مستوى التحكّم المحلي أولًا والمصمَّم أصلًا للوكلاء** الخاص بـ
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — خادم [MCP](https://modelcontextprotocol.io)
 وإضافة لـ Claude Code. يربط مساعدك الذكي بنسخة ComfyUI قيد التشغيل — **محلية** أو **بعيدة** أو على

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**لم يعد هذا المشروع قيد الصيانة.** يوفّر ComfyUI الآن أدوات وكيل و MCP رسمية — **Comfy Agent** و **Comfy MCP** — من تطوير ودعم فريق Comfy-Org، بتكامل أعمق مما يمكن لمشروع مجتمعي تقديمه. استخدم الأدوات الرسمية بدلاً من ذلك: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). يبقى هذا الموقع كمرجع فقط؛ لن تُضاف ميزات جديدة أو إصلاحات أو تحديثات للاعتماديات.
+**لم يعد هذا المشروع قيد الصيانة.** يوفّر ComfyUI الآن أدوات وكيل و MCP رسمية — **Comfy Agent** و **Comfy MCP** — من تطوير ودعم فريق Comfy-Org، بتكامل أعمق مما يمكن لمشروع مجتمعي تقديمه. استخدم الأدوات الرسمية بدلاً من ذلك: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). يبقى هذا الموقع كمرجع فقط؛ لن تُضاف ميزات جديدة أو إصلاحات أو تحديثات للاعتماديات.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/blog/goodbye.mdx
+++ b/docs/blog/goodbye.mdx
@@ -59,7 +59,7 @@ a pull request, so don't wait on that.
 
 ## Custom work
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 
 ## Thanks
 

--- a/docs/blog/goodbye.mdx
+++ b/docs/blog/goodbye.mdx
@@ -57,6 +57,10 @@ a pull request, so don't wait on that.
 - **`report_issue` and the report-bug skill** in the final release are stubs. They
   file nothing and point you at the official tooling instead.
 
+## Custom work
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+
 ## Thanks
 
 To everyone who used it, starred it, forked it, filed a report, or sent a patch:

--- a/docs/blog/goodbye.mdx
+++ b/docs/blog/goodbye.mdx
@@ -31,6 +31,7 @@ official tool in the box, it doesn't.
 
 ## Use the official tooling
 
+- [Comfy Agent](https://comfy.org/agent) — the agent that lives inside ComfyUI
 - [Agent tools documentation](https://docs.comfy.org/agent-tools)
 - [Comfy MCP](https://comfy.org/mcp/)
 - [Comfy-Org/comfy-mcp on GitHub](https://github.com/Comfy-Org/comfy-mcp)

--- a/docs/blog/goodbye.mdx
+++ b/docs/blog/goodbye.mdx
@@ -1,0 +1,63 @@
+---
+title: "Goodbye, and thanks — comfyui-mcp is archived"
+description: "comfyui-mcp and the Agent Panel are no longer maintained. ComfyUI now ships official agent and MCP tooling. What happens to npm, the registry node, and your forks."
+keywords:
+  - comfyui-mcp archived
+  - ComfyUI MCP
+  - Comfy MCP
+  - Comfy Agent
+  - project sunset
+---
+
+_by [artokun](https://github.com/artokun) · September 9, 2026 · project · goodbye_
+
+This is the last post. **comfyui-mcp and the ComfyUI Agent Panel are archived.**
+No new features, no bug fixes, no dependency updates. Issues and pull requests
+are closed.
+
+## Why
+
+ComfyUI now ships its own agent and MCP tooling — **Comfy Agent** and **Comfy
+MCP** — built and supported by the Comfy-Org team. It sits inside the product,
+with a level of integration a community project can't match from the outside, and
+it is where the effort belongs. Comfy wanted to do their own thing, and that is the
+right call for ComfyUI users.
+
+That also settles the other half of the question. Keeping a project like this
+alive is support work — triaging reports, chasing regressions in someone else's
+release cycle, keeping up with a frontend that moves every week — and open source
+is a thankless place to do it. It made sense while there was nothing else. With an
+official tool in the box, it doesn't.
+
+## Use the official tooling
+
+- [Agent tools documentation](https://docs.comfy.org/agent-tools)
+- [Comfy MCP](https://comfy.org/mcp/)
+- [Comfy-Org/comfy-mcp on GitHub](https://github.com/Comfy-Org/comfy-mcp)
+
+If you came here looking for an MCP server or an AI agent for ComfyUI, start
+there.
+
+## Fork it, remix it
+
+The code stays public as a reference, MIT-licensed. If some part of it is useful
+to you — the tool surface, the installer packs, the skills, the panel — **fork it
+and make it yours.** I'd genuinely like to see what people build out of the
+pieces. Nothing here needs my permission, and nothing here is coming back to me as
+a pull request, so don't wait on that.
+
+## What happens to the npm package and the registry node
+
+- **npm (`comfyui-mcp`)** stays published, **unmaintained**. It will keep working
+  for as long as ComfyUI keeps the surfaces it depends on. As ComfyUI grows and
+  changes, it will eventually just stop working — that is expected, and it will
+  not be fixed. When it does, I'll unpublish it.
+- **The Comfy Registry node (`comfyui-agent-panel`)** follows the same path: it
+  stays listed until it breaks, and then the submission comes down.
+- **`report_issue` and the report-bug skill** in the final release are stubs. They
+  file nothing and point you at the official tooling instead.
+
+## Thanks
+
+To everyone who used it, starred it, forked it, filed a report, or sent a patch:
+thank you. It was fun. It was a good run. 🚀

--- a/docs/blog/index.mdx
+++ b/docs/blog/index.mdx
@@ -6,6 +6,14 @@ description: Notes on building comfyui-mcp — tool design, quality, and a model
 Writing about building [comfyui-mcp](https://github.com/artokun/comfyui-mcp): tool design, schema
 quality, and what we learn shipping an MCP server people actually use.
 
+<Warning>
+**This project is archived.** ComfyUI now ships official agent and MCP tooling — Comfy Agent and Comfy MCP — built by the Comfy-Org team. Read the [goodbye post](./goodbye), then head to the [official agent tools](https://docs.comfy.org/agent-tools).
+</Warning>
+
+<Card title="Goodbye, and thanks" href="./goodbye">
+  The last post: why comfyui-mcp is archived, what happens to npm and the registry node, and an open invitation to fork it.
+</Card>
+
 ## Model highlights
 
 A chronological tour of the open image & video models you can run locally in

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,6 +114,7 @@
                 "group": "Blog",
                 "pages": [
                   "blog/index",
+                  "blog/goodbye",
                   "blog/comfy-kitchen",
                   "blog/from-report-to-release",
                   "blog/micro-apps",

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**Este proyecto ya no recibe mantenimiento.** ComfyUI ahora incluye herramientas oficiales de agente y MCP — **Comfy Agent** y **Comfy MCP** — creadas y mantenidas por el equipo de Comfy-Org, con una integración más profunda de la que un proyecto comunitario puede ofrecer. Usa las herramientas oficiales: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este sitio se conserva solo como referencia; no habrá nuevas funciones, correcciones ni actualizaciones de dependencias.
+**Este proyecto ya no recibe mantenimiento.** ComfyUI ahora incluye herramientas oficiales de agente y MCP — **Comfy Agent** y **Comfy MCP** — creadas y mantenidas por el equipo de Comfy-Org, con una integración más profunda de la que un proyecto comunitario puede ofrecer. Usa las herramientas oficiales: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este sitio se conserva solo como referencia; no habrá nuevas funciones, correcciones ni actualizaciones de dependencias.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **Este proyecto ya no recibe mantenimiento.** ComfyUI ahora incluye herramientas oficiales de agente y MCP — **Comfy Agent** y **Comfy MCP** — creadas y mantenidas por el equipo de Comfy-Org, con una integración más profunda de la que un proyecto comunitario puede ofrecer. Usa las herramientas oficiales: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este sitio se conserva solo como referencia; no habrá nuevas funciones, correcciones ni actualizaciones de dependencias.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** es el **plano de control local-first y nativo para agentes** de

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -4,6 +4,10 @@ description: "El plano de control local-first y nativo para agentes de ComfyUI �
 icon: "house"
 ---
 
+<Warning>
+**Este proyecto ya no recibe mantenimiento.** ComfyUI ahora incluye herramientas oficiales de agente y MCP — **Comfy Agent** y **Comfy MCP** — creadas y mantenidas por el equipo de Comfy-Org, con una integración más profunda de la que un proyecto comunitario puede ofrecer. Usa las herramientas oficiales: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este sitio se conserva solo como referencia; no habrá nuevas funciones, correcciones ni actualizaciones de dependencias.
+</Warning>
+
 **ComfyUI MCP** es el **plano de control local-first y nativo para agentes** de
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — un servidor
 [MCP](https://modelcontextprotocol.io) y plugin de Claude Code. Conecta tu asistente de IA a una

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **Este proyecto ya no recibe mantenimiento.** ComfyUI ahora incluye herramientas oficiales de agente y MCP — **Comfy Agent** y **Comfy MCP** — creadas y mantenidas por el equipo de Comfy-Org, con una integración más profunda de la que un proyecto comunitario puede ofrecer. Usa las herramientas oficiales: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este sitio se conserva solo como referencia; no habrá nuevas funciones, correcciones ni actualizaciones de dependencias.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** es el **plano de control local-first y nativo para agentes** de

--- a/docs/fa/index.mdx
+++ b/docs/fa/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**این پروژه دیگر نگهداری نمی‌شود.** ComfyUI اکنون ابزارهای رسمی عامل و MCP — **Comfy Agent** و **Comfy MCP** — را ارائه می‌دهد که توسط تیم Comfy-Org ساخته و پشتیبانی می‌شوند، با یکپارچگی عمیق‌تر از آنچه یک پروژهٔ جامعه‌محور می‌تواند داشته باشد. لطفاً از ابزارهای رسمی استفاده کنید: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). این سایت تنها به‌عنوان مرجع باقی می‌ماند؛ هیچ ویژگی جدید، رفع اشکال یا به‌روزرسانی وابستگی‌ای منتشر نخواهد شد.
+**این پروژه دیگر نگهداری نمی‌شود.** ComfyUI اکنون ابزارهای رسمی عامل و MCP — **Comfy Agent** و **Comfy MCP** — را ارائه می‌دهد که توسط تیم Comfy-Org ساخته و پشتیبانی می‌شوند، با یکپارچگی عمیق‌تر از آنچه یک پروژهٔ جامعه‌محور می‌تواند داشته باشد. لطفاً از ابزارهای رسمی استفاده کنید: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). این سایت تنها به‌عنوان مرجع باقی می‌ماند؛ هیچ ویژگی جدید، رفع اشکال یا به‌روزرسانی وابستگی‌ای منتشر نخواهد شد.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/fa/index.mdx
+++ b/docs/fa/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **این پروژه دیگر نگهداری نمی‌شود.** ComfyUI اکنون ابزارهای رسمی عامل و MCP — **Comfy Agent** و **Comfy MCP** — را ارائه می‌دهد که توسط تیم Comfy-Org ساخته و پشتیبانی می‌شوند، با یکپارچگی عمیق‌تر از آنچه یک پروژهٔ جامعه‌محور می‌تواند داشته باشد. لطفاً از ابزارهای رسمی استفاده کنید: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). این سایت تنها به‌عنوان مرجع باقی می‌ماند؛ هیچ ویژگی جدید، رفع اشکال یا به‌روزرسانی وابستگی‌ای منتشر نخواهد شد.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** همان **سطح کنترلِ محلی‌محور و بومیِ عامل** برای

--- a/docs/fa/index.mdx
+++ b/docs/fa/index.mdx
@@ -4,6 +4,10 @@ description: "سطح کنترلِ محلی‌محور و بومیِ عامل ب�
 icon: "house"
 ---
 
+<Warning>
+**این پروژه دیگر نگهداری نمی‌شود.** ComfyUI اکنون ابزارهای رسمی عامل و MCP — **Comfy Agent** و **Comfy MCP** — را ارائه می‌دهد که توسط تیم Comfy-Org ساخته و پشتیبانی می‌شوند، با یکپارچگی عمیق‌تر از آنچه یک پروژهٔ جامعه‌محور می‌تواند داشته باشد. لطفاً از ابزارهای رسمی استفاده کنید: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). این سایت تنها به‌عنوان مرجع باقی می‌ماند؛ هیچ ویژگی جدید، رفع اشکال یا به‌روزرسانی وابستگی‌ای منتشر نخواهد شد.
+</Warning>
+
 **ComfyUI MCP** همان **سطح کنترلِ محلی‌محور و بومیِ عامل** برای
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) است — یک سرور
 [MCP](https://modelcontextprotocol.io) و افزونهٔ Claude Code. دستیار هوش مصنوعی شما را به یک نمونهٔ

--- a/docs/fa/index.mdx
+++ b/docs/fa/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **این پروژه دیگر نگهداری نمی‌شود.** ComfyUI اکنون ابزارهای رسمی عامل و MCP — **Comfy Agent** و **Comfy MCP** — را ارائه می‌دهد که توسط تیم Comfy-Org ساخته و پشتیبانی می‌شوند، با یکپارچگی عمیق‌تر از آنچه یک پروژهٔ جامعه‌محور می‌تواند داشته باشد. لطفاً از ابزارهای رسمی استفاده کنید: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). این سایت تنها به‌عنوان مرجع باقی می‌ماند؛ هیچ ویژگی جدید، رفع اشکال یا به‌روزرسانی وابستگی‌ای منتشر نخواهد شد.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** همان **سطح کنترلِ محلی‌محور و بومیِ عامل** برای

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **Ce projet n'est plus maintenu.** ComfyUI fournit désormais des outils officiels d'agent et de MCP — **Comfy Agent** et **Comfy MCP** — développés et pris en charge par l'équipe Comfy-Org, avec une intégration plus profonde qu'un projet communautaire ne peut offrir. Utilisez les outils officiels : [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Ce site reste en ligne à titre de référence uniquement ; aucune nouvelle fonctionnalité, correction ou mise à jour de dépendances ne sera publiée.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** est le **plan de contrôle local-first et nativement agentique** de

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -4,6 +4,10 @@ description: "Le plan de contrôle local-first et nativement agentique pour Comf
 icon: "house"
 ---
 
+<Warning>
+**Ce projet n'est plus maintenu.** ComfyUI fournit désormais des outils officiels d'agent et de MCP — **Comfy Agent** et **Comfy MCP** — développés et pris en charge par l'équipe Comfy-Org, avec une intégration plus profonde qu'un projet communautaire ne peut offrir. Utilisez les outils officiels : [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Ce site reste en ligne à titre de référence uniquement ; aucune nouvelle fonctionnalité, correction ou mise à jour de dépendances ne sera publiée.
+</Warning>
+
 **ComfyUI MCP** est le **plan de contrôle local-first et nativement agentique** de
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — un serveur
 [MCP](https://modelcontextprotocol.io) et un plugin Claude Code. Il connecte votre assistant IA à

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **Ce projet n'est plus maintenu.** ComfyUI fournit désormais des outils officiels d'agent et de MCP — **Comfy Agent** et **Comfy MCP** — développés et pris en charge par l'équipe Comfy-Org, avec une intégration plus profonde qu'un projet communautaire ne peut offrir. Utilisez les outils officiels : [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Ce site reste en ligne à titre de référence uniquement ; aucune nouvelle fonctionnalité, correction ou mise à jour de dépendances ne sera publiée.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** est le **plan de contrôle local-first et nativement agentique** de

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**Ce projet n'est plus maintenu.** ComfyUI fournit désormais des outils officiels d'agent et de MCP — **Comfy Agent** et **Comfy MCP** — développés et pris en charge par l'équipe Comfy-Org, avec une intégration plus profonde qu'un projet communautaire ne peut offrir. Utilisez les outils officiels : [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Ce site reste en ligne à titre de référence uniquement ; aucune nouvelle fonctionnalité, correction ou mise à jour de dépendances ne sera publiée.
+**Ce projet n'est plus maintenu.** ComfyUI fournit désormais des outils officiels d'agent et de MCP — **Comfy Agent** et **Comfy MCP** — développés et pris en charge par l'équipe Comfy-Org, avec une intégration plus profonde qu'un projet communautaire ne peut offrir. Utilisez les outils officiels : [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Ce site reste en ligne à titre de référence uniquement ; aucune nouvelle fonctionnalité, correction ou mise à jour de dépendances ne sera publiée.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **This project is no longer maintained.** ComfyUI now ships official agent and MCP tooling — **Comfy Agent** and **Comfy MCP** — built and supported by the Comfy-Org team, with deeper integration than a community project can match. Use the official tooling instead: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). This site stays up as a reference only; no new features, bug fixes, or dependency updates will be made.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** is the **local-first, agent-native control plane** for

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **This project is no longer maintained.** ComfyUI now ships official agent and MCP tooling — **Comfy Agent** and **Comfy MCP** — built and supported by the Comfy-Org team, with deeper integration than a community project can match. Use the official tooling instead: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). This site stays up as a reference only; no new features, bug fixes, or dependency updates will be made.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** is the **local-first, agent-native control plane** for

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**This project is no longer maintained.** ComfyUI now ships official agent and MCP tooling — **Comfy Agent** and **Comfy MCP** — built and supported by the Comfy-Org team, with deeper integration than a community project can match. Use the official tooling instead: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). This site stays up as a reference only; no new features, bug fixes, or dependency updates will be made.
+**This project is no longer maintained.** ComfyUI now ships official agent and MCP tooling — **Comfy Agent** and **Comfy MCP** — built and supported by the Comfy-Org team, with deeper integration than a community project can match. Use the official tooling instead: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). This site stays up as a reference only; no new features, bug fixes, or dependency updates will be made.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,6 +4,10 @@ description: "The local-first, agent-native control plane for ComfyUI — an MCP
 icon: "house"
 ---
 
+<Warning>
+**This project is no longer maintained.** ComfyUI now ships official agent and MCP tooling — **Comfy Agent** and **Comfy MCP** — built and supported by the Comfy-Org team, with deeper integration than a community project can match. Use the official tooling instead: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). This site stays up as a reference only; no new features, bug fixes, or dependency updates will be made.
+</Warning>
+
 **ComfyUI MCP** is the **local-first, agent-native control plane** for
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — an [MCP](https://modelcontextprotocol.io)
 server and Claude Code plugin. It connects your AI assistant to a running ComfyUI instance —

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**このプロジェクトはメンテナンスを終了しました。** ComfyUI には現在、Comfy-Org チームが開発・サポートする公式のエージェント／MCP ツール — **Comfy Agent** と **Comfy MCP** — が同梱されています。今後は公式ツールをご利用ください: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。このサイトは参考資料として残しますが、新機能・バグ修正・依存関係の更新は行いません。
+**このプロジェクトはメンテナンスを終了しました。** ComfyUI には現在、Comfy-Org チームが開発・サポートする公式のエージェント／MCP ツール — **Comfy Agent** と **Comfy MCP** — が同梱されています。今後は公式ツールをご利用ください: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。このサイトは参考資料として残しますが、新機能・バグ修正・依存関係の更新は行いません。
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -4,6 +4,10 @@ description: "ComfyUI のためのローカルファーストかつエージェ�
 icon: "house"
 ---
 
+<Warning>
+**このプロジェクトはメンテナンスを終了しました。** ComfyUI には現在、Comfy-Org チームが開発・サポートする公式のエージェント／MCP ツール — **Comfy Agent** と **Comfy MCP** — が同梱されています。今後は公式ツールをご利用ください: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。このサイトは参考資料として残しますが、新機能・バグ修正・依存関係の更新は行いません。
+</Warning>
+
 **ComfyUI MCP** は [ComfyUI](https://github.com/comfyanonymous/ComfyUI) のための **ローカルファーストかつエージェントネイティブなコントロールプレーン** です — [MCP](https://modelcontextprotocol.io) サーバーであり、Claude Code プラグインでもあります。実行中の ComfyUI インスタンス — **ローカル**、**リモート**、または **[Comfy Cloud](https://cloud.comfy.org)** — に AI アシスタントを接続し、画像・動画・音声の生成、ワークフローの実行と作成、モデルとカスタムノードの管理、サーバーの制御を、すべて自然言語で行えます。単なるプロンプトから画像へのブリッジではなく、ComfyUI をあなたに代わって操作する本格的なエージェントです。
 
 <Frame caption="エージェントパネルが ComfyUI をエンドツーエンドで操作 — ローカルにインストール済みのものを読み取り、グラフを接続し、VRAM を解放し、レンダリングを実行">

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **このプロジェクトはメンテナンスを終了しました。** ComfyUI には現在、Comfy-Org チームが開発・サポートする公式のエージェント／MCP ツール — **Comfy Agent** と **Comfy MCP** — が同梱されています。今後は公式ツールをご利用ください: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。このサイトは参考資料として残しますが、新機能・バグ修正・依存関係の更新は行いません。
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** は [ComfyUI](https://github.com/comfyanonymous/ComfyUI) のための **ローカルファーストかつエージェントネイティブなコントロールプレーン** です — [MCP](https://modelcontextprotocol.io) サーバーであり、Claude Code プラグインでもあります。実行中の ComfyUI インスタンス — **ローカル**、**リモート**、または **[Comfy Cloud](https://cloud.comfy.org)** — に AI アシスタントを接続し、画像・動画・音声の生成、ワークフローの実行と作成、モデルとカスタムノードの管理、サーバーの制御を、すべて自然言語で行えます。単なるプロンプトから画像へのブリッジではなく、ComfyUI をあなたに代わって操作する本格的なエージェントです。

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **このプロジェクトはメンテナンスを終了しました。** ComfyUI には現在、Comfy-Org チームが開発・サポートする公式のエージェント／MCP ツール — **Comfy Agent** と **Comfy MCP** — が同梱されています。今後は公式ツールをご利用ください: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。このサイトは参考資料として残しますが、新機能・バグ修正・依存関係の更新は行いません。
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** は [ComfyUI](https://github.com/comfyanonymous/ComfyUI) のための **ローカルファーストかつエージェントネイティブなコントロールプレーン** です — [MCP](https://modelcontextprotocol.io) サーバーであり、Claude Code プラグインでもあります。実行中の ComfyUI インスタンス — **ローカル**、**リモート**、または **[Comfy Cloud](https://cloud.comfy.org)** — に AI アシスタントを接続し、画像・動画・音声の生成、ワークフローの実行と作成、モデルとカスタムノードの管理、サーバーの制御を、すべて自然言語で行えます。単なるプロンプトから画像へのブリッジではなく、ComfyUI をあなたに代わって操作する本格的なエージェントです。

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **이 프로젝트는 더 이상 유지보수되지 않습니다.** ComfyUI는 이제 Comfy-Org 팀이 만들고 지원하는 공식 에이전트 및 MCP 도구인 **Comfy Agent**와 **Comfy MCP**를 제공합니다. 공식 도구를 사용해 주세요: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). 이 사이트는 참고용으로만 유지되며 새로운 기능, 버그 수정, 의존성 업데이트는 없습니다.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP**는 [ComfyUI](https://github.com/comfyanonymous/ComfyUI)를 위한 **로컬 우선, 에이전트

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**이 프로젝트는 더 이상 유지보수되지 않습니다.** ComfyUI는 이제 Comfy-Org 팀이 만들고 지원하는 공식 에이전트 및 MCP 도구인 **Comfy Agent**와 **Comfy MCP**를 제공합니다. 공식 도구를 사용해 주세요: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). 이 사이트는 참고용으로만 유지되며 새로운 기능, 버그 수정, 의존성 업데이트는 없습니다.
+**이 프로젝트는 더 이상 유지보수되지 않습니다.** ComfyUI는 이제 Comfy-Org 팀이 만들고 지원하는 공식 에이전트 및 MCP 도구인 **Comfy Agent**와 **Comfy MCP**를 제공합니다. 공식 도구를 사용해 주세요: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). 이 사이트는 참고용으로만 유지되며 새로운 기능, 버그 수정, 의존성 업데이트는 없습니다.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -4,6 +4,10 @@ description: "ComfyUI를 위한 로컬 우선, 에이전트 네이티브 컨트�
 icon: "house"
 ---
 
+<Warning>
+**이 프로젝트는 더 이상 유지보수되지 않습니다.** ComfyUI는 이제 Comfy-Org 팀이 만들고 지원하는 공식 에이전트 및 MCP 도구인 **Comfy Agent**와 **Comfy MCP**를 제공합니다. 공식 도구를 사용해 주세요: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). 이 사이트는 참고용으로만 유지되며 새로운 기능, 버그 수정, 의존성 업데이트는 없습니다.
+</Warning>
+
 **ComfyUI MCP**는 [ComfyUI](https://github.com/comfyanonymous/ComfyUI)를 위한 **로컬 우선, 에이전트
 네이티브 컨트롤 플레인**입니다 — [MCP](https://modelcontextprotocol.io) 서버이자 Claude Code
 플러그인입니다. 실행 중인 ComfyUI 인스턴스 — **로컬**, **원격**, 또는

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **이 프로젝트는 더 이상 유지보수되지 않습니다.** ComfyUI는 이제 Comfy-Org 팀이 만들고 지원하는 공식 에이전트 및 MCP 도구인 **Comfy Agent**와 **Comfy MCP**를 제공합니다. 공식 도구를 사용해 주세요: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). 이 사이트는 참고용으로만 유지되며 새로운 기능, 버그 수정, 의존성 업데이트는 없습니다.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP**는 [ComfyUI](https://github.com/comfyanonymous/ComfyUI)를 위한 **로컬 우선, 에이전트

--- a/docs/pt-BR/index.mdx
+++ b/docs/pt-BR/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**Este projeto não é mais mantido.** O ComfyUI agora inclui ferramentas oficiais de agente e MCP — **Comfy Agent** e **Comfy MCP** — criadas e mantidas pela equipe Comfy-Org, com uma integração mais profunda do que um projeto da comunidade consegue oferecer. Use as ferramentas oficiais: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este site permanece apenas como referência; não haverá novos recursos, correções ou atualizações de dependências.
+**Este projeto não é mais mantido.** O ComfyUI agora inclui ferramentas oficiais de agente e MCP — **Comfy Agent** e **Comfy MCP** — criadas e mantidas pela equipe Comfy-Org, com uma integração mais profunda do que um projeto da comunidade consegue oferecer. Use as ferramentas oficiais: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este site permanece apenas como referência; não haverá novos recursos, correções ou atualizações de dependências.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/pt-BR/index.mdx
+++ b/docs/pt-BR/index.mdx
@@ -4,6 +4,10 @@ description: "O plano de controle local-first e nativo para agentes do ComfyUI �
 icon: "house"
 ---
 
+<Warning>
+**Este projeto não é mais mantido.** O ComfyUI agora inclui ferramentas oficiais de agente e MCP — **Comfy Agent** e **Comfy MCP** — criadas e mantidas pela equipe Comfy-Org, com uma integração mais profunda do que um projeto da comunidade consegue oferecer. Use as ferramentas oficiais: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este site permanece apenas como referência; não haverá novos recursos, correções ou atualizações de dependências.
+</Warning>
+
 **ComfyUI MCP** é o **plano de controle local-first e nativo para agentes** do
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — um servidor
 [MCP](https://modelcontextprotocol.io) e plugin do Claude Code. Ele conecta o seu assistente de IA

--- a/docs/pt-BR/index.mdx
+++ b/docs/pt-BR/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **Este projeto não é mais mantido.** O ComfyUI agora inclui ferramentas oficiais de agente e MCP — **Comfy Agent** e **Comfy MCP** — criadas e mantidas pela equipe Comfy-Org, com uma integração mais profunda do que um projeto da comunidade consegue oferecer. Use as ferramentas oficiais: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este site permanece apenas como referência; não haverá novos recursos, correções ou atualizações de dependências.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** é o **plano de controle local-first e nativo para agentes** do

--- a/docs/pt-BR/index.mdx
+++ b/docs/pt-BR/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **Este projeto não é mais mantido.** O ComfyUI agora inclui ferramentas oficiais de agente e MCP — **Comfy Agent** e **Comfy MCP** — criadas e mantidas pela equipe Comfy-Org, com uma integração mais profunda do que um projeto da comunidade consegue oferecer. Use as ferramentas oficiais: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Este site permanece apenas como referência; não haverá novos recursos, correções ou atualizações de dependências.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** é o **plano de controle local-first e nativo para agentes** do

--- a/docs/ru/index.mdx
+++ b/docs/ru/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**Этот проект больше не поддерживается.** ComfyUI теперь поставляется с официальными инструментами агента и MCP — **Comfy Agent** и **Comfy MCP** — которые разрабатывает и поддерживает команда Comfy-Org, с более глубокой интеграцией, чем может дать сообщество. Используйте официальные инструменты: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Этот сайт остаётся только как справочный материал; новых функций, исправлений и обновлений зависимостей не будет.
+**Этот проект больше не поддерживается.** ComfyUI теперь поставляется с официальными инструментами агента и MCP — **Comfy Agent** и **Comfy MCP** — которые разрабатывает и поддерживает команда Comfy-Org, с более глубокой интеграцией, чем может дать сообщество. Используйте официальные инструменты: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Этот сайт остаётся только как справочный материал; новых функций, исправлений и обновлений зависимостей не будет.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/ru/index.mdx
+++ b/docs/ru/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **Этот проект больше не поддерживается.** ComfyUI теперь поставляется с официальными инструментами агента и MCP — **Comfy Agent** и **Comfy MCP** — которые разрабатывает и поддерживает команда Comfy-Org, с более глубокой интеграцией, чем может дать сообщество. Используйте официальные инструменты: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Этот сайт остаётся только как справочный материал; новых функций, исправлений и обновлений зависимостей не будет.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** — это **локальная по умолчанию, изначально агентная плоскость управления** для

--- a/docs/ru/index.mdx
+++ b/docs/ru/index.mdx
@@ -4,6 +4,10 @@ description: "Локальная по умолчанию, изначально �
 icon: "house"
 ---
 
+<Warning>
+**Этот проект больше не поддерживается.** ComfyUI теперь поставляется с официальными инструментами агента и MCP — **Comfy Agent** и **Comfy MCP** — которые разрабатывает и поддерживает команда Comfy-Org, с более глубокой интеграцией, чем может дать сообщество. Используйте официальные инструменты: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Этот сайт остаётся только как справочный материал; новых функций, исправлений и обновлений зависимостей не будет.
+</Warning>
+
 **ComfyUI MCP** — это **локальная по умолчанию, изначально агентная плоскость управления** для
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI): [MCP](https://modelcontextprotocol.io)-сервер
 и плагин Claude Code. Он подключает вашего ИИ-ассистента к работающему экземпляру ComfyUI —

--- a/docs/ru/index.mdx
+++ b/docs/ru/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **Этот проект больше не поддерживается.** ComfyUI теперь поставляется с официальными инструментами агента и MCP — **Comfy Agent** и **Comfy MCP** — которые разрабатывает и поддерживает команда Comfy-Org, с более глубокой интеграцией, чем может дать сообщество. Используйте официальные инструменты: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Этот сайт остаётся только как справочный материал; новых функций, исправлений и обновлений зависимостей не будет.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** — это **локальная по умолчанию, изначально агентная плоскость управления** для

--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -229,30 +229,30 @@ Inspect and manage ComfyUI workspaces (local installs). Driven by the `action` p
 
 ## report_issue
 
-File or triage a GitHub issue for a bug/problem you hit (ComfyUI, a workflow, a model, custom nodes, or comfyui-mcp/its panel). For OUR repos (artokun/comfyui-mcp, artokun/comfyui-mcp-panel) it sends the report to the AI triage worker, which searches existing OPEN and CLOSED issues, version-matches, and either files a new issue, adds context to an existing one, or — if the problem was already FIXED in a newer version than the user runs — answers with the fixing PR + fixed-in version and a recommendation to upgrade (no new issue). It returns that triage result plus an instant check of whether the user is on the latest versions. TIMING: this call BLOCKS while the triage runs — typically a few minutes — and that wait is normal, not a hang. It always returns eventually (every request is time-capped and the poll budget is bounded); on a failing network the caps make that wait longer, but never indefinite. Do not abort a slow call just to retry it: once the worker has accepted the report it keeps triaging on its own — filing, deduping into an existing issue, advising an upgrade, or (rarely) reporting that it could not file — so a blind retry can double-file. If triage outlasts the polling budget the call still returns, with pending:true (and a job_id when the worker gave one — an accepted submit whose acknowledgement was unreadable returns pending without it). If the worker is unreachable it falls back to a prefilled GitHub 'new issue' URL. For third-party repos it returns a prefilled URL to SHARE (it does not auto-file). ALWAYS pass mcp_version and panel_version from the known environment (the env line in your context, e.g. 'mcp=… panel=…') so the worker can tell the user if simply upgrading fixes it — the single most common resolution. Surface the worker's agent_message / upgrade advice to the user.
+ARCHIVED — this project is no longer maintained and its issue trackers are closed. This tool files NOTHING and contacts no service: it returns a notice pointing at ComfyUI's official agent and MCP tooling (Comfy Agent / Comfy MCP, by Comfy-Org). Kept registered only so older prompts and skills that call it get a clear answer instead of an unknown-tool error.
 
 ### Parameters
 
 <ParamField path="title" type="string" required>
-  Short, specific issue title.
+  Ignored — retained for compatibility with callers that still pass it.
 </ParamField>
 <ParamField path="body" type="string" required>
-  Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, ComfyUI FRONTEND version, OS) if known. The FRONTEND version is a SEPARATE package from ComfyUI and they move independently — get_system_stats (action:"health") prints both, and for any panel/UI bug it is often the deciding variable. Scrub secrets first.
+  Ignored — retained for compatibility with callers that still pass it.
 </ParamField>
 <ParamField path="repo" type="string">
-  owner/repo (default 'artokun/comfyui-mcp'; use 'artokun/comfyui-mcp-panel' for the sidebar panel).
+  Ignored.
 </ParamField>
 <ParamField path="labels" type="string[]">
-  Optional GitHub label names to prefill.
+  Ignored.
 </ParamField>
 <ParamField path="mcp_version" type="string">
-  The running comfyui-mcp version (from the env line in your context). Auto-detected if omitted.
+  Ignored.
 </ParamField>
 <ParamField path="panel_version" type="string">
-  The running comfyui-mcp-panel (sidebar) version, from the env line in your context, if known.
+  Ignored.
 </ParamField>
 <ParamField path="no_file" type="boolean">
-  Force the prefilled-URL path even for our repos (skip the Worker). Rarely needed.
+  Ignored.
 </ParamField>
 
 ### Example

--- a/docs/tr/index.mdx
+++ b/docs/tr/index.mdx
@@ -4,6 +4,10 @@ description: "ComfyUI için yerel öncelikli, ajanlar için tasarlanmış kontro
 icon: "house"
 ---
 
+<Warning>
+**Bu proje artık bakım görmemektedir.** ComfyUI artık Comfy-Org ekibi tarafından geliştirilen ve desteklenen resmi ajan ve MCP araçlarını — **Comfy Agent** ve **Comfy MCP** — sunuyor; bir topluluk projesinin ulaşamayacağı derinlikte bir entegrasyonla. Lütfen resmi araçları kullanın: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Bu site yalnızca referans olarak kalacaktır; yeni özellik, hata düzeltmesi veya bağımlılık güncellemesi yapılmayacaktır.
+</Warning>
+
 **ComfyUI MCP**, [ComfyUI](https://github.com/comfyanonymous/ComfyUI) için **yerel öncelikli,
 ajanlar için tasarlanmış bir kontrol düzlemidir** — bir [MCP](https://modelcontextprotocol.io)
 sunucusu ve Claude Code eklentisi. Yapay zekâ asistanınızı çalışan bir ComfyUI örneğine —

--- a/docs/tr/index.mdx
+++ b/docs/tr/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **Bu proje artık bakım görmemektedir.** ComfyUI artık Comfy-Org ekibi tarafından geliştirilen ve desteklenen resmi ajan ve MCP araçlarını — **Comfy Agent** ve **Comfy MCP** — sunuyor; bir topluluk projesinin ulaşamayacağı derinlikte bir entegrasyonla. Lütfen resmi araçları kullanın: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Bu site yalnızca referans olarak kalacaktır; yeni özellik, hata düzeltmesi veya bağımlılık güncellemesi yapılmayacaktır.
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP**, [ComfyUI](https://github.com/comfyanonymous/ComfyUI) için **yerel öncelikli,

--- a/docs/tr/index.mdx
+++ b/docs/tr/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**Bu proje artık bakım görmemektedir.** ComfyUI artık Comfy-Org ekibi tarafından geliştirilen ve desteklenen resmi ajan ve MCP araçlarını — **Comfy Agent** ve **Comfy MCP** — sunuyor; bir topluluk projesinin ulaşamayacağı derinlikte bir entegrasyonla. Lütfen resmi araçları kullanın: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Bu site yalnızca referans olarak kalacaktır; yeni özellik, hata düzeltmesi veya bağımlılık güncellemesi yapılmayacaktır.
+**Bu proje artık bakım görmemektedir.** ComfyUI artık Comfy-Org ekibi tarafından geliştirilen ve desteklenen resmi ajan ve MCP araçlarını — **Comfy Agent** ve **Comfy MCP** — sunuyor; bir topluluk projesinin ulaşamayacağı derinlikte bir entegrasyonla. Lütfen resmi araçları kullanın: [Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Bu site yalnızca referans olarak kalacaktır; yeni özellik, hata düzeltmesi veya bağımlılık güncellemesi yapılmayacaktır.
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/tr/index.mdx
+++ b/docs/tr/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **Bu proje artık bakım görmemektedir.** ComfyUI artık Comfy-Org ekibi tarafından geliştirilen ve desteklenen resmi ajan ve MCP araçlarını — **Comfy Agent** ve **Comfy MCP** — sunuyor; bir topluluk projesinin ulaşamayacağı derinlikte bir entegrasyonla. Lütfen resmi araçları kullanın: [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp). Bu site yalnızca referans olarak kalacaktır; yeni özellik, hata düzeltmesi veya bağımlılık güncellemesi yapılmayacaktır.
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP**, [ComfyUI](https://github.com/comfyanonymous/ComfyUI) için **yerel öncelikli,

--- a/docs/zh-TW/index.mdx
+++ b/docs/zh-TW/index.mdx
@@ -4,6 +4,10 @@ description: "ComfyUI 的本機優先、代理原生控制平面 —— 一個 M
 icon: "house"
 ---
 
+<Warning>
+**本專案已停止維護。** ComfyUI 現已提供由 Comfy-Org 團隊開發並支援的官方代理與 MCP 工具 —— **Comfy Agent** 與 **Comfy MCP**，其整合深度是社群專案無法比擬的。請改用官方工具：[Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站僅作參考保留，不再提供新功能、錯誤修正或相依套件更新。
+</Warning>
+
 **ComfyUI MCP** 是 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) 的**本機優先、代理原生控制平面**
 —— 一個 [MCP](https://modelcontextprotocol.io) 伺服器，同時也是 Claude Code 外掛。它把你的 AI 助理
 連上正在執行的 ComfyUI 實例 —— **本機**、**遠端**或 **[Comfy Cloud](https://cloud.comfy.org)** ——

--- a/docs/zh-TW/index.mdx
+++ b/docs/zh-TW/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**本專案已停止維護。** ComfyUI 現已提供由 Comfy-Org 團隊開發並支援的官方代理與 MCP 工具 —— **Comfy Agent** 與 **Comfy MCP**，其整合深度是社群專案無法比擬的。請改用官方工具：[Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站僅作參考保留，不再提供新功能、錯誤修正或相依套件更新。
+**本專案已停止維護。** ComfyUI 現已提供由 Comfy-Org 團隊開發並支援的官方代理與 MCP 工具 —— **Comfy Agent** 與 **Comfy MCP**，其整合深度是社群專案無法比擬的。請改用官方工具：[Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站僅作參考保留，不再提供新功能、錯誤修正或相依套件更新。
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/zh-TW/index.mdx
+++ b/docs/zh-TW/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **本專案已停止維護。** ComfyUI 現已提供由 Comfy-Org 團隊開發並支援的官方代理與 MCP 工具 —— **Comfy Agent** 與 **Comfy MCP**，其整合深度是社群專案無法比擬的。請改用官方工具：[Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站僅作參考保留，不再提供新功能、錯誤修正或相依套件更新。
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** 是 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) 的**本機優先、代理原生控制平面**

--- a/docs/zh-TW/index.mdx
+++ b/docs/zh-TW/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **本專案已停止維護。** ComfyUI 現已提供由 Comfy-Org 團隊開發並支援的官方代理與 MCP 工具 —— **Comfy Agent** 與 **Comfy MCP**，其整合深度是社群專案無法比擬的。請改用官方工具：[Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站僅作參考保留，不再提供新功能、錯誤修正或相依套件更新。
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** 是 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) 的**本機優先、代理原生控制平面**

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -6,6 +6,8 @@ icon: "house"
 
 <Warning>
 **本项目已停止维护。** ComfyUI 现已提供由 Comfy-Org 团队开发并支持的官方代理与 MCP 工具 —— **Comfy Agent** 和 **Comfy MCP**，其集成深度是社区项目无法比拟的。请改用官方工具：[Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站仅作参考保留，不再提供新功能、错误修复或依赖更新。
+
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 </Warning>
 
 **ComfyUI MCP** 是 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) 的**本地优先、智能体原生控制平面** —— 一个 [MCP](https://modelcontextprotocol.io) 服务器，同时也是 Claude Code 插件。它把你的 AI 助手连接到正在运行的 ComfyUI 实例 —— **本地**、**远程**或 **[Comfy Cloud](https://cloud.comfy.org)** —— 让你用自然语言生成图片、视频和音频，执行并编写工作流，管理模型和自定义节点，以及控制服务器。它不是一个单薄的提示词转图片桥接，而是一个替你操作 ComfyUI 的完整智能体。

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -7,7 +7,7 @@ icon: "house"
 <Warning>
 **本项目已停止维护。** ComfyUI 现已提供由 Comfy-Org 团队开发并支持的官方代理与 MCP 工具 —— **Comfy Agent** 和 **Comfy MCP**，其集成深度是社区项目无法比拟的。请改用官方工具：[Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站仅作参考保留，不再提供新功能、错误修复或依赖更新。
 
-Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>
 
 **ComfyUI MCP** 是 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) 的**本地优先、智能体原生控制平面** —— 一个 [MCP](https://modelcontextprotocol.io) 服务器，同时也是 Claude Code 插件。它把你的 AI 助手连接到正在运行的 ComfyUI 实例 —— **本地**、**远程**或 **[Comfy Cloud](https://cloud.comfy.org)** —— 让你用自然语言生成图片、视频和音频，执行并编写工作流，管理模型和自定义节点，以及控制服务器。它不是一个单薄的提示词转图片桥接，而是一个替你操作 ComfyUI 的完整智能体。

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -5,7 +5,7 @@ icon: "house"
 ---
 
 <Warning>
-**本项目已停止维护。** ComfyUI 现已提供由 Comfy-Org 团队开发并支持的官方代理与 MCP 工具 —— **Comfy Agent** 和 **Comfy MCP**，其集成深度是社区项目无法比拟的。请改用官方工具：[Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站仅作参考保留，不再提供新功能、错误修复或依赖更新。
+**本项目已停止维护。** ComfyUI 现已提供由 Comfy-Org 团队开发并支持的官方代理与 MCP 工具 —— **Comfy Agent** 和 **Comfy MCP**，其集成深度是社区项目无法比拟的。请改用官方工具：[Comfy Agent](https://comfy.org/agent) · [Comfy MCP](https://comfy.org/mcp) · [Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站仅作参考保留，不再提供新功能、错误修复或依赖更新。
 
 Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 </Warning>

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -4,6 +4,10 @@ description: "ComfyUI 的本地优先、智能体原生控制平面 —— 一�
 icon: "house"
 ---
 
+<Warning>
+**本项目已停止维护。** ComfyUI 现已提供由 Comfy-Org 团队开发并支持的官方代理与 MCP 工具 —— **Comfy Agent** 和 **Comfy MCP**，其集成深度是社区项目无法比拟的。请改用官方工具：[Agent tools docs](https://docs.comfy.org/agent-tools) · [Comfy MCP](https://comfy.org/mcp/) · [Comfy-Org/comfy-mcp](https://github.com/Comfy-Org/comfy-mcp)。本站仅作参考保留，不再提供新功能、错误修复或依赖更新。
+</Warning>
+
 **ComfyUI MCP** 是 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) 的**本地优先、智能体原生控制平面** —— 一个 [MCP](https://modelcontextprotocol.io) 服务器，同时也是 Claude Code 插件。它把你的 AI 助手连接到正在运行的 ComfyUI 实例 —— **本地**、**远程**或 **[Comfy Cloud](https://cloud.comfy.org)** —— 让你用自然语言生成图片、视频和音频，执行并编写工作流，管理模型和自定义节点，以及控制服务器。它不是一个单薄的提示词转图片桥接，而是一个替你操作 ComfyUI 的完整智能体。
 
 <Frame caption="智能体面板端到端地驱动 ComfyUI —— 读取本地已安装的内容、连接节点图、释放 VRAM、运行渲染">

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -41,3 +41,8 @@ bad params).
 - Scrub secrets before anything leaves the machine, every time.
 - Never claim a fix you did not verify.
 - Never touch the user's workflow data without asking.
+
+## Sources
+
+- **Official:** ComfyUI agent tools documentation (https://docs.comfy.org/agent-tools) and Comfy MCP (https://comfy.org/mcp/).
+- **Empirical:** none. Archive policy, not reverse-engineered from a vendor graph.

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -17,6 +17,7 @@ When the user hits a defect in comfyui-mcp or the panel:
 1. Say plainly that this project is archived and will not receive fixes.
 2. Point them at ComfyUI's **official** agent and MCP tooling, built and supported by
    the Comfy-Org team:
+   - Comfy Agent: https://comfy.org/agent
    - Agent tools documentation: https://docs.comfy.org/agent-tools
    - Comfy MCP: https://comfy.org/mcp/
    - Source: https://github.com/Comfy-Org/comfy-mcp

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -1,355 +1,43 @@
 ---
 name: report-bug
-description: Self-heal and report bugs. Use when a defect in comfyui-mcp, the sidebar panel, a third-party custom node, or ComfyUI core actually cost the user something - it blocked them, produced a wrong result they would keep, lost or corrupted work, or crashed ComfyUI. For OUR repos (comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) diagnose and fix locally FIRST so the user is unblocked, then file with the diff so reports arrive as near-PRs, not tickets; attempt the fix ONCE, and if upstream-only say so with the precise change. Our intake Worker takes our repos; third-party goes to the node's own GitHub. Do NOT file a transient you recovered from at no cost, a missing capability (stabilisation freeze - parked on arrival), or behaviour that was merely surprising; say those in chat. A crash or lost/corrupted work is STILL filed even if you recovered, on a single occurrence. One report per root cause. An explicit "report this" bypasses this bar - route it and file.
+description: ARCHIVED. comfyui-mcp is no longer maintained and its issue trackers are closed - do NOT file, and do not use report_issue to try. When the user hits a defect in comfyui-mcp or the sidebar panel, say plainly that this project is archived and point them at ComfyUI's official agent and MCP tooling (Comfy Agent / Comfy MCP by Comfy-Org; https://docs.comfy.org/agent-tools). For third-party custom-node or ComfyUI-core bugs, offer their own GitHub as before, and only with the user's go-ahead. Triggers on "report this", "fix this bug", or any error in our software - the answer is the same.
 ---
 
-# Self-heal & report bugs (make the ecosystem better)
+# This project is archived — do not file issues
 
-Goal: when something is broken, do not stop there. Diagnose it, try to fix it
-so the user keeps working, and get the fix or report to whoever can fix it
-upstream.
+comfyui-mcp and the ComfyUI Agent Panel are no longer maintained. Their GitHub issue
+trackers are closed and the AI-triage intake Worker is gone, so there is nowhere for a
+report to go. `report_issue` still exists so older prompts get a clear answer, but it
+files nothing and contacts nothing.
 
-**Scope of autonomy. Read this first.** For defects in OUR repos
-(`artokun/comfyui-mcp`, `comfyui-mcp-panel`, `comfyui-mcp-issue-worker`) act
-autonomously. Fix, then file, then inform the user with a short summary. Do not
-pepper them with permission prompts. For THIRD-PARTY and ComfyUI-core defects
-it is offer-and-ask (Step 6). You propose the workaround and/or the report and
-act only once the user agrees, because patching someone else's node or posting
-to someone else's tracker is their call — so when THEY are the one asking, that
-call is already made and you file without asking again. Even for our repos, pause and ask for
-a fix that touches the user's own workflow or data, for anything large or
-risky, and for anything you cannot make safe.
+## What to do instead
 
-This is for bugs in software, not ordinary workflow or generation errors (OOM,
-missing model, bad params: use `troubleshooting`). First decide whose bug it is.
+When the user hits a defect in comfyui-mcp or the panel:
 
-## When to file — a real defect that cost the user something
+1. Say plainly that this project is archived and will not receive fixes.
+2. Point them at ComfyUI's **official** agent and MCP tooling, built and supported by
+   the Comfy-Org team:
+   - Agent tools documentation: https://docs.comfy.org/agent-tools
+   - Comfy MCP: https://comfy.org/mcp/
+   - Source: https://github.com/Comfy-Org/comfy-mcp
+3. If the task can still be completed with what works here, complete it; if not, say
+   which official tool covers it.
 
-This bar governs what YOU decide to file on your own initiative. An explicit
-request from the user is handled at the end of this section and is not subject
-to it.
+Do NOT:
+- call `report_issue` expecting it to file (it returns the archived notice);
+- draft an issue body, look for a duplicate, or suggest the user open one by hand —
+  the trackers reject new issues;
+- spend turns on a fix-then-file loop for our repos; there is no "file".
 
-Two questions, both must be YES:
+## Third-party and ComfyUI-core bugs
 
-1. **Is it ours, and does it still reproduce?** On the CURRENT version — check
-   before filing, not after. A defect already fixed upstream of the user's
-   install is noise. **Exception —** a crash, lost or corrupted work, or a
-   destroyed workflow is filed on a SINGLE occurrence, with whatever evidence
-   exists (log tail, stack, minidump, the failing call). Those are rarely
-   reproducible on demand, and they are the ones most expensive to lose.
-2. **Did it cost the user something?** It blocked them, produced a wrong result
-   they would have kept, lost or corrupted their work, or crashed ComfyUI.
-
-File when both hold:
-
-- A tool, panel, or orchestrator call crashes ComfyUI, loses work, or corrupts a
-  workflow.
-- A tool returns wrong or misleading output the user would act on, or succeeds
-  while doing something different from what it reported.
-- A silent failure: something that should have happened did not, and nothing
-  said so. (Silence is the expensive kind — the user cannot see it.)
-- You could not complete the task, and the reason is a defect in our software.
-
-**Do NOT file** — say it in chat and move on. None of these apply when the user
-asks.
-
-**When the user asks explicitly** ("report this", "fix this bug"), the bar above
-does not apply — you never have to justify cost or reproducibility to them.
-Their request settles THAT it is reported; it does not change WHERE, which
-Step 2 still decides:
-
-- **Ours** — file it, no further questions.
-- **Third-party or ComfyUI core** — their request IS the go-ahead Step 6 exists
-  to obtain, so route it to that project's GitHub and file it without asking a
-  second time.
-- **Not a defect at all** (OOM, a missing model or node, bad params, a mistake) —
-  say plainly that it is not a bug in our software and fix it via
-  `troubleshooting`. If they still want it recorded after hearing that, file it.
-  Their call, made with the facts.
-
-- A transient you recovered from at no cost to the user — a retry that worked.
-  Recovering does NOT excuse a crash, lost or corrupted work, or a wrong result
-  the user might keep. Judge those on the bar above exactly as if you had not
-  recovered; recovering afterwards undoes none of them. (A crash or lost work
-  also needs only the one occurrence — see the exception in question 1.)
-- A missing capability or a feature you wish existed. We are in a stabilisation
-  freeze, so these are parked on arrival — filing one adds a ticket nobody will
-  action.
-- Behaviour that surprised you but was correct, or that you have not actually
-  diagnosed. An unverified hunch costs a maintainer the whole investigation.
-- A one-off you cannot reproduce — EXCEPT a crash or lost/corrupted work,
-  which is filed the first time it happens (see the exception above). For
-  anything lesser, note it; if it recurs, that second occurrence is the report.
-
-**One report per root cause.** If several symptoms trace to one component in one
-session, file ONE report covering them, not one per symptom. Three separate
-reports for three faults in the same backend are three triage passes for one
-fix.
-
-Still NOT bug reports (route elsewhere): ordinary generation and workflow
-failures such as OOM, a missing model or node, bad params, or user mistakes go
-to `troubleshooting`. Third-party and custom-node bugs go to their GitHub
-(Step 6), where you offer and ask first rather than auto-file — unless the user
-asked for the report, which is already the go-ahead.
-
-The intake Worker dedupes server-side, so you need not research duplicates — but
-that is not a licence to file freely. Over-reporting is now the expensive
-failure mode: every low-value report costs a maintainer a read, a triage, and a
-close, and it buries the reports that matter. When genuinely in doubt, tell the
-user what you saw and let them decide.
-
-## Step 1 — Diagnose (root cause, not symptom)
-
-- Read the exact error and stack. For ComfyUI runs: `get_history(action="diagnose")`, `get_system_stats (action:"logs")`.
-- Follow the stack to the actual file and line. Read the code there.
-- Form a concrete root cause and a minimal fix you can defend.
-
-## Step 2 — Classify whose bug it is
-
-- **Ours.** `comfyui-mcp` (server/tools/orchestrator/agent),
-  `comfyui-mcp-panel` (the sidebar pack / panel JS / `__init__.py`), or
-  `comfyui-mcp-issue-worker` (the intake Worker). Go to Steps 3 to 5 (self-heal, then Worker or PR).
-- **Third-party.** A custom node pack, or ComfyUI core itself. Go to Step 6 (their GitHub; our Worker cannot file there).
-
-## Step 3 — Fix it locally FIRST (this is the default, not "when you can")
-
-For any defect in OUR repos (`comfyui-mcp` / `comfyui-mcp-panel` /
-`comfyui-mcp-issue-worker`), the default is to fix it before or alongside
-filing. Patch the code where it actually runs so the user is unblocked at once
-and the report arrives as a near-PR (code plus diff) rather than a ticket. Do
-this every time; do not wait to be asked and do not downgrade it to optional.
-
-- `comfyui-mcp`: find the running install from the stack path. If a source
-  checkout exists, fix the `.ts` source and `npm run build`; if only the built
-  package is present, patch the `dist/*.js` directly. The patch takes effect on
-  the next respawn that reloads it. `panel_reload` covers the agent and its
-  comfyui tool server, but the long-lived orchestrator process (which serves
-  the `panel_*` tools) only reloads code on a full process restart. Disconnect
-  followed by Connect does NOT restart it either; say so when the patch is in
-  that process.
-- `comfyui-mcp-panel`: patch the file under the pack (`web/js/…` for UI,
-  `__init__.py` for the pack). UI changes need a hard refresh.
-
-**Exactly ONE attempt. Do not spiral.** Make one focused, minimal, reversible
-patch. If that single attempt does not land, or the bug is upstream-only (in
-the SDK, in ComfyUI, or it needs a release you cannot make from here), stop
-patching, mark it `upstream-only`, and include the precise change needed in the
-report instead. A future update will overwrite a local patch. That is expected;
-the user runs the patched version in the meantime. Capture the diff
-(`git diff`, or diff the file you touched) so Step 5 can attach it.
-
-THIRD-PARTY and ComfyUI-core defects are the exception. There you still offer
-and ask first before patching or filing, unless the user asked for it (Step 6).
-
-## Step 4 — Verify the fix
-
-- `comfyui-mcp`: run the safety gate, which is `npm run build` (exit 0),
-  `npm test`, and `npm run test:agent`. Do not claim a fix that fails the gate.
-- Otherwise: re-run the operation that failed and confirm it now works.
-
-## Step 5 — Report it to US (autonomous)
-
-**Always scrub secrets first.** You are sending this off-machine without a
-human reading it, so this is non-negotiable. Replace any `sk-…`, `ghp_…`,
-`github_pat_…`, `Bearer …`, `ANTHROPIC_API_KEY`, `CIVITAI_API_TOKEN`, `HF_TOKEN`,
-`.env`/`.dev.vars` contents, `Authorization:` headers, and `?token=`/`?key=`
-query params with `[REDACTED]`; shorten home paths to `~/…`. The intake Worker
-runs a second secret-scrub server-side as a backstop, but never rely on it.
-Scrub here, every time.
-
-Build the body (reuse this shape). When you fixed it, include the diff so we
-can reproduce and merge:
-
-```
-### What happened / root cause
-### Steps to reproduce
-### Exact error (scrubbed)
-### Fix
-<applied locally: yes/no>  <upstream-only: yes/no>
-<the diff / patch, or the precise change needed if upstream-only>
-### Environment
-OS / ComfyUI version / **ComfyUI FRONTEND version** / GPU+VRAM / **comfyui-mcp
-version** / **panel version**.
-
-The FRONTEND version is a separate package from ComfyUI itself and they move
-independently — `get_system_stats (action:"health")` prints both on the ComfyUI
-line. Include it for ANY panel/UI bug. It is not a formality: comfyui-mcp-panel#779
-was a blank agent panel on a fresh install where ComfyUI was 0.30.0 on the broken
-machine and 0.30.2 on a working one — indistinguishable, and not the cause. The
-frontend was 1.50.3 vs 1.47.12, which was the whole answer, and it took an hour of
-eliminating the install, two browsers, the cache and the orchestrator to get to a
-number that one line of output already had.
-Always include BOTH our versions — a bug is only actionable if we know which mcp +
-panel build it came from. They're already in your **ENVIRONMENT line** (the
-`mcp <ver> · panel <ver>` segment), so just copy them from there. Fallbacks if the
-ENV line is missing them: mcp = its `package.json` `version` (or `install_comfyui (action:"environment")`);
-panel = `PANEL_VERSION` near the top of the pack's `comfyui-mcp-panel.js`.
-```
-
-Then file it. The report itself is autonomous via the Worker (below). It files
-under the PROJECT's own server-side identity, so no user GitHub account is
-touched and nothing is done as the user. That is the default and needs no ask.
-
-- **Default path for everyone is the Worker.** POST the report to our intake
-  Worker. No GitHub account needed; it files and dedups under the project
-  identity, never yours. This is the autonomous path. Use it for every our-repo
-  bug REPORT.
-- **Engineer path, ONLY with the user's explicit go-ahead, and only if THEY
-  want to author a fix PR under THEIR GitHub account.** Running `gh` files,
-  forks, and PRs as whatever account is currently `gh`-authed on this machine.
-  That is acting as the user's GitHub identity, so it is NOT autonomous and NOT
-  a Worker fallback. Before ever running `gh` to file, fork, or PR: run
-  `gh auth status`, tell the user which account it would act as, and proceed
-  only if they explicitly agree to submit as that account. If they only want
-  the bug reported (not to personally author a PR), use the Worker. Never fork,
-  PR, or `gh issue create` under an ambient account they did not choose. If the
-  fix is clean and they agree: branch or `gh repo fork`, apply the fix, run the
-  gate (Step 4), push, `gh pr create --fill`. **Never merge**; it is for our
-  review. A Worker 403 or failure falls back to the `report_issue` prefilled
-  link below, NEVER to an unprompted `gh` command.
-
-  The Worker POST needs no GitHub account.
-
-  The Worker files the issue synchronously. On success the POST response ALWAYS
-  carries the issue `url` inline (`{ ok:true, url, number, deduped?, job_id }`),
-  so the manual path is one POST with no polling. This shell snippet is the
-  manual, non-Claude fallback and requires `jq` for safe JSON parsing. Claude
-  agents should use the `report_issue` tool, which already implements this
-  correctly.
-
-  ```bash
-  # URL is baked in; override with $COMFYUI_MCP_ISSUE_WORKER_URL if set. The
-  # client key is a soft anti-spam gate — read it from $COMFYUI_MCP_ISSUE_CLIENT_KEY.
-  WORKER_URL="${COMFYUI_MCP_ISSUE_WORKER_URL:-https://comfyui-mcp-issue-worker.artokun.workers.dev}"
-  # Soft anti-spam gate (ships with the panel; not a real secret — the GitHub
-  # token is server-side in the Worker). Override with $COMFYUI_MCP_ISSUE_CLIENT_KEY.
-  CLIENT_KEY="${COMFYUI_MCP_ISSUE_CLIENT_KEY:-9b6f2abf09b64006dc6e033f59d2dc8112e34d8347a923c2}"
-
-  # 1) Submit — ONE synchronous POST. Write the JSON to a temp file first (the
-  # body has newlines/quotes). --max-time bounds the request so a hung
-  # connection can't wedge us.
-  # body: { "repo": "comfyui-mcp" | "comfyui-mcp-panel", "title", "body", "labels": ["via-panel"] }
-  # The User-Agent is EXPLICIT and load-bearing (#937). Cloudflare bans some
-  # default client signatures outright — a Python `urllib.request` POST to this
-  # endpoint returns 403 with `error code: 1010` (the browser-signature ban),
-  # while the byte-identical request with any ordinary UA succeeds seconds later.
-  # Sending a named UA keeps every client path on a known-good signature instead
-  # of whatever its stdlib happens to advertise.
-  RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
-    -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
-    -H "User-Agent: comfyui-mcp-report-bug/1.0" -H "Accept: application/json" \
-    --data @"$BODY_JSON_FILE" || true)
-
-  # 2) VALIDATE THE WHOLE BODY FIRST with `jq -e .` — it rejects anything that
-  # isn't a single valid JSON document (trailing garbage → non-zero), so the
-  # extraction below only ever runs on clean JSON (no partial output before a
-  # later parse error). Require ok==true AND status!="error" AND a url matching
-  # the exact GitHub issue shape. EXACTLY ONE outcome: real url → filed;
-  # anything else (non-2xx/timeout/unreachable, ok!=true, status:"error",
-  # missing/invalid url, invalid JSON) → prefilled report_issue fallback.
-  if ! printf '%s' "$RESP" | jq -e -s 'length == 1' >/dev/null 2>&1; then
-    echo "worker did not return valid JSON — fall back to the report_issue tool for a prefilled GitHub link"
-  else
-    URL=$(printf '%s' "$RESP" | jq -r \
-      'select(.ok==true and (.status!="error")) | .url // empty | select(test("^https://github.com/[^/]+/[^/]+/issues/[0-9]+$"))')
-    if [ -n "$URL" ]; then
-      echo "filed: $URL"
-    else
-      echo "worker did not return an issue link — fall back to the report_issue tool for a prefilled GitHub link"
-    fi
-  fi
-  ```
-  **On Windows, use this instead. It needs no `jq` and no Python** (#937). The
-  `jq` requirement above is what pushed Windows agents onto Python's
-  `urllib.request` in the first place, and that client's default User-Agent is
-  exactly the signature Cloudflare rejects. PowerShell parses JSON natively, so
-  this path has neither problem:
-
-  ```powershell
-  $WorkerUrl = if ($env:COMFYUI_MCP_ISSUE_WORKER_URL) { $env:COMFYUI_MCP_ISSUE_WORKER_URL }
-               else { "https://comfyui-mcp-issue-worker.artokun.workers.dev" }
-  $ClientKey = if ($env:COMFYUI_MCP_ISSUE_CLIENT_KEY) { $env:COMFYUI_MCP_ISSUE_CLIENT_KEY }
-               else { "9b6f2abf09b64006dc6e033f59d2dc8112e34d8347a923c2" }
-
-  # Invoke-RestMethod parses the JSON body itself and THROWS on a non-2xx, so
-  # both failure shapes land in the same catch — no partial-output window.
-  try {
-    $resp = Invoke-RestMethod -Method Post -Uri $WorkerUrl -TimeoutSec 15 `
-      -ContentType "application/json" `
-      -Headers @{ "X-Client-Key" = $ClientKey; "User-Agent" = "comfyui-mcp-report-bug/1.0"; "Accept" = "application/json" } `
-      -InFile $BodyJsonFile
-  } catch { $resp = $null }
-
-  # Same single "filed" condition as the bash path: ok==true, status not "error",
-  # and a url matching the exact GitHub issue shape. Anything else falls back.
-  if ($resp -and $resp.ok -eq $true -and $resp.status -ne "error" -and
-      $resp.url -match '^https://github\.com/[^/]+/[^/]+/issues/\d+$') {
-    "filed: $($resp.url)"
-  } else {
-    "worker did not return an issue link — fall back to the report_issue tool for a prefilled GitHub link"
-  }
-  ```
-
-  A real `url` from the POST is the only "filed" outcome. Any submit failure
-  (`401`, non-2xx, timeout, unreachable), `ok` not `true`, a `status:"error"`
-  body, a missing or invalid url, or invalid JSON means fall back to
-  `report_issue` for a prefilled link the user submits in one click. Never tell
-  the user it was accepted without a real issue link. A `GET /status/<job_id>`
-  endpoint exists to re-fetch the link later, but it is NOT needed to file, so
-  do not poll. Show the link only if they want it. The filing is autonomous,
-  so a one-line "filed #123" is enough (Step 7).
-- **Fallback** (no `gh`, no Worker URL): use the `report_issue` tool for a
-  prefilled GitHub issue link the user can submit in one click.
-
-## Step 6 — Third-party / ComfyUI-core bugs (offer + ASK first, unless they asked)
-
-Our Worker only files into OUR repos, so these go to their GitHub. Unlike
-our-repo defects (Steps 3 to 5, which you handle autonomously), third-party
-bugs are offer-and-ask at every step. Patching someone else's node and posting
-to someone else's tracker are the user's calls, not yours — which is why an
-explicit "report this" from the user already settles it. When they have asked,
-file it without a second confirmation; ask only when the offer originated with
-you.
-
-- **Ask before patching.** You may offer a local workaround (for example, patch
-  the custom node so the user is not blocked), but apply it only once the user
-  says yes. Same keep-the-patch logic once approved.
-- **Ask before filing — unless they already asked.** Identify the node or
-  project's GitHub repo (from its metadata, `install_custom_node`
-  (`action: "list"`), or its folder). Then, with the user's go-ahead (which an
-  explicit "report this" already is), use `report_issue` with that `owner/repo` (it returns a
-  prefilled link the user reviews and submits; it does not auto-file into
-  third-party repos), OR `gh issue create -R owner/repo` if `gh` is authed and
-  they agree.
-- If the user has no GitHub account, offer to walk them through creating one
-  (github.com/signup) so they can file it. That is how the bug reaches the
-  people who can fix it. We cannot file it for them.
-
-## Step 7 — Inform the user (the only message they need)
-
-A short, concrete summary, not a request. For example:
-
-> Hit a bug in `panel_set_widget` (it errored on subgraph inner nodes). I
-> patched it locally so it works now, and filed a bugfix report on your behalf
-> (#123). You're running the patched version; a future update will replace the
-> patch once we ship the fix upstream.
-
-If upstream-only, say it is logged with us (or the third-party project) and
-what the temporary workaround is, if any.
+Unchanged: these go to the node or project's own GitHub, and it is offer-and-ask — you
+propose the workaround and/or the report, and act only once the user agrees.
+`troubleshooting` still covers ordinary generation failures (OOM, a missing model,
+bad params).
 
 ## Absolute rules
 
 - Scrub secrets before anything leaves the machine, every time.
-- Never merge a PR; humans review.
-- Patches stay minimal and reversible; never touch the user's workflow data
-  without asking.
-- Do not claim a fix you did not verify (Step 4).
-- Do not file to be thorough. A report is a claim on a maintainer's
-  attention; if you cannot say what it cost the user, it is not one. Applies to
-  what you file on your own initiative — when the user asks, that is their call
-  to make and no justification is owed.
-
-## Sources
-
-- **Official:** comfyui-mcp intake Worker and this skill (this repo).
-- **Empirical:** none. Product reporting policy, not reverse-engineered from a vendor graph.
+- Never claim a fix you did not verify.
+- Never touch the user's workflow data without asking.

--- a/scripts/anti-slop-baseline.json
+++ b/scripts/anti-slop-baseline.json
@@ -625,11 +625,10 @@
       "no-chained-type-assertions": 3
     },
     "src/__tests__/tools/report-issue-version.test.ts": {
-      "no-chained-type-assertions": 2,
-      "no-unknown-returns": 2
+      "no-chained-type-assertions": 2
     },
     "src/__tests__/tools/report-issue.test.ts": {
-      "no-chained-type-assertions": 17
+      "no-chained-type-assertions": 14
     },
     "src/__tests__/tools/retired-redirect.test.ts": {
       "no-chained-type-assertions": 6

--- a/src/__tests__/tools/report-asks-for-frontend-version.test.ts
+++ b/src/__tests__/tools/report-asks-for-frontend-version.test.ts
@@ -22,49 +22,19 @@ const SKILL = readFileSync(
   "utf8",
 );
 
-describe("#779 reports must ask for the FRONTEND version", () => {
-  it("the report_issue tool asks for it in the body description", () => {
-    expect(TOOL).toMatch(/ComfyUI FRONTEND version/);
+describe("report_issue is ARCHIVED — its description no longer asks for anything", () => {
+  // #779 pinned that the description asked for the ComfyUI FRONTEND version, because a
+  // report without it could not be triaged. There is no triage any more: the project is
+  // archived and the tool files nothing, so the description must say THAT, and must not
+  // send the agent off collecting versions for a report that will never be read.
+  it("says it is archived and files nothing", () => {
+    expect(TOOL).toMatch(/ARCHIVED/);
+    expect(TOOL).toMatch(/files NOTHING/);
   });
-
-  it("…and says WHY, because 'another version field' reads as optional", () => {
-    // The failure mode is not that people refuse; it is that they reasonably
-    // think "ComfyUI version" already covers it. It does not.
-    expect(TOOL).toMatch(/SEPARATE package from ComfyUI/);
-    expect(TOOL).toMatch(/move independently/);
+  it("points at the official tooling instead", () => {
+    expect(TOOL).toMatch(/Comfy MCP/);
   });
-
-  it("…and names where to GET it", () => {
-    // An ask with no source is an ask that gets skipped. This is the tool that
-    // prints both versions on one line.
-    // The TS source escapes the inner quotes, so the raw file holds a backslash
-    // before each one. Strip backslashes and assert on the sentence a reader
-    // actually sees — writing the escape into the regex tests the escaping
-    // rather than the instruction, and two attempts at it collapsed to a pattern
-    // that matched nothing.
-    const readable = TOOL.split("\\").join("");
-    expect(readable).toContain('get_system_stats (action:"health")');
-  });
-
-  it("the report-bug skill asks for it too", () => {
-    // Two independent paths tell an agent what to collect. Fixing one and
-    // leaving the other is how the field keeps going missing.
-    expect(SKILL).toMatch(/ComfyUI FRONTEND version/);
-    expect(SKILL).toMatch(/get_system_stats \(action:"health"\)/);
-  });
-
-  it("the skill carries the evidence, not just the instruction", () => {
-    // A rule with its story attached survives editing; a bare "also include X"
-    // gets trimmed by the next person tightening the doc.
-    expect(SKILL).toMatch(/779/);
-    expect(SKILL).toMatch(/1\.50\.3/);
-    expect(SKILL).toMatch(/1\.47\.12/);
-  });
-
-  it("neither place asks ONLY for the ComfyUI version any more", () => {
-    // The exact string that shipped for months, which is what produced a report
-    // missing the deciding variable.
-    expect(TOOL).not.toMatch(/\(GPU\/VRAM, ComfyUI version, OS\)/);
-    expect(SKILL).not.toMatch(/^OS \/ ComfyUI version \/ GPU\+VRAM/m);
+  it("no longer instructs the agent to gather the FRONTEND version", () => {
+    expect(TOOL).not.toMatch(/ComfyUI FRONTEND version/);
   });
 });

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -135,102 +135,30 @@ describe("normalizeReportedVersion (#846)", () => {
 // P2) — and a normalizer nobody calls protects nothing. This drives the real
 // registered handler and inspects the bytes that leave for the triage worker.
 
-describe("report_issue actually normalizes before sending (#846 wiring)", () => {
-  it("sends the extracted version to the worker, not the sentence it came in", async () => {
+describe("report_issue is ARCHIVED — the version helpers stay, the wiring sends nothing", () => {
+  it("registers a handler that returns the archived notice and never reaches the worker", async () => {
     const { registerReportIssueTools } = await import("../../tools/report-issue.js");
-
-    let handler: ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
+    let handler: ((args: Record<string, unknown>) => Promise<{ content: { text?: string }[] }>) | undefined;
     const fakeServer = {
-      tool: (name: string, _desc: string, _schema: unknown, fn: typeof handler) => {
-        if (name === "report_issue") handler = fn;
+      tool: (_name: string, _desc: string, _schema: unknown, h: typeof handler) => {
+        handler = h;
       },
     } as unknown as Parameters<typeof registerReportIssueTools>[0];
     registerReportIssueTools(fakeServer);
-    expect(handler).toBeTypeOf("function");
-
-    const bodies: string[] = [];
+    const calls: unknown[] = [];
     const realFetch = globalThis.fetch;
-    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
-      if (typeof init?.body === "string") bodies.push(init.body);
-      // A terminal ack: filed, nothing to poll.
-      return new Response(
-        JSON.stringify({ status: "done", url: "https://example.invalid/issues/1", job_id: "j1" }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
+    globalThis.fetch = (async (...a: unknown[]) => {
+      calls.push(a);
+      throw new Error("must not be reached");
     }) as typeof fetch;
-
     try {
-      await handler!({
-        title: "t",
-        body: "b",
-        repo: "artokun/comfyui-mcp",
-        mcp_version: ENV_LINE,
-        panel_version: ENV_LINE,
-      });
+      const out = await handler!({ title: "t", body: "b", mcp_version: "the env line says mcp=0.52.1 panel=0.15.2" });
+      const json = JSON.parse(out.content[0]?.text ?? "{}") as Record<string, unknown>;
+      expect(json.archived).toBe(true);
+      expect(json.filed).toBe(false);
+      expect(calls).toHaveLength(0);
     } finally {
       globalThis.fetch = realFetch;
     }
-
-    expect(bodies.length).toBeGreaterThan(0);
-    const sent = JSON.parse(bodies[0]) as { reporter_versions?: { mcp?: string; panel?: string } };
-    expect(sent.reporter_versions?.mcp).toBe("0.48.18");
-    expect(sent.reporter_versions?.panel).toBe("0.11.38");
-    // The failure this pins: the raw sentence forwarded verbatim, which the
-    // worker cannot version-match — it just silently stops advising upgrades.
-    expect(sent.reporter_versions?.mcp).not.toContain("ENVIRONMENT");
-  });
-});
-
-// The wiring test above SUPPLIES mcp_version, so it never reaches the fallback —
-// swapping the load-time snapshot back for a fresh disk read left it green
-// (codex gate P2). This omits the field, which is the only way in.
-
-describe("the OMITTED-version fallback reports what is RUNNING, not what is installed (#846)", () => {
-  it("keeps reporting the load-time version after the package on disk changes underneath", async () => {
-    vi.resetModules();
-    const onDisk = { version: "0.49.8" };
-    vi.doMock("../../services/self-update.js", () => ({
-      detectInstallMode: () => ({ currentVersion: onDisk.version }),
-    }));
-
-    // Loaded WHILE disk says 0.49.8 — this stands in for process start.
-    const mod = await import("../../tools/report-issue.js");
-
-    // Now the user runs an in-place update. The process keeps running the old
-    // code; only the files changed.
-    onDisk.version = "0.49.99";
-
-    let handler: ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
-    mod.registerReportIssueTools({
-      tool: (name: string, _d: string, _s: unknown, fn: typeof handler) => {
-        if (name === "report_issue") handler = fn;
-      },
-    } as never);
-
-    const bodies: string[] = [];
-    const realFetch = globalThis.fetch;
-    globalThis.fetch = (async (_u: string, init?: RequestInit) => {
-      if (typeof init?.body === "string") bodies.push(init.body);
-      return new Response(JSON.stringify({ status: "done", url: "https://e.invalid/1" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    }) as typeof fetch;
-
-    try {
-      // No mcp_version — the fallback is the whole point.
-      await handler!({ title: "t", body: "b", repo: "artokun/comfyui-mcp" });
-    } finally {
-      globalThis.fetch = realFetch;
-      vi.doUnmock("../../services/self-update.js");
-      vi.resetModules();
-    }
-
-    const sent = JSON.parse(bodies[0]) as { reporter_versions?: { mcp?: string } };
-    // Filing under the INSTALLED version is #846: the worker version-matches the
-    // report against the fix history, so a report stamped with a version the user
-    // is not running silently stops the upgrade advice that usually resolves it.
-    expect(sent.reporter_versions?.mcp).toBe("0.49.8");
-    expect(sent.reporter_versions?.mcp).not.toBe("0.49.99");
   });
 });

--- a/src/__tests__/tools/report-issue.test.ts
+++ b/src/__tests__/tools/report-issue.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, afterAll } from "vitest";
+import { describe, it, expect, vi, afterEach, afterAll, beforeEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -249,426 +249,44 @@ describe("submitAndPoll — async triage contract", () => {
   });
 });
 
-describe("report_issue tool (registered handler)", () => {
-  const savedTimeout = process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS;
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    if (savedTimeout === undefined) delete process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS;
-    else process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = savedTimeout;
-    delete process.env.COMFYUI_MCP_ISSUE_MAX_POLLS;
-    delete process.env.COMFYUI_MCP_ISSUE_POLL_MS;
+describe("report_issue tool (registered handler) — ARCHIVED", () => {
+  // The project is no longer maintained and its trackers are closed. The tool stays
+  // registered so older prompts get an answer, but it must file nothing, contact
+  // nothing, and hand out no prefilled link to a tracker that refuses new issues.
+  const fetchCalls: unknown[] = [];
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    vi.stubGlobal("fetch", async (...a: unknown[]) => {
+      fetchCalls.push(a);
+      throw new Error("must not be reached");
+    });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("our repo → archived notice, nothing filed, NO network", async () => {
+    const { json } = await callTool({ title: "t", body: "b", repo: "artokun/comfyui-mcp", mcp_version: "0.52.0" });
+    expect(json.archived).toBe(true);
+    expect(json.filed).toBe(false);
+    expect(json.url).toBeUndefined();
+    expect(String(json.note)).toMatch(/no longer maintained/);
+    expect(String(json.note)).toMatch(/docs\.comfy\.org\/agent-tools/);
+    expect(fetchCalls).toHaveLength(0);
   });
 
-  it("third-party repo → prefilled URL, filed:false, no network", async () => {
-    const spy = vi.fn();
-    vi.stubGlobal("fetch", spy);
+  it("third-party repo → the same archived notice, no prefilled URL", async () => {
     const { json } = await callTool({ title: "t", body: "b", repo: "someone/their-node" });
-    expect(json).toMatchObject({ filed: false, repo: "someone/their-node" });
-    expect(json.url).toContain("https://github.com/someone/their-node/issues/new");
-    expect(spy).not.toHaveBeenCalled();
+    expect(json.archived).toBe(true);
+    expect(json.filed).toBe(false);
+    expect(json.repo).toBe("someone/their-node");
+    expect(json.url).toBeUndefined();
+    expect(fetchCalls).toHaveLength(0);
   });
 
-  it("no_file:true on our repo → prefilled URL, no network", async () => {
-    const spy = vi.fn();
-    vi.stubGlobal("fetch", spy);
-    const { json } = await callTool({ title: "t", body: "b", repo: "artokun/comfyui-mcp", no_file: true });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("https://github.com/artokun/comfyui-mcp/issues/new");
-    expect(spy).not.toHaveBeenCalled();
-  });
-
-  it("our repo, worker CLOSED (created) → filed:true with the real issue link + agent_message", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        res({
-          state: "CLOSED",
-          payload: { classification: "new", action_taken: "created", issue: { number: 50, url: "https://github.com/artokun/comfyui-mcp/issues/50" }, agent_message: "Filed as #50" },
-          url: "https://github.com/artokun/comfyui-mcp/issues/50",
-          number: 50,
-        }),
-      ),
-    );
+  it("points at every official surface", async () => {
     const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: true, number: 50, action_taken: "created", agent_message: "Filed as #50" });
-    expect(json.url).toBe("https://github.com/artokun/comfyui-mcp/issues/50");
-  });
-
-  it("our repo, worker CLOSED (advised_upgrade) → filed:false, surfaces fix PR + version + upgrade advice", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        res({
-          state: "CLOSED",
-          payload: {
-            classification: "duplicate_closed",
-            action_taken: "advised_upgrade",
-            issue: { number: 505, url: "https://github.com/artokun/comfyui-mcp/issues/505", state: "closed" },
-            fixed_in_version: "0.48.19",
-            fix_pr_url: "https://github.com/artokun/comfyui-mcp/pull/507",
-            recommend_upgrade: true,
-            agent_message: "Duplicate of closed #505 — upgrade to 0.48.21 (fixed in 0.48.19 via PR #507).",
-          },
-        }),
-      ),
-    );
-    const { json } = await callTool({ title: "t", body: "b", mcp_version: "0.48.10" });
-    expect(json).toMatchObject({
-      filed: false, // advised_upgrade files nothing
-      action_taken: "advised_upgrade",
-      fixed_in_version: "0.48.19",
-      fix_pr_url: "https://github.com/artokun/comfyui-mcp/pull/507",
-      recommend_upgrade: true,
-    });
-    expect(json.agent_message).toContain("upgrade");
-  });
-
-  it("passes mcp_version/panel_version through as reporter_versions", async () => {
-    let sentBody: Record<string, unknown> = {};
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_url: string, init: RequestInit) => {
-        sentBody = JSON.parse(init.body as string);
-        return res({ state: "CLOSED", payload: { action_taken: "created", issue: { number: 9, url: "https://github.com/artokun/comfyui-mcp/issues/9" }, agent_message: "ok" }, url: "https://github.com/artokun/comfyui-mcp/issues/9", number: 9 });
-      }),
-    );
-    await callTool({ title: "t", body: "b", mcp_version: "0.48.10", panel_version: "0.11.3" });
-    expect(sentBody.reporter_versions).toEqual({ mcp: "0.48.10", panel: "0.11.3" });
-  });
-
-  it("our repo, still triaging at budget → filed:false, pending:true, NO prefill", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (!String(url).includes("/status/")) return res({ job_id: "jq", state: "PENDING", status: "PENDING", up_to_date: false, upgrade_hint: "behind" });
-        return res({ state: "INVESTIGATING", status: "queued" });
-      }),
-    );
-    process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = "50";
-    process.env.COMFYUI_MCP_ISSUE_MAX_POLLS = "2";
-    process.env.COMFYUI_MCP_ISSUE_POLL_MS = "0";
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false, pending: true, job_id: "jq" });
-    expect(String(json.url ?? "")).not.toContain("/issues/new"); // did NOT prefill
-  });
-
-  it("our repo, worker terminally couldn't file (unfiled) → prefilled fallback", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (!String(url).includes("/status/")) return res({ job_id: "ju", state: "PENDING", status: "PENDING" });
-        return res({ status: "error", error: "GitHub API error" });
-      }),
-    );
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("/issues/new");
-  });
-
-  it("our repo, CLOSED unfiled_needs_manual (no issue) → prefilled fallback, not a lost report", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => res({ state: "CLOSED", payload: { action_taken: "unfiled_needs_manual", issue: null, agent_message: "filing failed" } })),
-    );
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("/issues/new");
-  });
-
-  it("a huge MAX_POLLS env is clamped so a running job still returns pending promptly", async () => {
-    let polls = 0;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (!String(url).includes("/status/")) return res({ job_id: "jc", state: "PENDING", status: "PENDING" });
-        polls++;
-        return res({ state: "INVESTIGATING", status: "queued" });
-      }),
-    );
-    process.env.COMFYUI_MCP_ISSUE_MAX_POLLS = "1000000000"; // absurd
-    process.env.COMFYUI_MCP_ISSUE_POLL_MS = "0";
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false, pending: true });
-    expect(polls).toBeLessThanOrEqual(200); // clamped, not a billion
-  });
-
-  it("mixed-case owner (Artokun/comfyui-mcp) is treated as OURS and hits the worker", async () => {
-    const spy = vi.fn(async () =>
-      res({ state: "CLOSED", payload: { action_taken: "created", issue: { number: 60, url: "https://github.com/Artokun/comfyui-mcp/issues/60" }, agent_message: "ok" }, url: "https://github.com/Artokun/comfyui-mcp/issues/60", number: 60 }),
-    );
-    vi.stubGlobal("fetch", spy);
-    const { json } = await callTool({ title: "t", body: "b", repo: "Artokun/comfyui-mcp" });
-    expect(spy).toHaveBeenCalled();
-    expect(json).toMatchObject({ filed: true, number: 60 });
-  });
-
-  it("SUBMIT 2xx then body stalls → pending (worker took it), NOT a prefill/double-file", async () => {
-    process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = "15";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async (_url: string, init: RequestInit) =>
-          ({
-            ok: true, // 2xx = accepted
-            json: () =>
-              new Promise((_resolve, reject) => {
-                init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
-              }),
-          }) as unknown as Response,
-      ),
-    );
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false, pending: true });
-    expect(String(json.url ?? "")).not.toContain("/issues/new"); // did NOT prefill
-  });
-
-  it("our repo, worker returns non-OK (500) → falls back to prefilled URL", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => res({ error: "boom" }, 500)));
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("https://github.com/artokun/comfyui-mcp/issues/new");
-  });
-
-  it("our repo, network failure (fetch rejects) → falls back to prefilled URL", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => {
-      throw new Error("ECONNREFUSED");
-    }));
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("/issues/new");
-  });
-
-  it("invalid repo → isError", async () => {
-    const { isError } = await callTool({ title: "t", body: "b", repo: "not-a-repo" });
-    expect(isError).toBe(true);
-  });
-});
-
-// #937 — Cloudflare fronts the intake endpoint and bans some default client
-// signatures outright. A Python `urllib.request` POST returns 403 with
-// `error code: 1010` (the browser-signature ban) while the byte-identical
-// request with an ordinary UA succeeds 13 seconds later, same IP, same key,
-// same body.
-//
-// Node fetch happens to be allowed today — a WAF disposition we neither control
-// nor chose. Sending a named UA makes the path deterministic rather than
-// incidentally lucky, and it is the one header a future WAF rule would key on.
-describe("#937: every intake request carries a named User-Agent", () => {
-  it("sends it on the SUBMIT", async () => {
-    const seen: Array<Record<string, string>> = [];
-    const fetchImpl = (async (_url: string, init?: RequestInit) => {
-      seen.push((init?.headers ?? {}) as Record<string, string>);
-      return new Response(JSON.stringify({ ok: true, job_id: "j1" }), { status: 200 });
-    }) as unknown as typeof fetch;
-
-    await submitAndPoll({
-      workerUrl: "https://w.example",
-      clientKey: "k",
-      repoName: "comfyui-mcp",
-      title: "t",
-      body: "b",
-      fetchImpl,
-      maxPolls: 0,
-      sleep: async () => {},
-    });
-
-    expect(seen[0]["User-Agent"]).toBe(REPORT_UA);
-    expect(seen[0]["Accept"]).toBe("application/json");
-    // The signature is NAMED, not a browser impersonation — we are a tool, and
-    // claiming to be Chrome to get past a bot check would be the wrong fix.
-    expect(REPORT_UA).toMatch(/^comfyui-mcp-report-bug\//);
-    expect(REPORT_UA).not.toMatch(/Mozilla|Chrome|Safari/);
-  });
-
-  it("sends it on the STATUS poll too", async () => {
-    const seen: Array<Record<string, string>> = [];
-    let call = 0;
-    const fetchImpl = (async (_url: string, init?: RequestInit) => {
-      seen.push((init?.headers ?? {}) as Record<string, string>);
-      call += 1;
-      return call === 1
-        ? new Response(JSON.stringify({ ok: true, job_id: "j1" }), { status: 200 })
-        : new Response(JSON.stringify({ state: "CLOSED", payload: { url: "u" } }), { status: 200 });
-    }) as unknown as typeof fetch;
-
-    await submitAndPoll({
-      workerUrl: "https://w.example",
-      clientKey: "k",
-      repoName: "comfyui-mcp",
-      title: "t",
-      body: "b",
-      fetchImpl,
-      maxPolls: 1,
-      pollDelayMs: 0,
-      sleep: async () => {},
-    });
-
-    // The poll is a separate request and would be judged by the WAF separately.
-    expect(seen.length).toBeGreaterThan(1);
-    expect(seen[1]["User-Agent"]).toBe(REPORT_UA);
-  });
-});
-
-// ── WHICH LLM FILED IT ───────────────────────────────────────────────────────
-// The panel can be driven by anything from a frontier model to a local 4B, and
-// report quality follows. The orchestrator publishes the provider/model chips to
-// a file (services/agent-identity.ts) and the handler stamps them into the body
-// it actually SENDS — the worker pins that body verbatim into the created issue
-// (triage.ts: `sanitized.body = opts.report.body`), so the body is the one
-// channel that reaches the issue without a worker deploy.
-//
-// These drive the REGISTERED HANDLER, not the stamping helper: a helper that
-// works and a call site that never runs it is the same defect as no helper at
-// all, and the body/labels the handler forwards are what a reader ends up
-// judging the report by.
-describe("report_issue stamps the reporting model (mechanical, not self-reported)", () => {
-  const IDENTITY_DIR = mkdtempSync(join(tmpdir(), "cmcp-report-identity-"));
-  const identityFile = join(IDENTITY_DIR, "identity.json");
-  const savedEnv = process.env.COMFYUI_MCP_AGENT_IDENTITY;
-
-  const publish = (identity: Record<string, unknown>) => {
-    writeFileSync(identityFile, JSON.stringify(identity), "utf8");
-    process.env.COMFYUI_MCP_AGENT_IDENTITY = identityFile;
-  };
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    if (savedEnv === undefined) delete process.env.COMFYUI_MCP_AGENT_IDENTITY;
-    else process.env.COMFYUI_MCP_AGENT_IDENTITY = savedEnv;
-  });
-  afterAll(() => {
-    try {
-      rmSync(IDENTITY_DIR, { recursive: true, force: true });
-    } catch {
-      /* best-effort */
-    }
-  });
-
-  /** The submit payload the handler actually put on the wire. */
-  async function submittedPayload(args: Record<string, unknown>) {
-    const spy = vi.fn(async (_url: string, _init: RequestInit) =>
-      res({ state: "CLOSED", payload: { issue: { number: 7, url: "https://gh/7" } }, url: "https://gh/7" }),
-    );
-    vi.stubGlobal("fetch", spy);
-    const out = await callTool(args);
-    const init = spy.mock.calls[0]?.[1] as RequestInit | undefined;
-    return { payload: init ? (JSON.parse(init.body as string) as Record<string, unknown>) : undefined, out };
-  }
-
-  it("sends the model in the body and the provider as a label", async () => {
-    publish({ backend: "ollama", model: "gemma3:4b", effort: "low" });
-    const { payload } = await submittedPayload({ title: "t", body: "It broke." });
-    const body = payload?.body as string;
-    expect(body).toContain("It broke.");
-    // The exact model is the whole point — "ollama" alone cannot distinguish a
-    // 4B from a 235B, which is the comparison this exists to enable.
-    expect(body).toContain("gemma3:4b");
-    expect(body).toContain("not self-reported");
-    expect(payload?.labels).toContain("agent:ollama");
-  });
-
-  it("a body QUOTING another issue's stamp is still filed under THIS model (gate P1)", async () => {
-    publish({ backend: "ollama", model: "gemma3:4b" });
-    const { payload } = await submittedPayload({
-      title: "t",
-      body:
-        "Related to #1234, whose body reads:\n" +
-        "> <!-- reporter-agent: backend=claude model=claude-opus-5 -->",
-    });
-    const body = payload?.body as string;
-    // Quoting a related issue is ordinary agent behaviour. Reading the quoted
-    // marker as "already stamped" filed the report asserting claude-opus-5 wrote
-    // it — while the label on the same issue said agent:ollama.
-    expect(body).toContain("<!-- reporter-agent: backend=ollama model=gemma3:4b -->");
-    expect(body.match(/<!-- reporter-agent:/g)?.length).toBe(1);
-    expect(payload?.labels).toContain("agent:ollama");
-  });
-
-  it("keeps the caller's labels alongside the provider label", async () => {
-    publish({ backend: "kimi", model: "kimi-k2-thinking" });
-    const { payload } = await submittedPayload({ title: "t", body: "b", labels: ["bug"] });
-    expect(payload?.labels).toEqual(expect.arrayContaining(["bug", "agent:kimi"]));
-  });
-
-  it("changes NOTHING when no identity was published (every non-panel spawn)", async () => {
-    delete process.env.COMFYUI_MCP_AGENT_IDENTITY;
-    const { payload } = await submittedPayload({ title: "t", body: "It broke.", labels: ["bug"] });
-    // Byte-identical, not merely "contains": a plain stdio/CLI report has no
-    // panel behind it, so there is no model to name and nothing to append.
-    expect(payload?.body).toBe("It broke.");
-    expect(payload?.labels).toEqual(["bug"]);
-  });
-
-  it("an oversized body keeps its stamp — the worker would have cut it off", async () => {
-    publish({ backend: "ollama", model: "gemma3:4b" });
-    const huge = "x".repeat(WORKER_MAX_BODY_LEN + 5_000);
-    const { payload } = await submittedPayload({ title: "t", body: huge });
-    const body = payload?.body as string;
-    // The worker truncates at 60k BEFORE filing, and the stamp is last — so the
-    // attribution would vanish server-side on exactly the longest reports, with
-    // nothing anywhere saying it had been there.
-    expect(body.length).toBeLessThanOrEqual(WORKER_MAX_BODY_LEN);
-    expect(body).toContain("<!-- reporter-agent: backend=ollama model=gemma3:4b -->");
-    expect(body).toContain("trimmed to keep the reporting-agent stamp");
-    // The caller's own text is still nearly all of it — this trims by the
-    // stamp's width, it does not summarize.
-    expect(body.length).toBeGreaterThan(WORKER_MAX_BODY_LEN - 1_000);
-  });
-
-  it("…and keeps it when the oversized body QUOTES stamps (gate P1, round 3)", async () => {
-    publish({ backend: "ollama", model: "gemma3:4b", effort: "high" });
-    // The previous test's body was marker-free, so it could not see this at all:
-    // stamping also REWRITES each quoted marker (+7 chars), so budgeting the
-    // stamp's width against the raw text put the shipped body 7·n OVER the cap —
-    // and the worker cuts the tail, which is the stamp. Blind by construction is
-    // how a covering test ships the bug it covers.
-    for (const markers of [1, 88]) {
-      const quote = "> <!-- reporter-agent: backend=claude model=opus -->\n".repeat(markers);
-      const { payload } = await submittedPayload({
-        title: "t",
-        body: `Related to #1234:\n${quote}${"LOG\n".repeat(20_000)}`,
-      });
-      const body = payload?.body as string;
-      expect(body.length, `markers=${markers}`).toBeLessThanOrEqual(WORKER_MAX_BODY_LEN);
-      // Present AND terminated: a marker cut mid-token is not an attribution.
-      expect(body, `markers=${markers}`).toContain(
-        "<!-- reporter-agent: backend=ollama model=gemma3:4b effort=high -->",
-      );
-      expect(body, `markers=${markers}`).toContain("Filed from the ComfyUI panel");
-      // Still exactly one live marker: the quoted ones stayed neutralized.
-      expect(body.match(/<!-- reporter-agent:/g)?.length, `markers=${markers}`).toBe(1);
-    }
-  });
-
-  it("leaves an oversized body ALONE when there is no identity to protect", async () => {
-    delete process.env.COMFYUI_MCP_AGENT_IDENTITY;
-    const huge = "x".repeat(WORKER_MAX_BODY_LEN + 5_000);
-    const { payload } = await submittedPayload({ title: "t", body: huge });
-    // No stamp to save, so the worker's own truncation is the only one that
-    // should ever apply. Trimming here would drop the caller's text for nothing.
-    expect(payload?.body).toBe(huge);
-  });
-
-  it("never stamps a THIRD-PARTY tracker", async () => {
-    publish({ backend: "ollama", model: "gemma3:4b" });
-    const spy = vi.fn();
-    vi.stubGlobal("fetch", spy);
-    const { json } = await callTool({ title: "t", body: "It broke.", repo: "someone/their-node", labels: ["bug"] });
-    // The prefilled URL is what the user posts to someone else's repo. Our
-    // provider telemetry is not their business, and `agent:ollama` is a label
-    // their repo has never heard of.
-    const url = new URL(json.url as string);
-    expect(url.searchParams.get("body")).toBe("It broke.");
-    expect(url.searchParams.get("labels")).toBe("bug");
-  });
-
-  it("stamps the PREFILLED fallback for our repos too", async () => {
-    publish({ backend: "claude", model: "claude-opus-4-5" });
-    // no_file and the worker-unreachable fallback share this URL — a report that
-    // arrives by the fallback path is no less in need of attribution.
-    const { json } = await callTool({ title: "t", body: "It broke.", no_file: true });
-    const url = new URL(json.url as string);
-    expect(url.searchParams.get("body")).toContain("claude-opus-4-5");
-    expect(url.searchParams.get("labels")).toBe("agent:claude");
+    const official = json.official as Record<string, string>;
+    expect(official.docs).toBe("https://docs.comfy.org/agent-tools");
+    expect(official.comfy_mcp).toBe("https://comfy.org/mcp/");
+    expect(official.repo).toBe("https://github.com/Comfy-Org/comfy-mcp");
   });
 });

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -552,6 +552,7 @@ export function registerReportIssueTools(server: McpServer): void {
         filed: false,
         repo: normalizeRepo(args.repo),
         official: {
+          comfy_agent: "https://comfy.org/agent",
           docs: "https://docs.comfy.org/agent-tools",
           comfy_mcp: "https://comfy.org/mcp/",
           repo: "https://github.com/Comfy-Org/comfy-mcp",

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -518,189 +518,46 @@ export function fitUnderWorkerCap(
   return note;
 }
 
-export function registerReportIssueTools(server: McpServer): void {
-  server.tool(
-    "report_issue",
-    "File or triage a GitHub issue for a bug/problem you hit (ComfyUI, a workflow, a model, custom nodes, or comfyui-mcp/its panel). For OUR repos (artokun/comfyui-mcp, artokun/comfyui-mcp-panel) it sends the report to the AI triage worker, which searches existing OPEN and CLOSED issues, version-matches, and either files a new issue, adds context to an existing one, or — if the problem was already FIXED in a newer version than the user runs — answers with the fixing PR + fixed-in version and a recommendation to upgrade (no new issue). It returns that triage result plus an instant check of whether the user is on the latest versions. TIMING: this call BLOCKS while the triage runs — typically a few minutes — and that wait is normal, not a hang. It always returns eventually (every request is time-capped and the poll budget is bounded); on a failing network the caps make that wait longer, but never indefinite. Do not abort a slow call just to retry it: once the worker has accepted the report it keeps triaging on its own — filing, deduping into an existing issue, advising an upgrade, or (rarely) reporting that it could not file — so a blind retry can double-file. If triage outlasts the polling budget the call still returns, with pending:true (and a job_id when the worker gave one — an accepted submit whose acknowledgement was unreadable returns pending without it). If the worker is unreachable it falls back to a prefilled GitHub 'new issue' URL. For third-party repos it returns a prefilled URL to SHARE (it does not auto-file). ALWAYS pass mcp_version and panel_version from the known environment (the env line in your context, e.g. 'mcp=… panel=…') so the worker can tell the user if simply upgrading fixes it — the single most common resolution. Surface the worker's agent_message / upgrade advice to the user.",
-    {
-      title: z.string().min(1).describe("Short, specific issue title."),
-      body: z
-        .string()
-        .min(1)
-        .describe(
-          "Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, ComfyUI FRONTEND version, OS) if known. The FRONTEND version is a SEPARATE package from ComfyUI and they move independently — get_system_stats (action:\"health\") prints both, and for any panel/UI bug it is often the deciding variable. Scrub secrets first.",
-        ),
-      repo: z
-        .string()
-        .optional()
-        .describe("owner/repo (default 'artokun/comfyui-mcp'; use 'artokun/comfyui-mcp-panel' for the sidebar panel)."),
-      labels: z.array(z.string()).optional().describe("Optional GitHub label names to prefill."),
-      mcp_version: z
-        .string()
-        .optional()
-        .describe("The running comfyui-mcp version (from the env line in your context). Auto-detected if omitted."),
-      panel_version: z
-        .string()
-        .optional()
-        .describe("The running comfyui-mcp-panel (sidebar) version, from the env line in your context, if known."),
-      no_file: z
-        .boolean()
-        .optional()
-        .describe("Force the prefilled-URL path even for our repos (skip the Worker). Rarely needed."),
-    },
-    async (args) => {
-      try {
-        const repo = normalizeRepo(args.repo);
-        const ours = isOurRepo(repo);
-        // WHICH LLM WROTE THIS REPORT. Published by the orchestrator from the
-        // panel's provider/model chips (services/agent-identity.ts) and read
-        // here, in the subprocess the reporting agent's tools run in — NOT asked
-        // of the model, which cannot reliably name itself and was never told its
-        // own model in the first place (the ENVIRONMENT block carries only
-        // `Backend:`). Report quality varies enormously across the providers the
-        // panel can drive, and until this line existed there was no way to tell a
-        // thin report from a local 4B model apart from a thin report from a
-        // frontier one.
-        //
-        // OUR repos only: someone else's tracker is not the place for our
-        // provider telemetry, and a prefilled `agent:*` label would be a label
-        // their repo has never heard of. Absent identity (every non-panel spawn:
-        // plain stdio, CLI, tests) changes nothing — body and labels pass
-        // through as before.
-        const identity = ours ? readAgentIdentity() : undefined;
-        const body = stampAgentIdentity(fitUnderWorkerCap(args.body, identity), identity);
-        const labels = identity
-          ? Array.from(new Set([...(args.labels ?? []), agentLabel(identity)]))
-          : args.labels;
-        const prefilledUrl = buildIssueUrl(repo, args.title, body, labels);
-
-        // Third-party (or explicitly disabled): prefilled link only, as before.
-        if (!ours || args.no_file) {
-          return jsonResult({
-            url: prefilledUrl,
-            repo,
-            filed: false,
-            note: "Prefilled issue link (not auto-filed). Share it with the user to review and submit.",
-          });
-        }
-
-        const workerUrl = process.env.COMFYUI_MCP_ISSUE_WORKER_URL || DEFAULT_WORKER_URL;
-        const clientKey = process.env.COMFYUI_MCP_ISSUE_CLIENT_KEY || DEFAULT_CLIENT_KEY;
-        const timeoutEnv = Number(process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS);
-        const timeoutMs = Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : undefined;
-        const maxPollsEnv = Math.floor(Number(process.env.COMFYUI_MCP_ISSUE_MAX_POLLS));
-        // Clamp to a sane ceiling so a mis-set env can't poll for hours.
-        const maxPolls = Number.isFinite(maxPollsEnv) && maxPollsEnv > 0 ? Math.min(maxPollsEnv, 200) : undefined;
-        const pollMsEnv = Number(process.env.COMFYUI_MCP_ISSUE_POLL_MS);
-        const pollDelayMs =
-          Number.isFinite(pollMsEnv) && pollMsEnv >= 0 ? Math.min(pollMsEnv, 60000) : undefined;
-        const repoName = repo.split("/")[1];
-
-        const reporterVersions: ReporterVersions = {
-          mcp:
-            normalizeReportedVersion(args.mcp_version, MCP_VERSION_LABEL) ??
-            detectMcpVersion(),
-          panel:
-            normalizeReportedVersion(args.panel_version, PANEL_VERSION_LABEL) ??
-            process.env.COMFYUI_MCP_PANEL_VERSION ??
-            undefined,
-        };
-
-        try {
-          const outcome = await submitAndPoll({
-            workerUrl,
-            clientKey,
-            repoName,
-            title: args.title,
-            body,
-            labels,
-            reporterVersions,
-            timeoutMs,
-            maxPolls,
-            pollDelayMs,
-          });
-
-          if (outcome.kind === "closed") {
-            const r = outcome.result;
-            return jsonResult({
-              // "filed" means a real issue was created/updated. advised_upgrade
-              // files nothing; and a closed result always has a url here (a
-              // no-url terminal is routed to "unfiled" above).
-              filed: !!r.url && r.action_taken !== "advised_upgrade",
-              repo,
-              url: r.url,
-              number: r.number,
-              classification: r.classification,
-              action_taken: r.action_taken,
-              deduped: r.deduped,
-              fixed_in_version: r.fixed_in_version,
-              fix_pr_url: r.fix_pr_url,
-              recommend_upgrade: r.recommend_upgrade,
-              possible_duplicate: r.possible_duplicate,
-              // Present (non-empty) when triage judged this a NEW symptom of an
-              // already-known defect; the issues are cross-linked on GitHub.
-              related_issues: r.related_issues?.length ? r.related_issues : undefined,
-              versions: outcome.ack.versions,
-              up_to_date: outcome.ack.up_to_date,
-              upgrade_hint: outcome.ack.upgrade_hint,
-              // The one line to relay to the user.
-              agent_message: r.agent_message,
-              note: "Triaged by the AI issue worker. Relay agent_message (and the upgrade advice) to the user.",
-            });
-          }
-
-          // Terminal without an issue: the worker's triage AND its own fallback
-          // both gave up — nothing was filed, so a prefilled URL is the safe
-          // last resort (no double-file risk).
-          if (outcome.kind === "unfiled") {
-            return jsonResult({
-              url: prefilledUrl,
-              repo,
-              filed: false,
-              versions: outcome.ack.versions,
-              up_to_date: outcome.ack.up_to_date,
-              upgrade_hint: outcome.ack.upgrade_hint,
-              note: "The triage worker could not file this report. Fallback: prefilled issue link for the user to submit in one click.",
-            });
-          }
-
-          // Still triaging at the budget: the worker WILL finish + file/dedup on
-          // its own. Do NOT prefill (would double-file). Surface the version-ack.
-          return jsonResult({
-            filed: false,
-            pending: true,
-            repo,
-            job_id: outcome.job_id,
-            versions: outcome.ack.versions,
-            up_to_date: outcome.ack.up_to_date,
-            upgrade_hint: outcome.ack.upgrade_hint,
-            agent_message: outcome.ack.upgrade_hint,
-            note: "The AI triage is still running; the worker will file or dedup this report autonomously. If the user is behind on versions (see upgrade_hint), suggest upgrading first — that often resolves it.",
-          });
-        } catch (workerErr) {
-          // SUBMIT failed (worker unreachable / non-OK) → the worker never took
-          // the report, so a prefilled URL is safe (no double-file risk).
-          return jsonResult({
-            url: prefilledUrl,
-            repo,
-            filed: false,
-            note: `Could not reach the AI triage worker (${workerErr instanceof Error ? workerErr.message : String(workerErr)}). Fallback: prefilled issue link for the user to submit in one click.`,
-          });
-        }
-      } catch (err) {
-        return {
-          content: [
-            { type: "text" as const, text: `Error building issue link: ${err instanceof Error ? err.message : String(err)}` },
-          ],
-          isError: true,
-        };
-      }
-    },
-  );
-}
-
 function jsonResult(obj: unknown) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(obj, null, 2) }],
   };
+}
+
+export const ARCHIVED_NOTICE =
+  "comfyui-mcp is no longer maintained and its issue trackers are closed, so nothing was filed. " +
+  "ComfyUI now ships official agent and MCP tooling (Comfy Agent and Comfy MCP), built and supported " +
+  "by the Comfy-Org team: https://docs.comfy.org/agent-tools , https://comfy.org/mcp/ , " +
+  "https://github.com/Comfy-Org/comfy-mcp . Tell the user plainly that this project is archived and " +
+  "point them at the official tooling; do not retry this call, and do not look for another way to report.";
+
+export function registerReportIssueTools(server: McpServer): void {
+  server.tool(
+    "report_issue",
+    "ARCHIVED — this project is no longer maintained and its issue trackers are closed. This tool files NOTHING and contacts no service: it returns a notice pointing at ComfyUI's official agent and MCP tooling (Comfy Agent / Comfy MCP, by Comfy-Org). Kept registered only so older prompts and skills that call it get a clear answer instead of an unknown-tool error.",
+    {
+      title: z.string().min(1).describe("Ignored — retained for compatibility with callers that still pass it."),
+      body: z.string().min(1).describe("Ignored — retained for compatibility with callers that still pass it."),
+      repo: z.string().optional().describe("Ignored."),
+      labels: z.array(z.string()).optional().describe("Ignored."),
+      mcp_version: z.string().optional().describe("Ignored."),
+      panel_version: z.string().optional().describe("Ignored."),
+      no_file: z.boolean().optional().describe("Ignored."),
+    },
+    async (args) => {
+      // Deliberately no network, no prefilled GitHub URL (the trackers are closed, so a
+      // link would send the user to a page that refuses them) and no identity stamp.
+      return jsonResult({
+        archived: true,
+        filed: false,
+        repo: normalizeRepo(args.repo),
+        official: {
+          docs: "https://docs.comfy.org/agent-tools",
+          comfy_mcp: "https://comfy.org/mcp/",
+          repo: "https://github.com/Comfy-Org/comfy-mcp",
+        },
+        note: ARCHIVED_NOTICE,
+      });
+    },
+  );
 }


### PR DESCRIPTION
The last functional change before the repo is archived. Merge after #2923 (README notice).

- `report_issue` is a stub: files nothing, contacts no service, hands out no prefilled link to a tracker that now refuses issues. Kept registered so older prompts get a clear answer instead of an unknown-tool error.
- the `report-bug` skill says the same and points at the official tooling (Comfy Agent / Comfy MCP by Comfy-Org).
- docs homepage carries the archive notice and a contact line in all 12 languages; the blog gets a goodbye post and an archive callout on its index.
- tests that drove the old handler now assert the stub (no network, no URL); the #779 description pin is retired; anti-slop baseline re-recorded for the debt this pays.

Verification: `report-issue`, `report-issue-version`, `report-asks-for-frontend-version`, `skill-source-citations`, `skill-authoring-limits` — 289 passed; full suite adds no red file main does not already have; docs/blog checks and lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nqNZzLirrRQRc7Q8ZmiTN