### PR TITLE
fix(node-management): detach to canonical remote ref so remote-only branches install

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -2059,6 +2059,48 @@ describe("node-management service", () => {
       ]);
     });
 
+    it("#2919 detaches to the canonical remote ref for a remote-only explicit branch", async () => {
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) {
+          return false;
+        }
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS)) return cloned;
+        return false;
+      });
+      const missingGitRef = () =>
+        Object.assign(new Error("fatal: 'refs/heads/main' - not a valid ref"), {
+          status: 1,
+        });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        if (bin === "git" && args[2] === "show-ref") throw missingGitRef();
+        if (bin === "git" && args[2] === "for-each-ref")
+          return "refs/remotes/origin/main\n";
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        ref: "main",
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      const checkoutCall = mockedExec.mock.calls.find(
+        (c) => c[0] === "git" && (c[1] as string[])[2] === "checkout",
+      );
+      expect(checkoutCall?.[1]).toEqual([
+        "-C",
+        NODE_DIR_UTILS,
+        "checkout",
+        "--detach",
+        "refs/remotes/origin/main",
+      ]);
+    });
+
     it("cleans up a clone when the version-derived nightly probe is unknown", async () => {
       stubFetch({ installedBody: {} });
       let cloned = false;
@@ -2433,7 +2475,7 @@ describe("node-management service", () => {
       });
 
       expect(res.mechanism).toBe("comfy-cli");
-      expect(mockedExec).toHaveBeenCalledTimes(3);
+      expect(mockedExec).toHaveBeenCalledTimes(4);
       expect(mockedExec.mock.calls[0][1]).toEqual([
         "--json",
         "--workspace",
@@ -2455,15 +2497,26 @@ describe("node-management service", () => {
         "--all",
         "--tags",
       ]);
+      // #2919 — explicit ref is probed before detach; locally-present refs
+      // keep the bare name.
       expect(mockedExec.mock.calls[2][0]).toBe("git");
       expect(mockedExec.mock.calls[2][1]).toEqual([
+        "-C",
+        BAR_DIR,
+        "show-ref",
+        "--verify",
+        "--quiet",
+        "refs/heads/abc123",
+      ]);
+      expect(mockedExec.mock.calls[3][0]).toBe("git");
+      expect(mockedExec.mock.calls[3][1]).toEqual([
         "-C",
         BAR_DIR,
         "checkout",
         "--detach",
         "abc123",
       ]);
-      expect(mockedExec.mock.calls[2][1]).not.toContain("--end-of-options");
+      expect(mockedExec.mock.calls[3][1]).not.toContain("--end-of-options");
     });
 
     it("does not use a SAVED DEFAULT workspace for cm-cli when COMFYUI_PATH is unset", async () => {
@@ -2509,7 +2562,10 @@ describe("node-management service", () => {
       expect(res.mechanism).toBe("comfy-cli");
       expect(mockedExec.mock.calls[0][1]).toContain("/split/data");
       expect(mockedExec.mock.calls[0][1]).not.toContain("/split/code");
-      expect(mockedExec.mock.calls[2][1]).toEqual([
+      const splitCheckout = mockedExec.mock.calls.find(
+        (c) => c[0] === "git" && (c[1] as string[])[2] === "checkout",
+      );
+      expect(splitCheckout?.[1]).toEqual([
         "-C",
         resolve("/split/data", "custom_nodes", "bar"),
         "checkout",

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2753,6 +2753,23 @@ function runGitCheckout(
       timeout: GIT_CLONE_TIMEOUT,
       env: nonInteractiveGitEnv(),
     });
+    // #2919 — a bare branch name that exists only as a remote-tracking ref
+    // (refs/remotes/origin/<name>) triggers git's DWIM branch-creation, which
+    // conflicts with --detach. Canonicalize to the fully-qualified remote ref
+    // path so DWIM never triggers. Locally-present branches/tags keep the bare
+    // name; genuinely missing refs keep it too and fail with the normal error.
+    if (
+      !(opts.refFromVersion === true && isGitHeadChannel(ref)) &&
+      !checkoutRef.startsWith("refs/")
+    ) {
+      const localExists =
+        gitShowRefExists(nodeDir, `refs/heads/${checkoutRef}`, comfyuiBase) ||
+        gitShowRefExists(nodeDir, `refs/tags/${checkoutRef}`, comfyuiBase);
+      if (!localExists) {
+        const remoteRef = gitRemoteRefFor(nodeDir, checkoutRef, comfyuiBase);
+        if (remoteRef) checkoutRef = remoteRef;
+      }
+    }
     // `--end-of-options` is not a portable `git checkout` argument.
     // checkoutRef has already passed validateGitRef(), which rejects leading
     // dashes and control/whitespace characters before it reaches argv.
@@ -2763,6 +2780,7 @@ function runGitCheckout(
       env: nonInteractiveGitEnv(),
     });
   } catch (err) {
+    if (err instanceof GitRefProbeError) throw err;
     const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
     throw new NodeManagementError(
       `Failed to check out git ref "${checkoutRef}" for custom node "${baseUrl}": ${e.message}`,


### PR DESCRIPTION
## Summary

Fixes #2919. `install_custom_node` (action:install, source:git) with a `ref` that names a branch existing only as a **remote-tracking** branch (i.e. it is not the clone's default HEAD, so no local branch of that name exists) fails because:

```
git checkout --detach main
fatal: '--detach' cannot be used with '-b/-B/--orphan'
```

git's DWIM "create a local branch from origin/<name>" kicks in for the bare name and conflicts with `--detach`. The install then errors and rolls back the clone.

## What

In `runGitCheckout` (`src/services/node-management.ts`), after `git fetch --all --tags` and before the detach, a bare branch/tag name on the **non-version path** is canonicalized when it does not exist locally:

- If `refs/heads/<name>` or `refs/tags/<name>` exists locally (via `gitShowRefExists`) → keep the bare name (no DWIM risk).
- Else if `refs/remotes/origin/<name>` exists (via `gitRemoteRefFor`) → use that canonical fully-qualified ref path. `git checkout --detach refs/remotes/origin/main` never triggers DWIM.
- Else → keep the bare name; a genuinely missing ref fails with the normal git error (behavior unchanged).

The `#1470` version-derived-channel branch (`refFromVersion === true && isGitHeadChannel`) is untouched. A probe failure (`GitRefProbeError`) is now rethrown instead of being misreported as a checkout error.

## Why

The repository's clone default HEAD can differ from the requested branch (e.g. the repro repo in #2919 defaults to `h3-community-r01`, so `main` is remote-only after clone). The user then gets nothing installed and has to `git clone -b main` by hand.

## Tests

- New `#2919` test: `ref: "main"` with a remote-only `main` asserts the checkout uses `["-C", <dir>, "checkout", "--detach", "refs/remotes/origin/main"]`.
- The existing explicit-tag test (`checkout --detach "v1.2.3"`) still passes unchanged, proving locally-present refs keep the bare name.
- Two cm-cli tests updated only to account for the new `show-ref` probe call (checkout assertions preserved in intent).

## Verification

- `npx vitest run src/__tests__/services/node-management.test.ts` → **244 passed** (243 baseline + 1 new).
- `npm run build` (tsc) → clean.
- **Mutation check**: with the canonicalization neutralized, the new `#2919` test fails (checkout uses the bare `main`); restoring the fix makes it pass — the regression test genuinely guards the remote-only-branch path.