### PR TITLE
fix(node-dev): report search matches relative to custom_nodes/ so read can open them

### DIFF
--- a/src/__tests__/services/node-dev.test.ts
+++ b/src/__tests__/services/node-dev.test.ts
@@ -315,6 +315,38 @@ describe("searchNodePacks", () => {
     expect(rgCallsSpy[0].args[rgCallsSpy[0].args.indexOf("--regexp") + 1]).toBe("hit");
   });
 
+  it("#2921: a match found inside a pack is returned root-relative so read can open it", () => {
+    const pack = join(customNodes, "Pack");
+    mkdirSync(pack, { recursive: true });
+    writeFileSync(join(pack, "nodes.py"), "class FooNode:\n    pass\n");
+    const { deps } = makeDeps(); // builtin engine
+    const res = searchNodePacks({ query: "FooNode", path: "Pack" }, deps);
+    expect(res.matches.length).toBe(1);
+    // Root-relative (custom_nodes/), NOT pack-relative — this is what read expects.
+    expect(res.matches[0].file).toBe("Pack/nodes.py");
+    // The exact round trip from the issue: the returned path must be readable.
+    const read = readNodeFile({ path: res.matches[0].file }, deps);
+    expect(read.content).toContain("FooNode");
+  });
+
+  it("#2921: ripgrep matches inside a pack are returned root-relative", () => {
+    const pack = join(customNodes, "Pack");
+    mkdirSync(pack, { recursive: true });
+    writeFileSync(join(pack, "nodes.py"), "hit here\n");
+    const rgCallsSpy: { args: string[]; cwd: string }[] = [];
+    const { deps } = makeDeps({
+      hasRipgrep: () => true,
+      runRipgrep: (args, opts) => {
+        rgCallsSpy.push({ args, cwd: opts.cwd });
+        return { status: 0, stdout: "nodes.py:3:hit here\n", stderr: "" };
+      },
+    });
+    const res = searchNodePacks({ query: "hit", path: "Pack" }, deps);
+    expect(res.engine).toBe("ripgrep");
+    expect(res.matches).toEqual([{ file: "Pack/nodes.py", line: 3, text: "hit here" }]);
+    expect(rgCallsSpy[0].cwd).toBe(realpathSync(pack));
+  });
+
   // #809 (codex gate) — BOTH directions of the truncation lie, run for real rather than
   // asserted against the source text.
   //

--- a/src/services/node-dev.ts
+++ b/src/services/node-dev.ts
@@ -837,11 +837,17 @@ export function searchNodePacks(
   if (!deps.isDirectory(searchDir)) {
     throw new NodeDevError(`Search path does not exist under custom_nodes/.`);
   }
+  // #2921: match paths are reported relative to custom_nodes/ (the base root that
+  // read/write/list_files resolve against) so a search result can be fed straight to
+  // action:"read". searchDir is only the WALK root; when it is a subdirectory such as a
+  // pack folder, prefix every reported path with that subdirectory.
+  const baseRoot = customNodesRoot(resolvedBase);
+  const relPrefix = relative(baseRoot, searchDir).split(/[\\/]/).join("/");
 
   if (deps.hasRipgrep()) {
-    return searchWithRipgrep(query, searchDir, cap, options, deps);
+    return searchWithRipgrep(query, searchDir, cap, options, deps, relPrefix);
   }
-  return searchBuiltin(query, searchDir, cap, options, deps);
+  return searchBuiltin(query, searchDir, cap, options, deps, relPrefix);
 }
 
 function searchWithRipgrep(
@@ -850,6 +856,7 @@ function searchWithRipgrep(
   cap: number,
   options: SearchOptions,
   deps: NodeDevDeps,
+  relPrefix: string,
 ): SearchResult {
   const args = [
     "--line-number",
@@ -902,7 +909,7 @@ function searchWithRipgrep(
       break;
     }
     matches.push({
-      file: m[1],
+      file: relPrefix ? `${relPrefix}/${m[1]}` : m[1],
       line: Number(m[2]),
       text: clipMatchLine(m[3]),
     });
@@ -927,6 +934,7 @@ function searchBuiltin(
   cap: number,
   options: SearchOptions,
   deps: NodeDevDeps,
+  relPrefix: string,
 ): SearchResult {
   const re = new RegExp(query, options.caseSensitive ? "" : "i");
   const globMatcher = options.glob ? globToRegExp(options.glob) : null;
@@ -989,7 +997,7 @@ function searchBuiltin(
             return;
           }
           matches.push({
-            file: rel,
+            file: relPrefix ? `${relPrefix}/${rel}` : rel,
             line: i + 1,
             text: clipMatchLine(lines[i]),
           });


### PR DESCRIPTION
**What**

`node_pack` action `search` reported every match path relative to the search's own `path`
walk root, while `read` / `write` / `list_files` resolve their `path` argument against the
`custom_nodes/` base root. So a path returned by `search` could not be fed back into
`read`: it failed with `NODE_DEV_ERROR: File not found under custom_nodes/: "<path>"`.

Reproduction from the issue: search with `path` set to a pack folder returns
`web/js/<file>.js`, and the matching `read` looks for `custom_nodes/web/js/<file>.js`.
The default `path: "."` happened to work only because the walk root *is* the base root.

**How**

- In `searchNodePacks`, compute the base root and the walk root's offset from it:

  ```ts
  const baseRoot = customNodesRoot(resolvedBase);
  const relPrefix = relative(baseRoot, searchDir).split(/[\\/]/).join("/");
  ```

- Pass `relPrefix` into both engines and prepend it to the reported `file`:
  - `searchBuiltin`: `file: relPrefix ? `${relPrefix}/${rel}` : rel`
  - `searchWithRipgrep`: `file: relPrefix ? `${relPrefix}/${m[1]}` : m[1]`
- Behavior with the default `path: "."` is unchanged (the prefix is empty), and the
  `path`/`glob` filtering still matches against the search-dir-relative path so glob
  semantics are untouched.

**Tests**

- New builtin regression test: create `Pack/nodes.py`, search `{ query: "FooNode", path: "Pack" }`,
  assert the reported file is `Pack/nodes.py`, then feed that exact string to `readNodeFile`
  and assert the content comes back — the full round trip from the issue.
- New ripgrep-path regression test asserting the same root-relative result through the
  mocked ripgrep seam.
- `npx vitest run src/__tests__/services/node-dev.test.ts` → 84 passed
- `npx tsc --noEmit` → clean

**Mutation check**

Reverting only the two `file:` expressions to their pre-fix form makes both new tests fail
(2 failed, 82 skipped); restoring the fix makes them pass. The new tests genuinely guard
the change.

Fixes #2921
