### PR TITLE
release: 0.52.203

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.52.203] - 2026-09-09
+
 ### MCP
 
 #### Changed
 - **This project is archived.** ComfyUI now ships official agent and MCP tooling (Comfy Agent and Comfy MCP, by Comfy-Org) — https://docs.comfy.org/agent-tools. `report_issue` is now a stub that files nothing and contacts no service, returning a notice that points at the official tooling; the `report-bug` skill says the same. The docs homepage carries the notice in every language. Issues and pull requests are closed.
+- remove clutter — .beads, .codex, infra/cloudflare, benchmarks + arena, design/, ROADMAP.md (#2926)
+- final release — archive notice, report_issue stub, docs homepage in every language (#2925)
+- archive notice — this project is no longer maintained (#2923)
+
 
 ## [0.52.202] - 2026-09-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.202",
+  "version": "0.52.203",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.52.202",
+      "version": "0.52.203",
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.52.202",
+  "version": "0.52.203",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
The last release: archive notice, `report_issue` stub, docs homepage notice in every language, declutter. Merge with a **merge commit** (not squash) so main carries the exact commit the `v0.52.203` tag will point at; the tag push publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nqNZzLirrRQRc7Q8ZmiTN