### PR TITLE
fix(node-management): preserve params.base when dispatching a Manager install_model task

### DIFF
--- a/src/__tests__/services/manager-install-model-base.test.ts
+++ b/src/__tests__/services/manager-install-model-base.test.ts
@@ -1,0 +1,153 @@
+// #2922 — the legacy Manager UI's whitelist checker reads item['base']
+// unconditionally, so a queued install_model task that omits `base` 500s with
+// `KeyError: 'base'` before the download is attempted. installModelViaManager
+// must therefore preserve a provided `base` hint in the dispatched task params,
+// while never sending the key at all when the hint is absent/blank (Manager
+// validates keys it receives, so `base: undefined` must not reach it).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Kept mutable to model the runtime target the panel applies. vi.hoisted makes
+// it available to the mock factory.
+const target = vi.hoisted(() => ({ base: "http://127.0.0.1:8188", generation: 0 }));
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: "/fake/comfy",
+    resolvedPort: 8188,
+    comfyuiHost: "127.0.0.1",
+    comfyuiSsl: false,
+    githubToken: undefined as string | undefined,
+  };
+  return {
+    config,
+    getComfyUIBaseUrl: () => target.base,
+    getComfyuiTargetGeneration: () => target.generation,
+    getComfyUIAuthHeaders: () => ({}),
+    isLoopbackHost: (host?: string) => host === "127.0.0.1" || host === "localhost",
+    isRemoteMode: () => false,
+  };
+});
+
+// node-management pulls in comfy-cli → workspace-env, which calls
+// promisify(execFile) at module load; keep the subprocess surface inert.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 0, stdout: "{}", stderr: "" })),
+}));
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs")>()),
+  existsSync: vi.fn(() => true),
+}));
+
+// The panel mutation lock is a FILE (panel-pin-guard). Point it at a temp path
+// so the suite never touches ~/.comfyui-mcp.
+process.env.COMFYUI_MCP_PANEL_LOCK = join(
+  tmpdir(),
+  `cmcp-lock-installmodelbase-${process.pid}.lock`,
+);
+process.env.COMFYUI_MCP_PANEL_PIN = "off";
+
+const {
+  installModelViaManager,
+  setQueueTimingForTests,
+  resetManagerApiCacheForTests,
+} = await import("../../services/node-management.js");
+
+const BASE = "http://127.0.0.1:8188";
+
+interface Call {
+  url: string;
+  path: string;
+  method: string;
+  body: unknown;
+}
+
+const DRAINED = { total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false };
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Minimal v4 Manager: unified task route answers, the queue drains
+ * immediately, and history reports no completed task for our ui_id.
+ */
+function stubV4Manager(): Call[] {
+  const calls: Call[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      const parsed = new URL(url);
+      calls.push({ url, path: parsed.pathname, method, body });
+      if (parsed.pathname === "/v2/manager/queue/status") return jsonResponse(DRAINED);
+      if (parsed.pathname === "/v2/manager/queue/start") return new Response("", { status: 200 });
+      if (parsed.pathname === "/v2/manager/is_legacy_manager_ui") {
+        return jsonResponse({ is_legacy_manager_ui: false });
+      }
+      if (parsed.pathname === "/v2/manager/queue/task") return jsonResponse({ accepted: true });
+      if (parsed.pathname === "/v2/manager/queue/history") return jsonResponse({ history: {} });
+      return new Response("", { status: 200 });
+    }),
+  );
+  return calls;
+}
+
+function taskParamsOf(calls: Call[]): Record<string, unknown> {
+  const enqueue = calls.find((c) => c.path === "/v2/manager/queue/task" && c.method === "POST");
+  expect(enqueue).toBeDefined();
+  const body = enqueue!.body as { kind: string; params: Record<string, unknown> };
+  expect(body.kind).toBe("install-model");
+  return body.params;
+}
+
+describe("installModelViaManager preserves the Manager model base hint (#2922)", () => {
+  beforeEach(() => {
+    target.base = BASE;
+    target.generation = 0;
+    resetManagerApiCacheForTests();
+    setQueueTimingForTests({ pollIntervalMs: 1, startupGraceMs: 0, timeoutMs: 5000 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("includes base in the queued install-model task params when provided", async () => {
+    const calls = stubV4Manager();
+
+    await installModelViaManager({
+      name: "sdxl-model.safetensors",
+      url: "https://huggingface.co/foo/sdxl-model.safetensors",
+      filename: "sdxl-model.safetensors",
+      type: "checkpoints",
+      base: "SDXL",
+    });
+
+    const params = taskParamsOf(calls);
+    expect(params).toMatchObject({ base: "SDXL" });
+  });
+
+  it("omits the base key entirely when no hint is provided", async () => {
+    const calls = stubV4Manager();
+
+    await installModelViaManager({
+      name: "model.safetensors",
+      url: "https://huggingface.co/foo/model.safetensors",
+      filename: "model.safetensors",
+      type: "checkpoints",
+    });
+
+    const params = taskParamsOf(calls);
+    expect(params).not.toHaveProperty("base");
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -4126,6 +4126,8 @@ async function downloadModelViaManagerRemote(
       save_path: managerSavePath,
       // Panel tray: watch OUR canonical category for the file to land (#143).
       trayCategory: modelType,
+      // #2922 — the legacy Manager whitelist checker reads item['base'] unconditionally.
+      base: /sdxl/i.test(resolvedFilename) ? "SDXL" : "SD1.5",
     });
   } catch (err) {
     // #1374 — the ONLY failure entitled to the route explanation: Manager was contacted

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -7059,6 +7059,12 @@ export interface InstallModelParams {
    * listing (in-progress files are hidden there, so "listed" = landed).
    */
   trayCategory?: string;
+  /**
+   * ComfyUI-Manager model `base` family (e.g. "SD1.5", "SDXL"). The legacy Manager
+   * UI's whitelist checker reads `item['base']` unconditionally, so a task that
+   * omits it fails with `KeyError: 'base'` before the download is attempted.
+   */
+  base?: string;
 }
 
 // Remote (Manager-dispatched) downloads run server-side: the queue reports
@@ -7155,6 +7161,9 @@ export async function installModelViaManager(
     filename: params.filename,
     type: params.type,
     save_path,
+    // Legacy Manager UI (check_whitelist_for_model) reads item['base'] unconditionally;
+    // omitting it 500s the queued task before the download is attempted (#2922).
+    ...(params.base && params.base.trim().length > 0 ? { base: params.base.trim() } : {}),
   };
   // One pinned target for the whole operation — the dispatch, its self-heal
   // retry/drain, AND the landing watcher (the file lands on the server the task


### PR DESCRIPTION
## What

`download_model(action=download)` returns HTTP 500 for an exact model-list whitelisted URL on a remote ComfyUI running ComfyUI-Manager v4 in `--enable-manager-legacy-ui` mode.

## Why

`installModelViaManager` rebuilds `taskParams` from scratch and dropped the `base` hint that model resolution had already computed. The legacy Manager UI's whitelist checker reads the key unconditionally (`check_whitelist_for_model`: `x['base'] == item['base']`), so the queued task 500s with `KeyError: 'base'` before the download is ever attempted.

## How

- `InstallModelParams` gains an optional `base` field with the reason documented inline.
- `installModelViaManager` forwards it into the queued task params, and only when it is present and non-blank, so no `base: undefined` reaches Manager.
- the `installModelViaManager` call site in `model-resolver.ts` supplies the family hint from the resolved filename (`SDXL` when it matches `sdxl`, otherwise `SD1.5`).

Resolving `base` from Manager's own model-list metadata instead of filename inference would be a stronger follow-up; this change keeps the task from failing in the meantime.

## Tests

New `src/__tests__/services/manager-install-model-base.test.ts`:

- forwards `base` into the queued install-model task params when it is set;
- sends no `base` key at all when the hint is absent.

```
npx vitest run src/__tests__/services/manager-install-model-base.test.ts \
  src/__tests__/services/manager-install-model-cause.test.ts \
  src/__tests__/services/manager-dialect-cache.test.ts
-> Test Files 3 passed (3), Tests 47 passed (47)

npx tsc --noEmit -p tsconfig.json
-> clean
```

Mutation check: deleting the new `...(params.base && ...)` spread makes the forwarding test fail (`1 failed | 1 passed`); restoring it passes again, so the test genuinely guards this fix.

Fixes #2922
